### PR TITLE
Military score build inference on Scores analytic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -276,6 +276,46 @@ _Avoid_: disabled analytic (generic), HW not applicable toast
 Settings-driven **homeworld region overlay** math shipped for **`hwdistribution=2` (Circular)** on round maps (`mapshape=0`) only. Other distributions remain active for baseline profile, evidence, and manual annotation, but skip sector/ring overlay geometry until extended.
 _Avoid_: full hwdistribution support (v1 claim)
 
+**Military score build inference**:
+Core **turn analytic** behavior (optional on the **Scores** analytic) that explains one player's scoreboard deltas on a turn as a ranked set of feasible build and load actions, not a single proved history. See [design-military-score-build-inference.md](docs/design-military-score-build-inference.md).
+_Avoid_: build solver, score guesser
+
+**Inference host turn**:
+The host turn whose activity is being explained. Scoreboard deltas are read from the **later** stored **TurnInfo** document (turn *N+1*); the **earlier** document (turn *N*) supplies inventory ground truth for complexity grading and Tier 2 checks.
+_Avoid_: inference turn (ambiguous with shell **turn**)
+
+**Inference corpus case**:
+One scored test targeting one **Player** on one **inference host turn**, discovered when `games/{gameId}/{perspective}/turns/{N}` and `.../{N+1}` both exist. Default scope: the **Player** at that **perspective** slot (what that slot built on the host turn). Sparse and complete stores are both valid.
+_Avoid_: scoreboard row test (too vague)
+
+**Inference case complexity**:
+An ordinal label (`minimal` through `adjunct`) for how hard a corpus case is to explain, derived from ground-truth inventory change between the paired turns for the case **Player** (ship builds, ammo and defenses, then adjunct effects such as trades and losses). **Adjunct** classification may require **multi-perspective ground truth** when an effect spans players (e.g. ship trades need every involved **perspective** stored). With sparse storage, classify from what the case **perspective** can see and treat missing cross-player views as unknown adjunct, not proven absence. Runners skip cases above `--max-complexity` with a recorded reason.
+_Avoid_: turn band (unless explicitly mapped to complexity)
+
+**Multi-perspective ground truth**:
+Inventory truth for a corpus case assembled from one or more stored **TurnInfo** documents at the same host turn (and the following turn), merging visibility across **perspective** slots when adjunct or Tier 2 checks need events that no single slot sees alone.
+_Avoid_: omniscient turn (informal)
+
+**Inference corpus runner**:
+Test-harness code (not shipped in the Core REST API package) that performs discovery, complexity grading, **catalog coverage**, case execution, and reporting. Two modes: **fixed corpus** (committed fixtures and manifest for CI) and **local corpus** (script `game_id` against a completed game in the **file backend** store). Invokes production inference APIs only; no corpus logic in `api/` business modules.
+_Avoid_: inference integration test (implementation name)
+
+**Ground truth explanation**:
+The feasible action multiset inferred from inventory change between the paired turns for the case **Player** (exact by construction when adjunct effects are absent or fully visible). Used for Tier 2 compatibility checks and for **top-K ranking** checks against solver output.
+_Avoid_: true build (implies uniqueness)
+
+**Inference top-K ranking check**:
+Whether the **ground truth explanation** appears among the solver's top *K* ranked solutions (default *K* = 3). A miss means constraints are satisfied but likelihood ordering may be wrong -- reported as an investigation signal, not necessarily a hard failure unless promoted in the fixed corpus.
+_Avoid_: best solution match (implies rank 1 only)
+
+**Catalog coverage** (inference):
+Whether the **ground truth explanation** can be expressed using the solver's candidate **action catalog** for that turn (aggregate actions and ship-build combos, within bounds). If not, the case is **out of search space** -- a distinct outcome from solver failure; the runner should not treat `no_exact_solution` as a solver regression on that row.
+_Avoid_: infeasible (ambiguous with CP-SAT status)
+
+**Out of search space**:
+Corpus case outcome when **catalog coverage** fails: the inferencer's modeled action inventory is incomplete for this host turn (deferred effect families, missing hull combo tier, bucket cap too low, etc.). Report separately from `skipped` (complexity cap) and from Tier 1 `exact` / `no_exact_solution`.
+_Avoid_: unsupported (too vague)
+
 ### Observability
 
 **Request diagnostics**:

--- a/docs/design-inference-corpus.md
+++ b/docs/design-inference-corpus.md
@@ -1,0 +1,378 @@
+# Design: Inference corpus (real-turn regression)
+
+Authoritative contract for the **inference corpus** harness (#62–#66 under epic #39). Summary and glossary: [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md) section 11.2, repo root `CONTEXT.md`.
+
+**Related:** [design-military-score-build-inference.md](design-military-score-build-inference.md), [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md).
+
+---
+
+## 1. Layout and imports
+
+| Path | Role |
+|------|------|
+| `packages/api/tests/inference_corpus/` | Harness package (discovery, classify, coverage, run, report) |
+| `packages/api/tests/fixtures/inference_corpus/` | Committed RST slices + `manifest.json` |
+| `packages/api/tests/test_inference_corpus_fixed.py` | CI entry (pytest) |
+| `scripts/run_inference_corpus.py` | Local Typer runner (#63) |
+
+**Import rule:** Harness code is imported as `from tests.inference_corpus.<module> import ...`. Pytest `pythonpath` for the API package is `.` (`packages/api`); `tests/` is a package (`tests/__init__.py` exists). Do **not** place harness modules under `api/`.
+
+**Production APIs to call:**
+
+- `turn_info_from_json` / `GameService` or `StorageBackend.get` for loads
+- `infer_military_score_build(score, turn)` for Tier 1 (#62)
+- `build_action_catalog_from_turn`, `build_inference_problem`, `solve_inference_problem` when coverage or constraint re-check needs the catalog (#64+)
+- `GameService.player_id_for_perspective(info, perspective, game_id)` to resolve the case player
+
+---
+
+## 2. Case identity
+
+A **inference corpus case** is identified by:
+
+| Field | Meaning |
+|-------|---------|
+| `gameId` | planets.nu game id |
+| `perspective` | 1-based slot `P` (storage path segment) |
+| `hostTurn` | Host turn `N` whose builds are explained |
+| `playerId` | `GameInfo.players[P - 1].id` unless manifest overrides |
+
+**Turn documents:**
+
+- `priorTurn` = `hostTurn` (`N`) -- inventory ground truth (older snapshot)
+- `scoreTurn` = `hostTurn + 1` (`N+1`) -- scoreboard deltas and catalog inputs (newer snapshot)
+
+**Inference call:** Load `TurnInfo` from `scoreTurn` at perspective `P`. Find `Score` where `score.ownerid == playerId`. Call `infer_military_score_build(score, turn)`.
+
+**Do not** run scoreboard inference on `priorTurn` (turn 1 has `no_prior_turn`).
+
+---
+
+## 3. Manifest schema (fixed corpus / CI)
+
+File: `packages/api/tests/fixtures/inference_corpus/manifest.json`
+
+```json
+{
+  "version": 1,
+  "gameInfoPath": "628580/info.json",
+  "cases": [
+    {
+      "id": "628580-p1-host2",
+      "gameId": 628580,
+      "perspective": 1,
+      "hostTurn": 2,
+      "playerId": null,
+      "priorTurnPath": "628580/1/turns/2.json",
+      "scoreTurnPath": "628580/1/turns/3.json",
+      "complexity": "minimal",
+      "tier": 1,
+      "expectedStatus": "exact",
+      "requireTopK": false,
+      "expectCoverage": false,
+      "requiredPerspectives": [],
+      "notes": "Seed case; refresh paths after fixture trim"
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | yes | Stable case id for logs |
+| `gameId` | yes | Must match paths |
+| `perspective` | yes | 1-based storage slot |
+| `hostTurn` | yes | `N`; `scoreTurn` is `hostTurn + 1` |
+| `playerId` | no | Default: slot owner from `gameInfoPath` |
+| `priorTurnPath` | yes | Relative to `fixtures/inference_corpus/` |
+| `scoreTurnPath` | yes | Relative to `fixtures/inference_corpus/` |
+| `gameInfoPath` | no | Once per manifest; used to resolve `playerId` |
+| `complexity` | no | Expected label for checks (`minimal` .. `adjunct`) |
+| `tier` | no | `1` or `2`; default `1` |
+| `expectedStatus` | no | Default `exact` for Tier 1; see section 7 |
+| `requireTopK` | no | Default `false`; if `true`, ranking miss is hard fail (#65) |
+| `expectCoverage` | no | If `true`, case must be in search space (#64) |
+| `requiredPerspectives` | no | Other slots required for multi-view (#66) |
+| `notes` | no | Human context |
+
+Paths are **rst-shaped JSON** (same object `turn_info_from_json` accepts), not storage breakpoint wrappers.
+
+---
+
+## 4. Fixture authoring
+
+### 4.1 Recommended seed game
+
+Use **game `628580`** for the first CI slice (already referenced in `game_info_sample.json` and local `.data`).
+
+Example host-turn pair for discovery smoke tests: **perspective `1`, hostTurn `2`** (files `turns/2.json` + `turns/3.json` under `.data/games/628580/1/`).
+
+### 4.2 Refresh procedure (from local store)
+
+1. Load-all or ensure turns exist under `.data/games/{gameId}/{perspective}/turns/{N}.json`.
+2. Copy rst JSON to `packages/api/tests/fixtures/inference_corpus/{gameId}/{perspective}/turns/`.
+3. Trim large arrays (section 4.3) so each turn file stays under ~200 KB if possible.
+4. Copy or subset `games/{gameId}/info.json` to `fixtures/inference_corpus/{gameId}/info.json`.
+5. Run `infer_military_score_build` locally on the trimmed `scoreTurn`; adjust manifest `expectedStatus` / pick another turn if not `exact`.
+6. Add or update `manifest.json` row; run `make test_api`.
+
+Optional helper (implement in #62 or ad hoc):
+
+```bash
+cd packages/api
+PYTHONPATH=. uv run python -c "
+from pathlib import Path
+import json, shutil
+src = Path('../../.data/games/628580/1/turns')
+dst = Path('tests/fixtures/inference_corpus/628580/1/turns')
+dst.mkdir(parents=True, exist_ok=True)
+for n in (2, 3):
+    shutil.copy2(src / f'{n}.json', dst / f'{n}.json')
+print('copied; trim before commit')
+"
+```
+
+### 4.3 Trim guidelines (v1)
+
+Full turn dumps (~800 KB+) are too large for git. Trim **in place** keeping deserialization valid:
+
+**Always keep:** `settings`, `game`, `player`, `players`, `races`, `scores`, `hulls`, `engines`, `beams`, `torpedos`, `ships` (see below), `planets` (only ids/owner/defense/fighters needed for defense deltas), `starbases` if present in payload.
+
+**Ships:** For Tier 1-only fixtures, keeping **all** `ships` is acceptable if under size budget. For smaller files, keep ships where `ownerid == case playerId` plus any hull that appears on a **new** ship id in `scoreTurn` vs `priorTurn` (for ground truth in #64).
+
+**May drop:** `messages`, `events`, large history arrays, `mines`, `fights`, `chartags`, and other fields not read by `turn_info_from_json` for inference (verify with `turn_info_from_json` after trim).
+
+After trim, run `turn_info_from_json` and one `infer_military_score_build` call in a one-off test or REPL.
+
+---
+
+## 5. Local discovery (#63)
+
+Enumerate without a manifest:
+
+1. `StoreService.read_shallow("games")` -- child game ids, or take `--game-id`.
+2. For each perspective directory under `games/{id}/` (numeric child names `1`..`11`, skip non-numeric):
+   - `read_shallow(f"games/{id}/{p}/turns")` -- turn numbers present.
+3. For each consecutive pair `(N, N+1)` in sorted turns, emit a case with `hostTurn=N`, `perspective=p`.
+
+Use `FileStorageBackend` with `ApiConfig(storage_backend="file", storage_root=...)`. Default storage root: load via `api.config.load_config()` (typically repo `.data`).
+
+**Finished game:** Script does not require load-all completeness; sparse pairs are valid. Optionally warn if `games/{id}/info.json` missing.
+
+---
+
+## 6. Complexity classification
+
+### 6.1 Levels (ordinal)
+
+| Level | Name | `maxComplexity` cap includes |
+|-------|------|------------------------------|
+| 0 | `minimal` | yes |
+| 1 | `routine` | yes |
+| 2 | `heavy` | yes |
+| 3 | `adjunct` | only with `--include-adjunct` (future) |
+
+CLI `--max-complexity` accepts names `minimal`, `routine`, `heavy`, `adjunct` or integers `0`–`3`. Skip when `case.level > cap`.
+
+### 6.2 Signals (evaluate in order; highest wins)
+
+Apply to inventory delta for **case `playerId`** between `priorTurn` and `scoreTurn`, using case perspective ships/planets/starbases first, then **multi-perspective merge** (section 8) for adjunct.
+
+**`adjunct` (3)** if any:
+
+- Net **ship count decrease** for owner (ships with `turnkilled` in window or id present at N gone at N+1 without matching build compensation)
+- **Starbase or planet count decrease** for owner
+- **Trade / capture hint:** hull appears under `playerId` at N+1 with id not in N snapshot, and same `hullid`+similar location existed under **another** `ownerid` at N in a merged perspective
+- Scoreboard `militarychange` magnitude exceeds explained build/load delta by more than **500** points (unmodeled loss/combat) after naive build tally
+
+**`heavy` (2)** if not adjunct and any:
+
+- **>= 3** new owned ships (ids in N+1 not in N, `turnkilled == 0`)
+- Or sum of new ship construction military value (rough hull MC from `ships` / hull table) implied **> 2000** MC
+- Or **>= 51** total aggregate load units (fighters on ships + starbase fighters + defense posts) inferred from score deltas or inventory
+
+**`routine` (1)** if not heavy/adjunct and any:
+
+- **2** new owned ships, or
+- **11–50** aggregate load units, or
+- **>= 2** distinct aggregate action families (fighters + torps + defense, etc.)
+
+**`minimal` (0):** otherwise (typically <=1 new ship, small loads, no losses).
+
+Document computed `complexity` and `complexityReasons: string[]` on each case result.
+
+### 6.3 Default skips
+
+- `complexity == adjunct` and not `--include-adjunct` -> `skipped_complexity` (reason `adjunct_disabled`)
+- Above `--max-complexity` -> `skipped_complexity`
+
+---
+
+## 7. Tier 1 assertions (#62)
+
+For each case (after skips/coverage):
+
+1. Call `infer_military_score_build`.
+2. **Status:** Compare to `expectedStatus` (default `exact`). Allowed manifest values: `exact`, `no_exact_solution`, `time_limited`, `invalid_problem`, `solver_error`, `no_prior_turn`.
+3. When status is `exact` and `expectedStatus` is `exact`:
+   - `solutionCount >= 1`
+   - **Constraint re-check** on **top solution** (index 0): rebuild sums from catalog `CandidateAction` entries matching each `actionId` in the serialized solution:
+
+```text
+sum(score_delta_2x * count) == observation.military_delta_2x
+sum(warship_delta * count) == observation.warship_delta
+sum(freighter_delta * count) == observation.freighter_delta
+```
+
+   Use `build_inference_observation(score, turn)` for observation. Do **not** assert priority-point equality (diagnostic-only per #50 / design).
+
+4. For `heavy` cases only: allow `time_limited` if `solutionCount >= 1` and constraint re-check passes on top solution.
+
+Implement constraint re-check in `tests/inference_corpus/verify.py` using the same catalog instance built for the run.
+
+---
+
+## 8. Multi-perspective ground truth (#63, #66)
+
+When classifying **adjunct** or running **Tier 2**, merge snapshots for host turn pair `(N, N+1)`:
+
+- Start with perspective `P` ships (and planets/starbases for defense).
+- For each other perspective `Q` with both turns stored, append ships/planets visible at N and N+1.
+
+If a trade hypothesis needs slot `Q` and `Q` is missing, set `incomplete_multi_view: true` and **do not** promote to `adjunct` on trade alone.
+
+`requiredPerspectives` in manifest: CI fails fast if listed paths are absent in fixed fixtures.
+
+---
+
+## 9. Ground truth explanation v1 (#64)
+
+### 9.1 Multiset format
+
+```python
+# sorted tuple for hashing/compare
+GroundTruth = tuple[tuple[str, int], ...]  # (action_id, count) ascending by action_id
+```
+
+### 9.2 Extraction scope (v1)
+
+Extract only when **adjunct** is false and complexity <= `heavy`. Otherwise set `groundTruthAvailable: false` and skip coverage/ranking/Tier 2.
+
+**Ship builds (interim catalog, pre-#51):**
+
+- New ship ids at N+1 not at N, `ownerid == playerId`, `turnkilled == 0`.
+- Map each to `build_{hullid}_{preset}` using the same preset rules as `_ship_build_actions` in `actions.py`:
+  - `empty` -- non-military freighter-style hull or warship with no armed preset match
+  - `torpedoes` -- only when hull `launchers > 0` and the interim catalog would add the torpedo preset (armed build score)
+  - If hull/beam/tube state does not match either catalog preset, set `groundTruthAvailable: false`
+
+**Aggregate loads (score-derived v1):**
+
+When ship builds alone do not explain `militarychange`, allocate residual scaled delta to aggregate action ids in priority order (first fit):
+
+| Action id | When |
+|-----------|------|
+| `ship_fighters_added_total` | Positive fighter-related military delta remainder |
+| `ship_torps_loaded_{torpedoId}` | Torp MC remainder matching a loaded torp type on new/existing ships |
+| `starbase_fighters_added_total` | Starbase fighter remainder |
+| `starbase_defense_posts_added_total` | Starbase defense remainder |
+| `planet_defense_posts_added_total` | Planet defense remainder |
+| `fighters_starbase_to_ship` / `fighters_ship_to_starbase` | Only when inventory shows starbase vs ship fighter counts support transfer |
+
+If residual cannot be assigned without deferred effects, set `groundTruthAvailable: false`.
+
+**Post-#51:** Replace `build_{hull}_{preset}` mapping with combo ids from `ship_build_combos.py`; update manifest notes and coverage mapper.
+
+### 9.3 Catalog coverage (v1)
+
+After `build_action_catalog_from_turn(observation, scoreTurn)`:
+
+For each `(action_id, count)` in ground truth:
+
+- Catalog contains `action_id`
+- `count <= action.upper_bound` and `count >= action.lower_bound`
+
+If any fail -> outcome `out_of_search_space`, `coverageReason` from section 9.4, **do not** call solver.
+
+If `groundTruthAvailable: false` -> skip coverage and ranking; still run Tier 1.
+
+### 9.4 `coverageReason` enum (stable strings)
+
+| Reason | Meaning |
+|--------|---------|
+| `deferred_trade` | Trade/capture implied, not in catalog |
+| `deferred_ship_loss` | Ship loss/combat not modeled |
+| `deferred_starbase_loss` | Base loss not modeled |
+| `deferred_planet_loss` | Planet loss not modeled |
+| `deferred_minefield` | Mine/scoop not modeled |
+| `combo_not_in_catalog` | Ship build combo not generated (tier too narrow) |
+| `action_not_in_catalog` | Unknown action id |
+| `count_above_upper_bound` | GT count exceeds catalog cap |
+| `ground_truth_unavailable` | Extractor could not build multiset |
+| `residual_unexplained` | Military delta not allocatable to v1 actions |
+
+---
+
+## 10. Top-K ranking check (#65)
+
+When `groundTruthAvailable` and catalog coverage passed and Tier 1 status is `exact`:
+
+1. Normalize solver solutions to `GroundTruth` from payload `solutions[i].actions` (`actionId`, `count`; ignore zero counts).
+2. Compare to ground truth multiset (order-insensitive).
+3. If not found in first `K` solutions (default `K=3`, `--top-k`): emit `ranking_miss`.
+4. **Soft** unless manifest `requireTopK: true` or `--fail-on-ranking-miss`.
+
+**Complexity:** soft for `minimal` and `routine`; manifest may harden for `heavy` later.
+
+---
+
+## 11. Tier 2 compatibility (#65)
+
+When `--tier 2` or manifest `tier: 2`:
+
+- Recompute inventory delta rules from section 9.2 without collapsing to aggregates where ship-level detail exists.
+- **Pass:** every GT ship build and aggregate count is **compatible** with visible inventory (no requirement that GT equals top solver solution).
+- **Fail:** GT implies ships or loads that contradict merged inventory.
+
+Skip Tier 2 when `groundTruthAvailable: false`.
+
+---
+
+## 12. Report and exit codes
+
+### 12.1 Per-case outcomes
+
+`passed` | `failed` | `skipped_complexity` | `skipped_incomplete_multi_view` | `out_of_search_space` | `ranking_miss`
+
+`ranking_miss` does not set exit code 1 unless hard mode (section 10).
+
+### 12.2 Script exit code
+
+- `0` -- no `failed` cases
+- `1` -- one or more `failed`
+
+Print summary counts and optional `--json` array of per-case records (`caseId`, `outcome`, `status`, `complexity`, `coverageReason`, ...).
+
+---
+
+## 13. Issue map
+
+| Issue | Spec sections |
+|-------|----------------|
+| #62 | 1–4, 7, 12; manifest example |
+| #63 | 5–6, 8, 12 |
+| #64 | 8–9 |
+| #65 | 10–11, 12 |
+| #66 | 4, 8, manifest `requiredPerspectives` |
+
+**Solver epic ordering:** #62 parallel #50; refresh fixtures after #51/#52; #66 with #49 when trades modeled.
+
+---
+
+## 14. Open evolution
+
+- Hybrid CP-SAT coverage probe when mapping says covered but solver returns `no_exact_solution` (section 11.2 parent doc).
+- `--include-adjunct` to run adjunct cases instead of skipping.
+- Combo-aware ground truth after #51 lands.

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -34,9 +34,9 @@ flowchart LR
     Observations --> Catalog["Candidate action catalog"]
     Catalog --> Model["CP-SAT model"]
     Model --> Solutions["Top-K feasible explanations"]
-    Solutions --> CoreAnalytic["Core analytic payload"]
-    CoreAnalytic --> BffTable["BFF table response"]
-    BffTable --> Frontend["Frontend analytic tile"]
+    Solutions --> CoreScores["Core scores payload"]
+    CoreScores --> BffScores["BFF scores table"]
+    BffScores --> Frontend["Scoreboard table with inference column"]
 ```
 
 The first implementation solves each player independently. Cross-player coupling is deferred until ship trading, ship capture, and ownership transfers are modeled.
@@ -57,14 +57,14 @@ packages/api/api/analytics/military_score_inference/
 `-- analytic.py         # turn-level analytic assembly
 ```
 
-Register the analytic from `packages/api/api/analytics/registry.py` after the Core payload is stable.
+Do not register `military_score_inference` as a separate user-facing analytic. The solver package should be called by the existing `scores` analytic when inference is requested.
 
 BFF and frontend files should follow existing analytics structure:
 
 ```text
-packages/bff/bff/analytics/military_score_inference.py
+packages/bff/bff/analytics/scores.py
 packages/bff/bff/analytics/registry.py
-packages/frontend/src/analytics/militaryScoreInference/
+packages/frontend/src/analytics/scores/
 ```
 
 The implementation should not put solver logic in the BFF or frontend.
@@ -102,13 +102,25 @@ class CandidateAction:
     probability_weight: int = 0
 ```
 
-The important modeling rule is that action variables are non-negative integers, but action contribution vectors may contain positive or negative values.
+The important modeling rule is that action variables are non-negative integers, but action contribution vectors may contain positive or negative values. `probability_weight` is enough for simple actions, but repeated actions also need count-dependent probability terms.
+
+```python
+@dataclass(frozen=True)
+class ProbabilityBucket:
+    label: str
+    lower_count: int
+    upper_count: int
+    marginal_weight: int
+```
+
+Use buckets when the probability of `n` repeated actions is not `n` independent repetitions of the same event. For example, building 10 defense posts is plausible, building 100 is much less plausible, but 100 defense posts should not be penalized as 100 independent rare choices.
 
 ```python
 @dataclass(frozen=True)
 class InferenceProblem:
     observation: InferenceObservation
     actions: tuple[CandidateAction, ...]
+    probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
     max_solutions: int = 20
     time_limit_seconds: float = 1.0
 
@@ -160,10 +172,41 @@ Priority points should be configurable at first. If queue behavior is not yet co
 Add an integer objective:
 
 ```text
-maximize sum(probability_weight[action] * count[action])
+maximize action_weights + bucketed_count_weights + interaction_weights
 ```
 
 Weights should be scaled integer log-probabilities or penalties. For example, a common race-appropriate hull receives a better weight than an unusual one, and generic defense-post explanations receive a penalty so they do not crowd out more informative ship-build explanations.
+
+### 5.1 Count-dependent probability terms
+
+Some actions need probability as a function of count, not as a constant per unit. Use bucket variables for these cases.
+
+Example for planetary defense posts:
+
+| Bucket | Count range | Marginal meaning |
+|--------|-------------|------------------|
+| modest build-up | 0-10 | plausible local development |
+| heavy build-up | 11-50 | less likely but common in border areas |
+| extreme build-up | 51-100 | possible but strongly penalized |
+
+The model can represent this with separate integer variables per bucket:
+
+```text
+defense_posts_total == defense_posts_bucket_1 + defense_posts_bucket_2 + defense_posts_bucket_3
+0 <= defense_posts_bucket_1 <= 10
+0 <= defense_posts_bucket_2 <= 40
+0 <= defense_posts_bucket_3 <= 50
+```
+
+Then the objective uses different marginal weights for each bucket. This keeps the CP-SAT objective linear while avoiding the wrong assumption that 100 defense posts are as unlikely as 100 fully independent one-post actions.
+
+This bucket pattern also applies to:
+
+- starbase defense posts,
+- starbase fighter increases,
+- loaded fighter increases,
+- loaded torpedoes by type,
+- future mine-laying quantities.
 
 ---
 
@@ -190,11 +233,69 @@ The solver should return:
 
 ---
 
-## 7. Action catalog
+## 7. Scoreboard integration
+
+The user-facing feature belongs to the existing **Scores** analytic. It should not appear as a separate analytic in the analytics list.
+
+### 7.1 Analytics pane
+
+Add an option inside the existing Scores tile:
+
+- label: `Include build inference`,
+- control: checkbox,
+- default: off,
+- disabled state: disabled only when Scores itself is unavailable,
+- behavior: when checked, the scoreboard table requests or computes inference details in addition to normal score rows.
+
+The checkbox should preserve the normal Scores analytic behavior. Turning it off should return the current scoreboard table shape with no inference column.
+
+### 7.2 Scoreboard table
+
+When inference is enabled, add one extra column to the existing scoreboard table.
+
+| Icon | Meaning | Hover text | Click behavior |
+|------|---------|------------|----------------|
+| Green tick | At least one feasible solution found | summarize top solution and alternative count | open modal with detailed ranked solutions |
+| Hourglass | solving is in progress for this player row | show that inference is still running | no modal until a result is available |
+| Red cross | no solution, timeout, invalid problem, or solver failure | summarize failure status and key diagnostics | optionally open diagnostic modal if details exist |
+
+The row-level hourglass means the frontend should track inference status per player, not block the whole scoreboard table until all rows are solved. The table should remain useful while slower rows are still pending.
+
+### 7.3 Modal details
+
+The modal for a green tick should show:
+
+- player and turn transition,
+- observed deltas used as constraints,
+- solver status and runtime,
+- ranked solutions in descending objective/probability order,
+- action breakdown for each solution,
+- score arithmetic for the selected solution,
+- warnings when priority points were diagnostic-only or when deferred effects may explain missing solutions.
+
+### 7.4 API shape
+
+Keep the Core solver as an internal component. The Core `scores` analytic should accept an option such as `include_military_score_inference`. When false, it returns the current score rows. When true, each row may include an `inference` object:
+
+```json
+{
+  "status": "exact",
+  "summary": "Best: built one Rush with 18 fighters; 3 alternatives",
+  "solutionCount": 4,
+  "isComplete": true,
+  "solutions": []
+}
+```
+
+The BFF can decide whether to include detailed solutions in the initial table response or fetch them lazily when the modal opens. The initial implementation should prefer a simple table response unless row-level solve time requires lazy per-player requests.
+
+---
+
+## 8. Action catalog
 
 Generate the initial catalog from the observation and static game data.
 
-### 7.1 Ship build actions
+### 8.1 Ship build actions
 
 Create build actions for hulls the player can build. Each concrete action should include hull, engines, beams, tubes, and optional initial ammo load if the loadout catalog is known.
 
@@ -207,7 +308,7 @@ Initial implementation can deliberately start with a reduced loadout catalog:
 
 Avoid generating every theoretical component combination until the performance envelope is measured.
 
-### 7.2 Low-value repeated actions
+### 8.2 Low-value repeated actions
 
 Aggregate noisy actions where location detail is not yet known:
 
@@ -219,7 +320,7 @@ Aggregate noisy actions where location detail is not yet known:
 
 These variables still have exact score contributions, but they avoid one variable per planet or starbase in the initial version.
 
-### 7.3 Negative actions
+### 8.3 Negative actions
 
 Support signed contribution vectors from the start:
 
@@ -231,7 +332,7 @@ Negative actions need explicit upper bounds. Without bounds, positive and negati
 
 ---
 
-## 8. Bounds and performance
+## 9. Bounds and performance
 
 The solver should receive a bounded, pruned action catalog.
 
@@ -249,91 +350,297 @@ The target scale for early implementation is hundreds to low thousands of variab
 
 ---
 
-## 9. Implementation phases
+## 10. Implementation phases
 
-### Phase 1: Core solver library
+These phases are intentionally small enough to hand to junior engineers. Each phase should be a reviewable PR unless the team explicitly batches adjacent phases.
 
-Deliver a solver package with synthetic test problems and no analytic registration.
+### Phase 1A: Add the solver dependency
 
-Scope:
+Goal: make OR-Tools available to Core API tests without changing product behavior.
 
-- add `ortools` to `packages/api/pyproject.toml` and update `uv.lock`,
-- add Core dataclasses,
-- add scaled military-score contribution helpers,
-- add a CP-SAT solver adapter,
-- support signed action coefficients,
-- support integer objective ranking,
-- support top-K repeated optimization,
-- return diagnostics for infeasible or time-limited solves.
+Files:
 
-Tests:
+- `packages/api/pyproject.toml`,
+- `uv.lock`.
 
-- score contribution unit tests,
-- exact one-solution fit,
-- multiple-solution top-K ranking,
-- negative contribution fit,
-- infeasible problem status,
-- no-good cut excludes duplicate solutions.
+Steps:
 
-Run:
+1. Add `ortools` to the API package dependencies with `uv`.
+2. Confirm the selected release satisfies the dependency cooldown rule.
+3. Add a tiny import smoke test in `packages/api/tests/test_military_score_inference_solver.py`.
+4. Do not create inference model code yet.
 
-```bash
-make lint
-make test_api
-```
+Done when:
 
-### Phase 2: Core analytic integration
+- `PYTHONPATH=packages/api uv run python -m pytest packages/api/tests/test_military_score_inference_solver.py` passes,
+- `make lint` passes.
 
-Register a Core analytic that builds observations from adjacent score rows and calls the solver.
+### Phase 1B: Add Core contracts and score helpers
 
-Scope:
+Goal: define the data shapes and deterministic score arithmetic before using CP-SAT.
 
-- add `analytic.py`,
-- add `ANALYTIC_ID = "military-score-inference"`,
-- derive observations from `TurnInfo.scores`,
-- build an initial action catalog from available hull and score data,
-- expose structured per-player inference results from Core.
+Files:
 
-Tests:
+- `packages/api/api/analytics/military_score_inference/models.py`,
+- `packages/api/api/analytics/military_score_inference/scoring.py`,
+- `packages/api/api/analytics/military_score_inference/__init__.py`,
+- `packages/api/tests/test_military_score_inference_scoring.py`.
 
-- analytics registry test,
-- synthetic turn analytic test,
-- missing prior-turn or missing score diagnostics,
-- per-player independence test.
+Steps:
 
-Run:
+1. Add dataclasses for observations, candidate actions, probability buckets, problems, solutions, and diagnostics.
+2. Add scaled score helpers for fighters, torpedoes, starbase fighters, starbase defense posts, and planet defense posts.
+3. Keep ship construction score as a helper that accepts already-known hull/component costs if full catalog data is not ready.
+4. Add tests for exact scaled values, including half-point components multiplied by two.
 
-```bash
-make lint
-make test_api
-```
+Done when:
 
-### Phase 3: BFF and frontend table
+- score helper tests pass,
+- dataclasses are frozen or otherwise safe to share between catalog and solver code,
+- no OR-Tools model code exists outside the solver adapter planned for Phase 1C.
 
-Expose the analytic as a selectable table in the SPA.
+### Phase 1C: Add minimal CP-SAT exact solver
 
-Scope:
+Goal: solve small synthetic inference problems exactly.
 
-- add BFF metadata and table shaping,
-- add frontend analytic module if generic table rendering is insufficient,
-- show observed deltas, status, top explanation, and alternative count,
-- include details in the payload for later expansion.
+Files:
+
+- `packages/api/api/analytics/military_score_inference/solver.py`,
+- `packages/api/tests/test_military_score_inference_solver.py`.
+
+Steps:
+
+1. Convert each `CandidateAction` into a bounded integer variable.
+2. Add hard equality constraints for scaled military score, warship count, freighter count, and priority points.
+3. Add the build-slot upper-bound constraint.
+4. Add support for signed action contribution vectors.
+5. Return structured statuses instead of raising for infeasible models.
 
 Tests:
 
-- BFF table shaping tests,
-- frontend render tests for exact, ambiguous, and no-solution rows,
-- generated OpenAPI TypeScript update if response contracts change.
+- one exact positive-action solution,
+- one solution using a negative action contribution,
+- one infeasible problem,
+- one invalid problem with bad action bounds.
 
-Run:
+Done when:
 
-```bash
-make lint
-make test_bff
-make test_frontend
-```
+- solver tests pass with small synthetic catalogs,
+- all solver-specific OR-Tools imports are isolated to `solver.py`.
 
-### Phase 4: richer constraints and deferred effects
+### Phase 1D: Add ranked top-K solving
+
+Goal: return the best few feasible solutions without enumerating the whole feasible space.
+
+Files:
+
+- `packages/api/api/analytics/military_score_inference/solver.py`,
+- `packages/api/tests/test_military_score_inference_solver.py`.
+
+Steps:
+
+1. Add the integer objective for constant action weights.
+2. Solve for the best feasible solution.
+3. Add no-good cuts to exclude each returned action vector.
+4. Re-solve until `max_solutions`, infeasibility, or time budget stops the loop.
+5. Include objective value and non-zero action counts in each solution.
+
+Tests:
+
+- higher-weight solution sorts first,
+- no-good cuts prevent duplicate solutions,
+- top-K stops at the configured limit,
+- time-limited or non-optimal status is surfaced in diagnostics.
+
+Done when:
+
+- top-K tests demonstrate descending objective order,
+- the solver never enumerates all feasible solutions by default.
+
+### Phase 1E: Add bucketed probability terms
+
+Goal: support count-dependent probability for repeated low-value actions.
+
+Files:
+
+- `packages/api/api/analytics/military_score_inference/models.py`,
+- `packages/api/api/analytics/military_score_inference/solver.py`,
+- `packages/api/tests/test_military_score_inference_solver.py`.
+
+Steps:
+
+1. Add `ProbabilityBucket` support to `InferenceProblem`.
+2. For each bucketed action, add bucket variables whose sum equals the action count.
+3. Apply bucket marginal weights in the objective.
+4. Prefer bucketed penalties for defense posts, starbase fighters, loaded fighters, and loaded torpedoes.
+
+Tests:
+
+- 10 defense posts has a different marginal penalty from 100 defense posts,
+- a bucketed action still satisfies the exact score constraint,
+- bucket variables cannot exceed their configured count ranges.
+
+Done when:
+
+- count-dependent priors are covered by tests,
+- constant-weight actions still work unchanged.
+
+### Phase 1F: Add initial action catalog
+
+Goal: generate a bounded catalog for the first useful scoreboard-inference cases.
+
+Files:
+
+- `packages/api/api/analytics/military_score_inference/actions.py`,
+- `packages/api/tests/test_military_score_inference_actions.py`.
+
+Steps:
+
+1. Add aggregate variables for low-value repeated actions.
+2. Add simple ship-build actions from a small, documented loadout catalog.
+3. Bound ship-build actions by observed warship/freighter deltas and starbase count.
+4. Bound noisy actions by residual score and configured caps.
+5. Add negative fighter-transfer actions with explicit caps.
+
+Tests:
+
+- generated actions have finite bounds,
+- noisy actions are aggregate actions rather than per-location actions,
+- ship-build actions respect observed count deltas,
+- negative actions cannot create unbounded cancellation loops.
+
+Done when:
+
+- action catalog tests pass,
+- generated catalog size is logged or exposed in diagnostics for performance checks.
+
+### Phase 2: Integrate with the existing Core scores analytic
+
+Goal: enrich `scores` rows with optional inference data while preserving current behavior when disabled.
+
+Files:
+
+- `packages/api/api/analytics/scores.py`,
+- `packages/api/api/analytics/options.py`,
+- `packages/api/api/analytics/military_score_inference/analytic.py`,
+- `packages/api/tests/test_analytics_registry.py`,
+- `packages/api/tests/test_military_score_inference_analytic.py`.
+
+Steps:
+
+1. Add a scores option such as `include_military_score_inference`.
+2. Keep `get_scores_table(turn)` behavior unchanged when the option is false.
+3. When enabled, build one `InferenceObservation` per score row with enough adjacent-turn data available.
+4. Call the internal solver package per player.
+5. Attach an `inference` object to each Core scores row.
+6. Do not add a new Core analytic ID for the user-facing feature.
+
+Tests:
+
+- current scores output remains unchanged when disabled,
+- enabled output includes per-row inference status,
+- missing prior score data produces a row-level diagnostic status,
+- one player's solver failure does not remove other players' score rows.
+
+Done when:
+
+- Core scores tests cover both disabled and enabled behavior,
+- the analytics registry still exposes `scores` as the user-facing analytic.
+
+### Phase 3: Add BFF request and table shaping
+
+Goal: expose the optional inference column through the existing BFF scores table.
+
+Files:
+
+- `packages/bff/bff/analytics/scores.py`,
+- `packages/bff/bff/analytics/models.py` if query options need to expand,
+- `packages/bff/bff/routers/analytics.py` if table query parsing needs a new option,
+- `packages/bff/tests/test_analytics.py`.
+
+Steps:
+
+1. Add a BFF query option for `includeBuildInference`.
+2. Forward the option to the Core scores analytic.
+3. Keep existing scores table columns unchanged when the option is false.
+4. Add an inference column when the option is true.
+5. Shape each inference cell with status, summary text, and detail payload or detail lookup key.
+
+Tests:
+
+- disabled BFF response exactly matches the current table contract,
+- enabled response adds the inference column,
+- exact, in-progress, and failure statuses format predictably,
+- diagnostics from Core are preserved enough for hover text.
+
+Done when:
+
+- BFF tests prove backward-compatible default behavior,
+- no solver logic exists in BFF code.
+
+### Phase 4: Add frontend scoreboard controls and status cells
+
+Goal: let users enable inference from the Scores tile and see row-level status in the scoreboard.
+
+Files:
+
+- `packages/frontend/src/analytics/scores/` or the existing scores-related frontend module,
+- `packages/frontend/src/AnalyticsBar.tsx` or the generic tile component that owns per-analytic controls,
+- `packages/frontend/src/MainArea.tsx` if query keys or table rendering need option wiring,
+- frontend tests near the touched components.
+
+Steps:
+
+1. Add a checkbox labeled `Include build inference` to the Scores analytic controls.
+2. Include the checkbox state in the scores query key.
+3. Render the inference column only when enabled.
+4. Render green tick, hourglass, or red cross based on row status.
+5. Add hover text with the row summary.
+6. Keep the normal scoreboard table fast and unchanged when the checkbox is off.
+
+Tests:
+
+- checkbox toggles the query option,
+- disabled state shows the current scoreboard columns,
+- enabled state renders the inference column,
+- each status renders the expected icon and accessible label.
+
+Done when:
+
+- frontend tests pass,
+- the scoreboard remains usable while inference is disabled.
+
+### Phase 5: Add solution-detail modal
+
+Goal: let users inspect ranked solutions for rows with feasible explanations.
+
+Files:
+
+- `packages/frontend/src/analytics/scores/` modal component,
+- any shared dialog component if one already exists,
+- frontend tests for modal behavior.
+
+Steps:
+
+1. Open the modal when the user clicks a green tick.
+2. Show solutions in descending objective/probability order.
+3. Show observed deltas, action breakdown, score arithmetic, and warnings.
+4. Do not open a solution modal for hourglass rows.
+5. For red cross rows, either show hover-only diagnostics or a separate diagnostic modal if details are already available.
+
+Tests:
+
+- clicking a green tick opens the modal,
+- solutions are displayed in order,
+- hourglass rows are non-clickable or explain that solving is pending,
+- modal closes cleanly and does not reset the Scores checkbox.
+
+Done when:
+
+- modal behavior is covered by frontend tests,
+- detailed solution rendering does not require BFF or frontend to understand OR-Tools internals.
+
+### Phase 6: richer constraints and deferred effects
 
 Add action families and constraints only after the initial pipeline is measurable.
 
@@ -350,24 +657,24 @@ Each addition should include tests showing both new feasible explanations and ca
 
 ---
 
-## 10. Testing strategy
+## 11. Testing strategy
 
 Keep most tests below HTTP boundaries until the model stabilizes.
 
 | Layer | Tests |
 |-------|-------|
 | Scoring helpers | exact scaled contribution values for ships, fighters, torpedoes, defenses |
-| Action catalog | bounds, signed actions, noisy-action aggregation |
-| Solver | exact fit, top-K, no-good cuts, negative coefficients, infeasible status |
-| Core analytic | observation construction, per-player results, diagnostics |
-| BFF | table columns and row formatting |
-| Frontend | rendering states and interaction with analytics selection |
+| Action catalog | bounds, signed actions, noisy-action aggregation, bucket assignments |
+| Solver | exact fit, top-K, no-good cuts, negative coefficients, bucketed objective terms, infeasible status |
+| Core scores analytic | disabled behavior, enabled row enrichment, per-player results, diagnostics |
+| BFF scores table | default table contract, optional inference column, hover summaries |
+| Frontend scores UI | checkbox control, row status icons, modal behavior |
 
 Prefer synthetic fixtures with small action catalogs. Large real-turn fixtures can be added later as performance regression tests.
 
 ---
 
-## 11. Risks and mitigations
+## 12. Risks and mitigations
 
 | Risk | Mitigation |
 |------|------------|
@@ -375,20 +682,30 @@ Prefer synthetic fixtures with small action catalogs. Large real-turn fixtures c
 | Solver runtime spikes | per-player time limits, action bounds, catalog pruning |
 | Incorrect priority-point model | make priority constraint configurable until queue semantics are confirmed |
 | False confidence | return multiple explanations and expose ambiguity |
+| Scoreboard regression | keep inference disabled by default and test the existing table contract |
+| Row-level solving blocks the table | track per-row status and consider lazy or asynchronous detail loading |
 | Dependency/platform issue | keep solver isolated behind an adapter so a fallback can be added |
 | Hard-to-debug CP-SAT models | emit diagnostics with action counts, bounds, constraint targets, and solver status |
 
 ---
 
-## 12. Acceptance criteria
+## 13. Acceptance criteria
 
-The first implementation PR should be considered complete when:
+Phase 1 should be considered complete when:
 
 - OR-Tools is isolated to the Core API solver adapter,
 - synthetic CP-SAT tests pass for positive and negative action vectors,
+- bucketed probability terms pass count-dependent objective tests,
 - top-K ranked solving returns distinct feasible explanations,
 - infeasible cases return diagnostics rather than exceptions,
-- no BFF or frontend code depends on OR-Tools directly,
 - `make lint` and the relevant package tests pass.
 
-Later PRs can expose the analytic to the UI once the Core solver behavior is stable.
+The user-facing scoreboard integration should be considered complete when:
+
+- inference remains disabled by default,
+- the existing Scores table contract is unchanged when inference is disabled,
+- the Scores tile includes an `Include build inference` checkbox,
+- enabling inference adds an inference column with row-level status,
+- green tick rows open a modal with ranked solution details,
+- BFF and frontend code never import OR-Tools or encode solver rules directly,
+- `make lint` and the relevant API, BFF, and frontend tests pass.

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -31,8 +31,10 @@ When adding the dependency, respect the dependency cooldown rule. At design time
 ```mermaid
 flowchart LR
     Scores["Adjacent scoreboard rows"] --> Observations["InferenceObservation"]
-    Observations --> Catalog["Candidate action catalog"]
-    Catalog --> Model["CP-SAT model"]
+    Observations --> Agg["Aggregate actions"]
+    Observations --> Combos["Ship build combos"]
+    Agg --> Model["CP-SAT model"]
+    Combos --> Model
     Model --> Solutions["Top-K feasible explanations"]
     Solutions --> CoreScores["Core scores payload"]
     CoreScores --> BffScores["BFF scores table"]
@@ -50,12 +52,15 @@ Start with a small Core API subpackage so the solver and scoring model do not cr
 ```text
 packages/api/api/analytics/military_score_inference/
 |-- __init__.py
-|-- actions.py          # action catalog and contribution helpers
-|-- models.py           # dataclasses for observations, actions, problems, solutions
-|-- scoring.py          # scaled military-score contribution formulas
-|-- solver.py           # OR-Tools CP-SAT adapter
-`-- analytic.py         # turn-level analytic assembly
+|-- actions.py            # aggregate noisy actions (defense, ammo load, transfers)
+|-- ship_build_combos.py  # eligible hull/engine/beam/torp combos and tier policy (Phase 1G+)
+|-- models.py             # dataclasses for observations, actions, problems, solutions
+|-- scoring.py            # scaled military-score contribution formulas
+|-- solver.py             # OR-Tools CP-SAT adapter
+`-- analytic.py           # turn-level analytic assembly
 ```
+
+Phase 1F shipped an interim flat `build_{hull}_{preset}` catalog in `actions.py`. Phase 1G moves ship builds into `ship_build_combos.py` and leaves aggregate actions in `actions.py`.
 
 Do not register `military_score_inference` as a separate user-facing analytic. The solver package should be called by the existing `scores` analytic when inference is requested.
 
@@ -123,6 +128,39 @@ class InferenceProblem:
     probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
     max_solutions: int = 20
     time_limit_seconds: float = 1.0
+```
+
+**Target extension (Phase 1G+):** ship builds become structured combos; aggregate noisy actions stay flat.
+
+```python
+@dataclass(frozen=True)
+class ShipBuildCombo:
+    combo_id: str
+    hull_id: int
+    engine_id: int
+    beam_id: int | None       # None = no beams fitted
+    torp_id: int | None       # None = no torp tubes fitted
+    beam_count: int           # 0 .. hull.beams
+    launcher_count: int       # 0 .. hull.launchers
+    labels: tuple[str, ...]   # display labels; multiple when score-equivalent
+    score_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    probability_weight: int
+
+
+@dataclass(frozen=True)
+class InferenceProblem:
+    observation: InferenceObservation
+    aggregate_actions: tuple[CandidateAction, ...]
+    ship_build_combos: tuple[ShipBuildCombo, ...]
+    ship_build_tier: int
+    probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
+    max_solutions: int = 20
+    time_limit_seconds: float = 1.0
+```
+
+The solver sums contributions from **both** aggregate action counts and ship-build combo counts into the same hard constraints.
 
 
 @dataclass(frozen=True)
@@ -293,34 +331,101 @@ The BFF can decide whether to include detailed solutions in the initial table re
 
 ## 8. Action catalog
 
-Generate the initial catalog from the observation and static game data.
+The catalog has **two layers** that feed the same CP-SAT hard constraints:
 
-### 8.1 Ship build actions
+1. **Aggregate actions** -- flat `CandidateAction` rows for repeated or location-agnostic effects.
+2. **Ship build combos** -- sparse `(hull, engine, beam?, torp?, counts)` tuples with integer count variables (Phase 1G+).
 
-Create build actions for hulls the player can build. Each concrete action should include hull, engines, beams, tubes, and optional initial ammo load if the loadout catalog is known.
+Do **not** fold build-time fighter or torpedo **ammo** into ship combos. Loaded fighters and loaded torpedoes are separate aggregate actions that can take non-zero counts alongside ship builds.
 
-Initial implementation can deliberately start with a reduced loadout catalog:
+### 8.1 Ship build combos (target model)
 
-- canonical empty or low-ammo build,
-- common full-fighter carrier build,
-- common torpedo-ship loadouts by torpedo tech,
-- race-specific preferred hull priors.
+Each combo describes **one ship construction configuration** built at a starbase:
 
-Avoid generating every theoretical component combination until the performance envelope is measured.
+- one hull type;
+- `hull.engines` copies of **one** engine type;
+- `beam_count` copies of **one** beam type, or zero beams fitted;
+- `launcher_count` copies of **one** torp tube type (via a torp's `launchercost`), or zero tubes fitted.
 
-### 8.2 Low-value repeated actions
+**Independence of beams and tubes:** omitting beams, omitting launchers, or omitting both is always allowed when the hull has the corresponding slots. Beams and tubes are not required to be fitted together.
 
-Aggregate noisy actions where location detail is not yet known:
+**Same-type rule:** when `beam_count > 0`, all fitted beams share one beam type. When `launcher_count > 0`, all fitted tubes share one torp type (`launchercost`).
+
+**Construction score** (scaled `score_delta_2x`):
+
+```text
+hull.cost
++ hull.engines * engine.cost
++ beam_count * beam.cost            (if beam_count > 0)
++ launcher_count * torp.launchercost (if launcher_count > 0)
+plus minerals via megacredits + 5 * minerals
+times 2 for military score scaling
+```
+
+Ammo (fighters loaded on ships, torpedoes loaded into tubes) is **not** part of this formula.
+
+**Warship vs freighter:** a hull is a warship when it has `beams > 0`, `launchers > 0`, or `fighterbays > 0`; otherwise it counts as a freighter for `shipchange` / `freighterchange` constraints.
+
+**Buildable hulls:** intersection of `player.activehulls`, race hull lists, `turn.racehulls`, and hulls present in `turn.hulls`. Do not filter hull catalog rows on `Hull.isbase`; Planets.nu marks normal starships with `isbase: true`.
+
+**Eligible components** (widened by search tier -- see 8.5):
+
+- engines from `player.activeengines` intersect `turn.engines`;
+- beams from `player.activebeams` intersect `turn.beams`;
+- torps from `player.activetorps` intersect `turn.torpedos` (tube cost only).
+
+**Combo families by tier:**
+
+| Tier focus | Beam / launcher counts | Typical use |
+|------------|------------------------|-------------|
+| Early tiers | `0` or maximum slot count only (`beam_count in {0, hull.beams}`, `launcher_count in {0, hull.launchers}`) | Default search; covers almost all practical builds |
+| Later tiers | Intermediate counts `1 .. hull.beams - 1` and `1 .. hull.launchers - 1` | Niche partial-fit builds; lower priority |
+
+Early tiers still include **minimal** builds `(beam_count=0, launcher_count=0)` for hulls with slots, including unarmed warships and torp hulls with empty tubes and/or empty beams.
+
+**Global linking** (same hard constraints as today, summed over both layers):
+
+```text
+sum_agg(score_delta_2x * count)
+  + sum_combo(score_delta_2x * build) == military_delta_2x
+
+sum_agg(warship_delta * count)
+  + sum_combo(warship_delta * build) == warship_delta
+
+sum_agg(freighter_delta * count)
+  + sum_combo(freighter_delta * build) == freighter_delta
+
+sum(build_slot_usage) <= starbases_owned
+```
+
+Ship combos use `build_slot_usage = 1` per ship. Priority-point deltas on ship builds remain **zero** until production-queue semantics are modeled; treat `prioritypointchange` as diagnostic-only until then.
+
+**Solution shape:** emit structured rows `{ hull, engine, beam?, torp?, beam_count, launcher_count, count }` rather than opaque `build_*` preset IDs.
+
+### 8.2 Interim flat ship builds (Phase 1F -- to be replaced)
+
+Phase 1F shipped a reduced flat catalog (`build_{hull}_{preset}`) with known gaps:
+
+- single default engine (lowest ID in `turn.engines`);
+- single default beam and torp type for armed presets;
+- no beam-type or engine-type enumeration;
+- preset names `empty` / `torpedoes` only.
+
+This was enough to prove the pipeline but produces frequent INFEASIBLE results when the true build used other components. Phase 1G replaces this block with section 8.1.
+
+### 8.3 Aggregate noisy actions
+
+Aggregate actions where location detail is not yet known:
 
 - `planet_defense_posts_added_total`,
 - `starbase_defense_posts_added_total`,
 - `starbase_fighters_added_total`,
 - `ship_fighters_added_total`,
-- `ship_torps_loaded_by_type`.
+- `ship_torps_loaded_{torpedo_id}` for each torp type in `turn.torpedos`.
 
 These variables still have exact score contributions, but they avoid one variable per planet or starbase in the initial version.
 
-### 8.3 Negative actions
+### 8.4 Negative actions
 
 Support signed contribution vectors from the start:
 
@@ -330,11 +435,51 @@ Support signed contribution vectors from the start:
 
 Negative actions need explicit upper bounds. Without bounds, positive and negative actions can create cancellation loops and a huge number of equivalent solutions.
 
+### 8.5 Tiered catalog expansion
+
+A full cross product of buildable hulls times eligible engines, beams, and torps can reach **low thousands to ~10k** combo variables in worst cases (many torp hulls, full turn catalogs, empty `active*` lists). Prefer **staged widening** over a single hand-tuned subset.
+
+Search tiers (increase component eligibility and, in later tiers, partial beam/launcher counts):
+
+| Tier | Engines | Beams | Torps (tube cost) | Partial beam/launcher counts |
+|------|---------|-------|-------------------|----------------------------|
+| 0 | single default (min id) | default | default | no |
+| 1 | `activeengines` or jump if empty | default | default | no |
+| 2 | active or full turn catalog if active empty | `activebeams` or jump | default | no |
+| 3 | active or full | active or full | `activetorps` or full | no |
+| 4 | full `turn.*` catalog | full | full | yes (niche counts) |
+
+**Empty `active*` lists:** do not linger on narrow tiers. **Jump** to the next tier that uses a usable component set (typically full turn-catalog intersection for that axis) rather than solving repeatedly with a single default component.
+
+Per player:
+
+1. Build combo list for tier *n* plus aggregate actions.
+2. Solve.
+3. Stop on FEASIBLE (or TIME_LIMITED with at least one solution).
+4. Else advance tier and retry until max tier or time budget.
+
+Record `ship_build_tier`, `tiers_attempted`, and `combo_count` in diagnostics.
+
+**Future refinement:** order tiers and intra-tier weights from fleet priors (histogram of engines, beams, and torps on existing ships). Likelihood informs search order and objective weights; it should not hard-exclude legal combos unless the product explicitly chooses a "most likely only" mode.
+
+### 8.6 Score-equivalent combos (solver-side merge)
+
+Multiple combos may share the same `(score_delta_2x, warship_delta, freighter_delta)` but differ in labels or probability weights (different hull names with identical construction cost, or different components that collide after scaling).
+
+For **feasibility**, the solver may merge such combos into one integer variable carrying multiple `labels`.
+
+For **top-K enumeration**, equal score does **not** imply equal probability. Distinct labels with the same score should still produce **distinct ranked solutions** when their probability weights differ. Implementation options:
+
+- keep separate objective terms until after solve, or
+- expand merged variables back into label-specific solution rows during extraction.
+
+Do not treat score-equivalent combos as interchangeable in the UI ranking solely because the military score constraint cannot distinguish them.
+
 ---
 
 ## 9. Bounds and performance
 
-The solver should receive a bounded, pruned action catalog.
+The solver should receive a bounded catalog. Ship builds use **tiered combo generation** (section 8.5) rather than materializing the full cross product on the first attempt.
 
 Use these bounds before building the CP-SAT model:
 
@@ -343,10 +488,11 @@ Use these bounds before building the CP-SAT model:
 - **Count-delta bound:** warship and freighter build actions are bounded by the observed count deltas when losses and trades are out of scope.
 - **Capacity bound:** ship fighters and torpedoes should be capped by plausible loadout capacity where known.
 - **Noisy-action cap:** defense posts, starbase fighters, and generic ammo adjustments should have conservative caps and lower probability weights.
+- **Combo tier cap:** stop widening ship-build tiers when feasible or when the per-player time budget is exhausted.
 - **Top-K cap:** default to a small solution count, such as 10 or 20 per player.
 - **Time cap:** use a per-player solver budget so a pathological player does not block the whole analytic.
 
-The target scale for early implementation is hundreds to low thousands of variables per player, not every possible per-location action. If the catalog grows beyond that, add staged solving or column generation before broadening the action families.
+Expect **hundreds to low thousands** of variables per player at mid tiers; worst-case full catalogs may approach **~10k** combo variables before partial-count expansion. Staged solving is the primary mitigation. Column generation remains a later option if tier search is still too slow.
 
 ---
 
@@ -489,6 +635,8 @@ Done when:
 
 Goal: generate a bounded catalog for the first useful scoreboard-inference cases.
 
+Status: **delivered** with interim flat ship-build presets (section 8.2). Replace in Phase 1G.
+
 Files:
 
 - `packages/api/api/analytics/military_score_inference/actions.py`,
@@ -497,22 +645,54 @@ Files:
 Steps:
 
 1. Add aggregate variables for low-value repeated actions.
-2. Add simple ship-build actions from a small, documented loadout catalog.
+2. Add interim flat ship-build actions from a small preset catalog.
 3. Bound ship-build actions by observed warship/freighter deltas and starbase count.
 4. Bound noisy actions by residual score and configured caps.
 5. Add negative fighter-transfer actions with explicit caps.
-
-Tests:
-
-- generated actions have finite bounds,
-- noisy actions are aggregate actions rather than per-location actions,
-- ship-build actions respect observed count deltas,
-- negative actions cannot create unbounded cancellation loops.
 
 Done when:
 
 - action catalog tests pass,
 - generated catalog size is logged or exposed in diagnostics for performance checks.
+
+### Phase 1G: Factored ship build combos and tiered search
+
+Goal: replace flat ship-build presets with structured combos (section 8.1) and staged tier widening (section 8.5).
+
+Files:
+
+- `packages/api/api/analytics/military_score_inference/ship_build_combos.py` (new),
+- `packages/api/api/analytics/military_score_inference/actions.py` (aggregate actions only),
+- `packages/api/api/analytics/military_score_inference/models.py`,
+- `packages/api/api/analytics/military_score_inference/solver.py`,
+- `packages/api/api/analytics/military_score_inference/analytic.py`,
+- `packages/api/tests/test_military_score_inference_ship_build_combos.py` (new),
+- updates to existing inference tests.
+
+Steps:
+
+1. Add `ShipBuildCombo` generation with validity rules (independent beam/tube omission, same-type rule, `hull.engines` engine count in score).
+2. Early tiers: combo counts limited to `{0, max slots}` per axis; later tier adds partial beam/launcher counts.
+3. Implement tier policy with **jump** when `activeengines` / `activebeams` / `activetorps` are empty.
+4. Extend `InferenceProblem` and CP-SAT model to sum aggregate actions and combo counts into shared constraints.
+5. Extend no-good cuts and solution extraction for combo variables; emit structured build rows.
+6. Optional solver-side merge of score-equivalent combos; preserve distinct top-K rows when probability weights differ (section 8.6).
+7. Expose `ship_build_tier`, `tiers_attempted`, and combo counts in diagnostics.
+8. Remove interim flat `build_{hull}_{preset}` actions once parity tests pass.
+
+Tests:
+
+- combo validity and construction score for minimal, beam-only, tube-only, and fully armed builds;
+- multi-engine hulls multiply engine cost by `hull.engines`;
+- tier widening finds a feasible solution when tier 0 is too narrow;
+- empty `active*` lists jump tiers without false INFEASIBLE from single-default components;
+- score-equivalent merge does not collapse distinct probability-ranked solutions.
+
+Done when:
+
+- real-turn cases that failed under Phase 1F (wrong engine/torp/beam type) become feasible at an documented tier,
+- diagnostics report tier and combo cardinality,
+- `make lint` and inference package tests pass.
 
 ### Phase 2: Integrate with the existing Core scores analytic
 
@@ -642,7 +822,7 @@ Done when:
 
 ### Phase 6: richer constraints and deferred effects
 
-Add action families and constraints only after the initial pipeline is measurable.
+Add action families and constraints only after Phase 1G ship-build combos are measurable.
 
 Candidates:
 
@@ -651,7 +831,8 @@ Candidates:
 - planet and starbase losses,
 - prior inventory and resource bounds,
 - per-location defense post and fighter attribution,
-- calibrated race/player probability priors.
+- production-queue priority-point effects on ship builds,
+- fleet-histogram priors for tier ordering and combo weights.
 
 Each addition should include tests showing both new feasible explanations and cases where the new action removes a previous false unsat.
 
@@ -664,13 +845,14 @@ Keep most tests below HTTP boundaries until the model stabilizes.
 | Layer | Tests |
 |-------|-------|
 | Scoring helpers | exact scaled contribution values for ships, fighters, torpedoes, defenses |
-| Action catalog | bounds, signed actions, noisy-action aggregation, bucket assignments |
-| Solver | exact fit, top-K, no-good cuts, negative coefficients, bucketed objective terms, infeasible status |
+| Aggregate action catalog | bounds, signed actions, noisy-action aggregation, bucket assignments |
+| Ship build combos | validity rules, tier widening, construction score, partial counts (later tier) |
+| Solver | exact fit, top-K, no-good cuts over aggregate + combo vars, tier diagnostics, infeasible status |
 | Core scores analytic | disabled behavior, enabled row enrichment, per-player results, diagnostics |
 | BFF scores table | default table contract, optional inference column, hover summaries |
 | Frontend scores UI | checkbox control, row status icons, modal behavior |
 
-Prefer synthetic fixtures with small action catalogs. Large real-turn fixtures can be added later as performance regression tests.
+Prefer synthetic fixtures with small combo catalogs. Large real-turn fixtures should include tier and combo-count regression checks.
 
 ---
 
@@ -679,13 +861,15 @@ Prefer synthetic fixtures with small action catalogs. Large real-turn fixtures c
 | Risk | Mitigation |
 |------|------------|
 | Too many low-probability exact solutions | optimize by probability first, top-K only, aggregate noisy actions |
-| Solver runtime spikes | per-player time limits, action bounds, catalog pruning |
-| Incorrect priority-point model | make priority constraint configurable until queue semantics are confirmed |
+| Ship-build catalog too narrow (INFEASIBLE) | factored combos with tiered widening; jump tiers when `active*` empty |
+| Ship-build catalog too wide (slow solve) | tier caps, per-player time limits, combo-count diagnostics |
+| Score-equivalent combos hide UI diversity | merge for feasibility only; split labels for top-K when weights differ |
+| Incorrect priority-point model | priority-point equality soft/diagnostic until queue semantics are modeled |
 | False confidence | return multiple explanations and expose ambiguity |
 | Scoreboard regression | keep inference disabled by default and test the existing table contract |
 | Row-level solving blocks the table | track per-row status and consider lazy or asynchronous detail loading |
 | Dependency/platform issue | keep solver isolated behind an adapter so a fallback can be added |
-| Hard-to-debug CP-SAT models | emit diagnostics with action counts, bounds, constraint targets, and solver status |
+| Hard-to-debug CP-SAT models | emit diagnostics with tier, combo counts, bounds, constraint targets, solver status |
 
 ---
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -858,7 +858,9 @@ Prefer synthetic fixtures with small combo catalogs. Large real-turn fixtures sh
 
 ### 11.2 Inference corpus (real-turn regression)
 
-The **inference corpus** exercises production inference APIs against stored **TurnInfo** from finished games. Harness code lives under the API **test hierarchy** (`packages/api/tests/inference_corpus/`), not under `api/` business modules. A thin Typer entrypoint lives at `scripts/run_inference_corpus.py`.
+**Authoritative contract:** [design-inference-corpus.md](design-inference-corpus.md) (manifest schema, complexity rubric, ground truth v1, coverage reasons, Tier 1 re-check, discovery, issue map #62–#66). This subsection is a summary only.
+
+The **inference corpus** exercises production inference APIs against stored **TurnInfo** from finished games. Harness code lives under the API **test hierarchy** (`packages/api/tests/inference_corpus/`), not under `api/` business modules. A thin Typer entrypoint lives at `scripts/run_inference_corpus.py`. Import as `tests.inference_corpus` with API package `pythonpath` `.` (see spec section 1).
 
 Glossary terms: repo root `CONTEXT.md` (**Inference corpus case**, **Inference host turn**, **Catalog coverage**, **Out of search space**, etc.).
 
@@ -929,7 +931,7 @@ Script exit code `0` when no hard failures; stdout supports human summary and op
 | After #53 | Optional manifest rows tied to combo diagnostics shapes |
 | With #49 (deferred effects) | Expand ground truth + coverage for trades/losses; adjunct fixtures |
 
-Epic #39 Phase 1G tracker: #50, #51, #52, #53, #54, #55. Corpus issues are siblings under #39 (see issue tracker).
+Epic #39 Phase 1G tracker: #50, #51, #52, #53, #54, #55. Corpus harness: #62, #63, #64, #65, #66 (spec: [design-inference-corpus.md](design-inference-corpus.md)).
 
 ---
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -840,7 +840,9 @@ Each addition should include tests showing both new feasible explanations and ca
 
 ## 11. Testing strategy
 
-Keep most tests below HTTP boundaries until the model stabilizes.
+Keep most unit tests below HTTP boundaries until the model stabilizes. See also **inference corpus** integration tests below (real finished-game turns).
+
+### 11.1 Unit and integration layers (existing)
 
 | Layer | Tests |
 |-------|-------|
@@ -853,6 +855,81 @@ Keep most tests below HTTP boundaries until the model stabilizes.
 | Frontend scores UI | checkbox control, row status icons, modal behavior |
 
 Prefer synthetic fixtures with small combo catalogs. Large real-turn fixtures should include tier and combo-count regression checks.
+
+### 11.2 Inference corpus (real-turn regression)
+
+The **inference corpus** exercises production inference APIs against stored **TurnInfo** from finished games. Harness code lives under the API **test hierarchy** (`packages/api/tests/inference_corpus/`), not under `api/` business modules. A thin Typer entrypoint lives at `scripts/run_inference_corpus.py`.
+
+Glossary terms: repo root `CONTEXT.md` (**Inference corpus case**, **Inference host turn**, **Catalog coverage**, **Out of search space**, etc.).
+
+#### Two runner modes
+
+| Mode | Purpose | Data source |
+|------|---------|-------------|
+| **Fixed corpus** | CI (`make test_api`) | `packages/api/tests/fixtures/inference_corpus/manifest.json` plus trimmed RST slices |
+| **Local corpus** | Dev / nightly against downloaded games | `scripts/run_inference_corpus.py --game-id <id>` reading the **file backend** store (default storage root from config, typically `.data`) |
+
+Both modes call the same harness library (`tests.inference_corpus`).
+
+#### Case discovery (local mode)
+
+Enumerate stored paths under `games/{gameId}/`. For each **perspective** `P` and each host turn `N` where **both** `games/{id}/P/turns/N` and `.../N+1` exist, emit one **inference corpus case**:
+
+- **Inference host turn:** `N` (activity being explained).
+- **Scoreboard input:** `TurnInfo` at turn **N+1** from perspective `P` (deltas on that document describe host turn `N`).
+- **Default player scope:** the **Player** at perspective slot `P` (what that slot built on host turn `N`).
+
+Sparse storage is valid: only perspectives and turn pairs that exist are discovered.
+
+#### Complexity grading and culling
+
+Before running the solver, classify each case into `minimal`, `routine`, `heavy`, or `adjunct` from **ground-truth inventory change** between turns `N` and `N+1` for the case player. Signals include ship build count, defense/fighter load-ups, and adjunct effects (losses, trades, captures).
+
+- **Multi-perspective ground truth:** adjunct detection (e.g. trades) may merge ship visibility from every perspective that has both turns stored. If a required other perspective is missing, do not infer a trade; mark `incomplete_multi_view` when relevant.
+- **`--max-complexity`:** skip cases above the cap (recorded reason, not a failure).
+- **Level 3 (`adjunct`):** skipped by default unless a future `--include-adjunct` flag is added.
+
+#### Per-case pipeline
+
+1. Skip if complexity > `--max-complexity`.
+2. Classify complexity (optional multi-perspective merge for adjunct signals).
+3. Extract **ground truth explanation** when the extractor supports this case; if unavailable, run **Tier 1 only** (observation closure).
+4. **Catalog coverage** (v1: action-level mapping of ground truth to the catalog built from turn `N+1` `TurnInfo`; later: optional CP-SAT feasibility probe when mapping says covered but solver is INFEASIBLE). If not covered, emit **out of search space** with `coverageReason` (e.g. `deferred_trade`, `combo_not_in_catalog`) and **do not** run the solver.
+5. **Tier 1:** `infer_military_score_build` for the case player on turn `N+1`. For `minimal` / `routine`: require `exact`, at least one solution, and programmatic verification of hard equalities on the top solution. For `heavy`: same, or allow `time_limited` with at least one feasible solution. CI fixed rows are `minimal` / `routine` with implicit `exact` expectation; manifest may add `expectedStatus` for known regressions.
+6. **Tier 2** (when enabled, e.g. `--tier 2`): assert ground truth is **compatible** with inventory (hard fail on mismatch).
+7. **Top-K ranking check** (default `K=3`, `--top-k`): when ground truth is available and catalog coverage passed, require the ground-truth action multiset to appear among the top `K` ranked solutions. A miss is an **investigation signal** (soft by default; manifest may set `requireTopK: true` for hard fail on selected CI rows). Levels 0-1: soft everywhere until priors stabilize.
+
+#### Outcome buckets (reporting)
+
+| Bucket | Meaning |
+|--------|---------|
+| `passed` | Tier 1 (and Tier 2 if enabled) satisfied |
+| `failed` | Hard Tier 1/2 failure |
+| `skipped_complexity` | Above `--max-complexity` |
+| `skipped_incomplete_multi_view` | Adjunct hypothesis needs missing perspectives |
+| `out_of_search_space` | Ground truth not expressible in current catalog (distinct from solver `no_exact_solution`) |
+| `ranking_miss` | `exact` but ground truth not in top-K (investigation, optionally hard) |
+
+Script exit code `0` when no hard failures; stdout supports human summary and optional `--json`.
+
+#### CI fixed corpus content
+
+- Small trimmed finished-game slice under `tests/fixtures/inference_corpus/`.
+- Manifest lists explicit cases with `hostTurn`, `perspective`, `complexity`, optional `requiredPerspectives`, optional `requireTopK`.
+- Most rows: `minimal` / `routine`, Tier 1 `exact` only.
+- Optional second snippet with multiple perspectives for future adjunct / coverage regressions.
+
+#### Ordering relative to solver work (GitHub epic #39)
+
+| When | Corpus milestone |
+|------|------------------|
+| Parallel with #50 | Harness + Tier 1 + CI fixed corpus on current flat catalog |
+| After #50 | Fewer false `no_exact_solution` from priority-point gaps; corpus Tier 1 more meaningful |
+| After #51, #52 | Revisit catalog coverage mapping for **ship build combos**; expand fixed corpus with combo-tier regressions |
+| After #53 | Optional manifest rows tied to combo diagnostics shapes |
+| With #49 (deferred effects) | Expand ground truth + coverage for trades/losses; adjunct fixtures |
+
+Epic #39 Phase 1G tracker: #50, #51, #52, #53, #54, #55. Corpus issues are siblings under #39 (see issue tracker).
 
 ---
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -1,0 +1,394 @@
+# Design: Military score inference implementation with OR-Tools
+
+This document turns [design-military-score-build-inference.md](design-military-score-build-inference.md) into a phased implementation plan using OR-Tools CP-SAT.
+
+The implementation should make exact feasibility the first-class contract: observed score and scoreboard deltas are hard constraints when enabled, while probability heuristics are encoded as an integer objective so the solver finds plausible explanations before low-probability noise.
+
+**Related:** [design-military-score-build-inference.md](design-military-score-build-inference.md), [design-analytics-structure.md](design-analytics-structure.md), [design-planets-api-data-model.md](design-planets-api-data-model.md), [vga-planets-domain-context.md](vga-planets-domain-context.md).
+
+---
+
+## 1. Dependency choice
+
+Use the Python package `ortools` for CP-SAT.
+
+| Property | Decision |
+|----------|----------|
+| Package | `ortools` |
+| Solver API | `ortools.sat.python.cp_model` |
+| License | Apache-2.0 |
+| Package location | `packages/api/pyproject.toml` |
+| Lockfile update | via `uv` |
+
+The dependency belongs in the Core API package because the inference model is domain logic. The BFF should only reshape Core results for the SPA, and the frontend should only render the analytic.
+
+When adding the dependency, respect the dependency cooldown rule. At design time, the current OR-Tools release observed was older than seven days and supports the repo's Python 3.14 baseline.
+
+---
+
+## 2. Data flow
+
+```mermaid
+flowchart LR
+    Scores["Adjacent scoreboard rows"] --> Observations["InferenceObservation"]
+    Observations --> Catalog["Candidate action catalog"]
+    Catalog --> Model["CP-SAT model"]
+    Model --> Solutions["Top-K feasible explanations"]
+    Solutions --> CoreAnalytic["Core analytic payload"]
+    CoreAnalytic --> BffTable["BFF table response"]
+    BffTable --> Frontend["Frontend analytic tile"]
+```
+
+The first implementation solves each player independently. Cross-player coupling is deferred until ship trading, ship capture, and ownership transfers are modeled.
+
+---
+
+## 3. Module layout
+
+Start with a small Core API subpackage so the solver and scoring model do not crowd the existing `scores` analytic:
+
+```text
+packages/api/api/analytics/military_score_inference/
+|-- __init__.py
+|-- actions.py          # action catalog and contribution helpers
+|-- models.py           # dataclasses for observations, actions, problems, solutions
+|-- scoring.py          # scaled military-score contribution formulas
+|-- solver.py           # OR-Tools CP-SAT adapter
+`-- analytic.py         # turn-level analytic assembly
+```
+
+Register the analytic from `packages/api/api/analytics/registry.py` after the Core payload is stable.
+
+BFF and frontend files should follow existing analytics structure:
+
+```text
+packages/bff/bff/analytics/military_score_inference.py
+packages/bff/bff/analytics/registry.py
+packages/frontend/src/analytics/militaryScoreInference/
+```
+
+The implementation should not put solver logic in the BFF or frontend.
+
+---
+
+## 4. Core dataclasses
+
+Use plain dataclasses in the Core package.
+
+```python
+@dataclass(frozen=True)
+class InferenceObservation:
+    player_id: int
+    turn: int
+    military_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    priority_point_delta: int
+    starbases_owned: int
+    is_after_ship_limit: bool
+
+
+@dataclass(frozen=True)
+class CandidateAction:
+    id: str
+    label: str
+    score_delta_2x: int
+    warship_delta: int = 0
+    freighter_delta: int = 0
+    priority_point_delta: int = 0
+    build_slot_usage: int = 0
+    lower_bound: int = 0
+    upper_bound: int = 0
+    probability_weight: int = 0
+```
+
+The important modeling rule is that action variables are non-negative integers, but action contribution vectors may contain positive or negative values.
+
+```python
+@dataclass(frozen=True)
+class InferenceProblem:
+    observation: InferenceObservation
+    actions: tuple[CandidateAction, ...]
+    max_solutions: int = 20
+    time_limit_seconds: float = 1.0
+
+
+@dataclass(frozen=True)
+class InferenceSolutionAction:
+    action_id: str
+    label: str
+    count: int
+
+
+@dataclass(frozen=True)
+class InferenceSolution:
+    objective_value: int
+    actions: tuple[InferenceSolutionAction, ...]
+
+
+@dataclass(frozen=True)
+class InferenceResult:
+    status: str
+    solutions: tuple[InferenceSolution, ...]
+    diagnostics: dict[str, object]
+```
+
+These contracts can be refined during implementation, but the boundary should stay explicit: observations and candidate actions go into the solver; ranked feasible explanations come out.
+
+---
+
+## 5. CP-SAT formulation
+
+For each `CandidateAction`, create one integer variable:
+
+```text
+count[action] in [lower_bound, upper_bound]
+```
+
+Add hard constraints:
+
+```text
+sum(score_delta_2x[action] * count[action]) == observation.military_delta_2x
+sum(warship_delta[action] * count[action]) == observation.warship_delta
+sum(freighter_delta[action] * count[action]) == observation.freighter_delta
+sum(priority_point_delta[action] * count[action]) == observation.priority_point_delta
+sum(build_slot_usage[action] * count[action]) <= observation.starbases_owned
+```
+
+Priority points should be configurable at first. If queue behavior is not yet confirmed for a scenario, run the solve with priority points as a diagnostic or optional constraint rather than silently accepting a wrong queue model.
+
+Add an integer objective:
+
+```text
+maximize sum(probability_weight[action] * count[action])
+```
+
+Weights should be scaled integer log-probabilities or penalties. For example, a common race-appropriate hull receives a better weight than an unusual one, and generic defense-post explanations receive a penalty so they do not crowd out more informative ship-build explanations.
+
+---
+
+## 6. Top-K solving
+
+Do not enumerate all feasible solutions. Low-value actions can produce many exact but unhelpful combinations.
+
+Use repeated optimization:
+
+1. Build the model and solve for the best objective value.
+2. Extract the non-zero action counts.
+3. Add a no-good cut excluding that exact action vector.
+4. Re-solve for the next best solution.
+5. Stop when `max_solutions`, solver status, or time budget is reached.
+
+A no-good cut can be encoded with indicator variables that detect whether each action count differs from its previous value, then require at least one difference. Keep this inside `solver.py` so the rest of the analytic only sees top-K results.
+
+The solver should return:
+
+- `exact` when at least one feasible solution is found,
+- `no_exact_solution` when the model is infeasible under enabled constraints,
+- `time_limited` when the solver reaches the time budget before proving optimality,
+- `invalid_problem` when generated action bounds or observations are inconsistent before solving.
+
+---
+
+## 7. Action catalog
+
+Generate the initial catalog from the observation and static game data.
+
+### 7.1 Ship build actions
+
+Create build actions for hulls the player can build. Each concrete action should include hull, engines, beams, tubes, and optional initial ammo load if the loadout catalog is known.
+
+Initial implementation can deliberately start with a reduced loadout catalog:
+
+- canonical empty or low-ammo build,
+- common full-fighter carrier build,
+- common torpedo-ship loadouts by torpedo tech,
+- race-specific preferred hull priors.
+
+Avoid generating every theoretical component combination until the performance envelope is measured.
+
+### 7.2 Low-value repeated actions
+
+Aggregate noisy actions where location detail is not yet known:
+
+- `planet_defense_posts_added_total`,
+- `starbase_defense_posts_added_total`,
+- `starbase_fighters_added_total`,
+- `ship_fighters_added_total`,
+- `ship_torps_loaded_by_type`.
+
+These variables still have exact score contributions, but they avoid one variable per planet or starbase in the initial version.
+
+### 7.3 Negative actions
+
+Support signed contribution vectors from the start:
+
+- fighter transfer from ship to starbase: negative score delta,
+- fighter transfer from starbase to ship: positive score delta,
+- future ship loss or transfer actions: negative or cross-player deltas.
+
+Negative actions need explicit upper bounds. Without bounds, positive and negative actions can create cancellation loops and a huge number of equivalent solutions.
+
+---
+
+## 8. Bounds and performance
+
+The solver should receive a bounded, pruned action catalog.
+
+Use these bounds before building the CP-SAT model:
+
+- **Residual score bound:** `abs(action.score_delta_2x) * count` cannot exceed a conservative residual cap unless the action is explicitly allowed to offset another signed action.
+- **Build slot bound:** total ship builds cannot exceed starbases owned in the initial no-loss model.
+- **Count-delta bound:** warship and freighter build actions are bounded by the observed count deltas when losses and trades are out of scope.
+- **Capacity bound:** ship fighters and torpedoes should be capped by plausible loadout capacity where known.
+- **Noisy-action cap:** defense posts, starbase fighters, and generic ammo adjustments should have conservative caps and lower probability weights.
+- **Top-K cap:** default to a small solution count, such as 10 or 20 per player.
+- **Time cap:** use a per-player solver budget so a pathological player does not block the whole analytic.
+
+The target scale for early implementation is hundreds to low thousands of variables per player, not every possible per-location action. If the catalog grows beyond that, add staged solving or column generation before broadening the action families.
+
+---
+
+## 9. Implementation phases
+
+### Phase 1: Core solver library
+
+Deliver a solver package with synthetic test problems and no analytic registration.
+
+Scope:
+
+- add `ortools` to `packages/api/pyproject.toml` and update `uv.lock`,
+- add Core dataclasses,
+- add scaled military-score contribution helpers,
+- add a CP-SAT solver adapter,
+- support signed action coefficients,
+- support integer objective ranking,
+- support top-K repeated optimization,
+- return diagnostics for infeasible or time-limited solves.
+
+Tests:
+
+- score contribution unit tests,
+- exact one-solution fit,
+- multiple-solution top-K ranking,
+- negative contribution fit,
+- infeasible problem status,
+- no-good cut excludes duplicate solutions.
+
+Run:
+
+```bash
+make lint
+make test_api
+```
+
+### Phase 2: Core analytic integration
+
+Register a Core analytic that builds observations from adjacent score rows and calls the solver.
+
+Scope:
+
+- add `analytic.py`,
+- add `ANALYTIC_ID = "military-score-inference"`,
+- derive observations from `TurnInfo.scores`,
+- build an initial action catalog from available hull and score data,
+- expose structured per-player inference results from Core.
+
+Tests:
+
+- analytics registry test,
+- synthetic turn analytic test,
+- missing prior-turn or missing score diagnostics,
+- per-player independence test.
+
+Run:
+
+```bash
+make lint
+make test_api
+```
+
+### Phase 3: BFF and frontend table
+
+Expose the analytic as a selectable table in the SPA.
+
+Scope:
+
+- add BFF metadata and table shaping,
+- add frontend analytic module if generic table rendering is insufficient,
+- show observed deltas, status, top explanation, and alternative count,
+- include details in the payload for later expansion.
+
+Tests:
+
+- BFF table shaping tests,
+- frontend render tests for exact, ambiguous, and no-solution rows,
+- generated OpenAPI TypeScript update if response contracts change.
+
+Run:
+
+```bash
+make lint
+make test_bff
+make test_frontend
+```
+
+### Phase 4: richer constraints and deferred effects
+
+Add action families and constraints only after the initial pipeline is measurable.
+
+Candidates:
+
+- mine laying and scooping,
+- ship trades and captures,
+- planet and starbase losses,
+- prior inventory and resource bounds,
+- per-location defense post and fighter attribution,
+- calibrated race/player probability priors.
+
+Each addition should include tests showing both new feasible explanations and cases where the new action removes a previous false unsat.
+
+---
+
+## 10. Testing strategy
+
+Keep most tests below HTTP boundaries until the model stabilizes.
+
+| Layer | Tests |
+|-------|-------|
+| Scoring helpers | exact scaled contribution values for ships, fighters, torpedoes, defenses |
+| Action catalog | bounds, signed actions, noisy-action aggregation |
+| Solver | exact fit, top-K, no-good cuts, negative coefficients, infeasible status |
+| Core analytic | observation construction, per-player results, diagnostics |
+| BFF | table columns and row formatting |
+| Frontend | rendering states and interaction with analytics selection |
+
+Prefer synthetic fixtures with small action catalogs. Large real-turn fixtures can be added later as performance regression tests.
+
+---
+
+## 11. Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Too many low-probability exact solutions | optimize by probability first, top-K only, aggregate noisy actions |
+| Solver runtime spikes | per-player time limits, action bounds, catalog pruning |
+| Incorrect priority-point model | make priority constraint configurable until queue semantics are confirmed |
+| False confidence | return multiple explanations and expose ambiguity |
+| Dependency/platform issue | keep solver isolated behind an adapter so a fallback can be added |
+| Hard-to-debug CP-SAT models | emit diagnostics with action counts, bounds, constraint targets, and solver status |
+
+---
+
+## 12. Acceptance criteria
+
+The first implementation PR should be considered complete when:
+
+- OR-Tools is isolated to the Core API solver adapter,
+- synthetic CP-SAT tests pass for positive and negative action vectors,
+- top-K ranked solving returns distinct feasible explanations,
+- infeasible cases return diagnostics rather than exceptions,
+- no BFF or frontend code depends on OR-Tools directly,
+- `make lint` and the relevant package tests pass.
+
+Later PRs can expose the analytic to the UI once the Core solver behavior is stable.

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -4,7 +4,7 @@ This document describes an approach for inferring likely per-turn builds from sc
 
 The goal is not to prove what happened. Military score is deliberately lossy: several combinations of ships, ammunition, and defenses can produce the same delta. The analytic should therefore return feasible explanations, rank them by plausibility, and make ambiguity visible.
 
-**Related:** [vga-planets-domain-context.md](vga-planets-domain-context.md), [design-analytics-structure.md](design-analytics-structure.md), [design-planets-api-data-model.md](design-planets-api-data-model.md).
+**Related:** [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md), [vga-planets-domain-context.md](vga-planets-domain-context.md), [design-analytics-structure.md](design-analytics-structure.md), [design-planets-api-data-model.md](design-planets-api-data-model.md).
 
 ---
 

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -338,7 +338,7 @@ It should not be embedded directly in the military-score equation.
 
 ## 8. Output shape
 
-The analytic should return a per-player list of explanations:
+The inference engine should return a per-player list of explanations that can enrich the existing scoreboard analytic:
 
 - observed deltas,
 - constraints used,
@@ -347,15 +347,10 @@ The analytic should return a per-player list of explanations:
 - explanation probability or score,
 - action breakdown,
 - residuals if any constraint was relaxed,
-- warnings about ignored deferred effects.
+- warnings about ignored deferred effects,
+- a compact summary suitable for a scoreboard cell.
 
-For the initial UI, a table is enough:
-
-| Player | Deltas | Status | Top explanation | Alternatives |
-|--------|--------|--------|-----------------|--------------|
-| Robots | `+1 warship, +4180 military` | exact | Built Golem with fighters | 3 close |
-
-The detailed view can show the action vector and score arithmetic for each explanation.
+The user-facing feature should be an optional capability of the existing Scores analytic rather than a separate analytic. When enabled, the scoreboard adds an inference column with row-level status: green tick for at least one solution, hourglass while a row is still solving, and red cross for no solution or solver failure. Hover text should summarize the result. Clicking a green tick should open a modal with the detailed ranked explanations, including action vectors and score arithmetic.
 
 ---
 

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -1,0 +1,385 @@
+# Design: Military score build inference
+
+This document describes an approach for inferring likely per-turn builds from scoreboard military-score deltas and related scoreboard constraints.
+
+The goal is not to prove what happened. Military score is deliberately lossy: several combinations of ships, ammunition, and defenses can produce the same delta. The analytic should therefore return feasible explanations, rank them by plausibility, and make ambiguity visible.
+
+**Related:** [vga-planets-domain-context.md](vga-planets-domain-context.md), [design-analytics-structure.md](design-analytics-structure.md), [design-planets-api-data-model.md](design-planets-api-data-model.md).
+
+---
+
+## 1. Purpose
+
+Given two adjacent scoreboard turns, infer possible actions for each player that explain:
+
+- change in military score,
+- change in number of military ships,
+- change in number of freighters,
+- change in priority points,
+- hulls buildable by that player,
+- number of starbases owned by that player,
+- whether the turn is before or after the ship limit.
+
+The output should be a small ranked set of explanations per player, not one forced answer. A typical explanation might be "built one Rush and loaded 18 fighters" or "built one medium warship, added starbase fighters, and transferred fighters from a starbase to ships."
+
+---
+
+## 2. Military score model
+
+The Planets.nu military score is based on AutoScore-style construction value. The score counts warships, loaded ship torpedoes and fighters, starbase defense posts and fighters, planetary defense posts, and minefields. Mobile military assets count at full value. Fixed-position assets count at half value.
+
+The score has half-point components, so the inference model should multiply all score contributions by 2 and solve with integers:
+
+| Component | Military score | Scaled contribution |
+|-----------|----------------|---------------------|
+| Warship hull, engines, beams, tubes | construction value | `2 * value` |
+| Loaded ship fighter | `125` | `250` |
+| Loaded ship torpedo | torpedo MC cost | `2 * torpedo_mc_cost` |
+| Starbase fighter | `62.5` | `125` |
+| Starbase defense post | `7.5` | `15` |
+| Planet defense post | `5.5` | `11` |
+| Minefields | derived from mine units | deferred initially |
+
+Construction value is `megacredits + 5 * minerals`. For ships, the value includes hull, engines, beams, and torpedo tubes, but not cargo and not cloning surcharge. A ship counts as a military ship for score purposes if it has at least one beam, torpedo tube, or fighter bay. Freighters can still affect constraints through freighter count and priority points, but usually do not add military score except through edge cases that should be handled by the ship catalog rules.
+
+---
+
+## 3. Initial scope
+
+### 3.1 In scope
+
+The first version should model these action families:
+
+- **Ship builds:** one built hull at a starbase, with a concrete engine, beam count/type, tube count/type, and possible initial ammo load.
+- **Freighter builds:** constrained by `freighterchange`, buildable hull list, starbase count, and priority-point behavior.
+- **Warship builds:** constrained by `shipchange`, buildable hull list, starbase count, and priority-point behavior.
+- **Loaded torpedoes:** score increase from torpedoes loaded onto ships.
+- **Ship fighters:** score increase from fighters loaded onto ships.
+- **Starbase fighters:** score contribution at half value.
+- **Starbase defense posts:** score contribution at half value.
+- **Planet defense posts:** score contribution at half value.
+- **Fighter transfers:** movement of fighters between ships and starbases, changing score by `+62.5` when a fighter moves from starbase to ship and `-62.5` in the reverse direction.
+
+### 3.2 Deferred
+
+The first version should not try to explain:
+
+- mine laying or mine scooping,
+- ship trades, captures, or losses,
+- planet losses, including planets with defense posts,
+- starbase losses, including bases with fighters or defense,
+- ship destruction or combat ammo use,
+- hard prior constraints from known inventory, minerals, cash, or ship locations.
+
+The design should still make those extensions natural. Deferred effects should be added as new action families and constraints, not as special-case patches to the solver.
+
+---
+
+## 4. Problem formulation
+
+For one player and one turn transition, define a set of candidate actions. Each action has:
+
+- a scaled military-score delta,
+- a warship-count delta,
+- a freighter-count delta,
+- a priority-point delta,
+- a starbase build-slot usage,
+- optional resource or inventory effects for later phases,
+- a heuristic log-probability contribution.
+
+The solver chooses non-negative integer counts for those actions subject to hard constraints:
+
+```text
+sum(action.score_delta_2x * count) == 2 * militarychange
+sum(action.warship_delta * count) == shipchange
+sum(action.freighter_delta * count) == freighterchange
+sum(action.priority_delta * count) == prioritypointchange
+sum(action.build_slot_usage * count) <= starbases_owned
+```
+
+Additional constraints depend on the queue and ship-limit state. Before the ship limit, the build-slot constraint dominates and priority points may only be checked as a consistency signal. After the ship limit, each ship-build action should carry the relevant priority-point effect from the production queue model.
+
+The objective is not simply "minimize score error"; score equality is a hard constraint for the initial model. Among feasible solutions, rank by heuristic probability:
+
+```text
+maximize sum(action.log_probability * count) + explanation_adjustments
+```
+
+Probability heuristics should be isolated from legality. If a low-probability explanation is the only feasible solution, it should still appear.
+
+---
+
+## 5. Candidate algorithms
+
+### 5.1 Integer programming / CP-SAT
+
+Model each candidate action as an integer variable and solve the linear constraints exactly. Use the objective for probability ranking, and ask for top-K feasible solutions.
+
+**Pros**
+
+- Directly matches the integer-constrained formulation.
+- Cleanly separates hard constraints from ranking heuristics.
+- Easy to add new action families, upper bounds, and prior-knowledge constraints.
+- Mature solvers can prune large search spaces far better than brute force.
+- Unsatisfiable cases produce useful diagnostics: which constraints conflict or how much residual score remains if relaxed.
+
+**Cons**
+
+- Adds a solver dependency and a modeling layer.
+- Top-K enumeration needs care because many solutions can differ only by small ammo or defense changes.
+- Solver behavior can feel opaque unless explanations and diagnostics are designed well.
+
+**Fit:** Best default approach. CP-SAT is especially attractive because all variables are integer and constraints are linear after score scaling.
+
+### 5.2 Domain-specific branch-and-bound
+
+Search over action families in a fixed order, pruning branches by remaining score, count deltas, priority points, starbase slots, and probability bound.
+
+**Pros**
+
+- No solver dependency.
+- Easy to encode domain-specific pruning and explanation ordering.
+- Can stream partial results and stop after enough high-quality solutions.
+- Transparent when debugging a single player's inference.
+
+**Cons**
+
+- More bespoke algorithm code to maintain.
+- Extension pressure can make pruning logic complicated.
+- Harder to guarantee good performance across all game states.
+- Top-K correctness depends on careful bound design.
+
+**Fit:** Good fallback or solver-independent implementation, but more fragile as constraints grow.
+
+### 5.3 Multiple-choice knapsack / dynamic programming
+
+Treat each build slot or action group as a knapsack choice, with dimensions for scaled score, ship deltas, freighter deltas, and priority points.
+
+**Pros**
+
+- Deterministic and exact within bounded dimensions.
+- Can be fast when score deltas and build slots are small.
+- Naturally returns counts or ways to reach a target delta.
+
+**Cons**
+
+- Multi-dimensional state can explode quickly.
+- Less natural for unbounded ammo, defense posts, and transfer actions.
+- Hard to express later constraints such as prior inventory or per-planet ownership changes.
+
+**Fit:** Useful as a subroutine for bounded ship-build combinations, not as the whole architecture.
+
+### 5.4 Meet-in-the-middle enumeration
+
+Split candidate actions into groups, enumerate partial sums for each group, and join compatible partials.
+
+**Pros**
+
+- Exact for bounded action sets.
+- Often much faster than naive enumeration.
+- Good for combining ship-build possibilities with non-ship score adjustments.
+
+**Cons**
+
+- Requires tight bounds before enumeration.
+- Memory can grow quickly with several constraint dimensions.
+- Awkward for top-K ranking unless partial states keep probability summaries and backpointers.
+
+**Fit:** Useful optimization inside a branch-and-bound or custom exact solver.
+
+### 5.5 Best-first / A* top-K search
+
+Explore partial explanations by descending optimistic probability, using admissible bounds to avoid lower-quality branches.
+
+**Pros**
+
+- Produces the most plausible explanations early.
+- Can stop once the UI has enough explanations.
+- Works well when good heuristics exist.
+
+**Cons**
+
+- Requires an admissible or at least conservative upper bound to avoid missing better solutions.
+- Still needs strong feasibility pruning to avoid large open sets.
+- More complex than CP-SAT for the same hard constraints.
+
+**Fit:** Attractive for a later ranking layer or custom solver, but not the simplest first implementation.
+
+### 5.6 Bayesian or factor-graph inference
+
+Represent builds, ammo, defenses, transfers, and observed deltas as random variables, then infer posterior probabilities.
+
+**Pros**
+
+- Conceptually matches "several explanations with probabilities."
+- Can incorporate soft evidence from previous turns, race tendencies, visible economy, and known fleet composition.
+- Handles uncertainty explicitly.
+
+**Cons**
+
+- Exact inference is still hard; practical methods become approximate or solver-backed.
+- Requires calibrated priors to avoid false confidence.
+- More difficult to explain to users than a constrained solution list.
+
+**Fit:** Good long-term framing for probability calibration, but too heavy as the initial solving mechanism.
+
+### 5.7 Genetic algorithms
+
+Evolve candidate explanations and score them by constraint fit and probability.
+
+**Pros**
+
+- Simple to prototype for very large spaces.
+- Can find plausible approximate explanations when exact modeling is incomplete.
+
+**Cons**
+
+- No guarantee of feasibility or completeness.
+- Poor fit for equality constraints where exact score and count deltas matter.
+- Reproducibility and user trust are weak unless heavily constrained.
+
+**Fit:** Not recommended for the first version.
+
+### 5.8 Simulated annealing
+
+Randomly walk the explanation space, sometimes accepting worse moves to escape local optima.
+
+**Pros**
+
+- Can explore rough probability landscapes with little solver infrastructure.
+- Useful for stress-testing heuristic objectives.
+
+**Cons**
+
+- Approximate, stochastic, and hard to explain.
+- May miss exact feasible solutions.
+- Requires tuning schedules and move operators.
+
+**Fit:** Not recommended for the first version.
+
+### 5.9 SAT / SMT
+
+Encode action counts and constraints into a satisfiability or SMT solver, optionally optimizing with repeated calls.
+
+**Pros**
+
+- Precise hard-constraint reasoning.
+- Unsat cores can help diagnose impossible observations.
+- SMT handles richer constraints than linear integer programming if needed.
+
+**Cons**
+
+- Linear integer optimization is the natural shape here; SMT adds complexity without much initial benefit.
+- Optimization and top-K enumeration can be less straightforward than CP-SAT.
+
+**Fit:** Consider if later constraints become non-linear or highly logical.
+
+### 5.10 Column generation
+
+Generate only promising composite actions, solve a restricted master problem, then add columns that can improve the explanation set.
+
+**Pros**
+
+- Scales when the full action catalog is huge.
+- Separates "generate possible builds" from "fit observed deltas."
+
+**Cons**
+
+- More architecture than the initial problem needs.
+- Harder to debug and test.
+
+**Fit:** A later scaling technique if ship-loadout catalogs become too large.
+
+---
+
+## 6. Recommended approach
+
+Use a hybrid exact-plus-ranking architecture:
+
+1. **Build an action catalog** for the player and turn. Include legal hull builds from that player's hull list, bounded ammunition and defense actions, starbase fighter actions, planet defense actions, and fighter-transfer actions.
+2. **Apply cheap bounds before solving.** Drop actions whose score contribution cannot fit the residual, whose ship class cannot match count deltas, or whose priority-point behavior is impossible for the ship-limit state.
+3. **Solve hard constraints with CP-SAT or an integer-programming adapter.** Treat exact score, ship-count, freighter-count, priority-point, and starbase-slot constraints as mandatory.
+4. **Enumerate top-K feasible solutions.** Use no-good cuts or solver-native solution callbacks to avoid returning the same explanation repeatedly.
+5. **Rank by heuristic log-probability.** Prefer common builds, race-appropriate hulls, plausible ammo loads, and smaller unexplained fixed-defense changes. Keep the heuristic model separate from hard constraints.
+6. **Return ambiguity deliberately.** Show several explanations when they are close in probability, and report when no exact explanation exists under the current scope.
+
+The solver interface should hide the concrete backend:
+
+```text
+InferenceProblem -> CandidateAction[] -> ConstraintSolver -> FeasibleExplanation[] -> Ranker
+```
+
+This keeps the first implementation independent of whether the backend is CP-SAT, another integer-programming solver, or a domain-specific branch-and-bound fallback.
+
+---
+
+## 7. Extensibility
+
+The design should grow by adding action families and constraints:
+
+- **Mine laying:** add minefield-score actions with negative torpedo inventory and positive minefield score.
+- **Ship trades and captures:** add ownership-transfer actions with paired loss/gain effects across players.
+- **Ship losses:** add negative ship and score actions, constrained by prior known or inferred fleet state.
+- **Planet losses:** add negative planet defense-post score and planet-count changes.
+- **Starbase losses:** add negative base fighter and defense score, plus starbase-count changes.
+- **Prior inventory:** add upper bounds from known ships, starbases, torpedoes, fighters, planets, and resources.
+- **Resource feasibility:** add mineral, cash, supply, and tech-level constraints when enough data is known.
+
+The important rule is that every new phenomenon becomes either:
+
+- a new candidate action with a contribution vector,
+- a new hard constraint,
+- a new prior probability term,
+- or a diagnostic residual category.
+
+It should not be embedded directly in the military-score equation.
+
+---
+
+## 8. Output shape
+
+The analytic should return a per-player list of explanations:
+
+- observed deltas,
+- constraints used,
+- status: exact, exact-with-deferred-risk, no-exact-solution, or skipped,
+- ranked explanations,
+- explanation probability or score,
+- action breakdown,
+- residuals if any constraint was relaxed,
+- warnings about ignored deferred effects.
+
+For the initial UI, a table is enough:
+
+| Player | Deltas | Status | Top explanation | Alternatives |
+|--------|--------|--------|-----------------|--------------|
+| Robots | `+1 warship, +4180 military` | exact | Built Golem with fighters | 3 close |
+
+The detailed view can show the action vector and score arithmetic for each explanation.
+
+---
+
+## 9. Validation strategy
+
+Validation should start before any UI work:
+
+- Unit-test the scaled score contribution for each component type.
+- Use synthetic turn transitions with known builds and ammo changes.
+- Test unsatisfiable cases, especially score deltas that require deferred minefield or loss effects.
+- Test ambiguous cases where multiple hulls or ammo mixes fit the same score.
+- Compare inferred explanations against real turn histories where the player's own builds are known.
+- Track solver runtime per player and cap top-K enumeration for UI responsiveness.
+
+The first implementation should prefer correct "unknown or ambiguous" output over overconfident guesses.
+
+---
+
+## 10. Open design decisions for implementation
+
+- Which solver backend to use first.
+- How to represent buildable hulls and component costs in the Core domain model.
+- How detailed the initial loadout catalog should be for engines, beams, tubes, and ammo.
+- Whether priority-point deltas are treated as hard constraints immediately or as diagnostics until the queue model is confirmed.
+- How much of the probability model should be user-configurable.
+
+These decisions affect implementation, not the overall approach. The core design remains: exact integer feasibility first, probabilistic ranking second.

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -50,9 +50,9 @@ Construction value is `megacredits + 5 * minerals`. For ships, the value include
 
 The first version should model these action families:
 
-- **Ship builds:** one built hull at a starbase, with a concrete engine, beam count/type, tube count/type, and possible initial ammo load.
-- **Freighter builds:** constrained by `freighterchange`, buildable hull list, starbase count, and priority-point behavior.
-- **Warship builds:** constrained by `shipchange`, buildable hull list, starbase count, and priority-point behavior.
+- **Ship builds:** one built hull at a starbase, with a concrete engine type, optional beam type and count, and optional torp tube type and count. Construction score includes hull, engines (`hull.engines` copies of one type), fitted beams, and tube hardware (`launchercost`). Beams and tubes may be omitted independently. **Do not** include fighters or torpedo ammo loaded at build time; those are separate aggregate actions.
+- **Freighter builds:** constrained by `freighterchange`, buildable hull list, starbase count, and priority-point behavior (diagnostic until queue model lands).
+- **Warship builds:** constrained by `shipchange`, buildable hull list, starbase count, and priority-point behavior (diagnostic until queue model lands).
 - **Loaded torpedoes:** score increase from torpedoes loaded onto ships.
 - **Ship fighters:** score increase from fighters loaded onto ships.
 - **Starbase fighters:** score contribution at half value.
@@ -77,7 +77,12 @@ The design should still make those extensions natural. Deferred effects should b
 
 ## 4. Problem formulation
 
-For one player and one turn transition, define a set of candidate actions. Each action has:
+For one player and one turn transition, define candidate actions in **two layers**:
+
+1. **Aggregate actions** -- flat integer variables for defense posts, starbase fighters, ship ammo loading, fighter transfers, and similar location-agnostic effects.
+2. **Ship build combos** -- sparse integer variables for `(hull, engine, beam?, torp?, beam_count, launcher_count)` configurations. See [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md) section 8.
+
+Each aggregate action or ship build combo has:
 
 - a scaled military-score delta,
 - a warship-count delta,
@@ -87,7 +92,7 @@ For one player and one turn transition, define a set of candidate actions. Each 
 - optional resource or inventory effects for later phases,
 - a heuristic log-probability contribution.
 
-The solver chooses non-negative integer counts for those actions subject to hard constraints:
+The solver chooses non-negative integer counts subject to hard constraints summed over **both** layers:
 
 ```text
 sum(action.score_delta_2x * count) == 2 * militarychange
@@ -97,7 +102,7 @@ sum(action.priority_delta * count) == prioritypointchange
 sum(action.build_slot_usage * count) <= starbases_owned
 ```
 
-Additional constraints depend on the queue and ship-limit state. Before the ship limit, the build-slot constraint dominates and priority points may only be checked as a consistency signal. After the ship limit, each ship-build action should carry the relevant priority-point effect from the production queue model.
+Additional constraints depend on the queue and ship-limit state. Before the ship limit, the build-slot constraint dominates. **Priority-point equality is diagnostic-only in the initial model** until production-queue semantics (standard vs priority build) are encoded per ship-build combo.
 
 The objective is not simply "minimize score error"; score equality is a hard constraint for the initial model. Among feasible solutions, rank by heuristic probability:
 
@@ -288,7 +293,7 @@ Generate only promising composite actions, solve a restricted master problem, th
 - More architecture than the initial problem needs.
 - Harder to debug and test.
 
-**Fit:** A later scaling technique if ship-loadout catalogs become too large.
+**Fit:** A later scaling technique if tiered combo generation is still too slow after Phase 1G.
 
 ---
 
@@ -296,17 +301,17 @@ Generate only promising composite actions, solve a restricted master problem, th
 
 Use a hybrid exact-plus-ranking architecture:
 
-1. **Build an action catalog** for the player and turn. Include legal hull builds from that player's hull list, bounded ammunition and defense actions, starbase fighter actions, planet defense actions, and fighter-transfer actions.
+1. **Build a two-layer catalog** for the player and turn: aggregate actions (defense, ammo load, transfers) plus **ship build combos** from eligible hulls and components. Use **tiered widening** when a narrow combo set is INFEASIBLE; jump tiers when `activeengines` / `activebeams` / `activetorps` are empty. Early tiers use beam/launcher counts of `0` or full slot fill; partial slot counts are a later tier (niche builds).
 2. **Apply cheap bounds before solving.** Drop actions whose score contribution cannot fit the residual, whose ship class cannot match count deltas, or whose priority-point behavior is impossible for the ship-limit state.
-3. **Solve hard constraints with CP-SAT or an integer-programming adapter.** Treat exact score, ship-count, freighter-count, priority-point, and starbase-slot constraints as mandatory.
-4. **Enumerate top-K feasible solutions.** Use no-good cuts or solver-native solution callbacks to avoid returning the same explanation repeatedly.
-5. **Rank by heuristic log-probability.** Prefer common builds, race-appropriate hulls, plausible ammo loads, and smaller unexplained fixed-defense changes. Keep the heuristic model separate from hard constraints.
-6. **Return ambiguity deliberately.** Show several explanations when they are close in probability, and report when no exact explanation exists under the current scope.
+3. **Solve hard constraints with CP-SAT or an integer-programming adapter.** Treat exact score, ship-count, and freighter-count as mandatory; treat priority-point fit as diagnostic until the queue model is added. Enforce starbase build-slot limits.
+4. **Enumerate top-K feasible solutions.** Use no-good cuts over both aggregate and combo variables. Score-equivalent combos may share solver variables for feasibility, but distinct labels/weights should still yield distinct ranked explanations when probabilities differ.
+5. **Rank by heuristic log-probability.** Prefer common builds, race-appropriate hulls, and plausible ammo loads. Keep the heuristic model separate from hard constraints.
+6. **Return ambiguity deliberately.** Show several explanations when they are close in probability, and report when no exact explanation exists under the current scope and tier.
 
 The solver interface should hide the concrete backend:
 
 ```text
-InferenceProblem -> CandidateAction[] -> ConstraintSolver -> FeasibleExplanation[] -> Ranker
+InferenceProblem -> [AggregateActions + ShipBuildCombos] -> ConstraintSolver -> FeasibleExplanation[] -> Ranker
 ```
 
 This keeps the first implementation independent of whether the backend is CP-SAT, another integer-programming solver, or a domain-specific branch-and-bound fallback.
@@ -369,12 +374,28 @@ The first implementation should prefer correct "unknown or ambiguous" output ove
 
 ---
 
-## 10. Open design decisions for implementation
+## 10. Design decisions
 
-- Which solver backend to use first.
-- How to represent buildable hulls and component costs in the Core domain model.
-- How detailed the initial loadout catalog should be for engines, beams, tubes, and ammo.
-- Whether priority-point deltas are treated as hard constraints immediately or as diagnostics until the queue model is confirmed.
+### Resolved
+
+| Topic | Decision |
+|-------|----------|
+| Solver backend | OR-Tools CP-SAT in Core API (`design-military-score-build-inference-implementation.md`) |
+| Buildable hulls | `activehulls` intersect race and turn catalogs; ignore `Hull.isbase` as a build filter |
+| Build-time ammo | Not on ship combos; use aggregate `ship_fighters_added_total` and `ship_torps_loaded_*` |
+| Beams vs tubes | May be omitted independently; same-type rule within each fitted component |
+| Partial slot fills | Allowed; `{0, max}` counts in early tiers; intermediate counts in later tier (niche) |
+| Ship build catalog shape | Factored combos (Phase 1G), not flat cross-product preset IDs |
+| Catalog widening | Tiered search with jump when `active*` lists are empty |
+| Score-equivalent combos | Solver-side merge for feasibility; distinct top-K when probability differs |
+| Priority points | Diagnostic-only until production-queue model assigns per-build PP deltas |
+| Fleet priors | Deferred; will inform tier order and weights, not hard exclusion |
+
+### Still open
+
+- Engine/hull tech-legality rules beyond active component lists.
 - How much of the probability model should be user-configurable.
+- Whether BFF returns full solutions inline or lazily per row at scale.
+- Column generation if tier-4 combo search exceeds time budget on large games.
 
 These decisions affect implementation, not the overall approach. The core design remains: exact integer feasibility first, probabilistic ranking second.

--- a/packages/api/api/analytics/military_score_inference/__init__.py
+++ b/packages/api/api/analytics/military_score_inference/__init__.py
@@ -22,12 +22,21 @@ from api.analytics.military_score_inference.scoring import (
     starbase_defense_post_score_delta_2x,
     starbase_fighter_score_delta_2x,
 )
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_INVALID_PROBLEM,
+    STATUS_NO_EXACT_SOLUTION,
+    solve_inference_problem,
+)
 
 __all__ = [
     "LOADED_SHIP_FIGHTER_SCORE_DELTA_2X",
     "PLANET_DEFENSE_POST_SCORE_DELTA_2X",
     "STARBASE_DEFENSE_POST_SCORE_DELTA_2X",
     "STARBASE_FIGHTER_SCORE_DELTA_2X",
+    "STATUS_EXACT",
+    "STATUS_INVALID_PROBLEM",
+    "STATUS_NO_EXACT_SOLUTION",
     "CandidateAction",
     "InferenceObservation",
     "InferenceProblem",
@@ -40,6 +49,7 @@ __all__ = [
     "loaded_ship_torpedo_score_delta_2x",
     "planet_defense_post_score_delta_2x",
     "ship_construction_score_delta_2x",
+    "solve_inference_problem",
     "starbase_defense_post_score_delta_2x",
     "starbase_fighter_score_delta_2x",
 ]

--- a/packages/api/api/analytics/military_score_inference/__init__.py
+++ b/packages/api/api/analytics/military_score_inference/__init__.py
@@ -1,5 +1,12 @@
 """Military score build inference (internal to the scores analytic)."""
 
+from api.analytics.military_score_inference.actions import (
+    ActionCatalog,
+    ActionCatalogConfig,
+    build_action_catalog,
+    build_action_catalog_from_turn,
+    build_inference_problem,
+)
 from api.analytics.military_score_inference.models import (
     CandidateAction,
     InferenceObservation,
@@ -39,6 +46,8 @@ __all__ = [
     "STATUS_INVALID_PROBLEM",
     "STATUS_NO_EXACT_SOLUTION",
     "STATUS_TIME_LIMITED",
+    "ActionCatalog",
+    "ActionCatalogConfig",
     "CandidateAction",
     "InferenceObservation",
     "InferenceProblem",
@@ -46,6 +55,9 @@ __all__ = [
     "InferenceSolution",
     "InferenceSolutionAction",
     "ProbabilityBucket",
+    "build_action_catalog",
+    "build_action_catalog_from_turn",
+    "build_inference_problem",
     "construction_value",
     "loaded_ship_fighter_score_delta_2x",
     "loaded_ship_torpedo_score_delta_2x",

--- a/packages/api/api/analytics/military_score_inference/__init__.py
+++ b/packages/api/api/analytics/military_score_inference/__init__.py
@@ -1,0 +1,45 @@
+"""Military score build inference (internal to the scores analytic)."""
+
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+    InferenceSolutionAction,
+    ProbabilityBucket,
+)
+from api.analytics.military_score_inference.scoring import (
+    LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
+    PLANET_DEFENSE_POST_SCORE_DELTA_2X,
+    STARBASE_DEFENSE_POST_SCORE_DELTA_2X,
+    STARBASE_FIGHTER_SCORE_DELTA_2X,
+    construction_value,
+    loaded_ship_fighter_score_delta_2x,
+    loaded_ship_torpedo_score_delta_2x,
+    planet_defense_post_score_delta_2x,
+    ship_construction_score_delta_2x,
+    starbase_defense_post_score_delta_2x,
+    starbase_fighter_score_delta_2x,
+)
+
+__all__ = [
+    "LOADED_SHIP_FIGHTER_SCORE_DELTA_2X",
+    "PLANET_DEFENSE_POST_SCORE_DELTA_2X",
+    "STARBASE_DEFENSE_POST_SCORE_DELTA_2X",
+    "STARBASE_FIGHTER_SCORE_DELTA_2X",
+    "CandidateAction",
+    "InferenceObservation",
+    "InferenceProblem",
+    "InferenceResult",
+    "InferenceSolution",
+    "InferenceSolutionAction",
+    "ProbabilityBucket",
+    "construction_value",
+    "loaded_ship_fighter_score_delta_2x",
+    "loaded_ship_torpedo_score_delta_2x",
+    "planet_defense_post_score_delta_2x",
+    "ship_construction_score_delta_2x",
+    "starbase_defense_post_score_delta_2x",
+    "starbase_fighter_score_delta_2x",
+]

--- a/packages/api/api/analytics/military_score_inference/__init__.py
+++ b/packages/api/api/analytics/military_score_inference/__init__.py
@@ -26,6 +26,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
+    STATUS_TIME_LIMITED,
     solve_inference_problem,
 )
 
@@ -37,6 +38,7 @@ __all__ = [
     "STATUS_EXACT",
     "STATUS_INVALID_PROBLEM",
     "STATUS_NO_EXACT_SOLUTION",
+    "STATUS_TIME_LIMITED",
     "CandidateAction",
     "InferenceObservation",
     "InferenceProblem",

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -240,9 +240,6 @@ def _residual_count_bound(
 
     abs_score = abs(score_delta_2x)
     abs_residual = abs(observation.military_delta_2x)
-    same_sign = (observation.military_delta_2x > 0) == (score_delta_2x > 0)
-    if same_sign:
-        return min(configured_cap, abs_residual // abs_score)
     return min(configured_cap, abs_residual // abs_score)
 
 

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -1,0 +1,498 @@
+"""Bounded candidate action catalog for military score build inference."""
+
+from dataclasses import dataclass
+
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+    ProbabilityBucket,
+)
+from api.analytics.military_score_inference.scoring import (
+    STARBASE_FIGHTER_SCORE_DELTA_2X,
+    loaded_ship_fighter_score_delta_2x,
+    loaded_ship_torpedo_score_delta_2x,
+    planet_defense_post_score_delta_2x,
+    ship_construction_score_delta_2x,
+    starbase_defense_post_score_delta_2x,
+    starbase_fighter_score_delta_2x,
+)
+from api.models.components import Beam, Engine, Hull, Torpedo
+from api.models.game import TurnInfo
+from api.models.player import Player, Race
+
+LOADOUT_PRESET_EMPTY = "empty"
+LOADOUT_PRESET_FIGHTERS = "fighters"
+LOADOUT_PRESET_TORPEDOES = "torpedoes"
+
+PLANET_DEFENSE_POST_BUCKETS = (
+    ProbabilityBucket("modest build-up", 0, 10, 100),
+    ProbabilityBucket("heavy build-up", 11, 50, 20),
+    ProbabilityBucket("extreme build-up", 51, 100, 5),
+)
+STARBASE_DEFENSE_POST_BUCKETS = (
+    ProbabilityBucket("modest build-up", 0, 10, 100),
+    ProbabilityBucket("heavy build-up", 11, 50, 20),
+    ProbabilityBucket("extreme build-up", 51, 100, 5),
+)
+STARBASE_FIGHTER_BUCKETS = (
+    ProbabilityBucket("modest build-up", 0, 20, 80),
+    ProbabilityBucket("heavy build-up", 21, 100, 15),
+    ProbabilityBucket("extreme build-up", 101, 200, 3),
+)
+SHIP_FIGHTER_BUCKETS = (
+    ProbabilityBucket("modest load", 0, 20, 70),
+    ProbabilityBucket("heavy load", 21, 100, 20),
+    ProbabilityBucket("extreme load", 101, 500, 5),
+)
+SHIP_TORPEDO_BUCKETS = (
+    ProbabilityBucket("modest load", 0, 20, 70),
+    ProbabilityBucket("heavy load", 21, 100, 20),
+    ProbabilityBucket("extreme load", 101, 200, 5),
+)
+
+BUCKETED_ACTION_IDS = frozenset(
+    {
+        "planet_defense_posts_added_total",
+        "starbase_defense_posts_added_total",
+        "starbase_fighters_added_total",
+        "ship_fighters_added_total",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ActionCatalogConfig:
+    max_planet_defense_posts: int = 100
+    max_starbase_defense_posts: int = 100
+    max_starbase_fighters: int = 200
+    max_ship_fighters: int = 500
+    max_ship_torpedoes_per_type: int = 200
+    max_fighter_transfers: int = 50
+    default_ship_build_probability_weight: int = 80
+    fighter_carrier_build_probability_weight: int = 90
+    torpedo_ship_build_probability_weight: int = 85
+    noisy_action_probability_weight: int = 10
+    fighter_transfer_probability_weight: int = 15
+
+
+@dataclass(frozen=True)
+class ActionCatalog:
+    actions: tuple[CandidateAction, ...]
+    probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
+
+    @property
+    def catalog_size(self) -> int:
+        return len(self.actions)
+
+    def diagnostics(self) -> dict[str, object]:
+        return {
+            "catalog_size": self.catalog_size,
+            "bucketed_action_count": sum(
+                1 for action in self.actions if action.id in BUCKETED_ACTION_IDS
+            ),
+            "ship_build_action_count": sum(
+                1 for action in self.actions if action.id.startswith("build_")
+            ),
+        }
+
+
+def build_inference_problem(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    *,
+    max_solutions: int = 20,
+    time_limit_seconds: float = 1.0,
+) -> InferenceProblem:
+    return InferenceProblem(
+        observation=observation,
+        actions=catalog.actions,
+        probability_buckets_by_action_id=catalog.probability_buckets_by_action_id,
+        max_solutions=max_solutions,
+        time_limit_seconds=time_limit_seconds,
+    )
+
+
+def parse_component_id_csv(component_ids: str) -> frozenset[int]:
+    if not component_ids.strip():
+        return frozenset()
+    return frozenset(int(component_id) for component_id in component_ids.split(",") if component_id)
+
+
+def buildable_hull_ids_for_player(turn: TurnInfo, player_id: int) -> frozenset[int]:
+    player = _player_by_id(turn, player_id)
+    race = _race_by_id_or_none(turn, player.raceid)
+    active_hull_ids = parse_component_id_csv(player.activehulls)
+    if race is not None:
+        eligible_hull_ids = active_hull_ids & (
+            parse_component_id_csv(race.hulls) | parse_component_id_csv(race.basehulls)
+        )
+    else:
+        eligible_hull_ids = active_hull_ids
+    turn_hull_ids = frozenset(turn.racehulls)
+    catalog_hull_ids = frozenset(hull.id for hull in turn.hulls)
+    return eligible_hull_ids & turn_hull_ids & catalog_hull_ids
+
+
+def build_action_catalog_from_turn(
+    observation: InferenceObservation,
+    turn: TurnInfo,
+    *,
+    config: ActionCatalogConfig | None = None,
+) -> ActionCatalog:
+    hulls_by_id = {hull.id: hull for hull in turn.hulls}
+    engines_by_id = {engine.id: engine for engine in turn.engines}
+    beams_by_id = {beam.id: beam for beam in turn.beams}
+    torpedos_by_id = {torpedo.id: torpedo for torpedo in turn.torpedos}
+    default_engine_id = min(engines_by_id) if engines_by_id else None
+    buildable_hull_ids = buildable_hull_ids_for_player(turn, observation.player_id)
+    return build_action_catalog(
+        observation,
+        hulls_by_id=hulls_by_id,
+        engines_by_id=engines_by_id,
+        beams_by_id=beams_by_id,
+        torpedos_by_id=torpedos_by_id,
+        buildable_hull_ids=buildable_hull_ids,
+        default_engine_id=default_engine_id,
+        config=config,
+    )
+
+
+def build_action_catalog(
+    observation: InferenceObservation,
+    *,
+    hulls_by_id: dict[int, Hull],
+    engines_by_id: dict[int, Engine],
+    beams_by_id: dict[int, Beam],
+    torpedos_by_id: dict[int, Torpedo],
+    buildable_hull_ids: frozenset[int],
+    default_engine_id: int | None,
+    config: ActionCatalogConfig | None = None,
+) -> ActionCatalog:
+    catalog_config = config or ActionCatalogConfig()
+    actions: list[CandidateAction] = []
+    probability_buckets: dict[str, tuple[ProbabilityBucket, ...]] = {}
+
+    actions.extend(_aggregate_noisy_actions(observation, catalog_config, torpedos_by_id))
+    actions.extend(
+        _fighter_transfer_actions(observation, catalog_config),
+    )
+    actions.extend(
+        _ship_build_actions(
+            observation,
+            catalog_config,
+            hulls_by_id=hulls_by_id,
+            engines_by_id=engines_by_id,
+            beams_by_id=beams_by_id,
+            torpedos_by_id=torpedos_by_id,
+            buildable_hull_ids=buildable_hull_ids,
+            default_engine_id=default_engine_id,
+        )
+    )
+
+    kept_actions: list[CandidateAction] = []
+    for action in actions:
+        if action.upper_bound <= 0:
+            continue
+        kept_actions.append(action)
+        if action.id in BUCKETED_ACTION_IDS:
+            probability_buckets[action.id] = _probability_buckets_for_action(action.id)
+        elif action.id.startswith("ship_torps_loaded_"):
+            probability_buckets[action.id] = SHIP_TORPEDO_BUCKETS
+
+    return ActionCatalog(
+        actions=tuple(kept_actions),
+        probability_buckets_by_action_id=probability_buckets,
+    )
+
+
+def _player_by_id(turn: TurnInfo, player_id: int) -> Player:
+    if turn.player.id == player_id:
+        return turn.player
+    for player in turn.players:
+        if player.id == player_id:
+            return player
+    raise ValueError(f"unknown player id: {player_id}")
+
+
+def _race_by_id_or_none(turn: TurnInfo, race_id: int) -> Race | None:
+    for race in turn.races:
+        if race.id == race_id:
+            return race
+    return None
+
+
+def _component_minerals(component: Hull | Engine | Beam | Torpedo) -> int:
+    return component.tritanium + component.duranium + component.molybdenum
+
+
+def _is_military_hull(hull: Hull) -> bool:
+    return hull.beams > 0 or hull.launchers > 0 or hull.fighterbays > 0
+
+
+def _residual_count_bound(
+    observation: InferenceObservation,
+    score_delta_2x: int,
+    configured_cap: int,
+) -> int:
+    if score_delta_2x == 0:
+        return 0
+    if observation.military_delta_2x == 0:
+        return 0
+
+    abs_score = abs(score_delta_2x)
+    abs_residual = abs(observation.military_delta_2x)
+    same_sign = (observation.military_delta_2x > 0) == (score_delta_2x > 0)
+    if same_sign:
+        return min(configured_cap, abs_residual // abs_score)
+    return min(configured_cap, abs_residual // abs_score)
+
+
+def _aggregate_noisy_actions(
+    observation: InferenceObservation,
+    config: ActionCatalogConfig,
+    torpedos_by_id: dict[int, Torpedo],
+) -> list[CandidateAction]:
+    actions = [
+        CandidateAction(
+            id="planet_defense_posts_added_total",
+            label="Planet defense posts added",
+            score_delta_2x=planet_defense_post_score_delta_2x(),
+            upper_bound=_residual_count_bound(
+                observation,
+                planet_defense_post_score_delta_2x(),
+                config.max_planet_defense_posts,
+            ),
+            probability_weight=config.noisy_action_probability_weight,
+        ),
+        CandidateAction(
+            id="starbase_defense_posts_added_total",
+            label="Starbase defense posts added",
+            score_delta_2x=starbase_defense_post_score_delta_2x(),
+            upper_bound=_residual_count_bound(
+                observation,
+                starbase_defense_post_score_delta_2x(),
+                config.max_starbase_defense_posts,
+            ),
+            probability_weight=config.noisy_action_probability_weight,
+        ),
+        CandidateAction(
+            id="starbase_fighters_added_total",
+            label="Starbase fighters added",
+            score_delta_2x=starbase_fighter_score_delta_2x(),
+            upper_bound=_residual_count_bound(
+                observation,
+                starbase_fighter_score_delta_2x(),
+                config.max_starbase_fighters,
+            ),
+            probability_weight=config.noisy_action_probability_weight,
+        ),
+        CandidateAction(
+            id="ship_fighters_added_total",
+            label="Ship fighters added",
+            score_delta_2x=loaded_ship_fighter_score_delta_2x(),
+            upper_bound=_residual_count_bound(
+                observation,
+                loaded_ship_fighter_score_delta_2x(),
+                config.max_ship_fighters,
+            ),
+            probability_weight=config.noisy_action_probability_weight,
+        ),
+    ]
+    for torpedo_id in sorted(torpedos_by_id):
+        torpedo = torpedos_by_id[torpedo_id]
+        per_torpedo_score = loaded_ship_torpedo_score_delta_2x(torpedo.torpedocost)
+        actions.append(
+            CandidateAction(
+                id=f"ship_torps_loaded_{torpedo_id}",
+                label=f"Ship torpedoes loaded ({torpedo.name})",
+                score_delta_2x=per_torpedo_score,
+                upper_bound=_residual_count_bound(
+                    observation,
+                    per_torpedo_score,
+                    config.max_ship_torpedoes_per_type,
+                ),
+                probability_weight=config.noisy_action_probability_weight,
+            )
+        )
+    return actions
+
+
+def _fighter_transfer_actions(
+    observation: InferenceObservation,
+    config: ActionCatalogConfig,
+) -> list[CandidateAction]:
+    transfer_cap = min(
+        config.max_fighter_transfers,
+        _residual_count_bound(
+            observation,
+            STARBASE_FIGHTER_SCORE_DELTA_2X,
+            config.max_fighter_transfers,
+        ),
+    )
+    return [
+        CandidateAction(
+            id="fighters_starbase_to_ship",
+            label="Fighters transferred starbase to ship",
+            score_delta_2x=STARBASE_FIGHTER_SCORE_DELTA_2X,
+            upper_bound=transfer_cap,
+            probability_weight=config.fighter_transfer_probability_weight,
+        ),
+        CandidateAction(
+            id="fighters_ship_to_starbase",
+            label="Fighters transferred ship to starbase",
+            score_delta_2x=-STARBASE_FIGHTER_SCORE_DELTA_2X,
+            upper_bound=transfer_cap,
+            probability_weight=config.fighter_transfer_probability_weight,
+        ),
+    ]
+
+
+def _ship_build_upper_bound(
+    observation: InferenceObservation,
+    *,
+    is_warship: bool,
+    is_freighter: bool,
+) -> int:
+    if is_warship:
+        count_delta = max(0, observation.warship_delta)
+    elif is_freighter:
+        count_delta = max(0, observation.freighter_delta)
+    else:
+        return 0
+    return min(count_delta, observation.starbases_owned)
+
+
+def _ship_build_actions(
+    observation: InferenceObservation,
+    config: ActionCatalogConfig,
+    *,
+    hulls_by_id: dict[int, Hull],
+    engines_by_id: dict[int, Engine],
+    beams_by_id: dict[int, Beam],
+    torpedos_by_id: dict[int, Torpedo],
+    buildable_hull_ids: frozenset[int],
+    default_engine_id: int | None,
+) -> list[CandidateAction]:
+    if default_engine_id is None or default_engine_id not in engines_by_id:
+        return []
+
+    default_engine = engines_by_id[default_engine_id]
+    default_beam = min(beams_by_id.values(), key=lambda beam: beam.id) if beams_by_id else None
+    default_torpedo = (
+        min(torpedos_by_id.values(), key=lambda torpedo: torpedo.techlevel)
+        if torpedos_by_id
+        else None
+    )
+    actions: list[CandidateAction] = []
+
+    for hull_id in sorted(buildable_hull_ids):
+        hull = hulls_by_id.get(hull_id)
+        if hull is None or hull.isbase:
+            continue
+
+        is_warship = _is_military_hull(hull)
+        is_freighter = not is_warship
+        build_upper_bound = _ship_build_upper_bound(
+            observation,
+            is_warship=is_warship,
+            is_freighter=is_freighter,
+        )
+        if build_upper_bound <= 0:
+            continue
+
+        presets = [(LOADOUT_PRESET_EMPTY, config.default_ship_build_probability_weight, 0, 0)]
+        if hull.fighterbays > 0:
+            presets.append(
+                (
+                    LOADOUT_PRESET_FIGHTERS,
+                    config.fighter_carrier_build_probability_weight,
+                    hull.fighterbays,
+                    0,
+                )
+            )
+        if hull.launchers > 0 and default_torpedo is not None:
+            presets.append(
+                (
+                    LOADOUT_PRESET_TORPEDOES,
+                    config.torpedo_ship_build_probability_weight,
+                    0,
+                    hull.launchers,
+                )
+            )
+
+        for preset_id, probability_weight, initial_fighters, initial_torpedoes in presets:
+            score_delta_2x = _ship_build_score_delta_2x(
+                hull,
+                default_engine,
+                default_beam,
+                default_torpedo,
+                beam_count=hull.beams if preset_id == LOADOUT_PRESET_TORPEDOES else 0,
+                torpedo_count=initial_torpedoes,
+                initial_fighters=initial_fighters,
+                initial_torpedoes=initial_torpedoes,
+            )
+            if score_delta_2x == 0:
+                continue
+            actions.append(
+                CandidateAction(
+                    id=f"build_{hull_id}_{preset_id}",
+                    label=f"Build {hull.name} ({preset_id})",
+                    score_delta_2x=score_delta_2x,
+                    warship_delta=1 if is_warship else 0,
+                    freighter_delta=1 if is_freighter else 0,
+                    build_slot_usage=1,
+                    upper_bound=build_upper_bound,
+                    probability_weight=probability_weight,
+                )
+            )
+
+    return actions
+
+
+def _ship_build_score_delta_2x(
+    hull: Hull,
+    engine: Engine,
+    beam: Beam | None,
+    torpedo: Torpedo | None,
+    *,
+    beam_count: int,
+    torpedo_count: int,
+    initial_fighters: int,
+    initial_torpedoes: int,
+) -> int:
+    construction_megacredits = hull.cost + engine.cost
+    construction_minerals = _component_minerals(hull) + _component_minerals(engine)
+
+    if beam is not None and beam_count > 0:
+        construction_megacredits += beam.cost * beam_count
+        construction_minerals += _component_minerals(beam) * beam_count
+
+    if torpedo is not None and torpedo_count > 0:
+        construction_megacredits += torpedo.launchercost * torpedo_count
+        construction_minerals += _component_minerals(torpedo) * torpedo_count
+
+    score_delta_2x = ship_construction_score_delta_2x(
+        construction_megacredits,
+        construction_minerals,
+    )
+    if initial_fighters > 0:
+        score_delta_2x += loaded_ship_fighter_score_delta_2x(initial_fighters)
+    if torpedo is not None and initial_torpedoes > 0:
+        score_delta_2x += loaded_ship_torpedo_score_delta_2x(
+            torpedo.torpedocost,
+            initial_torpedoes,
+        )
+    return score_delta_2x
+
+
+def _probability_buckets_for_action(action_id: str) -> tuple[ProbabilityBucket, ...]:
+    if action_id == "planet_defense_posts_added_total":
+        return PLANET_DEFENSE_POST_BUCKETS
+    if action_id == "starbase_defense_posts_added_total":
+        return STARBASE_DEFENSE_POST_BUCKETS
+    if action_id == "starbase_fighters_added_total":
+        return STARBASE_FIGHTER_BUCKETS
+    if action_id == "ship_fighters_added_total":
+        return SHIP_FIGHTER_BUCKETS
+    raise ValueError(f"no probability buckets configured for action {action_id}")

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -22,7 +22,6 @@ from api.models.game import TurnInfo
 from api.models.player import Player, Race
 
 LOADOUT_PRESET_EMPTY = "empty"
-LOADOUT_PRESET_FIGHTERS = "fighters"
 LOADOUT_PRESET_TORPEDOES = "torpedoes"
 
 PLANET_DEFENSE_POST_BUCKETS = (
@@ -70,7 +69,6 @@ class ActionCatalogConfig:
     max_ship_torpedoes_per_type: int = 200
     max_fighter_transfers: int = 50
     default_ship_build_probability_weight: int = 80
-    fighter_carrier_build_probability_weight: int = 90
     torpedo_ship_build_probability_weight: int = 85
     noisy_action_probability_weight: int = 10
     fighter_transfer_probability_weight: int = 15
@@ -388,7 +386,7 @@ def _ship_build_actions(
 
     for hull_id in sorted(buildable_hull_ids):
         hull = hulls_by_id.get(hull_id)
-        if hull is None or hull.isbase:
+        if hull is None:
             continue
 
         is_warship = _is_military_hull(hull)
@@ -401,36 +399,23 @@ def _ship_build_actions(
         if build_upper_bound <= 0:
             continue
 
-        presets = [(LOADOUT_PRESET_EMPTY, config.default_ship_build_probability_weight, 0, 0)]
-        if hull.fighterbays > 0:
-            presets.append(
-                (
-                    LOADOUT_PRESET_FIGHTERS,
-                    config.fighter_carrier_build_probability_weight,
-                    hull.fighterbays,
-                    0,
-                )
-            )
+        presets: list[tuple[str, int]] = [
+            (LOADOUT_PRESET_EMPTY, config.default_ship_build_probability_weight),
+        ]
         if hull.launchers > 0 and default_torpedo is not None:
             presets.append(
-                (
-                    LOADOUT_PRESET_TORPEDOES,
-                    config.torpedo_ship_build_probability_weight,
-                    0,
-                    hull.launchers,
-                )
+                (LOADOUT_PRESET_TORPEDOES, config.torpedo_ship_build_probability_weight),
             )
 
-        for preset_id, probability_weight, initial_fighters, initial_torpedoes in presets:
+        for preset_id, probability_weight in presets:
+            armed_build = preset_id == LOADOUT_PRESET_TORPEDOES
             score_delta_2x = _ship_build_score_delta_2x(
                 hull,
                 default_engine,
                 default_beam,
                 default_torpedo,
-                beam_count=hull.beams if preset_id == LOADOUT_PRESET_TORPEDOES else 0,
-                torpedo_count=initial_torpedoes,
-                initial_fighters=initial_fighters,
-                initial_torpedoes=initial_torpedoes,
+                beam_count=hull.beams if armed_build else 0,
+                launcher_count=hull.launchers if armed_build else 0,
             )
             if score_delta_2x == 0:
                 continue
@@ -457,33 +442,25 @@ def _ship_build_score_delta_2x(
     torpedo: Torpedo | None,
     *,
     beam_count: int,
-    torpedo_count: int,
-    initial_fighters: int,
-    initial_torpedoes: int,
+    launcher_count: int,
 ) -> int:
-    construction_megacredits = hull.cost + engine.cost
-    construction_minerals = _component_minerals(hull) + _component_minerals(engine)
+    """Hull construction score only; ammo is modeled by separate catalog actions."""
+    engine_count = hull.engines
+    construction_megacredits = hull.cost + engine.cost * engine_count
+    construction_minerals = _component_minerals(hull) + _component_minerals(engine) * engine_count
 
     if beam is not None and beam_count > 0:
         construction_megacredits += beam.cost * beam_count
         construction_minerals += _component_minerals(beam) * beam_count
 
-    if torpedo is not None and torpedo_count > 0:
-        construction_megacredits += torpedo.launchercost * torpedo_count
-        construction_minerals += _component_minerals(torpedo) * torpedo_count
+    if torpedo is not None and launcher_count > 0:
+        construction_megacredits += torpedo.launchercost * launcher_count
+        construction_minerals += _component_minerals(torpedo) * launcher_count
 
-    score_delta_2x = ship_construction_score_delta_2x(
+    return ship_construction_score_delta_2x(
         construction_megacredits,
         construction_minerals,
     )
-    if initial_fighters > 0:
-        score_delta_2x += loaded_ship_fighter_score_delta_2x(initial_fighters)
-    if torpedo is not None and initial_torpedoes > 0:
-        score_delta_2x += loaded_ship_torpedo_score_delta_2x(
-            torpedo.torpedocost,
-            initial_torpedoes,
-        )
-    return score_delta_2x
 
 
 def _probability_buckets_for_action(action_id: str) -> tuple[ProbabilityBucket, ...]:

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,0 +1,295 @@
+"""Scores analytic integration for military score build inference."""
+
+from api.analytics.military_score_inference.actions import (
+    ActionCatalog,
+    build_action_catalog_from_turn,
+    build_inference_problem,
+)
+from api.analytics.military_score_inference.models import (
+    InferenceObservation,
+    InferenceResult,
+    InferenceSolution,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_INVALID_PROBLEM,
+    STATUS_NO_EXACT_SOLUTION,
+    STATUS_TIME_LIMITED,
+    solve_inference_problem,
+)
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+STATUS_NO_PRIOR_TURN = "no_prior_turn"
+STATUS_SOLVER_ERROR = "solver_error"
+
+
+def prior_turn_score_data_available(turn: TurnInfo) -> bool:
+    """Return whether this turn has a prior scoreboard row to infer from."""
+    return turn.settings.turn > 1
+
+
+def is_after_ship_limit(turn: TurnInfo, score: Score) -> bool:
+    """Return whether ship-limit queue rules apply for this player on this turn."""
+    settings = turn.settings
+    player_ships = score.capitalships + score.freighters
+    if settings.shiplimittype != 0:
+        player_limit = (
+            settings.plsminships
+            + settings.plsextraships
+            + settings.plsshipsperplanet * score.planets
+        )
+        return player_ships >= player_limit
+    total_ships = sum(
+        other_score.capitalships + other_score.freighters for other_score in turn.scores
+    )
+    return total_ships >= settings.shiplimit
+
+
+def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObservation:
+    """Build solver observation from one scoreboard row and turn context."""
+    return InferenceObservation(
+        player_id=score.ownerid,
+        turn=turn.settings.turn,
+        military_delta_2x=2 * score.militarychange,
+        warship_delta=score.shipchange,
+        freighter_delta=score.freighterchange,
+        priority_point_delta=score.prioritypointchange,
+        starbases_owned=score.starbases,
+        is_after_ship_limit=is_after_ship_limit(turn, score),
+    )
+
+
+def observation_to_constraints_payload(observation: InferenceObservation) -> dict[str, object]:
+    """Serialize hard solver constraints for diagnostics."""
+    return {
+        "turn": observation.turn,
+        "playerId": observation.player_id,
+        "militaryDelta2x": observation.military_delta_2x,
+        "warshipDelta": observation.warship_delta,
+        "freighterDelta": observation.freighter_delta,
+        "priorityPointDelta": observation.priority_point_delta,
+        "starbasesOwned": observation.starbases_owned,
+        "isAfterShipLimit": observation.is_after_ship_limit,
+        "appliedEqualities": [
+            f"sum(scoreDelta2x * count) == {observation.military_delta_2x}",
+            f"sum(warshipDelta * count) == {observation.warship_delta}",
+            f"sum(freighterDelta * count) == {observation.freighter_delta}",
+            f"sum(priorityPointDelta * count) == {observation.priority_point_delta}",
+            f"sum(buildSlotUsage * count) <= {observation.starbases_owned}",
+        ],
+    }
+
+
+def catalog_to_actions_payload(
+    catalog: ActionCatalog,
+    *,
+    turn: TurnInfo | None = None,
+    observation: InferenceObservation | None = None,
+) -> dict[str, object]:
+    """Serialize the bounded action catalog for diagnostics."""
+    ship_build_actions = [action for action in catalog.actions if action.id.startswith("build_")]
+    payload: dict[str, object] = {
+        "catalogSize": catalog.catalog_size,
+        "shipBuildActionCount": len(ship_build_actions),
+        "actions": [
+            {
+                "id": action.id,
+                "label": action.label,
+                "scoreDelta2x": action.score_delta_2x,
+                "warshipDelta": action.warship_delta,
+                "freighterDelta": action.freighter_delta,
+                "priorityPointDelta": action.priority_point_delta,
+                "buildSlotUsage": action.build_slot_usage,
+                "lowerBound": action.lower_bound,
+                "upperBound": action.upper_bound,
+                "probabilityWeight": action.probability_weight,
+            }
+            for action in catalog.actions
+        ],
+        "shipBuildActions": [
+            {
+                "id": action.id,
+                "label": action.label,
+                "upperBound": action.upper_bound,
+                "scoreDelta2x": action.score_delta_2x,
+            }
+            for action in ship_build_actions
+        ],
+    }
+    if turn is not None and observation is not None:
+        from api.analytics.military_score_inference.actions import buildable_hull_ids_for_player
+
+        buildable_hull_ids = buildable_hull_ids_for_player(turn, observation.player_id)
+        hulls_by_id = {hull.id: hull for hull in turn.hulls}
+        buildable_starship_hull_ids = sorted(
+            hull_id for hull_id in buildable_hull_ids if hull_id in hulls_by_id
+        )
+        payload["meta"] = {
+            "buildableHullIds": sorted(buildable_hull_ids),
+            "buildableStarshipHullIds": buildable_starship_hull_ids,
+            "buildableHullIdsMissingFromCatalog": sorted(
+                hull_id for hull_id in buildable_hull_ids if hull_id not in hulls_by_id
+            ),
+            "shipBuildActionIds": [action.id for action in ship_build_actions],
+        }
+    return payload
+
+
+def build_inference_solver_diagnostics(
+    *,
+    turn: int,
+    observation: InferenceObservation | None = None,
+    catalog: ActionCatalog | None = None,
+    turn_info: TurnInfo | None = None,
+    solver: dict[str, object] | None = None,
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Structured solver diagnostics for the diagnostics panel."""
+    payload: dict[str, object] = {"turn": turn}
+    if observation is not None:
+        payload["constraints"] = observation_to_constraints_payload(observation)
+    if catalog is not None:
+        payload["actionCatalog"] = catalog_to_actions_payload(
+            catalog,
+            turn=turn_info,
+            observation=observation,
+        )
+        payload.update(catalog.diagnostics())
+    if solver is not None:
+        payload["solver"] = solver
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object]:
+    """Run build inference for one scoreboard row, isolating failures to that row."""
+    turn_number = turn.settings.turn
+    if not prior_turn_score_data_available(turn):
+        observation = build_inference_observation(score, turn)
+        return _inference_api_payload(
+            status=STATUS_NO_PRIOR_TURN,
+            summary="Prior turn score data unavailable",
+            solutions=(),
+            diagnostics=build_inference_solver_diagnostics(
+                turn=turn_number,
+                observation=observation,
+                turn_info=turn,
+                extra={"reason": "first_turn"},
+            ),
+        )
+
+    observation = build_inference_observation(score, turn)
+    catalog: ActionCatalog | None = None
+    try:
+        catalog = build_action_catalog_from_turn(observation, turn)
+        problem = build_inference_problem(observation, catalog)
+        result = solve_inference_problem(problem)
+        return inference_result_to_api_payload(result, catalog, observation, turn)
+    except Exception as exc:
+        return _inference_api_payload(
+            status=STATUS_SOLVER_ERROR,
+            summary="Build inference failed",
+            solutions=(),
+            diagnostics=build_inference_solver_diagnostics(
+                turn=turn_number,
+                observation=observation,
+                catalog=catalog,
+                turn_info=turn,
+                extra={"error": str(exc)},
+            ),
+        )
+
+
+def inference_result_to_api_payload(
+    result: InferenceResult,
+    catalog: ActionCatalog,
+    observation: InferenceObservation,
+    turn: TurnInfo,
+) -> dict[str, object]:
+    """Shape a solver result into the Core scores row inference object."""
+    solver_diagnostics = {
+        "status": result.status,
+        **result.diagnostics,
+    }
+    diagnostics = build_inference_solver_diagnostics(
+        turn=turn.settings.turn,
+        observation=observation,
+        catalog=catalog,
+        turn_info=turn,
+        solver=solver_diagnostics,
+    )
+    return _inference_api_payload(
+        status=result.status,
+        summary=format_inference_summary(result),
+        solutions=result.solutions,
+        diagnostics=diagnostics,
+    )
+
+
+def format_inference_summary(result: InferenceResult) -> str:
+    """Return compact row-level summary text for the inference column."""
+    if result.status == STATUS_NO_PRIOR_TURN:
+        return "Prior turn score data unavailable"
+    if result.status == STATUS_INVALID_PROBLEM:
+        reason = result.diagnostics.get("reason")
+        if isinstance(reason, str) and reason:
+            return f"Invalid inference problem: {reason}"
+        return "Invalid inference problem"
+    if result.status == STATUS_NO_EXACT_SOLUTION:
+        return "No feasible build explanation found"
+    if result.status == STATUS_SOLVER_ERROR:
+        return "Build inference failed"
+    if result.status == STATUS_TIME_LIMITED and not result.solutions:
+        return "Inference timed out before finding a solution"
+    if not result.solutions:
+        return "No feasible build explanation found"
+
+    best_summary = _format_solution_brief(result.solutions[0])
+    alternative_count = len(result.solutions) - 1
+    if alternative_count == 0:
+        return f"Best: {best_summary}"
+    if alternative_count == 1:
+        return f"Best: {best_summary}; 1 alternative"
+    return f"Best: {best_summary}; {alternative_count} alternatives"
+
+
+def _format_solution_brief(solution: InferenceSolution) -> str:
+    parts: list[str] = []
+    for action in solution.actions:
+        if action.count == 1:
+            parts.append(action.label)
+        else:
+            parts.append(f"{action.count}x {action.label}")
+    return "; ".join(parts) if parts else "no actions"
+
+
+def _inference_api_payload(
+    *,
+    status: str,
+    summary: str,
+    solutions: tuple[InferenceSolution, ...],
+    diagnostics: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "summary": summary,
+        "solutionCount": len(solutions),
+        "isComplete": status != STATUS_TIME_LIMITED,
+        "solutions": [_serialize_solution(solution) for solution in solutions],
+        "diagnostics": diagnostics,
+    }
+
+
+def _serialize_solution(solution: InferenceSolution) -> dict[str, object]:
+    return {
+        "objectiveValue": solution.objective_value,
+        "actions": [
+            {
+                "actionId": action.action_id,
+                "label": action.label,
+                "count": action.count,
+            }
+            for action in solution.actions
+        ],
+    }

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -59,25 +59,43 @@ def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObserv
     )
 
 
-def observation_to_constraints_payload(observation: InferenceObservation) -> dict[str, object]:
+_PRIORITY_POINT_DIAGNOSTIC_NOTE = (
+    "Priority-point equality is not a hard solver constraint until production-queue "
+    "semantics assign per-build priority_point_delta values."
+)
+
+
+def observation_to_constraints_payload(
+    observation: InferenceObservation,
+    *,
+    enforce_priority_point_constraint: bool = False,
+) -> dict[str, object]:
     """Serialize hard solver constraints for diagnostics."""
-    return {
+    applied_equalities = [
+        f"sum(scoreDelta2x * count) == {observation.military_delta_2x}",
+        f"sum(warshipDelta * count) == {observation.warship_delta}",
+        f"sum(freighterDelta * count) == {observation.freighter_delta}",
+    ]
+    if enforce_priority_point_constraint:
+        applied_equalities.append(
+            f"sum(priorityPointDelta * count) == {observation.priority_point_delta}"
+        )
+    applied_equalities.append(f"sum(buildSlotUsage * count) <= {observation.starbases_owned}")
+    payload: dict[str, object] = {
         "turn": observation.turn,
         "playerId": observation.player_id,
         "militaryDelta2x": observation.military_delta_2x,
         "warshipDelta": observation.warship_delta,
         "freighterDelta": observation.freighter_delta,
-        "priorityPointDelta": observation.priority_point_delta,
+        "requestedPriorityPointDelta": observation.priority_point_delta,
+        "priorityPointConstraintEnforced": enforce_priority_point_constraint,
         "starbasesOwned": observation.starbases_owned,
         "isAfterShipLimit": observation.is_after_ship_limit,
-        "appliedEqualities": [
-            f"sum(scoreDelta2x * count) == {observation.military_delta_2x}",
-            f"sum(warshipDelta * count) == {observation.warship_delta}",
-            f"sum(freighterDelta * count) == {observation.freighter_delta}",
-            f"sum(priorityPointDelta * count) == {observation.priority_point_delta}",
-            f"sum(buildSlotUsage * count) <= {observation.starbases_owned}",
-        ],
+        "appliedEqualities": applied_equalities,
     }
+    if not enforce_priority_point_constraint:
+        payload["priorityPointConstraintNote"] = _PRIORITY_POINT_DIAGNOSTIC_NOTE
+    return payload
 
 
 def catalog_to_actions_payload(
@@ -143,11 +161,15 @@ def build_inference_solver_diagnostics(
     turn_info: TurnInfo | None = None,
     solver: dict[str, object] | None = None,
     extra: dict[str, object] | None = None,
+    enforce_priority_point_constraint: bool = False,
 ) -> dict[str, object]:
     """Structured solver diagnostics for the diagnostics panel."""
     payload: dict[str, object] = {"turn": turn}
     if observation is not None:
-        payload["constraints"] = observation_to_constraints_payload(observation)
+        payload["constraints"] = observation_to_constraints_payload(
+            observation,
+            enforce_priority_point_constraint=enforce_priority_point_constraint,
+        )
     if catalog is not None:
         payload["actionCatalog"] = catalog_to_actions_payload(
             catalog,
@@ -185,7 +207,13 @@ def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object
         catalog = build_action_catalog_from_turn(observation, turn)
         problem = build_inference_problem(observation, catalog)
         result = solve_inference_problem(problem)
-        return inference_result_to_api_payload(result, catalog, observation, turn)
+        return inference_result_to_api_payload(
+            result,
+            catalog,
+            observation,
+            turn,
+            enforce_priority_point_constraint=problem.enforce_priority_point_constraint,
+        )
     except Exception as exc:
         return _inference_api_payload(
             status=STATUS_SOLVER_ERROR,
@@ -206,6 +234,8 @@ def inference_result_to_api_payload(
     catalog: ActionCatalog,
     observation: InferenceObservation,
     turn: TurnInfo,
+    *,
+    enforce_priority_point_constraint: bool = False,
 ) -> dict[str, object]:
     """Shape a solver result into the Core scores row inference object."""
     solver_diagnostics = {
@@ -218,6 +248,7 @@ def inference_result_to_api_payload(
         catalog=catalog,
         turn_info=turn,
         solver=solver_diagnostics,
+        enforce_priority_point_constraint=enforce_priority_point_constraint,
     )
     return _inference_api_payload(
         status=result.status,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -5,8 +5,13 @@ from api.analytics.military_score_inference.actions import (
     build_action_catalog_from_turn,
     build_inference_problem,
 )
+from api.analytics.military_score_inference.constraints import (
+    InferenceHardConstraints,
+    observation_to_constraints_payload,
+)
 from api.analytics.military_score_inference.models import (
     InferenceObservation,
+    InferenceProblem,
     InferenceResult,
     InferenceSolution,
 )
@@ -57,45 +62,6 @@ def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObserv
         starbases_owned=score.starbases,
         is_after_ship_limit=is_after_ship_limit(turn, score),
     )
-
-
-_PRIORITY_POINT_DIAGNOSTIC_NOTE = (
-    "Priority-point equality is not a hard solver constraint until production-queue "
-    "semantics assign per-build priority_point_delta values."
-)
-
-
-def observation_to_constraints_payload(
-    observation: InferenceObservation,
-    *,
-    enforce_priority_point_constraint: bool = False,
-) -> dict[str, object]:
-    """Serialize hard solver constraints for diagnostics."""
-    applied_equalities = [
-        f"sum(scoreDelta2x * count) == {observation.military_delta_2x}",
-        f"sum(warshipDelta * count) == {observation.warship_delta}",
-        f"sum(freighterDelta * count) == {observation.freighter_delta}",
-    ]
-    if enforce_priority_point_constraint:
-        applied_equalities.append(
-            f"sum(priorityPointDelta * count) == {observation.priority_point_delta}"
-        )
-    applied_equalities.append(f"sum(buildSlotUsage * count) <= {observation.starbases_owned}")
-    payload: dict[str, object] = {
-        "turn": observation.turn,
-        "playerId": observation.player_id,
-        "militaryDelta2x": observation.military_delta_2x,
-        "warshipDelta": observation.warship_delta,
-        "freighterDelta": observation.freighter_delta,
-        "requestedPriorityPointDelta": observation.priority_point_delta,
-        "priorityPointConstraintEnforced": enforce_priority_point_constraint,
-        "starbasesOwned": observation.starbases_owned,
-        "isAfterShipLimit": observation.is_after_ship_limit,
-        "appliedEqualities": applied_equalities,
-    }
-    if not enforce_priority_point_constraint:
-        payload["priorityPointConstraintNote"] = _PRIORITY_POINT_DIAGNOSTIC_NOTE
-    return payload
 
 
 def catalog_to_actions_payload(
@@ -157,18 +123,23 @@ def build_inference_solver_diagnostics(
     *,
     turn: int,
     observation: InferenceObservation | None = None,
+    problem: InferenceProblem | None = None,
     catalog: ActionCatalog | None = None,
     turn_info: TurnInfo | None = None,
     solver: dict[str, object] | None = None,
     extra: dict[str, object] | None = None,
-    enforce_priority_point_constraint: bool = False,
 ) -> dict[str, object]:
     """Structured solver diagnostics for the diagnostics panel."""
     payload: dict[str, object] = {"turn": turn}
     if observation is not None:
+        hard_constraints = (
+            InferenceHardConstraints.from_problem(problem)
+            if problem is not None
+            else InferenceHardConstraints()
+        )
         payload["constraints"] = observation_to_constraints_payload(
             observation,
-            enforce_priority_point_constraint=enforce_priority_point_constraint,
+            hard_constraints=hard_constraints,
         )
     if catalog is not None:
         payload["actionCatalog"] = catalog_to_actions_payload(
@@ -207,13 +178,7 @@ def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object
         catalog = build_action_catalog_from_turn(observation, turn)
         problem = build_inference_problem(observation, catalog)
         result = solve_inference_problem(problem)
-        return inference_result_to_api_payload(
-            result,
-            catalog,
-            observation,
-            turn,
-            enforce_priority_point_constraint=problem.enforce_priority_point_constraint,
-        )
+        return inference_result_to_api_payload(result, catalog, observation, turn, problem)
     except Exception as exc:
         return _inference_api_payload(
             status=STATUS_SOLVER_ERROR,
@@ -234,8 +199,7 @@ def inference_result_to_api_payload(
     catalog: ActionCatalog,
     observation: InferenceObservation,
     turn: TurnInfo,
-    *,
-    enforce_priority_point_constraint: bool = False,
+    problem: InferenceProblem,
 ) -> dict[str, object]:
     """Shape a solver result into the Core scores row inference object."""
     solver_diagnostics = {
@@ -245,10 +209,10 @@ def inference_result_to_api_payload(
     diagnostics = build_inference_solver_diagnostics(
         turn=turn.settings.turn,
         observation=observation,
+        problem=problem,
         catalog=catalog,
         turn_info=turn,
         solver=solver_diagnostics,
-        enforce_priority_point_constraint=enforce_priority_point_constraint,
     )
     return _inference_api_payload(
         status=result.status,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -15,6 +15,9 @@ from api.analytics.military_score_inference.models import (
     InferenceResult,
     InferenceSolution,
 )
+from api.analytics.military_score_inference.score_arithmetic import (
+    solution_military_score_arithmetic_payload,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
@@ -219,6 +222,8 @@ def inference_result_to_api_payload(
         summary=format_inference_summary(result),
         solutions=result.solutions,
         diagnostics=diagnostics,
+        observation=observation,
+        catalog=catalog,
     )
 
 
@@ -265,18 +270,48 @@ def _inference_api_payload(
     summary: str,
     solutions: tuple[InferenceSolution, ...],
     diagnostics: dict[str, object],
+    observation: InferenceObservation | None = None,
+    catalog: ActionCatalog | None = None,
 ) -> dict[str, object]:
     return {
         "status": status,
         "summary": summary,
         "solutionCount": len(solutions),
         "isComplete": status != STATUS_TIME_LIMITED,
-        "solutions": [_serialize_solution(solution) for solution in solutions],
+        "solutions": (
+            [_serialize_solution(solution, observation, catalog) for solution in solutions]
+            if observation is not None and catalog is not None
+            else [_serialize_solution_without_arithmetic(solution) for solution in solutions]
+        ),
         "diagnostics": diagnostics,
     }
 
 
-def _serialize_solution(solution: InferenceSolution) -> dict[str, object]:
+def _serialize_solution(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> dict[str, object]:
+    actions_by_id = {action.id: action for action in catalog.actions}
+    return {
+        "objectiveValue": solution.objective_value,
+        "actions": [
+            {
+                "actionId": action.action_id,
+                "label": action.label,
+                "count": action.count,
+            }
+            for action in solution.actions
+        ],
+        "militaryScoreArithmetic": solution_military_score_arithmetic_payload(
+            solution,
+            observation,
+            actions_by_id,
+        ),
+    }
+
+
+def _serialize_solution_without_arithmetic(solution: InferenceSolution) -> dict[str, object]:
     return {
         "objectiveValue": solution.objective_value,
         "actions": [

--- a/packages/api/api/analytics/military_score_inference/constraints.py
+++ b/packages/api/api/analytics/military_score_inference/constraints.py
@@ -1,0 +1,121 @@
+"""Hard CP-SAT constraints and matching diagnostics for military score build inference."""
+
+from dataclasses import dataclass
+
+from ortools.sat.python import cp_model
+
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+)
+
+PRIORITY_POINT_DIAGNOSTIC_NOTE = (
+    "Priority-point equality is not a hard solver constraint until production-queue "
+    "semantics assign per-build priority_point_delta values."
+)
+
+
+@dataclass(frozen=True)
+class _SumEqualityConstraint:
+    diagnostic_label: str
+    observation_attr: str
+    coefficient_attr: str
+
+    def applied_equality_string(self, observation: InferenceObservation) -> str:
+        rhs = getattr(observation, self.observation_attr)
+        return f"sum({self.diagnostic_label} * count) == {rhs}"
+
+    def add_to_model(
+        self,
+        model: cp_model.CpModel,
+        actions: tuple[CandidateAction, ...],
+        count_vars: dict[str, cp_model.IntVar],
+        observation: InferenceObservation,
+    ) -> None:
+        rhs = getattr(observation, self.observation_attr)
+        model.add(
+            sum(
+                getattr(action, self.coefficient_attr) * count_vars[action.id] for action in actions
+            )
+            == rhs
+        )
+
+
+_MILITARY_SCORE_EQUALITY = _SumEqualityConstraint(
+    "scoreDelta2x", "military_delta_2x", "score_delta_2x"
+)
+_WARSHIP_EQUALITY = _SumEqualityConstraint("warshipDelta", "warship_delta", "warship_delta")
+_FREIGHTER_EQUALITY = _SumEqualityConstraint("freighterDelta", "freighter_delta", "freighter_delta")
+_PRIORITY_POINT_EQUALITY = _SumEqualityConstraint(
+    "priorityPointDelta", "priority_point_delta", "priority_point_delta"
+)
+
+_ALWAYS_ENFORCED_EQUALITIES = (
+    _MILITARY_SCORE_EQUALITY,
+    _WARSHIP_EQUALITY,
+    _FREIGHTER_EQUALITY,
+)
+
+
+@dataclass(frozen=True)
+class InferenceHardConstraints:
+    """Which hard equalities and inequalities apply for one inference solve."""
+
+    enforce_priority_point_constraint: bool = False
+
+    @classmethod
+    def from_problem(cls, problem: InferenceProblem) -> InferenceHardConstraints:
+        return cls(enforce_priority_point_constraint=problem.enforce_priority_point_constraint)
+
+    def enforced_equalities(self) -> tuple[_SumEqualityConstraint, ...]:
+        if self.enforce_priority_point_constraint:
+            return _ALWAYS_ENFORCED_EQUALITIES + (_PRIORITY_POINT_EQUALITY,)
+        return _ALWAYS_ENFORCED_EQUALITIES
+
+    def applied_equalities(self, observation: InferenceObservation) -> list[str]:
+        strings = [
+            constraint.applied_equality_string(observation)
+            for constraint in self.enforced_equalities()
+        ]
+        strings.append(f"sum(buildSlotUsage * count) <= {observation.starbases_owned}")
+        return strings
+
+    def add_to_model(
+        self,
+        model: cp_model.CpModel,
+        problem: InferenceProblem,
+        count_vars: dict[str, cp_model.IntVar],
+    ) -> None:
+        observation = problem.observation
+        actions = problem.actions
+        for constraint in self.enforced_equalities():
+            constraint.add_to_model(model, actions, count_vars, observation)
+        model.add(
+            sum(action.build_slot_usage * count_vars[action.id] for action in actions)
+            <= observation.starbases_owned
+        )
+
+
+def observation_to_constraints_payload(
+    observation: InferenceObservation,
+    *,
+    hard_constraints: InferenceHardConstraints | None = None,
+) -> dict[str, object]:
+    """Serialize hard solver constraints for diagnostics."""
+    constraints = hard_constraints or InferenceHardConstraints()
+    payload: dict[str, object] = {
+        "turn": observation.turn,
+        "playerId": observation.player_id,
+        "militaryDelta2x": observation.military_delta_2x,
+        "warshipDelta": observation.warship_delta,
+        "freighterDelta": observation.freighter_delta,
+        "requestedPriorityPointDelta": observation.priority_point_delta,
+        "priorityPointConstraintEnforced": constraints.enforce_priority_point_constraint,
+        "starbasesOwned": observation.starbases_owned,
+        "isAfterShipLimit": observation.is_after_ship_limit,
+        "appliedEqualities": constraints.applied_equalities(observation),
+    }
+    if not constraints.enforce_priority_point_constraint:
+        payload["priorityPointConstraintNote"] = PRIORITY_POINT_DIAGNOSTIC_NOTE
+    return payload

--- a/packages/api/api/analytics/military_score_inference/models.py
+++ b/packages/api/api/analytics/military_score_inference/models.py
@@ -1,0 +1,66 @@
+"""Data contracts for military score build inference."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InferenceObservation:
+    player_id: int
+    turn: int
+    military_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    priority_point_delta: int
+    starbases_owned: int
+    is_after_ship_limit: bool
+
+
+@dataclass(frozen=True)
+class CandidateAction:
+    id: str
+    label: str
+    score_delta_2x: int
+    warship_delta: int = 0
+    freighter_delta: int = 0
+    priority_point_delta: int = 0
+    build_slot_usage: int = 0
+    lower_bound: int = 0
+    upper_bound: int = 0
+    probability_weight: int = 0
+
+
+@dataclass(frozen=True)
+class ProbabilityBucket:
+    label: str
+    lower_count: int
+    upper_count: int
+    marginal_weight: int
+
+
+@dataclass(frozen=True)
+class InferenceProblem:
+    observation: InferenceObservation
+    actions: tuple[CandidateAction, ...]
+    probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
+    max_solutions: int = 20
+    time_limit_seconds: float = 1.0
+
+
+@dataclass(frozen=True)
+class InferenceSolutionAction:
+    action_id: str
+    label: str
+    count: int
+
+
+@dataclass(frozen=True)
+class InferenceSolution:
+    objective_value: int
+    actions: tuple[InferenceSolutionAction, ...]
+
+
+@dataclass(frozen=True)
+class InferenceResult:
+    status: str
+    solutions: tuple[InferenceSolution, ...]
+    diagnostics: dict[str, object]

--- a/packages/api/api/analytics/military_score_inference/models.py
+++ b/packages/api/api/analytics/military_score_inference/models.py
@@ -44,6 +44,7 @@ class InferenceProblem:
     probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
     max_solutions: int = 20
     time_limit_seconds: float = 1.0
+    enforce_priority_point_constraint: bool = False
 
 
 @dataclass(frozen=True)

--- a/packages/api/api/analytics/military_score_inference/score_arithmetic.py
+++ b/packages/api/api/analytics/military_score_inference/score_arithmetic.py
@@ -1,0 +1,48 @@
+"""Per-solution military score arithmetic for inference API payloads."""
+
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceSolution,
+)
+
+
+def solution_military_score_arithmetic_payload(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    actions_by_id: dict[str, CandidateAction],
+) -> dict[str, object]:
+    """Explain how solution action counts sum to the observed military score delta."""
+    line_items: list[dict[str, object]] = []
+    explained_military_delta_2x = 0
+    for solution_action in solution.actions:
+        if solution_action.count == 0:
+            continue
+        catalog_action = actions_by_id.get(solution_action.action_id)
+        score_delta_2x_per_unit = catalog_action.score_delta_2x if catalog_action is not None else 0
+        subtotal_score_delta_2x = score_delta_2x_per_unit * solution_action.count
+        explained_military_delta_2x += subtotal_score_delta_2x
+        military_change_per_unit = score_delta_2x_per_unit // 2
+        line_items.append(
+            {
+                "actionId": solution_action.action_id,
+                "label": solution_action.label,
+                "count": solution_action.count,
+                "scoreDelta2xPerUnit": score_delta_2x_per_unit,
+                "militaryChangePerUnit": military_change_per_unit,
+                "scoreDelta2xSubtotal": subtotal_score_delta_2x,
+                "militaryChangeSubtotal": subtotal_score_delta_2x // 2,
+            }
+        )
+
+    observed_military_delta_2x = observation.military_delta_2x
+    observed_military_change = observed_military_delta_2x // 2
+    explained_military_change = explained_military_delta_2x // 2
+    return {
+        "observedMilitaryChange": observed_military_change,
+        "observedMilitaryDelta2x": observed_military_delta_2x,
+        "explainedMilitaryChange": explained_military_change,
+        "explainedMilitaryDelta2x": explained_military_delta_2x,
+        "matchesObserved": explained_military_delta_2x == observed_military_delta_2x,
+        "lineItems": line_items,
+    }

--- a/packages/api/api/analytics/military_score_inference/scoring.py
+++ b/packages/api/api/analytics/military_score_inference/scoring.py
@@ -1,0 +1,44 @@
+"""Scaled military-score contribution helpers for build inference."""
+
+LOADED_SHIP_FIGHTER_SCORE_DELTA_2X = 250
+STARBASE_FIGHTER_SCORE_DELTA_2X = 125
+STARBASE_DEFENSE_POST_SCORE_DELTA_2X = 15
+PLANET_DEFENSE_POST_SCORE_DELTA_2X = 11
+
+
+def construction_value(megacredits: int, minerals: int) -> int:
+    """AutoScore-style construction value: megacredits plus five times minerals."""
+    return megacredits + 5 * minerals
+
+
+def ship_construction_score_delta_2x(
+    construction_megacredits: int,
+    construction_minerals: int,
+) -> int:
+    """Scaled military-score delta for one ship hull plus fitted components."""
+    return 2 * construction_value(construction_megacredits, construction_minerals)
+
+
+def loaded_ship_fighter_score_delta_2x(count: int = 1) -> int:
+    """Scaled score delta for fighters loaded onto ships (full military value)."""
+    return LOADED_SHIP_FIGHTER_SCORE_DELTA_2X * count
+
+
+def loaded_ship_torpedo_score_delta_2x(torpedo_megacredits: int, count: int = 1) -> int:
+    """Scaled score delta for torpedoes loaded onto ships."""
+    return 2 * torpedo_megacredits * count
+
+
+def starbase_fighter_score_delta_2x(count: int = 1) -> int:
+    """Scaled score delta for starbase fighters (half military value)."""
+    return STARBASE_FIGHTER_SCORE_DELTA_2X * count
+
+
+def starbase_defense_post_score_delta_2x(count: int = 1) -> int:
+    """Scaled score delta for starbase defense posts (half military value)."""
+    return STARBASE_DEFENSE_POST_SCORE_DELTA_2X * count
+
+
+def planet_defense_post_score_delta_2x(count: int = 1) -> int:
+    """Scaled score delta for planetary defense posts (half military value)."""
+    return PLANET_DEFENSE_POST_SCORE_DELTA_2X * count

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -1,0 +1,142 @@
+"""OR-Tools CP-SAT adapter for military score build inference."""
+
+from ortools.sat.python import cp_model
+
+from api.analytics.military_score_inference.models import (
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+    InferenceSolutionAction,
+)
+
+STATUS_EXACT = "exact"
+STATUS_INVALID_PROBLEM = "invalid_problem"
+STATUS_NO_EXACT_SOLUTION = "no_exact_solution"
+
+
+def _validate_problem(problem: InferenceProblem) -> str | None:
+    seen_action_ids: set[str] = set()
+    for action in problem.actions:
+        if action.id in seen_action_ids:
+            return f"duplicate action id: {action.id}"
+        seen_action_ids.add(action.id)
+        if action.lower_bound < 0:
+            return f"action {action.id} has negative lower_bound"
+        if action.lower_bound > action.upper_bound:
+            return f"action {action.id} has lower_bound greater than upper_bound"
+    return None
+
+
+def _observation_has_no_deltas(problem: InferenceProblem) -> bool:
+    observation = problem.observation
+    return (
+        observation.military_delta_2x == 0
+        and observation.warship_delta == 0
+        and observation.freighter_delta == 0
+        and observation.priority_point_delta == 0
+    )
+
+
+def _extract_solution(
+    problem: InferenceProblem,
+    count_vars: dict[str, cp_model.IntVar],
+    solver: cp_model.CpSolver,
+) -> InferenceSolution:
+    solution_actions: list[InferenceSolutionAction] = []
+    objective_value = 0
+    for action in problem.actions:
+        count = solver.value(count_vars[action.id])
+        if count == 0:
+            continue
+        solution_actions.append(
+            InferenceSolutionAction(
+                action_id=action.id,
+                label=action.label,
+                count=count,
+            )
+        )
+        objective_value += action.probability_weight * count
+    return InferenceSolution(
+        objective_value=objective_value,
+        actions=tuple(solution_actions),
+    )
+
+
+def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
+    """Return one exact feasible solution when one exists, otherwise a structured status."""
+    validation_error = _validate_problem(problem)
+    if validation_error is not None:
+        return InferenceResult(
+            status=STATUS_INVALID_PROBLEM,
+            solutions=(),
+            diagnostics={"reason": validation_error},
+        )
+
+    if not problem.actions:
+        if _observation_has_no_deltas(problem):
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(InferenceSolution(objective_value=0, actions=()),),
+                diagnostics={"solver_status": "NO_ACTIONS"},
+            )
+        return InferenceResult(
+            status=STATUS_NO_EXACT_SOLUTION,
+            solutions=(),
+            diagnostics={"reason": "no candidate actions for non-zero observation deltas"},
+        )
+
+    model = cp_model.CpModel()
+    count_vars = {
+        action.id: model.new_int_var(action.lower_bound, action.upper_bound, action.id)
+        for action in problem.actions
+    }
+    observation = problem.observation
+
+    model.add(
+        sum(action.score_delta_2x * count_vars[action.id] for action in problem.actions)
+        == observation.military_delta_2x
+    )
+    model.add(
+        sum(action.warship_delta * count_vars[action.id] for action in problem.actions)
+        == observation.warship_delta
+    )
+    model.add(
+        sum(action.freighter_delta * count_vars[action.id] for action in problem.actions)
+        == observation.freighter_delta
+    )
+    model.add(
+        sum(action.priority_point_delta * count_vars[action.id] for action in problem.actions)
+        == observation.priority_point_delta
+    )
+    model.add(
+        sum(action.build_slot_usage * count_vars[action.id] for action in problem.actions)
+        <= observation.starbases_owned
+    )
+
+    model.maximize(
+        sum(action.probability_weight * count_vars[action.id] for action in problem.actions)
+    )
+
+    solver = cp_model.CpSolver()
+    solver.parameters.max_time_in_seconds = problem.time_limit_seconds
+    solver_status = solver.solve(model)
+
+    if solver_status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        solution = _extract_solution(problem, count_vars, solver)
+        return InferenceResult(
+            status=STATUS_EXACT,
+            solutions=(solution,),
+            diagnostics={
+                "solver_status": solver.status_name(solver_status),
+                "wall_time_seconds": solver.wall_time,
+            },
+        )
+
+    return InferenceResult(
+        status=STATUS_NO_EXACT_SOLUTION,
+        solutions=(),
+        diagnostics={
+            "solver_status": solver.status_name(solver_status),
+            "wall_time_seconds": solver.wall_time,
+        },
+    )

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -1,5 +1,7 @@
 """OR-Tools CP-SAT adapter for military score build inference."""
 
+import time
+
 from ortools.sat.python import cp_model
 
 from api.analytics.military_score_inference.models import (
@@ -12,6 +14,9 @@ from api.analytics.military_score_inference.models import (
 STATUS_EXACT = "exact"
 STATUS_INVALID_PROBLEM = "invalid_problem"
 STATUS_NO_EXACT_SOLUTION = "no_exact_solution"
+STATUS_TIME_LIMITED = "time_limited"
+
+_SUCCESS_STATUSES = (cp_model.OPTIMAL, cp_model.FEASIBLE)
 
 
 def _validate_problem(problem: InferenceProblem) -> str | None:
@@ -37,54 +42,9 @@ def _observation_has_no_deltas(problem: InferenceProblem) -> bool:
     )
 
 
-def _extract_solution(
+def _build_model(
     problem: InferenceProblem,
-    count_vars: dict[str, cp_model.IntVar],
-    solver: cp_model.CpSolver,
-) -> InferenceSolution:
-    solution_actions: list[InferenceSolutionAction] = []
-    objective_value = 0
-    for action in problem.actions:
-        count = solver.value(count_vars[action.id])
-        if count == 0:
-            continue
-        solution_actions.append(
-            InferenceSolutionAction(
-                action_id=action.id,
-                label=action.label,
-                count=count,
-            )
-        )
-        objective_value += action.probability_weight * count
-    return InferenceSolution(
-        objective_value=objective_value,
-        actions=tuple(solution_actions),
-    )
-
-
-def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
-    """Return one exact feasible solution when one exists, otherwise a structured status."""
-    validation_error = _validate_problem(problem)
-    if validation_error is not None:
-        return InferenceResult(
-            status=STATUS_INVALID_PROBLEM,
-            solutions=(),
-            diagnostics={"reason": validation_error},
-        )
-
-    if not problem.actions:
-        if _observation_has_no_deltas(problem):
-            return InferenceResult(
-                status=STATUS_EXACT,
-                solutions=(InferenceSolution(objective_value=0, actions=()),),
-                diagnostics={"solver_status": "NO_ACTIONS"},
-            )
-        return InferenceResult(
-            status=STATUS_NO_EXACT_SOLUTION,
-            solutions=(),
-            diagnostics={"reason": "no candidate actions for non-zero observation deltas"},
-        )
-
+) -> tuple[cp_model.CpModel, dict[str, cp_model.IntVar]]:
     model = cp_model.CpModel()
     count_vars = {
         action.id: model.new_int_var(action.lower_bound, action.upper_bound, action.id)
@@ -112,31 +72,153 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
         sum(action.build_slot_usage * count_vars[action.id] for action in problem.actions)
         <= observation.starbases_owned
     )
-
     model.maximize(
         sum(action.probability_weight * count_vars[action.id] for action in problem.actions)
     )
+    return model, count_vars
 
-    solver = cp_model.CpSolver()
-    solver.parameters.max_time_in_seconds = problem.time_limit_seconds
-    solver_status = solver.solve(model)
 
-    if solver_status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
-        solution = _extract_solution(problem, count_vars, solver)
+def _read_action_counts(
+    problem: InferenceProblem,
+    count_vars: dict[str, cp_model.IntVar],
+    solver: cp_model.CpSolver,
+) -> dict[str, int]:
+    return {action.id: solver.value(count_vars[action.id]) for action in problem.actions}
+
+
+def _extract_solution(
+    problem: InferenceProblem,
+    action_counts: dict[str, int],
+) -> InferenceSolution:
+    action_by_id = {action.id: action for action in problem.actions}
+    solution_actions: list[InferenceSolutionAction] = []
+    objective_value = 0
+    for action_id, count in action_counts.items():
+        if count == 0:
+            continue
+        action = action_by_id[action_id]
+        solution_actions.append(
+            InferenceSolutionAction(
+                action_id=action.id,
+                label=action.label,
+                count=count,
+            )
+        )
+        objective_value += action.probability_weight * count
+    return InferenceSolution(
+        objective_value=objective_value,
+        actions=tuple(solution_actions),
+    )
+
+
+def _add_no_good_cut(
+    model: cp_model.CpModel,
+    count_vars: dict[str, cp_model.IntVar],
+    action_counts: dict[str, int],
+    cut_index: int,
+) -> None:
+    differs: list[cp_model.IntVar] = []
+    for action_id, previous_count in action_counts.items():
+        differs_from_previous = model.new_bool_var(f"diff_{cut_index}_{action_id}")
+        model.add(count_vars[action_id] != previous_count).only_enforce_if(differs_from_previous)
+        model.add(count_vars[action_id] == previous_count).only_enforce_if(
+            differs_from_previous.Not()
+        )
+        differs.append(differs_from_previous)
+    model.add_at_least_one(differs)
+
+
+def _solution_signature(solution: InferenceSolution) -> tuple[tuple[str, int], ...]:
+    counts = ((action.action_id, action.count) for action in solution.actions)
+    return tuple(sorted(counts))
+
+
+def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
+    """Return up to max_solutions ranked feasible explanations for one player turn."""
+    validation_error = _validate_problem(problem)
+    if validation_error is not None:
         return InferenceResult(
-            status=STATUS_EXACT,
-            solutions=(solution,),
-            diagnostics={
-                "solver_status": solver.status_name(solver_status),
-                "wall_time_seconds": solver.wall_time,
-            },
+            status=STATUS_INVALID_PROBLEM,
+            solutions=(),
+            diagnostics={"reason": validation_error},
         )
 
-    return InferenceResult(
-        status=STATUS_NO_EXACT_SOLUTION,
-        solutions=(),
-        diagnostics={
-            "solver_status": solver.status_name(solver_status),
-            "wall_time_seconds": solver.wall_time,
-        },
-    )
+    if not problem.actions:
+        if _observation_has_no_deltas(problem):
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(InferenceSolution(objective_value=0, actions=()),),
+                diagnostics={"solver_status": "NO_ACTIONS", "solution_count": 1},
+            )
+        return InferenceResult(
+            status=STATUS_NO_EXACT_SOLUTION,
+            solutions=(),
+            diagnostics={"reason": "no candidate actions for non-zero observation deltas"},
+        )
+
+    model, count_vars = _build_model(problem)
+    solver = cp_model.CpSolver()
+    solutions: list[InferenceSolution] = []
+    seen_signatures: set[tuple[tuple[str, int], ...]] = set()
+    started_at = time.monotonic()
+    last_solver_status = cp_model.UNKNOWN
+    stopped_reason = "exhausted"
+    time_limited = False
+
+    while len(solutions) < problem.max_solutions:
+        elapsed_seconds = time.monotonic() - started_at
+        remaining_seconds = problem.time_limit_seconds - elapsed_seconds
+        if remaining_seconds <= 0:
+            time_limited = True
+            stopped_reason = "time_budget"
+            break
+
+        solver.parameters.max_time_in_seconds = remaining_seconds
+        last_solver_status = solver.solve(model)
+        if last_solver_status not in _SUCCESS_STATUSES:
+            if last_solver_status == cp_model.UNKNOWN and solutions:
+                time_limited = True
+                stopped_reason = "time_budget"
+            elif not solutions:
+                stopped_reason = "infeasible"
+            else:
+                stopped_reason = "infeasible"
+            break
+
+        if last_solver_status == cp_model.FEASIBLE:
+            elapsed_seconds = time.monotonic() - started_at
+            if elapsed_seconds >= problem.time_limit_seconds:
+                time_limited = True
+                stopped_reason = "time_budget"
+
+        action_counts = _read_action_counts(problem, count_vars, solver)
+        solution = _extract_solution(problem, action_counts)
+        signature = _solution_signature(solution)
+        if signature in seen_signatures:
+            stopped_reason = "duplicate_solution"
+            break
+
+        seen_signatures.add(signature)
+        solutions.append(solution)
+        _add_no_good_cut(model, count_vars, action_counts, len(solutions))
+
+        if len(solutions) >= problem.max_solutions:
+            stopped_reason = "max_solutions"
+            break
+
+    diagnostics: dict[str, object] = {
+        "solver_status": solver.status_name(last_solver_status),
+        "solution_count": len(solutions),
+        "stopped_reason": stopped_reason,
+        "wall_time_seconds": time.monotonic() - started_at,
+    }
+    if time_limited:
+        diagnostics["time_limited"] = True
+
+    if not solutions:
+        status = STATUS_TIME_LIMITED if time_limited else STATUS_NO_EXACT_SOLUTION
+        return InferenceResult(status=status, solutions=(), diagnostics=diagnostics)
+
+    solutions.sort(key=lambda solution: solution.objective_value, reverse=True)
+    status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
+    return InferenceResult(status=status, solutions=tuple(solutions), diagnostics=diagnostics)

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -121,10 +121,11 @@ def _build_model(problem: InferenceProblem) -> _BuiltModel:
         sum(action.freighter_delta * count_vars[action.id] for action in problem.actions)
         == observation.freighter_delta
     )
-    model.add(
-        sum(action.priority_point_delta * count_vars[action.id] for action in problem.actions)
-        == observation.priority_point_delta
-    )
+    if problem.enforce_priority_point_constraint:
+        model.add(
+            sum(action.priority_point_delta * count_vars[action.id] for action in problem.actions)
+            == observation.priority_point_delta
+        )
     model.add(
         sum(action.build_slot_usage * count_vars[action.id] for action in problem.actions)
         <= observation.starbases_owned

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -1,6 +1,7 @@
 """OR-Tools CP-SAT adapter for military score build inference."""
 
 import time
+from dataclasses import dataclass
 
 from ortools.sat.python import cp_model
 
@@ -9,6 +10,7 @@ from api.analytics.military_score_inference.models import (
     InferenceResult,
     InferenceSolution,
     InferenceSolutionAction,
+    ProbabilityBucket,
 )
 
 STATUS_EXACT = "exact"
@@ -17,6 +19,13 @@ STATUS_NO_EXACT_SOLUTION = "no_exact_solution"
 STATUS_TIME_LIMITED = "time_limited"
 
 _SUCCESS_STATUSES = (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+
+@dataclass(frozen=True)
+class _BuiltModel:
+    model: cp_model.CpModel
+    count_vars: dict[str, cp_model.IntVar]
+    bucket_vars_by_action_id: dict[str, tuple[cp_model.IntVar, ...]]
 
 
 def _validate_problem(problem: InferenceProblem) -> str | None:
@@ -29,7 +38,37 @@ def _validate_problem(problem: InferenceProblem) -> str | None:
             return f"action {action.id} has negative lower_bound"
         if action.lower_bound > action.upper_bound:
             return f"action {action.id} has lower_bound greater than upper_bound"
+
+    for action_id, buckets in problem.probability_buckets_by_action_id.items():
+        if action_id not in seen_action_ids:
+            return f"unknown bucket action id: {action_id}"
+        if not buckets:
+            return f"empty probability buckets for action {action_id}"
+
+        action = next(candidate for candidate in problem.actions if candidate.id == action_id)
+        previous_upper_count = -1
+        total_bucket_capacity = 0
+        for bucket in buckets:
+            if bucket.lower_count > bucket.upper_count:
+                return f"bucket {bucket.label} for action {action_id} has invalid count range"
+            if bucket.lower_count <= previous_upper_count:
+                return f"bucket {bucket.label} for action {action_id} overlaps prior bucket"
+            previous_upper_count = bucket.upper_count
+            total_bucket_capacity += _bucket_capacity(bucket)
+
+        if total_bucket_capacity < action.upper_bound:
+            return (
+                f"probability buckets for action {action_id} "
+                f"cover only {total_bucket_capacity} counts but upper_bound is {action.upper_bound}"
+            )
+
     return None
+
+
+def _bucket_capacity(bucket: ProbabilityBucket) -> int:
+    if bucket.lower_count == 0:
+        return bucket.upper_count
+    return bucket.upper_count - bucket.lower_count + 1
 
 
 def _observation_has_no_deltas(problem: InferenceProblem) -> bool:
@@ -42,14 +81,32 @@ def _observation_has_no_deltas(problem: InferenceProblem) -> bool:
     )
 
 
-def _build_model(
-    problem: InferenceProblem,
-) -> tuple[cp_model.CpModel, dict[str, cp_model.IntVar]]:
+def _build_model(problem: InferenceProblem) -> _BuiltModel:
     model = cp_model.CpModel()
     count_vars = {
         action.id: model.new_int_var(action.lower_bound, action.upper_bound, action.id)
         for action in problem.actions
     }
+    bucket_vars_by_action_id: dict[str, tuple[cp_model.IntVar, ...]] = {}
+    objective_terms: list[cp_model.LinearExpr] = []
+
+    for action in problem.actions:
+        buckets = problem.probability_buckets_by_action_id.get(action.id)
+        if buckets:
+            bucket_vars: list[cp_model.IntVar] = []
+            for index, bucket in enumerate(buckets):
+                bucket_var = model.new_int_var(
+                    0,
+                    _bucket_capacity(bucket),
+                    f"{action.id}_bucket_{index}",
+                )
+                bucket_vars.append(bucket_var)
+                objective_terms.append(bucket_var * bucket.marginal_weight)
+            bucket_vars_by_action_id[action.id] = tuple(bucket_vars)
+            model.add(count_vars[action.id] == sum(bucket_vars))
+        else:
+            objective_terms.append(count_vars[action.id] * action.probability_weight)
+
     observation = problem.observation
 
     model.add(
@@ -72,10 +129,12 @@ def _build_model(
         sum(action.build_slot_usage * count_vars[action.id] for action in problem.actions)
         <= observation.starbases_owned
     )
-    model.maximize(
-        sum(action.probability_weight * count_vars[action.id] for action in problem.actions)
+    model.maximize(sum(objective_terms))
+    return _BuiltModel(
+        model=model,
+        count_vars=count_vars,
+        bucket_vars_by_action_id=bucket_vars_by_action_id,
     )
-    return model, count_vars
 
 
 def _read_action_counts(
@@ -86,13 +145,40 @@ def _read_action_counts(
     return {action.id: solver.value(count_vars[action.id]) for action in problem.actions}
 
 
+def _read_bucket_counts(
+    bucket_vars_by_action_id: dict[str, tuple[cp_model.IntVar, ...]],
+    solver: cp_model.CpSolver,
+) -> dict[str, tuple[int, ...]]:
+    return {
+        action_id: tuple(solver.value(bucket_var) for bucket_var in bucket_vars)
+        for action_id, bucket_vars in bucket_vars_by_action_id.items()
+    }
+
+
+def _objective_value(
+    problem: InferenceProblem,
+    action_counts: dict[str, int],
+    bucket_counts_by_action_id: dict[str, tuple[int, ...]],
+) -> int:
+    objective_value = 0
+    for action in problem.actions:
+        buckets = problem.probability_buckets_by_action_id.get(action.id)
+        if buckets:
+            bucket_counts = bucket_counts_by_action_id[action.id]
+            for bucket, count in zip(buckets, bucket_counts, strict=True):
+                objective_value += bucket.marginal_weight * count
+        else:
+            objective_value += action.probability_weight * action_counts[action.id]
+    return objective_value
+
+
 def _extract_solution(
     problem: InferenceProblem,
     action_counts: dict[str, int],
+    bucket_counts_by_action_id: dict[str, tuple[int, ...]],
 ) -> InferenceSolution:
     action_by_id = {action.id: action for action in problem.actions}
     solution_actions: list[InferenceSolutionAction] = []
-    objective_value = 0
     for action_id, count in action_counts.items():
         if count == 0:
             continue
@@ -104,9 +190,8 @@ def _extract_solution(
                 count=count,
             )
         )
-        objective_value += action.probability_weight * count
     return InferenceSolution(
-        objective_value=objective_value,
+        objective_value=_objective_value(problem, action_counts, bucket_counts_by_action_id),
         actions=tuple(solution_actions),
     )
 
@@ -156,7 +241,10 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
             diagnostics={"reason": "no candidate actions for non-zero observation deltas"},
         )
 
-    model, count_vars = _build_model(problem)
+    built_model = _build_model(problem)
+    model = built_model.model
+    count_vars = built_model.count_vars
+    bucket_vars_by_action_id = built_model.bucket_vars_by_action_id
     solver = cp_model.CpSolver()
     solutions: list[InferenceSolution] = []
     seen_signatures: set[tuple[tuple[str, int], ...]] = set()
@@ -164,6 +252,7 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
     last_solver_status = cp_model.UNKNOWN
     stopped_reason = "exhausted"
     time_limited = False
+    top_solution_bucket_counts: dict[str, tuple[int, ...]] = {}
 
     while len(solutions) < problem.max_solutions:
         elapsed_seconds = time.monotonic() - started_at
@@ -192,7 +281,8 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
                 stopped_reason = "time_budget"
 
         action_counts = _read_action_counts(problem, count_vars, solver)
-        solution = _extract_solution(problem, action_counts)
+        bucket_counts = _read_bucket_counts(bucket_vars_by_action_id, solver)
+        solution = _extract_solution(problem, action_counts, bucket_counts)
         signature = _solution_signature(solution)
         if signature in seen_signatures:
             stopped_reason = "duplicate_solution"
@@ -200,6 +290,7 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
 
         seen_signatures.add(signature)
         solutions.append(solution)
+        top_solution_bucket_counts = bucket_counts
         _add_no_good_cut(model, count_vars, action_counts, len(solutions))
 
         if len(solutions) >= problem.max_solutions:
@@ -214,6 +305,8 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
     }
     if time_limited:
         diagnostics["time_limited"] = True
+    if top_solution_bucket_counts:
+        diagnostics["bucket_counts_by_action_id"] = top_solution_bucket_counts
 
     if not solutions:
         status = STATUS_TIME_LIMITED if time_limited else STATUS_NO_EXACT_SOLUTION

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 from ortools.sat.python import cp_model
 
+from api.analytics.military_score_inference.constraints import InferenceHardConstraints
 from api.analytics.military_score_inference.models import (
     InferenceProblem,
     InferenceResult,
@@ -107,29 +108,7 @@ def _build_model(problem: InferenceProblem) -> _BuiltModel:
         else:
             objective_terms.append(count_vars[action.id] * action.probability_weight)
 
-    observation = problem.observation
-
-    model.add(
-        sum(action.score_delta_2x * count_vars[action.id] for action in problem.actions)
-        == observation.military_delta_2x
-    )
-    model.add(
-        sum(action.warship_delta * count_vars[action.id] for action in problem.actions)
-        == observation.warship_delta
-    )
-    model.add(
-        sum(action.freighter_delta * count_vars[action.id] for action in problem.actions)
-        == observation.freighter_delta
-    )
-    if problem.enforce_priority_point_constraint:
-        model.add(
-            sum(action.priority_point_delta * count_vars[action.id] for action in problem.actions)
-            == observation.priority_point_delta
-        )
-    model.add(
-        sum(action.build_slot_usage * count_vars[action.id] for action in problem.actions)
-        <= observation.starbases_owned
-    )
+    InferenceHardConstraints.from_problem(problem).add_to_model(model, problem, count_vars)
     model.maximize(sum(objective_terms))
     return _BuiltModel(
         model=model,

--- a/packages/api/api/analytics/options.py
+++ b/packages/api/api/analytics/options.py
@@ -13,5 +13,4 @@ class TurnAnalyticsOptions:
     connection_flare_mode: FlareConnectionMode | str = FlareConnectionMode.OFF
     connection_flare_depth: int = 1
     connection_include_illustrative_routes: bool = False
-    include_military_score_inference: bool = False
     diagnostics: Diagnostics = NOOP_DIAGNOSTICS

--- a/packages/api/api/analytics/options.py
+++ b/packages/api/api/analytics/options.py
@@ -13,4 +13,5 @@ class TurnAnalyticsOptions:
     connection_flare_mode: FlareConnectionMode | str = FlareConnectionMode.OFF
     connection_flare_depth: int = 1
     connection_include_illustrative_routes: bool = False
+    include_military_score_inference: bool = False
     diagnostics: Diagnostics = NOOP_DIAGNOSTICS

--- a/packages/api/api/analytics/registry.py
+++ b/packages/api/api/analytics/registry.py
@@ -22,7 +22,7 @@ def _base_map_handler(turn: TurnInfo, options: TurnAnalyticsOptions) -> dict:
 
 
 def _scores_handler(turn: TurnInfo, options: TurnAnalyticsOptions) -> dict:
-    return get_scores_table(turn)
+    return get_scores_table(turn, options)
 
 
 TURN_ANALYTICS: dict[str, TurnAnalyticHandler] = {

--- a/packages/api/api/analytics/scores.py
+++ b/packages/api/api/analytics/scores.py
@@ -7,42 +7,66 @@ from api.models.game import TurnInfo
 ANALYTIC_ID = "scores"
 
 
+def _score_row(
+    score,
+    *,
+    players_by_id: dict[int, object],
+    races_by_id: dict[int, object],
+) -> dict[str, object]:
+    player = players_by_id.get(score.ownerid)
+    race = races_by_id.get(player.raceid) if player is not None else None
+    if race is not None and player is not None:
+        race_player = f"{race.name} ({player.username})"
+    elif player is not None:
+        race_player = player.username
+    else:
+        race_player = f"Player {score.ownerid}"
+    return {
+        "playerId": score.ownerid,
+        "racePlayer": race_player,
+        "planets": {"value": score.planets, "change": score.planetchange},
+        "starbases": {"value": score.starbases, "change": score.starbasechange},
+        "warShips": {"value": score.capitalships, "change": score.shipchange},
+        "freighters": {"value": score.freighters, "change": score.freighterchange},
+        "military": {
+            "value": score.militaryscore,
+            "change": score.militarychange,
+        },
+        "priorityPoints": {
+            "value": score.prioritypoints,
+            "change": score.prioritypointchange,
+        },
+    }
+
+
 def get_scores_table(
     turn: TurnInfo,
     options: TurnAnalyticsOptions | None = None,
 ) -> dict:
     """Return scoreboard values for each player in a turn."""
-    resolved_options = options or TurnAnalyticsOptions()
+    _ = options or TurnAnalyticsOptions()
     players_by_id = {player.id: player for player in [turn.player, *turn.players]}
     races_by_id = {race.id: race for race in turn.races}
 
-    rows = []
-    for score in turn.scores:
-        player = players_by_id.get(score.ownerid)
-        race = races_by_id.get(player.raceid) if player is not None else None
-        if race is not None and player is not None:
-            race_player = f"{race.name} ({player.username})"
-        elif player is not None:
-            race_player = player.username
-        else:
-            race_player = f"Player {score.ownerid}"
-        row: dict[str, object] = {
-            "playerId": score.ownerid,
-            "racePlayer": race_player,
-            "planets": {"value": score.planets, "change": score.planetchange},
-            "starbases": {"value": score.starbases, "change": score.starbasechange},
-            "warShips": {"value": score.capitalships, "change": score.shipchange},
-            "freighters": {"value": score.freighters, "change": score.freighterchange},
-            "military": {
-                "value": score.militaryscore,
-                "change": score.militarychange,
-            },
-            "priorityPoints": {
-                "value": score.prioritypoints,
-                "change": score.prioritypointchange,
-            },
-        }
-        if resolved_options.include_military_score_inference:
-            row["inference"] = infer_military_score_build(score, turn)
-        rows.append(row)
+    rows = [
+        _score_row(score, players_by_id=players_by_id, races_by_id=races_by_id)
+        for score in turn.scores
+    ]
     return {"analyticId": ANALYTIC_ID, "rows": rows}
+
+
+def get_scores_row_inference(turn: TurnInfo, player_id: int) -> dict[str, object]:
+    """Run military score build inference for one scoreboard row."""
+    score = next((row for row in turn.scores if row.ownerid == player_id), None)
+    if score is None:
+        return {
+            "playerId": player_id,
+            "status": "player_not_found",
+            "summary": f"No score row for player {player_id}",
+            "solutionCount": 0,
+            "isComplete": True,
+            "solutions": [],
+            "diagnostics": {"playerId": player_id, "turn": turn.settings.turn},
+        }
+    inference = infer_military_score_build(score, turn)
+    return {"playerId": player_id, **inference}

--- a/packages/api/api/analytics/scores.py
+++ b/packages/api/api/analytics/scores.py
@@ -1,12 +1,18 @@
 """Core scoreboard analytic."""
 
+from api.analytics.military_score_inference.analytic import infer_military_score_build
+from api.analytics.options import TurnAnalyticsOptions
 from api.models.game import TurnInfo
 
 ANALYTIC_ID = "scores"
 
 
-def get_scores_table(turn: TurnInfo) -> dict:
+def get_scores_table(
+    turn: TurnInfo,
+    options: TurnAnalyticsOptions | None = None,
+) -> dict:
     """Return scoreboard values for each player in a turn."""
+    resolved_options = options or TurnAnalyticsOptions()
     players_by_id = {player.id: player for player in [turn.player, *turn.players]}
     races_by_id = {race.id: race for race in turn.races}
 
@@ -20,22 +26,23 @@ def get_scores_table(turn: TurnInfo) -> dict:
             race_player = player.username
         else:
             race_player = f"Player {score.ownerid}"
-        rows.append(
-            {
-                "playerId": score.ownerid,
-                "racePlayer": race_player,
-                "planets": {"value": score.planets, "change": score.planetchange},
-                "starbases": {"value": score.starbases, "change": score.starbasechange},
-                "warShips": {"value": score.capitalships, "change": score.shipchange},
-                "freighters": {"value": score.freighters, "change": score.freighterchange},
-                "military": {
-                    "value": score.militaryscore,
-                    "change": score.militarychange,
-                },
-                "priorityPoints": {
-                    "value": score.prioritypoints,
-                    "change": score.prioritypointchange,
-                },
-            }
-        )
+        row: dict[str, object] = {
+            "playerId": score.ownerid,
+            "racePlayer": race_player,
+            "planets": {"value": score.planets, "change": score.planetchange},
+            "starbases": {"value": score.starbases, "change": score.starbasechange},
+            "warShips": {"value": score.capitalships, "change": score.shipchange},
+            "freighters": {"value": score.freighters, "change": score.freighterchange},
+            "military": {
+                "value": score.militaryscore,
+                "change": score.militarychange,
+            },
+            "priorityPoints": {
+                "value": score.prioritypoints,
+                "change": score.prioritypointchange,
+            },
+        }
+        if resolved_options.include_military_score_inference:
+            row["inference"] = infer_military_score_build(score, turn)
+        rows.append(row)
     return {"analyticId": ANALYTIC_ID, "rows": rows}

--- a/packages/api/api/routers/games.py
+++ b/packages/api/api/routers/games.py
@@ -110,6 +110,23 @@ def get_turn_info(
     return turns.get_turn_info(game_id, perspective, turn_number)
 
 
+@router.get("/{game_id}/{perspective}/turns/{turn_number}/analytics/scores/inference")
+def get_scores_row_inference(
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_id: int = Query(..., alias="playerId", ge=0),
+    analytics: TurnAnalyticService = Depends(get_turn_analytic_service),
+):
+    """Return military score build inference for one scoreboard row."""
+    return analytics.get_scores_row_inference(
+        game_id,
+        perspective,
+        turn_number,
+        player_id,
+    )
+
+
 @router.get("/{game_id}/{perspective}/turns/{turn_number}/analytics/{analytic_id}")
 def get_turn_analytics(
     game_id: int,

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -24,6 +24,7 @@ class TurnAnalyticService:
         connection_flare_mode: FlareConnectionMode | str = FlareConnectionMode.OFF,
         connection_flare_depth: int = 1,
         connection_include_illustrative_routes: bool = False,
+        include_military_score_inference: bool = False,
         diagnostics: Diagnostics = NOOP_DIAGNOSTICS,
     ) -> dict:
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
@@ -36,6 +37,7 @@ class TurnAnalyticService:
                 connection_flare_mode=connection_flare_mode,
                 connection_flare_depth=connection_flare_depth,
                 connection_include_illustrative_routes=connection_include_illustrative_routes,
+                include_military_score_inference=include_military_score_inference,
                 diagnostics=diagnostics,
             ),
         )

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -24,7 +24,6 @@ class TurnAnalyticService:
         connection_flare_mode: FlareConnectionMode | str = FlareConnectionMode.OFF,
         connection_flare_depth: int = 1,
         connection_include_illustrative_routes: bool = False,
-        include_military_score_inference: bool = False,
         diagnostics: Diagnostics = NOOP_DIAGNOSTICS,
     ) -> dict:
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
@@ -37,7 +36,18 @@ class TurnAnalyticService:
                 connection_flare_mode=connection_flare_mode,
                 connection_flare_depth=connection_flare_depth,
                 connection_include_illustrative_routes=connection_include_illustrative_routes,
-                include_military_score_inference=include_military_score_inference,
                 diagnostics=diagnostics,
             ),
         )
+
+    def get_scores_row_inference(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        from api.analytics.scores import get_scores_row_inference
+
+        turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        return get_scores_row_inference(turn, player_id)

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "dacite>=1.8.0",
     "httpx>=0.27.0",
+    "ortools>=9.15.6755",
 ]
 
 [project.optional-dependencies]

--- a/packages/api/tests/test_analytics_registry.py
+++ b/packages/api/tests/test_analytics_registry.py
@@ -32,6 +32,13 @@ def test_scores_module_returns_structured_score_rows(sample_turn):
     assert data["analyticId"] == "scores"
     assert data["rows"][0]["racePlayer"] == "koshling"
     assert data["rows"][0]["military"] == {"value": 2509092, "change": -53869}
+    assert "inference" not in data["rows"][0]
+
+
+def test_registry_scores_dispatch_unchanged_without_inference_option(sample_turn):
+    data = get_turn_analytic("scores", sample_turn, TurnAnalyticsOptions())
+    assert data["analyticId"] == "scores"
+    assert "inference" not in data["rows"][0]
 
 
 def test_registry_rejects_unknown_analytic(sample_turn):

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -1,6 +1,7 @@
 """Tests for military score inference action catalog generation."""
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -263,6 +264,61 @@ def test_catalog_size_exposed_in_diagnostics(synthetic_catalog_context):
     assert diagnostics["catalog_size"] == len(catalog.actions)
 
 
+def test_ship_build_presets_exclude_build_time_ammo(synthetic_catalog_context):
+    catalog = build_action_catalog(_observation(), **synthetic_catalog_context)
+    build_action_ids = {action.id for action in catalog.actions if action.id.startswith("build_")}
+
+    assert "build_71_fighters" not in build_action_ids
+    assert not any(action_id.endswith("_fighters") for action_id in build_action_ids)
+
+    carrier_empty = next(action for action in catalog.actions if action.id == "build_71_empty")
+    hull = synthetic_catalog_context["hulls_by_id"][71]
+    engine = synthetic_catalog_context["engines_by_id"][1]
+    from api.analytics.military_score_inference.scoring import ship_construction_score_delta_2x
+
+    expected_score = ship_construction_score_delta_2x(
+        hull.cost + engine.cost * hull.engines,
+        hull.tritanium + hull.duranium + hull.molybdenum
+        + (engine.tritanium + engine.duranium + engine.molybdenum) * hull.engines,
+    )
+    assert carrier_empty.score_delta_2x == expected_score
+
+
+def test_ship_build_score_scales_engine_cost_by_hull_engine_slots(synthetic_catalog_context):
+    catalog = build_action_catalog(
+        _observation(warship_delta=1, freighter_delta=1),
+        **synthetic_catalog_context,
+    )
+    carrier_build = next(action for action in catalog.actions if action.id == "build_71_empty")
+    hull = synthetic_catalog_context["hulls_by_id"][71]
+    engine = synthetic_catalog_context["engines_by_id"][1]
+    from api.analytics.military_score_inference.scoring import ship_construction_score_delta_2x
+
+    engine_minerals = engine.tritanium + engine.duranium + engine.molybdenum
+    hull_minerals = hull.tritanium + hull.duranium + hull.molybdenum
+    expected = ship_construction_score_delta_2x(
+        hull.cost + engine.cost * hull.engines,
+        hull_minerals + engine_minerals * hull.engines,
+    )
+    assert carrier_build.score_delta_2x == expected
+    assert hull.engines == 2
+
+
+def test_ship_build_actions_are_not_filtered_by_hull_isbase_flag(synthetic_catalog_context):
+    """Planets.nu hull catalog entries use isbase=true for starships too."""
+    hulls_by_id = {
+        hull_id: replace(hull, isbase=True)
+        for hull_id, hull in synthetic_catalog_context["hulls_by_id"].items()
+    }
+    context = {**synthetic_catalog_context, "hulls_by_id": hulls_by_id}
+    catalog = build_action_catalog(
+        _observation(warship_delta=1, freighter_delta=0, starbases_owned=3),
+        **context,
+    )
+    ship_build_actions = [action for action in catalog.actions if action.id.startswith("build_")]
+    assert ship_build_actions
+
+
 def test_build_action_catalog_from_turn_sample(sample_turn):
     observation = _observation(
         military_delta_2x=110,
@@ -276,11 +332,9 @@ def test_build_action_catalog_from_turn_sample(sample_turn):
     assert catalog.catalog_size > 0
     assert "planet_defense_posts_added_total" in {action.id for action in catalog.actions}
     assert buildable_hulls
-    buildable_non_base_hulls = [
-        hull for hull in sample_turn.hulls if hull.id in buildable_hulls and not hull.isbase
-    ]
     ship_build_actions = [action for action in catalog.actions if action.id.startswith("build_")]
-    if buildable_non_base_hulls and (
-        observation.warship_delta > 0 or observation.freighter_delta > 0
-    ):
-        assert ship_build_actions
+    if observation.warship_delta > 0 or observation.freighter_delta > 0:
+        catalog_hull_ids = {hull.id for hull in sample_turn.hulls}
+        buildable_in_catalog = buildable_hulls & catalog_hull_ids
+        if buildable_in_catalog:
+            assert ship_build_actions

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -1,0 +1,286 @@
+"""Tests for military score inference action catalog generation."""
+
+import json
+from pathlib import Path
+
+import pytest
+from api.analytics.military_score_inference.actions import (
+    ActionCatalogConfig,
+    build_action_catalog,
+    build_action_catalog_from_turn,
+    buildable_hull_ids_for_player,
+)
+from api.analytics.military_score_inference.models import InferenceObservation
+from api.analytics.military_score_inference.scoring import (
+    STARBASE_FIGHTER_SCORE_DELTA_2X,
+)
+from api.models.components import Beam, Engine, Hull, Torpedo
+from api.serialization.turn import turn_info_from_json
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+def _observation(
+    *,
+    military_delta_2x: int = 1100,
+    warship_delta: int = 1,
+    freighter_delta: int = 0,
+    starbases_owned: int = 3,
+) -> InferenceObservation:
+    return InferenceObservation(
+        player_id=8,
+        turn=111,
+        military_delta_2x=military_delta_2x,
+        warship_delta=warship_delta,
+        freighter_delta=freighter_delta,
+        priority_point_delta=0,
+        starbases_owned=starbases_owned,
+        is_after_ship_limit=False,
+    )
+
+
+@pytest.fixture
+def sample_turn():
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        return turn_info_from_json(json.load(handle))
+
+
+@pytest.fixture
+def synthetic_catalog_context():
+    freighter = Hull(
+        id=15,
+        name="Small Deep Space Freighter",
+        tritanium=2,
+        duranium=2,
+        molybdenum=3,
+        fueltank=100,
+        crew=10,
+        engines=1,
+        mass=10,
+        techlevel=1,
+        cargo=70,
+        fighterbays=0,
+        launchers=0,
+        beams=0,
+        cancloak=False,
+        cost=10,
+        special="",
+        description="",
+        advantage=0,
+        isbase=False,
+        dur=0,
+        tri=0,
+        mol=0,
+        mc=0,
+        parentid=0,
+        academy=False,
+    )
+    warship = Hull(
+        id=24,
+        name="Serpent Class Escort",
+        tritanium=33,
+        duranium=15,
+        molybdenum=5,
+        fueltank=160,
+        crew=35,
+        engines=1,
+        mass=55,
+        techlevel=1,
+        cargo=20,
+        fighterbays=0,
+        launchers=0,
+        beams=2,
+        cancloak=False,
+        cost=40,
+        special="",
+        description="",
+        advantage=0,
+        isbase=False,
+        dur=0,
+        tri=0,
+        mol=0,
+        mc=0,
+        parentid=0,
+        academy=False,
+    )
+    carrier = Hull(
+        id=71,
+        name="Carrier",
+        tritanium=10,
+        duranium=10,
+        molybdenum=10,
+        fueltank=200,
+        crew=100,
+        engines=2,
+        mass=100,
+        techlevel=5,
+        cargo=50,
+        fighterbays=5,
+        launchers=0,
+        beams=0,
+        cancloak=False,
+        cost=100,
+        special="",
+        description="",
+        advantage=0,
+        isbase=False,
+        dur=0,
+        tri=0,
+        mol=0,
+        mc=0,
+        parentid=0,
+        academy=False,
+    )
+    engine = Engine(
+        id=1,
+        name="Stardrive 1",
+        cost=5,
+        tritanium=1,
+        duranium=1,
+        molybdenum=1,
+        techlevel=1,
+        warp1=50,
+        warp2=40,
+        warp3=30,
+        warp4=20,
+        warp5=10,
+        warp6=0,
+        warp7=0,
+        warp8=0,
+        warp9=0,
+    )
+    beam = Beam(
+        id=1,
+        name="Laser",
+        cost=1,
+        tritanium=1,
+        duranium=0,
+        molybdenum=0,
+        mass=1,
+        techlevel=1,
+        crewkill=10,
+        damage=3,
+    )
+    torpedo = Torpedo(
+        id=1,
+        fullid=1,
+        name="Mark 1 Photon",
+        torpedocost=1,
+        launchercost=1,
+        tritanium=1,
+        duranium=1,
+        molybdenum=0,
+        mass=1,
+        techlevel=1,
+        crewkill=10,
+        damage=5,
+        combatrange=3,
+    )
+    return {
+        "hulls_by_id": {freighter.id: freighter, warship.id: warship, carrier.id: carrier},
+        "engines_by_id": {engine.id: engine},
+        "beams_by_id": {beam.id: beam},
+        "torpedos_by_id": {torpedo.id: torpedo},
+        "buildable_hull_ids": frozenset({freighter.id, warship.id, carrier.id}),
+        "default_engine_id": engine.id,
+    }
+
+
+def test_generated_actions_have_finite_bounds(synthetic_catalog_context):
+    catalog = build_action_catalog(
+        _observation(),
+        config=ActionCatalogConfig(max_fighter_transfers=10),
+        **synthetic_catalog_context,
+    )
+
+    assert catalog.catalog_size > 0
+    for action in catalog.actions:
+        assert action.lower_bound >= 0
+        assert action.upper_bound >= action.lower_bound
+        assert action.upper_bound < 10_000
+
+
+def test_noisy_actions_are_aggregate_actions(synthetic_catalog_context):
+    catalog = build_action_catalog(_observation(), **synthetic_catalog_context)
+    aggregate_actions = [
+        action
+        for action in catalog.actions
+        if action.id.endswith("_total") or action.id.startswith("ship_torps_loaded_")
+    ]
+
+    assert aggregate_actions
+    for action in aggregate_actions:
+        assert "planet" in action.id or "starbase" in action.id or "ship_" in action.id
+
+
+def test_ship_build_actions_respect_observed_count_deltas(synthetic_catalog_context):
+    catalog = build_action_catalog(
+        _observation(warship_delta=2, freighter_delta=1, starbases_owned=5),
+        **synthetic_catalog_context,
+    )
+
+    warship_builds = [action for action in catalog.actions if action.warship_delta == 1]
+    freighter_builds = [action for action in catalog.actions if action.freighter_delta == 1]
+
+    assert warship_builds
+    assert freighter_builds
+    assert all(action.upper_bound <= 2 for action in warship_builds)
+    assert all(action.upper_bound <= 1 for action in freighter_builds)
+    assert all(action.build_slot_usage == 1 for action in warship_builds + freighter_builds)
+
+
+def test_negative_fighter_transfer_cannot_create_unbounded_cancellation_loops():
+    config = ActionCatalogConfig(max_fighter_transfers=7)
+    catalog = build_action_catalog(
+        _observation(military_delta_2x=500),
+        hulls_by_id={},
+        engines_by_id={},
+        beams_by_id={},
+        torpedos_by_id={},
+        buildable_hull_ids=frozenset(),
+        default_engine_id=None,
+        config=config,
+    )
+
+    negative_transfer = next(
+        action for action in catalog.actions if action.id == "fighters_ship_to_starbase"
+    )
+    positive_transfer = next(
+        action for action in catalog.actions if action.id == "fighters_starbase_to_ship"
+    )
+
+    assert negative_transfer.score_delta_2x == -STARBASE_FIGHTER_SCORE_DELTA_2X
+    assert negative_transfer.upper_bound <= config.max_fighter_transfers
+    assert positive_transfer.upper_bound <= config.max_fighter_transfers
+    assert negative_transfer.upper_bound == 500 // STARBASE_FIGHTER_SCORE_DELTA_2X
+
+
+def test_catalog_size_exposed_in_diagnostics(synthetic_catalog_context):
+    catalog = build_action_catalog(_observation(), **synthetic_catalog_context)
+
+    diagnostics = catalog.diagnostics()
+    assert diagnostics["catalog_size"] == catalog.catalog_size
+    assert diagnostics["catalog_size"] == len(catalog.actions)
+
+
+def test_build_action_catalog_from_turn_sample(sample_turn):
+    observation = _observation(
+        military_delta_2x=110,
+        warship_delta=0,
+        freighter_delta=1,
+        starbases_owned=10,
+    )
+    buildable_hulls = buildable_hull_ids_for_player(sample_turn, observation.player_id)
+    catalog = build_action_catalog_from_turn(observation, sample_turn)
+
+    assert catalog.catalog_size > 0
+    assert "planet_defense_posts_added_total" in {action.id for action in catalog.actions}
+    assert buildable_hulls
+    buildable_non_base_hulls = [
+        hull for hull in sample_turn.hulls if hull.id in buildable_hulls and not hull.isbase
+    ]
+    ship_build_actions = [action for action in catalog.actions if action.id.startswith("build_")]
+    if buildable_non_base_hulls and (
+        observation.warship_delta > 0 or observation.freighter_delta > 0
+    ):
+        assert ship_build_actions

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -278,7 +278,9 @@ def test_ship_build_presets_exclude_build_time_ammo(synthetic_catalog_context):
 
     expected_score = ship_construction_score_delta_2x(
         hull.cost + engine.cost * hull.engines,
-        hull.tritanium + hull.duranium + hull.molybdenum
+        hull.tritanium
+        + hull.duranium
+        + hull.molybdenum
         + (engine.tritanium + engine.duranium + engine.molybdenum) * hull.engines,
     )
     assert carrier_empty.score_delta_2x == expected_score

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from api.analytics.military_score_inference.actions import (
     ActionCatalogConfig,
+    _residual_count_bound,
     build_action_catalog,
     build_action_catalog_from_turn,
     buildable_hull_ids_for_player,
@@ -228,6 +229,27 @@ def test_ship_build_actions_respect_observed_count_deltas(synthetic_catalog_cont
     assert all(action.upper_bound <= 2 for action in warship_builds)
     assert all(action.upper_bound <= 1 for action in freighter_builds)
     assert all(action.build_slot_usage == 1 for action in warship_builds + freighter_builds)
+
+
+@pytest.mark.parametrize(
+    ("military_delta_2x", "score_delta_2x", "configured_cap", "expected"),
+    [
+        (500, 125, 100, 4),
+        (500, -125, 100, 4),
+        (-500, 125, 100, 4),
+        (-500, -125, 100, 4),
+        (10, 125, 100, 0),
+        (500, 125, 3, 3),
+    ],
+)
+def test_residual_count_bound_uses_abs_residual_regardless_of_sign(
+    military_delta_2x,
+    score_delta_2x,
+    configured_cap,
+    expected,
+):
+    observation = _observation(military_delta_2x=military_delta_2x)
+    assert _residual_count_bound(observation, score_delta_2x, configured_cap) == expected
 
 
 def test_negative_fighter_transfer_cannot_create_unbounded_cancellation_loops():

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -19,11 +19,15 @@ from api.analytics.military_score_inference.analytic import (
     prior_turn_score_data_available,
 )
 from api.analytics.military_score_inference.models import (
+    CandidateAction,
     InferenceObservation,
     InferenceProblem,
     InferenceResult,
     InferenceSolution,
     InferenceSolutionAction,
+)
+from api.analytics.military_score_inference.score_arithmetic import (
+    solution_military_score_arithmetic_payload,
 )
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
@@ -194,6 +198,95 @@ def test_inference_result_payload_serializes_solutions(sample_turn):
     assert payload["solutionCount"] == 1
     assert payload["solutions"][0]["objectiveValue"] == 42
     assert payload["solutions"][0]["actions"][0]["actionId"] == "build_24_empty"
+
+
+def test_inference_result_payload_includes_military_score_arithmetic(sample_turn):
+    defense_action = CandidateAction(
+        id="planet_defense",
+        label="Planet defense post",
+        score_delta_2x=22,
+        lower_bound=0,
+        upper_bound=10,
+    )
+    catalog = ActionCatalog(
+        actions=(defense_action,),
+        probability_buckets_by_action_id={},
+    )
+    score = sample_turn.scores[0]
+    observation = InferenceObservation(
+        player_id=score.ownerid,
+        turn=12,
+        military_delta_2x=44,
+        warship_delta=0,
+        freighter_delta=0,
+        priority_point_delta=0,
+        starbases_owned=2,
+        is_after_ship_limit=False,
+    )
+    problem = _minimal_inference_problem(observation, catalog)
+    result = InferenceResult(
+        status=STATUS_EXACT,
+        solutions=(
+            InferenceSolution(
+                objective_value=99,
+                actions=(
+                    InferenceSolutionAction(
+                        action_id="planet_defense",
+                        label="Planet defense post",
+                        count=2,
+                    ),
+                ),
+            ),
+        ),
+        diagnostics={},
+    )
+    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn, problem)
+    arithmetic = payload["solutions"][0]["militaryScoreArithmetic"]
+    assert arithmetic["observedMilitaryChange"] == 22
+    assert arithmetic["observedMilitaryDelta2x"] == 44
+    assert arithmetic["explainedMilitaryChange"] == 22
+    assert arithmetic["explainedMilitaryDelta2x"] == 44
+    assert arithmetic["matchesObserved"] is True
+    line_item = arithmetic["lineItems"][0]
+    assert line_item["count"] == 2
+    assert line_item["scoreDelta2xPerUnit"] == 22
+    assert line_item["militaryChangePerUnit"] == 11
+    assert line_item["militaryChangeSubtotal"] == 22
+
+
+def test_solution_military_score_arithmetic_flags_mismatch():
+    observation = InferenceObservation(
+        player_id=1,
+        turn=3,
+        military_delta_2x=100,
+        warship_delta=0,
+        freighter_delta=0,
+        priority_point_delta=0,
+        starbases_owned=1,
+        is_after_ship_limit=False,
+    )
+    action = CandidateAction(
+        id="starbase_fighter",
+        label="Starbase fighter",
+        score_delta_2x=125,
+    )
+    solution = InferenceSolution(
+        objective_value=1,
+        actions=(
+            InferenceSolutionAction(
+                action_id="starbase_fighter",
+                label="Starbase fighter",
+                count=1,
+            ),
+        ),
+    )
+    arithmetic = solution_military_score_arithmetic_payload(
+        solution,
+        observation,
+        {action.id: action},
+    )
+    assert arithmetic["matchesObserved"] is False
+    assert arithmetic["explainedMilitaryChange"] == 62
 
 
 def test_constraints_payload_exposes_requested_pp_as_diagnostic_only():

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -20,6 +20,7 @@ from api.analytics.military_score_inference.analytic import (
 )
 from api.analytics.military_score_inference.models import (
     InferenceObservation,
+    InferenceProblem,
     InferenceResult,
     InferenceSolution,
     InferenceSolutionAction,
@@ -142,15 +143,26 @@ def test_solver_failure_is_isolated_per_player(sample_turn):
     assert all("inference" in row for row in other_rows)
 
 
+def _minimal_inference_problem(
+    observation: InferenceObservation, catalog: ActionCatalog
+) -> InferenceProblem:
+    return InferenceProblem(
+        observation=observation,
+        actions=catalog.actions,
+        probability_buckets_by_action_id=catalog.probability_buckets_by_action_id,
+    )
+
+
 def test_inference_result_payload_merges_catalog_diagnostics(sample_turn):
     catalog = ActionCatalog(actions=(), probability_buckets_by_action_id={})
     observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+    problem = _minimal_inference_problem(observation, catalog)
     result = InferenceResult(
         status=STATUS_INVALID_PROBLEM,
         solutions=(),
         diagnostics={"reason": "empty catalog"},
     )
-    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn)
+    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn, problem)
     assert payload["status"] == STATUS_INVALID_PROBLEM
     assert payload["diagnostics"]["solver"]["reason"] == "empty catalog"
     assert payload["diagnostics"]["catalog_size"] == 0
@@ -161,6 +173,7 @@ def test_inference_result_payload_merges_catalog_diagnostics(sample_turn):
 def test_inference_result_payload_serializes_solutions(sample_turn):
     catalog = ActionCatalog(actions=(), probability_buckets_by_action_id={})
     observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+    problem = _minimal_inference_problem(observation, catalog)
     result = InferenceResult(
         status=STATUS_EXACT,
         solutions=(
@@ -177,7 +190,7 @@ def test_inference_result_payload_serializes_solutions(sample_turn):
         ),
         diagnostics={"solution_count": 1},
     )
-    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn)
+    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn, problem)
     assert payload["solutionCount"] == 1
     assert payload["solutions"][0]["objectiveValue"] == 42
     assert payload["solutions"][0]["actions"][0]["actionId"] == "build_24_empty"

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -34,7 +34,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     solve_inference_problem,
 )
-from api.analytics.scores import get_scores_table
+from api.analytics.scores import get_scores_row_inference, get_scores_table
 from api.serialization.turn import turn_info_from_json
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
@@ -61,12 +61,18 @@ def test_scores_output_unchanged_when_inference_disabled(sample_turn):
     assert "inference" not in disabled["rows"][0]
 
 
-def test_scores_output_includes_inference_when_enabled(sample_turn):
+def test_scores_table_never_includes_inference(sample_turn):
     data = get_scores_table(
         sample_turn,
-        TurnAnalyticsOptions(include_military_score_inference=True),
+        TurnAnalyticsOptions(),
     )
-    inference = data["rows"][0]["inference"]
+    assert "inference" not in data["rows"][0]
+
+
+def test_scores_row_inference_returns_solver_payload(sample_turn):
+    player_id = sample_turn.scores[0].ownerid
+    inference = get_scores_row_inference(sample_turn, player_id)
+    assert inference["playerId"] == player_id
     assert inference["status"] in {
         STATUS_EXACT,
         STATUS_INVALID_PROBLEM,
@@ -86,13 +92,12 @@ def test_first_turn_produces_no_prior_turn_status(first_turn):
     assert inference["diagnostics"]["reason"] == "first_turn"
 
 
-def test_enabled_first_turn_attaches_row_level_diagnostic(first_turn):
-    data = get_scores_table(
-        first_turn,
-        TurnAnalyticsOptions(include_military_score_inference=True),
-    )
-    for row in data["rows"]:
-        assert row["inference"]["status"] == STATUS_NO_PRIOR_TURN
+def test_first_turn_row_inference_produces_no_prior_turn_status(first_turn):
+    score = first_turn.scores[0]
+    inference = get_scores_row_inference(first_turn, score.ownerid)
+    assert inference["status"] == STATUS_NO_PRIOR_TURN
+    assert inference["summary"] == "Prior turn score data unavailable"
+    assert inference["diagnostics"]["reason"] == "first_turn"
 
 
 def test_build_inference_observation_maps_score_deltas(sample_turn):
@@ -135,16 +140,16 @@ def test_solver_failure_is_isolated_per_player(sample_turn):
         "api.analytics.military_score_inference.analytic.solve_inference_problem",
         side_effect=_solve_side_effect,
     ):
-        data = get_scores_table(
-            sample_turn,
-            TurnAnalyticsOptions(include_military_score_inference=True),
-        )
+        failing_inference = get_scores_row_inference(sample_turn, failing_player_id)
+        other_inferences = [
+            get_scores_row_inference(sample_turn, row.ownerid)
+            for row in sample_turn.scores
+            if row.ownerid != failing_player_id
+        ]
 
-    failed_rows = [row for row in data["rows"] if row["playerId"] == failing_player_id]
-    other_rows = [row for row in data["rows"] if row["playerId"] != failing_player_id]
-    assert len(data["rows"]) == len(sample_turn.scores)
-    assert failed_rows[0]["inference"]["status"] == STATUS_SOLVER_ERROR
-    assert all("inference" in row for row in other_rows)
+    assert failing_inference["status"] == STATUS_SOLVER_ERROR
+    assert len(other_inferences) == len(sample_turn.scores) - 1
+    assert all("status" in inference for inference in other_inferences)
 
 
 def _minimal_inference_problem(
@@ -310,12 +315,9 @@ def test_constraints_payload_exposes_requested_pp_as_diagnostic_only():
     assert not any("priorityPointDelta" in equality for equality in applied)
 
 
-def test_enabled_output_includes_structured_solver_diagnostics(sample_turn):
-    data = get_scores_table(
-        sample_turn,
-        TurnAnalyticsOptions(include_military_score_inference=True),
-    )
-    inference = data["rows"][0]["inference"]
+def test_row_inference_includes_structured_solver_diagnostics(sample_turn):
+    player_id = sample_turn.scores[0].ownerid
+    inference = get_scores_row_inference(sample_turn, player_id)
     diagnostics = inference["diagnostics"]
     assert diagnostics["turn"] == sample_turn.settings.turn
     assert "constraints" in diagnostics
@@ -336,7 +338,7 @@ def test_registry_still_exposes_only_scores_analytic(sample_turn):
     data = get_turn_analytic(
         "scores",
         sample_turn,
-        TurnAnalyticsOptions(include_military_score_inference=True),
+        TurnAnalyticsOptions(),
     )
     assert data["analyticId"] == "scores"
-    assert "inference" in data["rows"][0]
+    assert "inference" not in data["rows"][0]

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -1,0 +1,211 @@
+"""Tests for military score inference integration with the scores analytic."""
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from api.analytics import TurnAnalyticsOptions, get_turn_analytic
+from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.analytic import (
+    STATUS_NO_PRIOR_TURN,
+    STATUS_SOLVER_ERROR,
+    build_inference_observation,
+    infer_military_score_build,
+    inference_result_to_api_payload,
+    is_after_ship_limit,
+    prior_turn_score_data_available,
+)
+from api.analytics.military_score_inference.models import (
+    InferenceResult,
+    InferenceSolution,
+    InferenceSolutionAction,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_INVALID_PROBLEM,
+    solve_inference_problem,
+)
+from api.analytics.scores import get_scores_table
+from api.serialization.turn import turn_info_from_json
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def sample_turn():
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        return turn_info_from_json(json.load(handle))
+
+
+@pytest.fixture
+def first_turn(sample_turn):
+    return replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=1),
+    )
+
+
+def test_scores_output_unchanged_when_inference_disabled(sample_turn):
+    disabled = get_scores_table(sample_turn)
+    default_options = get_scores_table(sample_turn, TurnAnalyticsOptions())
+    assert disabled == default_options
+    assert "inference" not in disabled["rows"][0]
+
+
+def test_scores_output_includes_inference_when_enabled(sample_turn):
+    data = get_scores_table(
+        sample_turn,
+        TurnAnalyticsOptions(include_military_score_inference=True),
+    )
+    inference = data["rows"][0]["inference"]
+    assert inference["status"] in {
+        STATUS_EXACT,
+        STATUS_INVALID_PROBLEM,
+        "no_exact_solution",
+        "time_limited",
+    }
+    assert isinstance(inference["summary"], str)
+    assert inference["solutionCount"] == len(inference["solutions"])
+    assert "catalog_size" in inference["diagnostics"]
+
+
+def test_first_turn_produces_no_prior_turn_status(first_turn):
+    score = first_turn.scores[0]
+    inference = infer_military_score_build(score, first_turn)
+    assert inference["status"] == STATUS_NO_PRIOR_TURN
+    assert inference["summary"] == "Prior turn score data unavailable"
+    assert inference["diagnostics"]["reason"] == "first_turn"
+
+
+def test_enabled_first_turn_attaches_row_level_diagnostic(first_turn):
+    data = get_scores_table(
+        first_turn,
+        TurnAnalyticsOptions(include_military_score_inference=True),
+    )
+    for row in data["rows"]:
+        assert row["inference"]["status"] == STATUS_NO_PRIOR_TURN
+
+
+def test_build_inference_observation_maps_score_deltas(sample_turn):
+    score = sample_turn.scores[0]
+    observation = build_inference_observation(score, sample_turn)
+    assert observation.player_id == score.ownerid
+    assert observation.turn == sample_turn.settings.turn
+    assert observation.military_delta_2x == 2 * score.militarychange
+    assert observation.warship_delta == score.shipchange
+    assert observation.freighter_delta == score.freighterchange
+    assert observation.priority_point_delta == score.prioritypointchange
+    assert observation.starbases_owned == score.starbases
+
+
+def test_prior_turn_score_data_available(sample_turn, first_turn):
+    assert prior_turn_score_data_available(sample_turn) is True
+    assert prior_turn_score_data_available(first_turn) is False
+
+
+def test_is_after_ship_limit_uses_game_total_for_standard_queue(sample_turn):
+    score = sample_turn.scores[0]
+    assert is_after_ship_limit(sample_turn, score) is False
+
+    over_limit_turn = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, shiplimit=10),
+    )
+    assert is_after_ship_limit(over_limit_turn, score) is True
+
+
+def test_solver_failure_is_isolated_per_player(sample_turn):
+    failing_player_id = sample_turn.scores[0].ownerid
+
+    def _solve_side_effect(problem):
+        if problem.observation.player_id == failing_player_id:
+            raise RuntimeError("solver exploded")
+        return solve_inference_problem(problem)
+
+    with patch(
+        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        side_effect=_solve_side_effect,
+    ):
+        data = get_scores_table(
+            sample_turn,
+            TurnAnalyticsOptions(include_military_score_inference=True),
+        )
+
+    failed_rows = [row for row in data["rows"] if row["playerId"] == failing_player_id]
+    other_rows = [row for row in data["rows"] if row["playerId"] != failing_player_id]
+    assert len(data["rows"]) == len(sample_turn.scores)
+    assert failed_rows[0]["inference"]["status"] == STATUS_SOLVER_ERROR
+    assert all("inference" in row for row in other_rows)
+
+
+def test_inference_result_payload_merges_catalog_diagnostics(sample_turn):
+    catalog = ActionCatalog(actions=(), probability_buckets_by_action_id={})
+    observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+    result = InferenceResult(
+        status=STATUS_INVALID_PROBLEM,
+        solutions=(),
+        diagnostics={"reason": "empty catalog"},
+    )
+    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn)
+    assert payload["status"] == STATUS_INVALID_PROBLEM
+    assert payload["diagnostics"]["solver"]["reason"] == "empty catalog"
+    assert payload["diagnostics"]["catalog_size"] == 0
+    assert payload["diagnostics"]["constraints"]["playerId"] == sample_turn.scores[0].ownerid
+    assert payload["diagnostics"]["actionCatalog"]["catalogSize"] == 0
+
+
+def test_inference_result_payload_serializes_solutions(sample_turn):
+    catalog = ActionCatalog(actions=(), probability_buckets_by_action_id={})
+    observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+    result = InferenceResult(
+        status=STATUS_EXACT,
+        solutions=(
+            InferenceSolution(
+                objective_value=42,
+                actions=(
+                    InferenceSolutionAction(
+                        action_id="build_24_empty",
+                        label="Build Serpent Class Escort (empty)",
+                        count=1,
+                    ),
+                ),
+            ),
+        ),
+        diagnostics={"solution_count": 1},
+    )
+    payload = inference_result_to_api_payload(result, catalog, observation, sample_turn)
+    assert payload["solutionCount"] == 1
+    assert payload["solutions"][0]["objectiveValue"] == 42
+    assert payload["solutions"][0]["actions"][0]["actionId"] == "build_24_empty"
+
+
+def test_enabled_output_includes_structured_solver_diagnostics(sample_turn):
+    data = get_scores_table(
+        sample_turn,
+        TurnAnalyticsOptions(include_military_score_inference=True),
+    )
+    inference = data["rows"][0]["inference"]
+    diagnostics = inference["diagnostics"]
+    assert diagnostics["turn"] == sample_turn.settings.turn
+    assert "constraints" in diagnostics
+    assert "actionCatalog" in diagnostics
+    assert "solver" in diagnostics
+    assert isinstance(diagnostics["constraints"]["appliedEqualities"], list)
+    assert isinstance(diagnostics["actionCatalog"]["actions"], list)
+    assert "meta" in diagnostics["actionCatalog"]
+    assert "shipBuildActions" in diagnostics["actionCatalog"]
+
+
+def test_registry_still_exposes_only_scores_analytic(sample_turn):
+    from api.analytics.registry import TURN_ANALYTICS
+
+    assert set(TURN_ANALYTICS) == {"base-map", "connections", "scores", "stellar-cartography"}
+    data = get_turn_analytic(
+        "scores",
+        sample_turn,
+        TurnAnalyticsOptions(include_military_score_inference=True),
+    )
+    assert data["analyticId"] == "scores"
+    assert "inference" in data["rows"][0]

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -15,9 +15,11 @@ from api.analytics.military_score_inference.analytic import (
     infer_military_score_build,
     inference_result_to_api_payload,
     is_after_ship_limit,
+    observation_to_constraints_payload,
     prior_turn_score_data_available,
 )
 from api.analytics.military_score_inference.models import (
+    InferenceObservation,
     InferenceResult,
     InferenceSolution,
     InferenceSolutionAction,
@@ -181,6 +183,27 @@ def test_inference_result_payload_serializes_solutions(sample_turn):
     assert payload["solutions"][0]["actions"][0]["actionId"] == "build_24_empty"
 
 
+def test_constraints_payload_exposes_requested_pp_as_diagnostic_only():
+    observation = InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=0,
+        warship_delta=0,
+        freighter_delta=0,
+        priority_point_delta=54,
+        starbases_owned=3,
+        is_after_ship_limit=False,
+    )
+    constraints = observation_to_constraints_payload(observation)
+
+    assert constraints["requestedPriorityPointDelta"] == 54
+    assert constraints["priorityPointConstraintEnforced"] is False
+    assert "not a hard solver constraint" in str(constraints["priorityPointConstraintNote"])
+    assert "priorityPointDelta" not in constraints
+    applied = constraints["appliedEqualities"]
+    assert not any("priorityPointDelta" in equality for equality in applied)
+
+
 def test_enabled_output_includes_structured_solver_diagnostics(sample_turn):
     data = get_scores_table(
         sample_turn,
@@ -193,6 +216,8 @@ def test_enabled_output_includes_structured_solver_diagnostics(sample_turn):
     assert "actionCatalog" in diagnostics
     assert "solver" in diagnostics
     assert isinstance(diagnostics["constraints"]["appliedEqualities"], list)
+    assert diagnostics["constraints"]["priorityPointConstraintEnforced"] is False
+    assert "priorityPointConstraintNote" in diagnostics["constraints"]
     assert isinstance(diagnostics["actionCatalog"]["actions"], list)
     assert "meta" in diagnostics["actionCatalog"]
     assert "shipBuildActions" in diagnostics["actionCatalog"]

--- a/packages/api/tests/test_military_score_inference_constraints.py
+++ b/packages/api/tests/test_military_score_inference_constraints.py
@@ -1,0 +1,133 @@
+"""Parity tests: CP-SAT hard constraints and diagnostic appliedEqualities stay aligned."""
+
+from api.analytics.military_score_inference.constraints import (
+    PRIORITY_POINT_DIAGNOSTIC_NOTE,
+    InferenceHardConstraints,
+    observation_to_constraints_payload,
+)
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_NO_EXACT_SOLUTION,
+    solve_inference_problem,
+)
+
+
+def _observation(
+    *,
+    military_delta_2x: int = 400,
+    warship_delta: int = 1,
+    freighter_delta: int = 0,
+    priority_point_delta: int = 0,
+    starbases_owned: int = 3,
+) -> InferenceObservation:
+    return InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=military_delta_2x,
+        warship_delta=warship_delta,
+        freighter_delta=freighter_delta,
+        priority_point_delta=priority_point_delta,
+        starbases_owned=starbases_owned,
+        is_after_ship_limit=False,
+    )
+
+
+def _build_warship_action(*, priority_point_delta: int = 0) -> CandidateAction:
+    return CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        priority_point_delta=priority_point_delta,
+        build_slot_usage=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+
+
+def test_applied_equalities_default_omit_priority_point():
+    observation = _observation(priority_point_delta=54)
+    constraints = InferenceHardConstraints()
+    payload = observation_to_constraints_payload(observation, hard_constraints=constraints)
+
+    assert constraints.enforced_equalities() == InferenceHardConstraints().enforced_equalities()
+    assert payload["appliedEqualities"] == constraints.applied_equalities(observation)
+    assert payload["priorityPointConstraintEnforced"] is False
+    assert payload["priorityPointConstraintNote"] == PRIORITY_POINT_DIAGNOSTIC_NOTE
+    assert not any("priorityPointDelta" in line for line in payload["appliedEqualities"])
+
+
+def test_applied_equalities_from_problem_matches_hard_constraints_descriptor():
+    observation = _observation(priority_point_delta=54)
+    for enforce in (False, True):
+        problem = InferenceProblem(
+            observation=observation,
+            actions=(_build_warship_action(),),
+            probability_buckets_by_action_id={},
+            enforce_priority_point_constraint=enforce,
+        )
+        hard_constraints = InferenceHardConstraints.from_problem(problem)
+        payload = observation_to_constraints_payload(observation, hard_constraints=hard_constraints)
+
+        assert payload["appliedEqualities"] == hard_constraints.applied_equalities(observation)
+        assert payload["priorityPointConstraintEnforced"] is enforce
+        has_pp_line = any("priorityPointDelta" in line for line in payload["appliedEqualities"])
+        assert has_pp_line is enforce
+        if enforce:
+            assert "priorityPointConstraintNote" not in payload
+        else:
+            assert payload["priorityPointConstraintNote"] == PRIORITY_POINT_DIAGNOSTIC_NOTE
+
+
+def test_solver_behavior_tracks_enforced_priority_point_flag():
+    """Shared descriptor: PP off is feasible, PP on is infeasible for this catalog."""
+    build_action = _build_warship_action()
+    observation = _observation(priority_point_delta=54)
+
+    without_pp = InferenceProblem(
+        observation=observation,
+        actions=(build_action,),
+        probability_buckets_by_action_id={},
+    )
+    with_pp = InferenceProblem(
+        observation=observation,
+        actions=(build_action,),
+        probability_buckets_by_action_id={},
+        enforce_priority_point_constraint=True,
+    )
+
+    assert solve_inference_problem(without_pp).status == STATUS_EXACT
+    assert solve_inference_problem(with_pp).status == STATUS_NO_EXACT_SOLUTION
+
+    without_payload = observation_to_constraints_payload(
+        observation, hard_constraints=InferenceHardConstraints.from_problem(without_pp)
+    )
+    with_payload = observation_to_constraints_payload(
+        observation, hard_constraints=InferenceHardConstraints.from_problem(with_pp)
+    )
+    assert without_payload["priorityPointConstraintEnforced"] is False
+    assert with_payload["priorityPointConstraintEnforced"] is True
+    assert len(with_payload["appliedEqualities"]) == len(without_payload["appliedEqualities"]) + 1
+
+
+def test_enforced_priority_point_equality_satisfiable_when_catalog_matches():
+    build_action = _build_warship_action(priority_point_delta=54)
+    observation = _observation(priority_point_delta=54)
+    problem = InferenceProblem(
+        observation=observation,
+        actions=(build_action,),
+        probability_buckets_by_action_id={},
+        enforce_priority_point_constraint=True,
+    )
+    result = solve_inference_problem(problem)
+    payload = observation_to_constraints_payload(
+        observation, hard_constraints=InferenceHardConstraints.from_problem(problem)
+    )
+
+    assert result.status == STATUS_EXACT
+    assert any("priorityPointDelta" in line for line in payload["appliedEqualities"])

--- a/packages/api/tests/test_military_score_inference_scoring.py
+++ b/packages/api/tests/test_military_score_inference_scoring.py
@@ -1,0 +1,129 @@
+"""Tests for military score inference contracts and scaled score arithmetic."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+    InferenceSolutionAction,
+    ProbabilityBucket,
+)
+from api.analytics.military_score_inference.scoring import (
+    LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
+    PLANET_DEFENSE_POST_SCORE_DELTA_2X,
+    STARBASE_DEFENSE_POST_SCORE_DELTA_2X,
+    STARBASE_FIGHTER_SCORE_DELTA_2X,
+    construction_value,
+    loaded_ship_fighter_score_delta_2x,
+    loaded_ship_torpedo_score_delta_2x,
+    planet_defense_post_score_delta_2x,
+    ship_construction_score_delta_2x,
+    starbase_defense_post_score_delta_2x,
+    starbase_fighter_score_delta_2x,
+)
+
+
+def test_construction_value_uses_megacredits_and_minerals():
+    assert construction_value(100, 20) == 200
+
+
+def test_ship_construction_score_delta_2x_scales_construction_value():
+    assert ship_construction_score_delta_2x(100, 20) == 400
+
+
+def test_loaded_ship_fighter_score_delta_2x():
+    assert loaded_ship_fighter_score_delta_2x() == 250
+    assert loaded_ship_fighter_score_delta_2x(3) == 750
+    assert LOADED_SHIP_FIGHTER_SCORE_DELTA_2X == 250
+
+
+def test_loaded_ship_torpedo_score_delta_2x():
+    assert loaded_ship_torpedo_score_delta_2x(1) == 2
+    assert loaded_ship_torpedo_score_delta_2x(5, count=4) == 40
+
+
+def test_starbase_fighter_score_delta_2x():
+    assert starbase_fighter_score_delta_2x() == 125
+    assert starbase_fighter_score_delta_2x(2) == 250
+    assert STARBASE_FIGHTER_SCORE_DELTA_2X == 125
+
+
+def test_starbase_defense_post_score_delta_2x():
+    assert starbase_defense_post_score_delta_2x() == 15
+    assert starbase_defense_post_score_delta_2x(10) == 150
+    assert STARBASE_DEFENSE_POST_SCORE_DELTA_2X == 15
+
+
+def test_planet_defense_post_score_delta_2x():
+    assert planet_defense_post_score_delta_2x() == 11
+    assert planet_defense_post_score_delta_2x(100) == 1100
+    assert PLANET_DEFENSE_POST_SCORE_DELTA_2X == 11
+
+
+def test_inference_dataclasses_are_frozen():
+    observation = InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=400,
+        warship_delta=1,
+        freighter_delta=0,
+        priority_point_delta=0,
+        starbases_owned=3,
+        is_after_ship_limit=False,
+    )
+    with pytest.raises(FrozenInstanceError):
+        observation.turn = 6
+
+
+def test_inference_problem_carries_actions_and_buckets():
+    observation = InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=11,
+        warship_delta=0,
+        freighter_delta=0,
+        priority_point_delta=0,
+        starbases_owned=1,
+        is_after_ship_limit=False,
+    )
+    action = CandidateAction(
+        id="planet_defense_posts",
+        label="Planet defense posts",
+        score_delta_2x=PLANET_DEFENSE_POST_SCORE_DELTA_2X,
+        upper_bound=100,
+    )
+    bucket = ProbabilityBucket(
+        label="modest build-up",
+        lower_count=0,
+        upper_count=10,
+        marginal_weight=100,
+    )
+    problem = InferenceProblem(
+        observation=observation,
+        actions=(action,),
+        probability_buckets_by_action_id={action.id: (bucket,)},
+    )
+    result = InferenceResult(
+        status="exact",
+        solutions=(
+            InferenceSolution(
+                objective_value=100,
+                actions=(
+                    InferenceSolutionAction(
+                        action_id=action.id,
+                        label=action.label,
+                        count=1,
+                    ),
+                ),
+            ),
+        ),
+        diagnostics={"solver_status": "OPTIMAL"},
+    )
+
+    assert problem.actions[0].score_delta_2x == 11
+    assert problem.probability_buckets_by_action_id[action.id][0].marginal_weight == 100
+    assert result.solutions[0].actions[0].count == 1

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -1,0 +1,7 @@
+"""Smoke tests for OR-Tools CP-SAT availability (military score inference dependency)."""
+
+
+def test_cp_model_imports():
+    from ortools.sat.python import cp_model
+
+    assert cp_model.CpModel is not None

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -133,6 +133,54 @@ def test_solve_solution_with_negative_action_contribution():
     assert counts["transfer_to_starbase"] == 1
 
 
+def test_solve_non_zero_priority_points_with_zero_pp_catalog_actions():
+    """Regression: PP delta is diagnostic-only until queue semantics model per-build PP."""
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=400, warship_delta=1, priority_point_delta=54),
+            build_warship,
+        )
+    )
+
+    assert result.status == STATUS_EXACT
+    assert result.solutions[0].actions[0].action_id == "build_rush"
+
+
+def test_solve_enforced_priority_point_constraint_requires_catalog_pp_deltas():
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    problem = InferenceProblem(
+        observation=_observation(
+            military_delta_2x=400,
+            warship_delta=1,
+            priority_point_delta=54,
+        ),
+        actions=(build_warship,),
+        probability_buckets_by_action_id={},
+        enforce_priority_point_constraint=True,
+    )
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_NO_EXACT_SOLUTION
+    assert result.solutions == ()
+
+
 def test_solve_infeasible_problem_returns_no_exact_solution():
     build_warship = CandidateAction(
         id="build_rush",

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -14,6 +14,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
+    STATUS_TIME_LIMITED,
     solve_inference_problem,
 )
 
@@ -41,11 +42,15 @@ def _observation(
 def _problem(
     observation: InferenceObservation,
     *actions: CandidateAction,
+    max_solutions: int = 20,
+    time_limit_seconds: float = 1.0,
 ) -> InferenceProblem:
     return InferenceProblem(
         observation=observation,
         actions=actions,
         probability_buckets_by_action_id={},
+        max_solutions=max_solutions,
+        time_limit_seconds=time_limit_seconds,
     )
 
 
@@ -139,3 +144,155 @@ def test_solve_invalid_problem_with_bad_action_bounds():
     assert result.status == STATUS_INVALID_PROBLEM
     assert result.solutions == ()
     assert "lower_bound" in str(result.diagnostics["reason"])
+
+
+def test_top_k_returns_higher_weight_solutions_first():
+    preferred_build = CandidateAction(
+        id="build_preferred",
+        label="Build preferred hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    alternate_build = CandidateAction(
+        id="build_alternate",
+        label="Build alternate hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    paired_build = CandidateAction(
+        id="build_small",
+        label="Build small hull twice",
+        score_delta_2x=200,
+        upper_bound=2,
+        probability_weight=30,
+    )
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=400),
+            preferred_build,
+            alternate_build,
+            paired_build,
+            max_solutions=3,
+        )
+    )
+
+    assert result.status == STATUS_EXACT
+    assert [solution.objective_value for solution in result.solutions] == [100, 60, 50]
+    assert result.solutions[0].actions[0].action_id == "build_preferred"
+
+
+def test_top_k_no_good_cuts_prevent_duplicate_action_vectors():
+    preferred_build = CandidateAction(
+        id="build_preferred",
+        label="Build preferred hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    alternate_build = CandidateAction(
+        id="build_alternate",
+        label="Build alternate hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=400),
+            preferred_build,
+            alternate_build,
+            max_solutions=5,
+        )
+    )
+
+    signatures = [
+        tuple(sorted((action.action_id, action.count) for action in solution.actions))
+        for solution in result.solutions
+    ]
+    assert len(signatures) == len(set(signatures))
+
+
+def test_top_k_stops_at_configured_max_solutions():
+    preferred_build = CandidateAction(
+        id="build_preferred",
+        label="Build preferred hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    alternate_build = CandidateAction(
+        id="build_alternate",
+        label="Build alternate hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    paired_build = CandidateAction(
+        id="build_small",
+        label="Build small hull twice",
+        score_delta_2x=200,
+        upper_bound=2,
+        probability_weight=30,
+    )
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=400),
+            preferred_build,
+            alternate_build,
+            paired_build,
+            max_solutions=2,
+        )
+    )
+
+    assert result.status == STATUS_EXACT
+    assert len(result.solutions) == 2
+    assert result.diagnostics["stopped_reason"] == "max_solutions"
+
+
+def test_top_k_surfaces_time_limited_status(monkeypatch):
+    from api.analytics.military_score_inference import solver as inference_solver
+
+    preferred_build = CandidateAction(
+        id="build_preferred",
+        label="Build preferred hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    alternate_build = CandidateAction(
+        id="build_alternate",
+        label="Build alternate hull",
+        score_delta_2x=400,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    solve_calls = {"count": 0}
+    original_solve = inference_solver.cp_model.CpSolver.solve
+
+    def solve_once_then_time_out(self, model):
+        solve_calls["count"] += 1
+        if solve_calls["count"] == 1:
+            return original_solve(self, model)
+        return inference_solver.cp_model.UNKNOWN
+
+    monkeypatch.setattr(
+        inference_solver.cp_model.CpSolver,
+        "solve",
+        solve_once_then_time_out,
+    )
+
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=400),
+            preferred_build,
+            alternate_build,
+            max_solutions=5,
+        )
+    )
+
+    assert result.status == STATUS_TIME_LIMITED
+    assert len(result.solutions) == 1
+    assert result.diagnostics["time_limited"] is True
+    assert result.diagnostics["stopped_reason"] == "time_budget"

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -5,9 +5,11 @@ from api.analytics.military_score_inference.models import (
     InferenceObservation,
     InferenceProblem,
     InferenceSolutionAction,
+    ProbabilityBucket,
 )
 from api.analytics.military_score_inference.scoring import (
     LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
+    PLANET_DEFENSE_POST_SCORE_DELTA_2X,
     STARBASE_FIGHTER_SCORE_DELTA_2X,
 )
 from api.analytics.military_score_inference.solver import (
@@ -44,13 +46,30 @@ def _problem(
     *actions: CandidateAction,
     max_solutions: int = 20,
     time_limit_seconds: float = 1.0,
+    probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]] | None = None,
 ) -> InferenceProblem:
     return InferenceProblem(
         observation=observation,
         actions=actions,
-        probability_buckets_by_action_id={},
+        probability_buckets_by_action_id=probability_buckets_by_action_id or {},
         max_solutions=max_solutions,
         time_limit_seconds=time_limit_seconds,
+    )
+
+
+PLANET_DEFENSE_POST_BUCKETS = (
+    ProbabilityBucket("modest build-up", 0, 10, 100),
+    ProbabilityBucket("heavy build-up", 11, 50, 20),
+    ProbabilityBucket("extreme build-up", 51, 100, 5),
+)
+
+
+def _planet_defense_posts_action(*, upper_bound: int = 100) -> CandidateAction:
+    return CandidateAction(
+        id="planet_defense_posts",
+        label="Planet defense posts",
+        score_delta_2x=PLANET_DEFENSE_POST_SCORE_DELTA_2X,
+        upper_bound=upper_bound,
     )
 
 
@@ -296,3 +315,63 @@ def test_top_k_surfaces_time_limited_status(monkeypatch):
     assert len(result.solutions) == 1
     assert result.diagnostics["time_limited"] is True
     assert result.diagnostics["stopped_reason"] == "time_budget"
+
+
+def test_bucketed_defense_posts_use_different_marginal_penalties_for_10_and_100():
+    action = _planet_defense_posts_action()
+    buckets = {"planet_defense_posts": PLANET_DEFENSE_POST_BUCKETS}
+
+    result_ten = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=10 * PLANET_DEFENSE_POST_SCORE_DELTA_2X),
+            action,
+            probability_buckets_by_action_id=buckets,
+        )
+    )
+    result_hundred = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=100 * PLANET_DEFENSE_POST_SCORE_DELTA_2X),
+            action,
+            probability_buckets_by_action_id=buckets,
+        )
+    )
+
+    assert result_ten.solutions[0].actions[0].count == 10
+    assert result_ten.solutions[0].objective_value == 10 * 100
+    assert result_hundred.solutions[0].actions[0].count == 100
+    assert result_hundred.solutions[0].objective_value == 10 * 100 + 40 * 20 + 50 * 5
+    assert result_ten.solutions[0].objective_value / 10 != (
+        result_hundred.solutions[0].objective_value / 100
+    )
+
+
+def test_bucketed_action_satisfies_exact_score_constraint():
+    action = _planet_defense_posts_action()
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=55 * PLANET_DEFENSE_POST_SCORE_DELTA_2X),
+            action,
+            probability_buckets_by_action_id={"planet_defense_posts": PLANET_DEFENSE_POST_BUCKETS},
+        )
+    )
+
+    assert result.status == STATUS_EXACT
+    assert result.solutions[0].actions[0].count == 55
+
+
+def test_bucket_variables_respect_configured_count_ranges():
+    action = _planet_defense_posts_action()
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=100 * PLANET_DEFENSE_POST_SCORE_DELTA_2X),
+            action,
+            probability_buckets_by_action_id={"planet_defense_posts": PLANET_DEFENSE_POST_BUCKETS},
+        )
+    )
+
+    bucket_counts = result.diagnostics["bucket_counts_by_action_id"]["planet_defense_posts"]
+    assert bucket_counts == (10, 40, 50)
+    assert bucket_counts[0] <= 10
+    assert bucket_counts[1] <= 40
+    assert bucket_counts[2] <= 50
+    assert sum(bucket_counts) == 100

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -1,7 +1,141 @@
-"""Smoke tests for OR-Tools CP-SAT availability (military score inference dependency)."""
+"""Tests for the military score inference CP-SAT solver."""
+
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    InferenceProblem,
+    InferenceSolutionAction,
+)
+from api.analytics.military_score_inference.scoring import (
+    LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
+    STARBASE_FIGHTER_SCORE_DELTA_2X,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_INVALID_PROBLEM,
+    STATUS_NO_EXACT_SOLUTION,
+    solve_inference_problem,
+)
 
 
-def test_cp_model_imports():
-    from ortools.sat.python import cp_model
+def _observation(
+    *,
+    military_delta_2x: int = 0,
+    warship_delta: int = 0,
+    freighter_delta: int = 0,
+    priority_point_delta: int = 0,
+    starbases_owned: int = 3,
+) -> InferenceObservation:
+    return InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=military_delta_2x,
+        warship_delta=warship_delta,
+        freighter_delta=freighter_delta,
+        priority_point_delta=priority_point_delta,
+        starbases_owned=starbases_owned,
+        is_after_ship_limit=False,
+    )
 
-    assert cp_model.CpModel is not None
+
+def _problem(
+    observation: InferenceObservation,
+    *actions: CandidateAction,
+) -> InferenceProblem:
+    return InferenceProblem(
+        observation=observation,
+        actions=actions,
+        probability_buckets_by_action_id={},
+    )
+
+
+def test_cp_model_available_via_solver_module():
+    from api.analytics.military_score_inference import solver as inference_solver
+
+    assert inference_solver.cp_model.CpModel is not None
+
+
+def test_solve_exact_positive_action_solution():
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    result = solve_inference_problem(
+        _problem(_observation(military_delta_2x=400, warship_delta=1), build_warship)
+    )
+
+    assert result.status == STATUS_EXACT
+    assert result.solutions[0].actions == (
+        InferenceSolutionAction(
+            action_id="build_rush",
+            label="Build Rush",
+            count=1,
+        ),
+    )
+    assert result.solutions[0].objective_value == 100
+
+
+def test_solve_solution_with_negative_action_contribution():
+    load_fighters = CandidateAction(
+        id="load_fighters",
+        label="Load ship fighters",
+        score_delta_2x=LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    transfer_to_starbase = CandidateAction(
+        id="transfer_to_starbase",
+        label="Transfer fighters ship to starbase",
+        score_delta_2x=-STARBASE_FIGHTER_SCORE_DELTA_2X,
+        upper_bound=1,
+        probability_weight=10,
+    )
+    result = solve_inference_problem(
+        _problem(
+            _observation(military_delta_2x=125),
+            load_fighters,
+            transfer_to_starbase,
+        )
+    )
+
+    assert result.status == STATUS_EXACT
+    counts = {action.action_id: action.count for action in result.solutions[0].actions}
+    assert counts["load_fighters"] == 1
+    assert counts["transfer_to_starbase"] == 1
+
+
+def test_solve_infeasible_problem_returns_no_exact_solution():
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+    )
+    result = solve_inference_problem(
+        _problem(_observation(military_delta_2x=401, warship_delta=1), build_warship)
+    )
+
+    assert result.status == STATUS_NO_EXACT_SOLUTION
+    assert result.solutions == ()
+
+
+def test_solve_invalid_problem_with_bad_action_bounds():
+    invalid_action = CandidateAction(
+        id="planet_defense_posts",
+        label="Planet defense posts",
+        score_delta_2x=11,
+        lower_bound=5,
+        upper_bound=2,
+    )
+    result = solve_inference_problem(_problem(_observation(military_delta_2x=11), invalid_action))
+
+    assert result.status == STATUS_INVALID_PROBLEM
+    assert result.solutions == ()
+    assert "lower_bound" in str(result.diagnostics["reason"])

--- a/packages/bff/bff/analytics/__init__.py
+++ b/packages/bff/bff/analytics/__init__.py
@@ -3,6 +3,7 @@
 from bff.analytics.models import ConnectionsMapQuery, FlareConnectionMode, TurnScope
 from bff.analytics.registry import (
     ANALYTICS_LIST,
+    get_inference_response,
     get_map_response,
     get_table_response,
     map_diagnostic_values,
@@ -14,6 +15,7 @@ __all__ = [
     "ConnectionsMapQuery",
     "FlareConnectionMode",
     "TurnScope",
+    "get_inference_response",
     "get_map_response",
     "get_table_response",
     "map_diagnostic_values",

--- a/packages/bff/bff/analytics/models.py
+++ b/packages/bff/bff/analytics/models.py
@@ -23,6 +23,11 @@ class ConnectionsMapQuery:
     include_illustrative_routes: bool
 
 
+@dataclass(frozen=True)
+class ScoresTableQuery:
+    include_build_inference: bool = False
+
+
 CoreAnalyticsLoader = Callable[..., dict]
 
 

--- a/packages/bff/bff/analytics/registry.py
+++ b/packages/bff/bff/analytics/registry.py
@@ -50,6 +50,28 @@ def get_table_response(
     return descriptor.get_table(scope, load_core, diagnostics)
 
 
+def get_inference_response(
+    analytic_id: str,
+    scope: TurnScope,
+    load_core: CoreAnalyticsLoader,
+    diagnostics: Diagnostics,
+    *,
+    player_id: int,
+) -> dict:
+    if analytic_id != "scores":
+        raise BFFValidationError(f"Analytic {analytic_id!r} does not support inference")
+    core_inference = load_core(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        analytic_id,
+        diagnostics=diagnostics,
+        player_id=player_id,
+        inference_only=True,
+    )
+    return scores.inference_from_core(core_inference, player_id=player_id)
+
+
 def map_diagnostic_values(analytic_id: str, query: ConnectionsMapQuery) -> dict:
     descriptor = _BY_ID.get(analytic_id)
     if descriptor is None or descriptor.map_diagnostic_values is None:

--- a/packages/bff/bff/analytics/registry.py
+++ b/packages/bff/bff/analytics/registry.py
@@ -34,10 +34,19 @@ def get_table_response(
     scope: TurnScope,
     load_core: CoreAnalyticsLoader,
     diagnostics: Diagnostics,
+    *,
+    include_build_inference: bool = False,
 ) -> dict:
     descriptor = _require_descriptor(analytic_id)
     if descriptor.get_table is None:
         raise BFFValidationError(f"Analytic {analytic_id!r} does not support table view")
+    if analytic_id == "scores":
+        return descriptor.get_table(
+            scope,
+            load_core,
+            diagnostics,
+            include_build_inference=include_build_inference,
+        )
     return descriptor.get_table(scope, load_core, diagnostics)
 
 

--- a/packages/bff/bff/analytics/scores.py
+++ b/packages/bff/bff/analytics/scores.py
@@ -17,6 +17,8 @@ TABLE_COLUMNS = [
     "Priority Points",
 ]
 
+INFERENCE_COLUMN = "Build inference"
+
 TABLE_FIELDS = [
     "planets",
     "starbases",
@@ -39,27 +41,95 @@ def _format_score_cell(cell: object) -> str:
     return f"{value} ({change})"
 
 
-def table_from_core(core_data: dict) -> dict:
-    rows = []
+def _inference_cell_display_status(inference: dict[str, object]) -> str:
+    status = str(inference.get("status", ""))
+    solution_count = inference.get("solutionCount", 0)
+    if status == "exact":
+        return "success"
+    if status == "time_limited" and isinstance(solution_count, int) and solution_count > 0:
+        return "success"
+    if status == "time_limited" and inference.get("isComplete") is False:
+        return "pending"
+    return "failure"
+
+
+def _shape_inference_detail(
+    inference: object,
+    *,
+    player_id: object = None,
+) -> dict[str, object]:
+    if not isinstance(inference, dict):
+        shaped = {
+            "displayStatus": "failure",
+            "status": "missing_inference",
+            "summary": "Inference data unavailable",
+            "solutionCount": 0,
+            "isComplete": True,
+            "solutions": [],
+            "diagnostics": {},
+        }
+    else:
+        shaped = {
+            "displayStatus": _inference_cell_display_status(inference),
+            "status": inference.get("status"),
+            "summary": inference.get("summary", ""),
+            "solutionCount": inference.get("solutionCount", 0),
+            "isComplete": inference.get("isComplete", True),
+            "solutions": inference.get("solutions", []),
+            "diagnostics": inference.get("diagnostics", {}),
+        }
+    if isinstance(player_id, int):
+        shaped["playerId"] = player_id
+    return shaped
+
+
+def table_from_core(core_data: dict, *, include_build_inference: bool = False) -> dict:
+    columns = list(TABLE_COLUMNS)
+    if include_build_inference:
+        columns.append(INFERENCE_COLUMN)
+
+    rows: list[list[str]] = []
+    inference_by_row: list[dict[str, object]] = []
     for row in core_data.get("rows", []):
         if not isinstance(row, dict):
             continue
-        rows.append(
-            [
-                str(row.get("racePlayer", "")),
-                *[_format_score_cell(row.get(field)) for field in TABLE_FIELDS],
-            ]
-        )
-    return {
+        table_row = [
+            str(row.get("racePlayer", "")),
+            *[_format_score_cell(row.get(field)) for field in TABLE_FIELDS],
+        ]
+        if include_build_inference:
+            inference_by_row.append(
+                _shape_inference_detail(row.get("inference"), player_id=row.get("playerId"))
+            )
+            table_row.append("")
+        rows.append(table_row)
+
+    payload: dict[str, object] = {
         "analyticId": ANALYTIC_ID,
-        "columns": TABLE_COLUMNS,
+        "columns": columns,
         "rows": rows,
     }
+    if include_build_inference:
+        payload["includeBuildInference"] = True
+        payload["inferenceByRow"] = inference_by_row
+    return payload
 
 
-def get_table(scope: TurnScope, load_core: CoreAnalyticsLoader, diagnostics: Diagnostics) -> dict:
-    core_data = load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
-    return table_from_core(core_data)
+def get_table(
+    scope: TurnScope,
+    load_core: CoreAnalyticsLoader,
+    diagnostics: Diagnostics,
+    *,
+    include_build_inference: bool = False,
+) -> dict:
+    core_data = load_core_analytic(
+        load_core,
+        scope,
+        ANALYTIC_ID,
+        diagnostics=diagnostics,
+        include_military_score_inference=include_build_inference,
+    )
+    return table_from_core(core_data, include_build_inference=include_build_inference)
 
 
 DESCRIPTOR = AnalyticDescriptor(

--- a/packages/bff/bff/analytics/scores.py
+++ b/packages/bff/bff/analytics/scores.py
@@ -83,6 +83,13 @@ def _shape_inference_detail(
     return shaped
 
 
+def _pending_inference_stub(player_id: object) -> dict[str, object]:
+    stub: dict[str, object] = {}
+    if isinstance(player_id, int):
+        stub["playerId"] = player_id
+    return stub
+
+
 def table_from_core(core_data: dict, *, include_build_inference: bool = False) -> dict:
     columns = list(TABLE_COLUMNS)
     if include_build_inference:
@@ -98,9 +105,7 @@ def table_from_core(core_data: dict, *, include_build_inference: bool = False) -
             *[_format_score_cell(row.get(field)) for field in TABLE_FIELDS],
         ]
         if include_build_inference:
-            inference_by_row.append(
-                _shape_inference_detail(row.get("inference"), player_id=row.get("playerId"))
-            )
+            inference_by_row.append(_pending_inference_stub(row.get("playerId")))
         rows.append(table_row)
 
     payload: dict[str, object] = {
@@ -126,9 +131,13 @@ def get_table(
         scope,
         ANALYTIC_ID,
         diagnostics=diagnostics,
-        include_military_score_inference=include_build_inference,
     )
     return table_from_core(core_data, include_build_inference=include_build_inference)
+
+
+def inference_from_core(core_inference: object, *, player_id: int) -> dict[str, object]:
+    """Shape one Core scores-row inference payload for the SPA."""
+    return _shape_inference_detail(core_inference, player_id=player_id)
 
 
 DESCRIPTOR = AnalyticDescriptor(

--- a/packages/bff/bff/analytics/scores.py
+++ b/packages/bff/bff/analytics/scores.py
@@ -101,7 +101,6 @@ def table_from_core(core_data: dict, *, include_build_inference: bool = False) -
             inference_by_row.append(
                 _shape_inference_detail(row.get("inference"), player_id=row.get("playerId"))
             )
-            table_row.append("")
         rows.append(table_row)
 
     payload: dict[str, object] = {

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -269,6 +269,25 @@ class CoreClient:
             )
         )
 
+    def get_scores_row_inference(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+        *,
+        diagnostics: Diagnostics = NOOP_DIAGNOSTICS,
+    ) -> dict[str, object]:
+        _ = diagnostics
+        return self._invoke(
+            lambda: self._analytics.get_scores_row_inference(
+                game_id,
+                perspective,
+                turn_number,
+                player_id,
+            )
+        )
+
 
 def get_core_client() -> CoreClient:
     return CoreClient()

--- a/packages/bff/bff/routers/analytics.py
+++ b/packages/bff/bff/routers/analytics.py
@@ -19,6 +19,7 @@ from bff.analytics import (
     ANALYTICS_LIST,
     ConnectionsMapQuery,
     TurnScope,
+    get_inference_response,
     get_map_response,
     get_table_response,
     map_diagnostic_values,
@@ -44,6 +45,19 @@ def _turn_analytics_from_core(
     diagnostics: Diagnostics = NOOP_DIAGNOSTICS,
     **kwargs: object,
 ) -> dict:
+    if kwargs.pop("inference_only", False):
+        player_id = kwargs.pop("player_id", None)
+        if not isinstance(player_id, int):
+            raise ValueError("player_id is required for scores inference")
+        if kwargs:
+            raise ValueError(f"Unexpected kwargs for scores inference: {sorted(kwargs)}")
+        return get_core_client().get_scores_row_inference(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+            diagnostics=diagnostics,
+        )
     return get_core_client().get_turn_analytics(
         game_id,
         perspective,
@@ -96,6 +110,41 @@ def get_analytic_table(
             _turn_analytics_from_core,
             table_node,
             include_build_inference=include_build_inference,
+        )
+    return finish_response(body, root)
+
+
+@router.get("/{analytic_id}/inference")
+def get_analytic_inference(
+    analytic_id: str,
+    game_id: int = Query(..., alias="gameId"),
+    turn: int = Query(..., ge=1),
+    perspective: int = Query(..., ge=0),
+    player_id: int = Query(..., alias="playerId", ge=0),
+    include: IncludeDiagnostics = False,
+):
+    """Per-row military score build inference for the Scores analytic."""
+    bff_path = f"/analytics/{analytic_id}/inference"
+    scope = TurnScope(game_id=game_id, perspective=perspective, turn=turn)
+
+    root = optional_request_root(
+        include,
+        "GET",
+        bff_path,
+        gameId=game_id,
+        turn=turn,
+        perspective=perspective,
+        playerId=player_id,
+        handler="get_analytic_inference",
+    )
+    inference_node = root.child("get_analytic_inference")
+    with timed_section(inference_node, "total"):
+        body = get_inference_response(
+            analytic_id,
+            scope,
+            _turn_analytics_from_core,
+            inference_node,
+            player_id=player_id,
         )
     return finish_response(body, root)
 

--- a/packages/bff/bff/routers/analytics.py
+++ b/packages/bff/bff/routers/analytics.py
@@ -71,6 +71,7 @@ def get_analytic_table(
     game_id: int = Query(..., alias="gameId"),
     turn: int = Query(..., ge=1),
     perspective: int = Query(..., ge=0),
+    include_build_inference: bool = Query(False, alias="includeBuildInference"),
     include: IncludeDiagnostics = False,
 ):
     """Tabular data scoped to the selected game, turn, and perspective."""
@@ -84,11 +85,18 @@ def get_analytic_table(
         gameId=game_id,
         turn=turn,
         perspective=perspective,
+        includeBuildInference=include_build_inference,
         handler="get_analytic_table",
     )
     table_node = root.child("get_analytic_table")
     with timed_section(table_node, "total"):
-        body = get_table_response(analytic_id, scope, _turn_analytics_from_core, table_node)
+        body = get_table_response(
+            analytic_id,
+            scope,
+            _turn_analytics_from_core,
+            table_node,
+            include_build_inference=include_build_inference,
+        )
     return finish_response(body, root)
 
 

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -105,8 +105,7 @@ def test_scores_table_with_build_inference_adds_column_and_details():
     data = response.json()
     assert data["includeBuildInference"] is True
     assert data["columns"][-1] == "Build inference"
-    assert len(data["rows"][0]) == len(data["columns"])
-    assert data["rows"][0][-1] == ""
+    assert len(data["rows"][0]) == len(data["columns"]) - 1
     inference = data["inferenceByRow"][0]
     assert inference["displayStatus"] in {"success", "failure", "pending"}
     assert isinstance(inference["summary"], str)

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -99,6 +99,38 @@ def test_scores_table_returns_scoreboard_columns_and_deltas():
     ]
 
 
+def test_scores_table_with_build_inference_adds_column_and_details():
+    response = client.get(f"/analytics/scores/table?{SCOPE_QS}&includeBuildInference=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["includeBuildInference"] is True
+    assert data["columns"][-1] == "Build inference"
+    assert len(data["rows"][0]) == len(data["columns"])
+    assert data["rows"][0][-1] == ""
+    inference = data["inferenceByRow"][0]
+    assert inference["displayStatus"] in {"success", "failure", "pending"}
+    assert isinstance(inference["summary"], str)
+    assert "status" in inference
+    assert "diagnostics" in inference
+    assert inference["playerId"] == 8
+    assert inference["diagnostics"]["turn"] == 111
+    assert "constraints" in inference["diagnostics"]
+    assert "actionCatalog" in inference["diagnostics"]
+    assert "solver" in inference["diagnostics"]
+
+
+def test_scores_table_build_inference_disabled_matches_default_contract():
+    default_response = client.get(f"/analytics/scores/table?{SCOPE_QS}")
+    explicit_response = client.get(
+        f"/analytics/scores/table?{SCOPE_QS}&includeBuildInference=false"
+    )
+    assert default_response.status_code == 200
+    assert explicit_response.status_code == 200
+    assert default_response.json() == explicit_response.json()
+    assert "includeBuildInference" not in default_response.json()
+    assert "inferenceByRow" not in default_response.json()
+
+
 def test_base_map_returns_planets_and_no_edges():
     """GET /analytics/base-map/map returns planet nodes and no edges."""
     response = client.get(f"/analytics/base-map/map?{SCOPE_QS}")

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -99,14 +99,20 @@ def test_scores_table_returns_scoreboard_columns_and_deltas():
     ]
 
 
-def test_scores_table_with_build_inference_adds_column_and_details():
+def test_scores_table_with_build_inference_adds_column_and_player_stubs():
     response = client.get(f"/analytics/scores/table?{SCOPE_QS}&includeBuildInference=true")
     assert response.status_code == 200
     data = response.json()
     assert data["includeBuildInference"] is True
     assert data["columns"][-1] == "Build inference"
     assert len(data["rows"][0]) == len(data["columns"]) - 1
-    inference = data["inferenceByRow"][0]
+    assert data["inferenceByRow"][0] == {"playerId": 8}
+
+
+def test_scores_inference_returns_row_detail():
+    response = client.get(f"/analytics/scores/inference?{SCOPE_QS}&playerId=8")
+    assert response.status_code == 200
+    inference = response.json()
     assert inference["displayStatus"] in {"success", "failure", "pending"}
     assert isinstance(inference["summary"], str)
     assert "status" in inference

--- a/packages/bff/tests/test_analytics_registry.py
+++ b/packages/bff/tests/test_analytics_registry.py
@@ -97,7 +97,7 @@ def test_scores_table_dispatch_shapes_core_rows():
     def load_core(game_id, perspective, turn, analytic_id, **kwargs):
         assert (game_id, perspective, turn, analytic_id) == (628580, 1, 111, "scores")
         assert kwargs["diagnostics"] is NOOP_DIAGNOSTICS
-        assert kwargs.get("include_military_score_inference") is False
+        assert kwargs.get("include_military_score_inference") is None
         return {
             "analyticId": "scores",
             "rows": [
@@ -125,7 +125,7 @@ def test_scores_table_dispatch_shapes_core_rows():
     ]
 
 
-def test_scores_table_dispatch_forwards_build_inference_to_core():
+def test_scores_table_dispatch_with_build_inference_returns_player_stubs():
     calls = []
 
     def load_core(game_id, perspective, turn, analytic_id, **kwargs):
@@ -134,6 +134,7 @@ def test_scores_table_dispatch_forwards_build_inference_to_core():
             "analyticId": "scores",
             "rows": [
                 {
+                    "playerId": 8,
                     "racePlayer": "The Solar Federation (sylk)",
                     "planets": {"value": 76, "change": 1},
                     "starbases": {"value": 23, "change": 0},
@@ -141,14 +142,6 @@ def test_scores_table_dispatch_forwards_build_inference_to_core():
                     "freighters": {"value": 18, "change": -1},
                     "military": {"value": 639101, "change": -1594},
                     "priorityPoints": {"value": 17, "change": 0},
-                    "inference": {
-                        "status": "exact",
-                        "summary": "Best: Build Serpent Class Escort (empty)",
-                        "solutionCount": 1,
-                        "isComplete": True,
-                        "solutions": [],
-                        "diagnostics": {"catalog_size": 3},
-                    },
                 }
             ],
         }
@@ -162,8 +155,8 @@ def test_scores_table_dispatch_forwards_build_inference_to_core():
     )
     assert data["includeBuildInference"] is True
     assert data["columns"][-1] == "Build inference"
-    assert data["inferenceByRow"][0]["displayStatus"] == "success"
-    assert calls[0][4]["include_military_score_inference"] is True
+    assert data["inferenceByRow"] == [{"playerId": 8}]
+    assert calls[0][4].get("include_military_score_inference") is None
 
 
 def test_connections_map_dispatch_forwards_query_as_core_kwargs():

--- a/packages/bff/tests/test_analytics_registry.py
+++ b/packages/bff/tests/test_analytics_registry.py
@@ -97,6 +97,7 @@ def test_scores_table_dispatch_shapes_core_rows():
     def load_core(game_id, perspective, turn, analytic_id, **kwargs):
         assert (game_id, perspective, turn, analytic_id) == (628580, 1, 111, "scores")
         assert kwargs["diagnostics"] is NOOP_DIAGNOSTICS
+        assert kwargs.get("include_military_score_inference") is False
         return {
             "analyticId": "scores",
             "rows": [
@@ -122,6 +123,47 @@ def test_scores_table_dispatch_shapes_core_rows():
         "639101 (-1594)",
         "17",
     ]
+
+
+def test_scores_table_dispatch_forwards_build_inference_to_core():
+    calls = []
+
+    def load_core(game_id, perspective, turn, analytic_id, **kwargs):
+        calls.append((game_id, perspective, turn, analytic_id, kwargs))
+        return {
+            "analyticId": "scores",
+            "rows": [
+                {
+                    "racePlayer": "The Solar Federation (sylk)",
+                    "planets": {"value": 76, "change": 1},
+                    "starbases": {"value": 23, "change": 0},
+                    "warShips": {"value": 71, "change": -1},
+                    "freighters": {"value": 18, "change": -1},
+                    "military": {"value": 639101, "change": -1594},
+                    "priorityPoints": {"value": 17, "change": 0},
+                    "inference": {
+                        "status": "exact",
+                        "summary": "Best: Build Serpent Class Escort (empty)",
+                        "solutionCount": 1,
+                        "isComplete": True,
+                        "solutions": [],
+                        "diagnostics": {"catalog_size": 3},
+                    },
+                }
+            ],
+        }
+
+    data = get_table_response(
+        "scores",
+        TurnScope(628580, 1, 111),
+        load_core,
+        NOOP_DIAGNOSTICS,
+        include_build_inference=True,
+    )
+    assert data["includeBuildInference"] is True
+    assert data["columns"][-1] == "Build inference"
+    assert data["inferenceByRow"][0]["displayStatus"] == "success"
+    assert calls[0][4]["include_military_score_inference"] is True
 
 
 def test_connections_map_dispatch_forwards_query_as_core_kwargs():

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
   fetchShellBootstrap,
   fetchStoredGameInfo,
   type ConnectionsMapParams,
+  type ScoresTableParams,
 } from './api/bff'
 import { useEnabledAnalyticsStore } from './stores/enabledAnalytics'
 import { useSessionStore } from './stores/session'
@@ -50,6 +51,9 @@ function ConsoleShell() {
     flareMode: 'include',
     /** 2+ includes full static table (1- and 3-pair host rows); 1 is 1-pair rows only. */
     flareDepth: 2,
+  })
+  const [scoresTableParams, setScoresTableParams] = useState<ScoresTableParams>({
+    includeBuildInference: false,
   })
   const [shellErrors, setShellErrors] = useState<ShellErrorItem[]>([])
 
@@ -273,6 +277,8 @@ function ConsoleShell() {
           viewMode={viewMode}
           connectionsMapParams={connectionsMapParams}
           onConnectionsMapParamsChange={setConnectionsMapParams}
+          scoresTableParams={scoresTableParams}
+          onScoresTableParamsChange={setScoresTableParams}
           stellarCartographyGates={stellarCartographyGates}
           ionStormCount={ionStormCount}
         />
@@ -292,6 +298,7 @@ function ConsoleShell() {
             turnEnsureError={turnEnsureError}
             turnBlockedNoLogin={turnBlockedNoLogin}
             connectionsMapParams={connectionsMapParams}
+            scoresTableParams={scoresTableParams}
             futureTurnOffset={futureTurnOffset}
             onMapZoomChange={handleMapZoomChange}
             onSetZoomReady={handleSetZoomReady}

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
@@ -1,0 +1,112 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ScoresInferenceRowDetail } from '../../api/bff'
+import { InferenceDetailModal } from './InferenceDetailModal'
+
+function detail(overrides: Partial<ScoresInferenceRowDetail> = {}): ScoresInferenceRowDetail {
+  return {
+    displayStatus: 'success',
+    status: 'exact',
+    summary: 'Best: two defense posts',
+    solutionCount: 1,
+    isComplete: true,
+    solutions: [],
+    diagnostics: {},
+    ...overrides,
+  }
+}
+
+describe('InferenceDetailModal', () => {
+  it('shows observed constraints and military score arithmetic', () => {
+    render(
+      <InferenceDetailModal
+        isOpen
+        onClose={vi.fn()}
+        racePlayer="Federation (alice)"
+        detail={detail({
+          playerId: 5,
+          diagnostics: {
+            turn: 9,
+            constraints: {
+              turn: 9,
+              playerId: 5,
+              militaryDelta2x: 44,
+              warshipDelta: 0,
+              freighterDelta: 0,
+              requestedPriorityPointDelta: 0,
+              priorityPointConstraintNote: 'Priority points are diagnostic only',
+              appliedEqualities: ['sum(scoreDelta2x * count) == 44'],
+            },
+            solver: { solver_status: 'OPTIMAL', wall_time_seconds: 0.42 },
+          },
+          solutions: [
+            {
+              objectiveValue: 999,
+              actions: [
+                {
+                  actionId: 'planet_defense',
+                  label: 'Planet defense post',
+                  count: 2,
+                },
+              ],
+              militaryScoreArithmetic: {
+                observedMilitaryChange: 22,
+                observedMilitaryDelta2x: 44,
+                explainedMilitaryChange: 22,
+                explainedMilitaryDelta2x: 44,
+                matchesObserved: true,
+                lineItems: [
+                  {
+                    actionId: 'planet_defense',
+                    label: 'Planet defense post',
+                    count: 2,
+                    scoreDelta2xPerUnit: 22,
+                    militaryChangePerUnit: 11,
+                    scoreDelta2xSubtotal: 44,
+                    militaryChangeSubtotal: 22,
+                  },
+                ],
+              },
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('Federation (alice)')
+    expect(screen.getByText('Observed constraints')).toBeInTheDocument()
+    expect(screen.getByRole('dialog')).toHaveTextContent('Turn 8')
+    expect(screen.getByRole('dialog')).toHaveTextContent('Player 5')
+    expect(screen.getByText(/Priority points are diagnostic only/)).toBeInTheDocument()
+    expect(screen.getByText('Explained military change')).toBeInTheDocument()
+    expect(screen.getByText('Planet defense post')).toBeInTheDocument()
+    expect(screen.queryByText(/score 999/)).toBeNull()
+    expect(screen.queryByText(/score 999/i)).toBeNull()
+  })
+
+  it('does not render when closed', () => {
+    render(
+      <InferenceDetailModal
+        isOpen={false}
+        onClose={vi.fn()}
+        racePlayer="Federation (alice)"
+        detail={detail()}
+      />
+    )
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('calls onClose from the close button', () => {
+    const onClose = vi.fn()
+    render(
+      <InferenceDetailModal
+        isOpen
+        onClose={onClose}
+        racePlayer="Federation (alice)"
+        detail={detail()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
@@ -84,6 +84,29 @@ describe('InferenceDetailModal', () => {
     expect(screen.queryByText(/score 999/i)).toBeNull()
   })
 
+  it('shows negative military change using integer halving of 2× scale', () => {
+    render(
+      <InferenceDetailModal
+        isOpen
+        onClose={vi.fn()}
+        racePlayer="Federation (alice)"
+        detail={detail({
+          diagnostics: {
+            constraints: {
+              militaryDelta2x: -107738,
+              warshipDelta: 0,
+              freighterDelta: 0,
+            },
+          },
+          solutions: [],
+        })}
+      />
+    )
+
+    expect(screen.getByRole('dialog')).toHaveTextContent('-53869')
+    expect(screen.getByRole('dialog')).not.toHaveTextContent('-53869.5')
+  })
+
   it('does not render when closed', () => {
     render(
       <InferenceDetailModal

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -5,6 +5,7 @@ import { restoreFocusToElementOrFallback } from '../../lib/restoreFocus'
 import { cn } from '../../lib/utils'
 import {
   formatSignedDelta,
+  militaryChangeFromDelta2x,
   readInferenceConstraints,
   readMilitaryScoreArithmetic,
   type MilitaryScoreArithmetic,
@@ -218,7 +219,9 @@ export function InferenceDetailModal({
                 <>
                   <dt className="text-slate-400">Military change</dt>
                   <dd className="tabular-nums">
-                    {formatSignedDelta(constraints.militaryDelta2x / 2)}
+                    {formatSignedDelta(
+                      militaryChangeFromDelta2x(constraints.militaryDelta2x)
+                    )}
                     <span className="ml-1 text-slate-500">
                       (2× scale {formatSignedDelta(constraints.militaryDelta2x)})
                     </span>

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -1,14 +1,132 @@
 import { useCallback, useLayoutEffect, useRef } from 'react'
-import type { ScoresInferenceRowDetail } from '../../api/bff'
+import type { ScoresInferenceRowDetail, ScoresInferenceSolution } from '../../api/bff'
 import { useModalKeydownFocusTrap } from '../../lib/modalKeydownFocusTrap'
 import { restoreFocusToElementOrFallback } from '../../lib/restoreFocus'
 import { cn } from '../../lib/utils'
+import {
+  formatSignedDelta,
+  readInferenceConstraints,
+  readMilitaryScoreArithmetic,
+  type MilitaryScoreArithmetic,
+} from './inferenceConstraints'
 
 type InferenceDetailModalProps = {
   isOpen: boolean
   onClose: () => void
   racePlayer: string
   detail: ScoresInferenceRowDetail | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readSolverSummary(diagnostics: Record<string, unknown>): {
+  status?: string
+  wallTimeSeconds?: number
+} {
+  const solver = diagnostics.solver
+  if (!isRecord(solver)) {
+    return {}
+  }
+  const solverStatus =
+    typeof solver.solver_status === 'string'
+      ? solver.solver_status
+      : typeof solver.solverStatus === 'string'
+        ? solver.solverStatus
+        : undefined
+  return {
+    status: solverStatus,
+    wallTimeSeconds:
+      typeof solver.wall_time_seconds === 'number'
+        ? solver.wall_time_seconds
+        : typeof solver.wallTimeSeconds === 'number'
+          ? solver.wallTimeSeconds
+          : undefined,
+  }
+}
+
+function MilitaryScoreArithmeticTable({ arithmetic }: { arithmetic: MilitaryScoreArithmetic }) {
+  return (
+    <div className="mt-2 overflow-x-auto">
+      <table className="w-full border-collapse text-xs text-slate-300">
+        <thead>
+          <tr className="border-b border-[#52575d]/60 text-left text-slate-400">
+            <th className="py-1 pr-2 font-medium">Action</th>
+            <th className="py-1 pr-2 font-medium">Count</th>
+            <th className="py-1 pr-2 font-medium">Per unit</th>
+            <th className="py-1 font-medium">Military subtotal</th>
+          </tr>
+        </thead>
+        <tbody>
+          {arithmetic.lineItems.map((line) => (
+            <tr key={line.actionId} className="border-b border-[#52575d]/40">
+              <td className="py-1 pr-2">{line.label}</td>
+              <td className="py-1 pr-2 tabular-nums">{line.count}</td>
+              <td className="py-1 pr-2 tabular-nums">
+                {formatSignedDelta(line.militaryChangePerUnit)}
+              </td>
+              <td className="py-1 tabular-nums">
+                {formatSignedDelta(line.militaryChangeSubtotal)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+        <tfoot>
+          <tr className="text-slate-200">
+            <td colSpan={3} className="py-1 pr-2 text-right font-medium">
+              Explained military change
+            </td>
+            <td className="py-1 tabular-nums font-medium">
+              {formatSignedDelta(arithmetic.explainedMilitaryChange)}
+            </td>
+          </tr>
+          <tr className="text-slate-400">
+            <td colSpan={3} className="py-1 pr-2 text-right">
+              Observed military change
+            </td>
+            <td className="py-1 tabular-nums">
+              {formatSignedDelta(arithmetic.observedMilitaryChange)}
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+      {!arithmetic.matchesObserved ? (
+        <p className="mt-2 text-xs text-amber-300/90">
+          Explained military change does not match the observed scoreboard delta.
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function SolutionSection({
+  solution,
+  index,
+}: {
+  solution: ScoresInferenceSolution
+  index: number
+}) {
+  const arithmetic = readMilitaryScoreArithmetic(solution.militaryScoreArithmetic)
+  return (
+    <section
+      className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3"
+    >
+      <h3 className="text-xs font-medium text-slate-200">Solution {index + 1}</h3>
+      {arithmetic != null && arithmetic.lineItems.length > 0 ? (
+        <MilitaryScoreArithmeticTable arithmetic={arithmetic} />
+      ) : (
+        <ul className="mt-2 flex flex-col gap-1 text-xs text-slate-300">
+          {solution.actions.map((action) => (
+            <li key={action.actionId}>
+              {action.count > 1 ? `${action.count}x ` : ''}
+              {action.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
 }
 
 export function InferenceDetailModal({
@@ -42,6 +160,12 @@ export function InferenceDetailModal({
 
   if (!isOpen || detail == null) return null
 
+  const diagnostics = isRecord(detail.diagnostics) ? detail.diagnostics : {}
+  const constraints = readInferenceConstraints(diagnostics)
+  const solver = readSolverSummary(diagnostics)
+  const priorTurn =
+    constraints?.turn != null && constraints.turn > 1 ? constraints.turn - 1 : null
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
@@ -70,6 +194,12 @@ export function InferenceDetailModal({
               Build inference
             </h2>
             <p className="mt-1 text-xs text-slate-400">{racePlayer}</p>
+            {constraints?.turn != null ? (
+              <p className="mt-1 text-xs text-slate-400">
+                {priorTurn != null ? `Turn ${priorTurn} → ${constraints.turn}` : `Turn ${constraints.turn}`}
+                {constraints.playerId != null ? ` · Player ${constraints.playerId}` : ''}
+              </p>
+            ) : null}
           </div>
           <button
             type="button"
@@ -79,32 +209,76 @@ export function InferenceDetailModal({
             Close
           </button>
         </div>
-        <p className="text-xs text-slate-300">{detail.summary}</p>
-        <div className="flex flex-col gap-3">
-          {detail.solutions.map((solution, index) => (
-            <section
-              key={`${solution.objectiveValue}-${index}`}
-              className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3"
-            >
-              <h3 className="text-xs font-medium text-slate-200">
-                Solution {index + 1}
-                {solution.objectiveValue !== 0 ? (
-                  <span className="ml-2 font-normal text-slate-400">
-                    score {solution.objectiveValue}
-                  </span>
-                ) : null}
-              </h3>
-              <ul className="mt-2 flex flex-col gap-1 text-xs text-slate-300">
-                {solution.actions.map((action) => (
-                  <li key={action.actionId}>
-                    {action.count > 1 ? `${action.count}x ` : ''}
-                    {action.label}
-                  </li>
+
+        {constraints != null ? (
+          <section className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3">
+            <h3 className="text-xs font-medium text-slate-200">Observed constraints</h3>
+            <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-slate-300">
+              {constraints.militaryDelta2x != null ? (
+                <>
+                  <dt className="text-slate-400">Military change</dt>
+                  <dd className="tabular-nums">
+                    {formatSignedDelta(constraints.militaryDelta2x / 2)}
+                    <span className="ml-1 text-slate-500">
+                      (2× scale {formatSignedDelta(constraints.militaryDelta2x)})
+                    </span>
+                  </dd>
+                </>
+              ) : null}
+              {constraints.warshipDelta != null ? (
+                <>
+                  <dt className="text-slate-400">Warship change</dt>
+                  <dd className="tabular-nums">{formatSignedDelta(constraints.warshipDelta)}</dd>
+                </>
+              ) : null}
+              {constraints.freighterDelta != null ? (
+                <>
+                  <dt className="text-slate-400">Freighter change</dt>
+                  <dd className="tabular-nums">{formatSignedDelta(constraints.freighterDelta)}</dd>
+                </>
+              ) : null}
+              {constraints.requestedPriorityPointDelta != null ? (
+                <>
+                  <dt className="text-slate-400">Priority point change</dt>
+                  <dd className="tabular-nums">
+                    {formatSignedDelta(constraints.requestedPriorityPointDelta)}
+                  </dd>
+                </>
+              ) : null}
+            </dl>
+            {constraints.appliedEqualities != null && constraints.appliedEqualities.length > 0 ? (
+              <ul className="mt-2 list-inside list-disc text-xs text-slate-500">
+                {constraints.appliedEqualities.map((equality) => (
+                  <li key={equality}>{equality}</li>
                 ))}
               </ul>
-            </section>
+            ) : null}
+          </section>
+        ) : null}
+
+        {constraints?.priorityPointConstraintNote != null ? (
+          <p className="rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+            {constraints.priorityPointConstraintNote}
+          </p>
+        ) : null}
+
+        <p className="text-xs text-slate-300">{detail.summary}</p>
+
+        {solver.status != null || solver.wallTimeSeconds != null ? (
+          <p className="text-xs text-slate-500">
+            {solver.status != null ? `Solver ${solver.status}` : 'Solver'}
+            {solver.wallTimeSeconds != null
+              ? ` · ${solver.wallTimeSeconds.toFixed(2)}s`
+              : ''}
+          </p>
+        ) : null}
+
+        <div className="flex flex-col gap-3">
+          {detail.solutions.map((solution, index) => (
+            <SolutionSection key={`solution-${index}`} solution={solution} index={index} />
           ))}
         </div>
+
         {!detail.isComplete ? (
           <p className="text-xs text-amber-300/90">
             Inference stopped before all alternatives were explored.

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+import type { ScoresInferenceRowDetail } from '../../api/bff'
+import { useModalKeydownFocusTrap } from '../../lib/modalKeydownFocusTrap'
+import { restoreFocusToElementOrFallback } from '../../lib/restoreFocus'
+import { cn } from '../../lib/utils'
+
+type InferenceDetailModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  racePlayer: string
+  detail: ScoresInferenceRowDetail | null
+}
+
+export function InferenceDetailModal({
+  isOpen,
+  onClose,
+  racePlayer,
+  detail,
+}: InferenceDetailModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const returnFocusRef = useRef<HTMLElement | null>(null)
+
+  const closeAndReturnFocus = useCallback(() => {
+    const target = returnFocusRef.current
+    onClose()
+    restoreFocusToElementOrFallback(target, undefined)
+  }, [onClose])
+
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    returnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const el = dialogRef.current
+    if (!el) return
+    const focusables = el.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    )
+    focusables[0]?.focus()
+  }, [isOpen])
+
+  useModalKeydownFocusTrap(isOpen, dialogRef, closeAndReturnFocus)
+
+  if (!isOpen || detail == null) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      aria-hidden="false"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          closeAndReturnFocus()
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="inference-detail-title"
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          'flex max-h-[min(90vh,40rem)] w-full max-w-2xl flex-col gap-3 overflow-y-auto',
+          'rounded border border-[#52575d] bg-[#40454a] p-4 shadow-lg',
+          'focus:outline-none'
+        )}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h2 id="inference-detail-title" className="text-sm font-medium text-slate-200">
+              Build inference
+            </h2>
+            <p className="mt-1 text-xs text-slate-400">{racePlayer}</p>
+          </div>
+          <button
+            type="button"
+            onClick={closeAndReturnFocus}
+            className="rounded px-2 py-1 text-xs text-slate-400 hover:bg-white/10 hover:text-slate-200"
+          >
+            Close
+          </button>
+        </div>
+        <p className="text-xs text-slate-300">{detail.summary}</p>
+        <div className="flex flex-col gap-3">
+          {detail.solutions.map((solution, index) => (
+            <section
+              key={`${solution.objectiveValue}-${index}`}
+              className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3"
+            >
+              <h3 className="text-xs font-medium text-slate-200">
+                Solution {index + 1}
+                {solution.objectiveValue !== 0 ? (
+                  <span className="ml-2 font-normal text-slate-400">
+                    score {solution.objectiveValue}
+                  </span>
+                ) : null}
+              </h3>
+              <ul className="mt-2 flex flex-col gap-1 text-xs text-slate-300">
+                {solution.actions.map((action) => (
+                  <li key={action.actionId}>
+                    {action.count > 1 ? `${action.count}x ` : ''}
+                    {action.label}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        {!detail.isComplete ? (
+          <p className="text-xs text-amber-300/90">
+            Inference stopped before all alternatives were explored.
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/analytics/scores/ScoresTableTile.test.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableTile.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ScoresTableTile } from './ScoresTableTile'
+
+describe('ScoresTableTile', () => {
+  it('shows include build inference checkbox when scores is enabled in tabular mode', () => {
+    const onScoresTableParamsChange = vi.fn()
+    render(
+      <ScoresTableTile
+        name="Scores"
+        enabled
+        supportsMode
+        depressed
+        onToggle={() => {}}
+        scoresTableParams={{ includeBuildInference: false }}
+        onScoresTableParamsChange={onScoresTableParamsChange}
+      />
+    )
+
+    const inferenceCheckbox = screen.getByLabelText('Include build inference')
+    fireEvent.click(inferenceCheckbox)
+    expect(onScoresTableParamsChange).toHaveBeenCalledWith({ includeBuildInference: true })
+  })
+
+  it('hides include build inference checkbox when scores is disabled', () => {
+    render(
+      <ScoresTableTile
+        name="Scores"
+        enabled={false}
+        supportsMode
+        depressed={false}
+        onToggle={() => {}}
+        scoresTableParams={{ includeBuildInference: false }}
+        onScoresTableParamsChange={() => {}}
+      />
+    )
+
+    expect(screen.queryByLabelText('Include build inference')).toBeNull()
+  })
+})

--- a/packages/frontend/src/analytics/scores/ScoresTableTile.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableTile.tsx
@@ -1,0 +1,69 @@
+import { cn } from '../../lib/utils'
+import { tileClassName } from '../tileChrome'
+import type { ScoresTableParams } from './api'
+
+type ScoresTableTileProps = {
+  name: string
+  enabled: boolean
+  supportsMode: boolean
+  depressed: boolean
+  onToggle: () => void
+  scoresTableParams: ScoresTableParams
+  onScoresTableParamsChange: (next: ScoresTableParams) => void
+}
+
+export function ScoresTableTile({
+  name,
+  enabled,
+  supportsMode,
+  depressed,
+  onToggle,
+  scoresTableParams,
+  onScoresTableParamsChange,
+}: ScoresTableTileProps) {
+  const showInferenceOption = supportsMode && enabled
+
+  return (
+    <div
+      className={cn(
+        tileClassName({ supportsMode, depressed }),
+        'flex min-w-0 max-w-full flex-col'
+      )}
+    >
+      <label
+        className={cn(
+          'flex cursor-pointer items-center gap-2 px-2 py-1.5',
+          !supportsMode && 'cursor-default'
+        )}
+      >
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={() => supportsMode && onToggle()}
+          disabled={!supportsMode}
+          className="h-4 w-4 shrink-0 rounded border-[#52575d] bg-slate-700 text-slate-200 accent-slate-400 focus:ring-[#52575d] focus:ring-offset-0"
+        />
+        <span className="min-w-0 truncate">{name}</span>
+      </label>
+      {showInferenceOption ? (
+        <label
+          className="flex cursor-pointer items-center gap-2 border-t border-[#52575d]/70 px-2 py-1.5 pl-8 text-xs text-slate-300"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <input
+            type="checkbox"
+            checked={scoresTableParams.includeBuildInference}
+            onChange={(e) =>
+              onScoresTableParamsChange({
+                ...scoresTableParams,
+                includeBuildInference: e.target.checked,
+              })
+            }
+            className="h-3.5 w-3.5 shrink-0 rounded border-[#52575d] bg-slate-700 accent-slate-400"
+          />
+          <span>Include build inference</span>
+        </label>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
@@ -15,12 +15,56 @@ function tableData(
 }
 
 describe('ScoresTableView', () => {
+  it('keeps priority points in the data column when build inference column is appended', () => {
+    render(
+      <ScoresTableView
+        data={tableData({
+          columns: [
+            'Race (player)',
+            'Planets',
+            'Starbases',
+            'War Ships',
+            'Freighters',
+            'Military',
+            'Priority Points',
+            'Build inference',
+          ],
+          rows: [
+            [
+              'Federation (alice)',
+              '10 (+1)',
+              '5',
+              '3',
+              '2',
+              '1000 (-50)',
+              '217 (+54)',
+            ],
+          ],
+          inferenceByRow: [
+            {
+              displayStatus: 'success',
+              status: 'exact',
+              summary: 'Best: one build',
+              solutionCount: 1,
+              isComplete: true,
+              solutions: [],
+              diagnostics: {},
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText('217 (+54)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Best: one build')).toBeInTheDocument()
+  })
+
   it('renders inference status from inferenceByRow when row has no placeholder cell', () => {
     render(
       <ScoresTableView
         data={tableData({
           columns: ['Race (player)', 'Military', 'Build inference'],
-          rows: [['Federation (alice)', '100']],
+          rows: [['Federation (alice)', '', '', '', '', '100', '']],
           inferenceByRow: [
             {
               displayStatus: 'success',
@@ -40,12 +84,12 @@ describe('ScoresTableView', () => {
     expect(screen.getByText('100')).toBeInTheDocument()
   })
 
-  it('renders inference icons from inferenceByRow even when a legacy row has a trailing empty cell', () => {
+  it('ignores a legacy trailing empty cell when resolving data column values', () => {
     render(
       <ScoresTableView
         data={tableData({
           columns: ['Race (player)', 'Military', 'Build inference'],
-          rows: [['Federation (alice)', '100', '']],
+          rows: [['Federation (alice)', '', '', '', '', '100', '']],
           inferenceByRow: [
             {
               displayStatus: 'pending',

--- a/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
@@ -1,13 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import type { TableDataResponse } from '../../api/bff'
+import type { ScoresTableWithInferenceData } from '../../api/bff'
 import { ScoresTableView } from './ScoresTableView'
 
 function tableData(
-  overrides: Partial<TableDataResponse> & Pick<TableDataResponse, 'columns' | 'rows'>
-): TableDataResponse {
+  overrides: Partial<ScoresTableWithInferenceData> &
+    Pick<ScoresTableWithInferenceData, 'columns' | 'rows' | 'inferenceByRow'>
+): ScoresTableWithInferenceData {
   return {
     analyticId: 'scores',
+    includeBuildInference: true,
     ...overrides,
   }
 }
@@ -17,7 +19,6 @@ describe('ScoresTableView', () => {
     render(
       <ScoresTableView
         data={tableData({
-          includeBuildInference: true,
           columns: ['Race (player)', 'Military', 'Build inference'],
           rows: [['Federation (alice)', '100']],
           inferenceByRow: [
@@ -43,7 +44,6 @@ describe('ScoresTableView', () => {
     render(
       <ScoresTableView
         data={tableData({
-          includeBuildInference: true,
           columns: ['Race (player)', 'Military', 'Build inference'],
           rows: [['Federation (alice)', '100', '']],
           inferenceByRow: [
@@ -69,7 +69,6 @@ describe('ScoresTableView', () => {
     render(
       <ScoresTableView
         data={tableData({
-          includeBuildInference: true,
           columns: ['Race (player)', 'Build inference'],
           rows: [['Federation (alice)']],
           inferenceByRow: [

--- a/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { TableDataResponse } from '../../api/bff'
+import { ScoresTableView } from './ScoresTableView'
+
+function tableData(
+  overrides: Partial<TableDataResponse> & Pick<TableDataResponse, 'columns' | 'rows'>
+): TableDataResponse {
+  return {
+    analyticId: 'scores',
+    ...overrides,
+  }
+}
+
+describe('ScoresTableView', () => {
+  it('renders inference status from inferenceByRow when row has no placeholder cell', () => {
+    render(
+      <ScoresTableView
+        data={tableData({
+          includeBuildInference: true,
+          columns: ['Race (player)', 'Military', 'Build inference'],
+          rows: [['Federation (alice)', '100']],
+          inferenceByRow: [
+            {
+              displayStatus: 'success',
+              status: 'exact',
+              summary: 'Best: one build',
+              solutionCount: 1,
+              isComplete: true,
+              solutions: [],
+              diagnostics: {},
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByLabelText('Best: one build')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+
+  it('renders inference icons from inferenceByRow even when a legacy row has a trailing empty cell', () => {
+    render(
+      <ScoresTableView
+        data={tableData({
+          includeBuildInference: true,
+          columns: ['Race (player)', 'Military', 'Build inference'],
+          rows: [['Federation (alice)', '100', '']],
+          inferenceByRow: [
+            {
+              displayStatus: 'pending',
+              status: 'time_limited',
+              summary: 'Still searching',
+              solutionCount: 0,
+              isComplete: false,
+              solutions: [],
+              diagnostics: {},
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByLabelText('Still searching')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+  })
+
+  it('opens inference detail modal when success icon is clicked', () => {
+    render(
+      <ScoresTableView
+        data={tableData({
+          includeBuildInference: true,
+          columns: ['Race (player)', 'Build inference'],
+          rows: [['Federation (alice)']],
+          inferenceByRow: [
+            {
+              displayStatus: 'success',
+              status: 'exact',
+              summary: 'Best: one build',
+              solutionCount: 1,
+              isComplete: true,
+              solutions: [{ objectiveValue: 1, actions: [] }],
+              diagnostics: {},
+            },
+          ],
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('Best: one build'))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent('Federation (alice)')
+    expect(dialog).toHaveTextContent('Solution 1')
+  })
+})

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import { Check, Hourglass, X } from 'lucide-react'
+import type { TableDataResponse } from '../../api/bff'
+import { InferenceDetailModal } from './InferenceDetailModal'
+import {
+  canOpenInferenceDetail,
+  inferenceAccessibleLabel,
+} from './inferenceStatus'
+
+type ScoresTableViewProps = {
+  data: TableDataResponse
+}
+
+function InferenceStatusCell({
+  detail,
+  onOpenDetail,
+}: {
+  detail: NonNullable<TableDataResponse['inferenceByRow']>[number]
+  onOpenDetail: () => void
+}) {
+  const label = inferenceAccessibleLabel(detail)
+  if (detail.displayStatus === 'success') {
+    const clickable = canOpenInferenceDetail(detail)
+    return (
+      <button
+        type="button"
+        title={label}
+        aria-label={label}
+        disabled={!clickable}
+        onClick={clickable ? onOpenDetail : undefined}
+        className="inline-flex items-center justify-center rounded p-1 text-emerald-400 hover:bg-white/10 disabled:cursor-default disabled:opacity-60"
+      >
+        <Check className="h-4 w-4" aria-hidden />
+      </button>
+    )
+  }
+  if (detail.displayStatus === 'pending') {
+    return (
+      <span
+        title={label}
+        aria-label={label}
+        className="inline-flex items-center justify-center p-1 text-amber-300"
+      >
+        <Hourglass className="h-4 w-4" aria-hidden />
+      </span>
+    )
+  }
+  return (
+    <span
+      title={label}
+      aria-label={label}
+      className="inline-flex items-center justify-center p-1 text-red-400"
+    >
+      <X className="h-4 w-4" aria-hidden />
+    </span>
+  )
+}
+
+export function ScoresTableView({ data }: ScoresTableViewProps) {
+  const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
+  const inferenceByRow = data.inferenceByRow
+  const selectedDetail =
+    selectedRowIndex != null && inferenceByRow != null
+      ? inferenceByRow[selectedRowIndex]
+      : null
+  const selectedRacePlayer =
+    selectedRowIndex != null ? data.rows[selectedRowIndex]?.[0] ?? '' : ''
+
+  return (
+    <>
+      <div className="overflow-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b border-[#52575d]">
+              {data.columns.map((column) => (
+                <th key={column} className="px-3 py-2 text-left font-medium text-slate-200">
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.rows.map((row, rowIndex) => (
+              <tr key={rowIndex} className="border-b border-[#52575d]/60">
+                {row.map((cell, columnIndex) => {
+                  const isInferenceColumn =
+                    data.includeBuildInference === true &&
+                    inferenceByRow != null &&
+                    columnIndex === row.length - 1
+                  if (isInferenceColumn) {
+                    return (
+                      <td key={columnIndex} className="px-3 py-2 text-gray-400">
+                        <InferenceStatusCell
+                          detail={inferenceByRow[rowIndex]}
+                          onOpenDetail={() => setSelectedRowIndex(rowIndex)}
+                        />
+                      </td>
+                    )
+                  }
+                  return (
+                    <td key={columnIndex} className="px-3 py-2 text-gray-400">
+                      {cell}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <InferenceDetailModal
+        isOpen={selectedRowIndex != null}
+        onClose={() => setSelectedRowIndex(null)}
+        racePlayer={selectedRacePlayer}
+        detail={selectedDetail}
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Check, Hourglass, X } from 'lucide-react'
-import type { TableDataResponse } from '../../api/bff'
+import type { ScoresInferenceRowDetail, ScoresTableWithInferenceData } from '../../api/bff'
 import { InferenceDetailModal } from './InferenceDetailModal'
 import {
   canOpenInferenceDetail,
@@ -8,14 +8,14 @@ import {
 } from './inferenceStatus'
 
 type ScoresTableViewProps = {
-  data: TableDataResponse
+  data: ScoresTableWithInferenceData
 }
 
 function InferenceStatusCell({
   detail,
   onOpenDetail,
 }: {
-  detail: NonNullable<TableDataResponse['inferenceByRow']>[number]
+  detail: ScoresInferenceRowDetail
   onOpenDetail: () => void
 }) {
   const label = inferenceAccessibleLabel(detail)

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -6,6 +6,10 @@ import {
   canOpenInferenceDetail,
   inferenceAccessibleLabel,
 } from './inferenceStatus'
+import {
+  isBuildInferenceColumn,
+  scoresTableCellForColumn,
+} from './scoresTableColumns'
 
 type ScoresTableViewProps = {
   data: ScoresTableWithInferenceData
@@ -56,15 +60,9 @@ function InferenceStatusCell({
   )
 }
 
-const BUILD_INFERENCE_COLUMN = 'Build inference'
-
 export function ScoresTableView({ data }: ScoresTableViewProps) {
   const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
   const inferenceByRow = data.inferenceByRow
-  const inferenceColumnIndex =
-    data.includeBuildInference === true && inferenceByRow != null
-      ? data.columns.indexOf(BUILD_INFERENCE_COLUMN)
-      : -1
   const selectedDetail =
     selectedRowIndex != null && inferenceByRow != null
       ? inferenceByRow[selectedRowIndex]
@@ -88,12 +86,12 @@ export function ScoresTableView({ data }: ScoresTableViewProps) {
           <tbody>
             {data.rows.map((row, rowIndex) => (
               <tr key={rowIndex} className="border-b border-[#52575d]/60">
-                {data.columns.map((column, columnIndex) => {
-                  if (columnIndex === inferenceColumnIndex) {
+                {data.columns.map((column) => {
+                  if (isBuildInferenceColumn(column) && inferenceByRow != null) {
                     return (
                       <td key={column} className="px-3 py-2 text-gray-400">
                         <InferenceStatusCell
-                          detail={inferenceByRow![rowIndex]}
+                          detail={inferenceByRow[rowIndex]}
                           onOpenDetail={() => setSelectedRowIndex(rowIndex)}
                         />
                       </td>
@@ -101,7 +99,7 @@ export function ScoresTableView({ data }: ScoresTableViewProps) {
                   }
                   return (
                     <td key={column} className="px-3 py-2 text-gray-400">
-                      {row[columnIndex] ?? ''}
+                      {scoresTableCellForColumn(row, column)}
                     </td>
                   )
                 })}

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -56,9 +56,15 @@ function InferenceStatusCell({
   )
 }
 
+const BUILD_INFERENCE_COLUMN = 'Build inference'
+
 export function ScoresTableView({ data }: ScoresTableViewProps) {
   const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
   const inferenceByRow = data.inferenceByRow
+  const inferenceColumnIndex =
+    data.includeBuildInference === true && inferenceByRow != null
+      ? data.columns.indexOf(BUILD_INFERENCE_COLUMN)
+      : -1
   const selectedDetail =
     selectedRowIndex != null && inferenceByRow != null
       ? inferenceByRow[selectedRowIndex]
@@ -82,24 +88,20 @@ export function ScoresTableView({ data }: ScoresTableViewProps) {
           <tbody>
             {data.rows.map((row, rowIndex) => (
               <tr key={rowIndex} className="border-b border-[#52575d]/60">
-                {row.map((cell, columnIndex) => {
-                  const isInferenceColumn =
-                    data.includeBuildInference === true &&
-                    inferenceByRow != null &&
-                    columnIndex === row.length - 1
-                  if (isInferenceColumn) {
+                {data.columns.map((column, columnIndex) => {
+                  if (columnIndex === inferenceColumnIndex) {
                     return (
-                      <td key={columnIndex} className="px-3 py-2 text-gray-400">
+                      <td key={column} className="px-3 py-2 text-gray-400">
                         <InferenceStatusCell
-                          detail={inferenceByRow[rowIndex]}
+                          detail={inferenceByRow![rowIndex]}
                           onOpenDetail={() => setSelectedRowIndex(rowIndex)}
                         />
                       </td>
                     )
                   }
                   return (
-                    <td key={columnIndex} className="px-3 py-2 text-gray-400">
-                      {cell}
+                    <td key={column} className="px-3 py-2 text-gray-400">
+                      {row[columnIndex] ?? ''}
                     </td>
                   )
                 })}

--- a/packages/frontend/src/analytics/scores/api.test.ts
+++ b/packages/frontend/src/analytics/scores/api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { appendScoresTableQueryParams } from './api'
+
+describe('appendScoresTableQueryParams', () => {
+  it('adds includeBuildInference when enabled', () => {
+    const params = new URLSearchParams({ gameId: '628580', turn: '111', perspective: '1' })
+    appendScoresTableQueryParams(params, { includeBuildInference: true })
+    expect(params.get('includeBuildInference')).toBe('true')
+  })
+
+  it('omits includeBuildInference when disabled', () => {
+    const params = new URLSearchParams({ gameId: '628580', turn: '111', perspective: '1' })
+    appendScoresTableQueryParams(params, { includeBuildInference: false })
+    expect(params.get('includeBuildInference')).toBeNull()
+  })
+})

--- a/packages/frontend/src/analytics/scores/api.ts
+++ b/packages/frontend/src/analytics/scores/api.ts
@@ -1,0 +1,22 @@
+/** Wire query names for Scores table GETs. */
+export const SCORES_QUERY_WIRE = {
+  includeBuildInference: 'includeBuildInference',
+} as const
+
+/** Query parameters for the Scores table analytic (BFF forwards to Core). */
+export type ScoresTableParams = {
+  includeBuildInference: boolean
+}
+
+export function appendScoresTableQueryParams(
+  params: URLSearchParams,
+  scoresParams: ScoresTableParams
+): void {
+  if (scoresParams.includeBuildInference) {
+    params.set(SCORES_QUERY_WIRE.includeBuildInference, 'true')
+  }
+}
+
+export function scoresTableQueryKey(scoresParams: ScoresTableParams): readonly [boolean] {
+  return [scoresParams.includeBuildInference] as const
+}

--- a/packages/frontend/src/analytics/scores/api.ts
+++ b/packages/frontend/src/analytics/scores/api.ts
@@ -1,3 +1,5 @@
+import type { AnalyticShellScope } from '../../api/bff'
+
 /** Wire query names for Scores table GETs. */
 export const SCORES_QUERY_WIRE = {
   includeBuildInference: 'includeBuildInference',
@@ -19,4 +21,11 @@ export function appendScoresTableQueryParams(
 
 export function scoresTableQueryKey(scoresParams: ScoresTableParams): readonly [boolean] {
   return [scoresParams.includeBuildInference] as const
+}
+
+export function scoresRowInferenceQueryKey(
+  scope: AnalyticShellScope,
+  playerId: number
+): readonly ['analytic', 'scores', 'inference', AnalyticShellScope, number] {
+  return ['analytic', 'scores', 'inference', scope, playerId] as const
 }

--- a/packages/frontend/src/analytics/scores/diagnosticsFromTable.test.ts
+++ b/packages/frontend/src/analytics/scores/diagnosticsFromTable.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { TableDataResponse } from '../../api/bff'
+import { scoresDiagnosticsFromTable } from './diagnosticsFromTable'
+
+describe('scoresDiagnosticsFromTable', () => {
+  it('returns null when build inference is disabled', () => {
+    const data: TableDataResponse = {
+      analyticId: 'scores',
+      columns: ['Race (player)'],
+      rows: [['koshling']],
+    }
+    expect(
+      scoresDiagnosticsFromTable(data, { gameId: '628580', turn: 111, perspective: 1 })
+    ).toBeNull()
+  })
+
+  it('extracts per-player constraints, catalog, and solver diagnostics', () => {
+    const data: TableDataResponse = {
+      analyticId: 'scores',
+      includeBuildInference: true,
+      columns: ['Race (player)', 'Build inference'],
+      rows: [['koshling', '']],
+      inferenceByRow: [
+        {
+          playerId: 8,
+          displayStatus: 'failure',
+          status: 'no_exact_solution',
+          summary: 'No feasible build explanation found',
+          solutionCount: 0,
+          isComplete: true,
+          solutions: [],
+          diagnostics: {
+            turn: 111,
+            constraints: { playerId: 8, militaryDelta2x: -107738 },
+            actionCatalog: { catalogSize: 9, actions: [{ id: 'planet_defense_posts_added_total' }] },
+            solver: { status: 'no_exact_solution', solver_status: 'INFEASIBLE' },
+          },
+        },
+      ],
+    }
+
+    const snapshot = scoresDiagnosticsFromTable(data, {
+      gameId: '628580',
+      turn: 111,
+      perspective: 1,
+    })
+
+    expect(snapshot?.players).toHaveLength(1)
+    expect(snapshot?.players[0]).toMatchObject({
+      playerId: 8,
+      racePlayer: 'koshling',
+      turn: 111,
+      status: 'no_exact_solution',
+      constraints: { playerId: 8, militaryDelta2x: -107738 },
+      actionCatalog: { catalogSize: 9 },
+      solver: { solver_status: 'INFEASIBLE' },
+    })
+  })
+
+  it('falls back to constraints.playerId when playerId is omitted on the row detail', () => {
+    const data: TableDataResponse = {
+      analyticId: 'scores',
+      includeBuildInference: true,
+      columns: ['Race (player)', 'Build inference'],
+      rows: [['koshling', '']],
+      inferenceByRow: [
+        {
+          displayStatus: 'failure',
+          status: 'no_exact_solution',
+          summary: 'No feasible build explanation found',
+          solutionCount: 0,
+          isComplete: true,
+          solutions: [],
+          diagnostics: {
+            turn: 111,
+            constraints: { playerId: 8, militaryDelta2x: -107738 },
+            actionCatalog: { catalogSize: 9, actions: [] },
+            solver: { status: 'no_exact_solution' },
+          },
+        },
+      ],
+    }
+
+    const snapshot = scoresDiagnosticsFromTable(data, {
+      gameId: '628580',
+      turn: 111,
+      perspective: 1,
+    })
+
+    expect(snapshot?.players[0]?.playerId).toBe(8)
+    expect(snapshot?.players[0]?.constraints?.militaryDelta2x).toBe(-107738)
+  })
+})

--- a/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
+++ b/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
@@ -1,8 +1,5 @@
-import type {
-  AnalyticShellScope,
-  ScoresInferenceRowDetail,
-  TableDataResponse,
-} from '../../api/bff'
+import type { AnalyticShellScope, ScoresInferenceRowDetail, TableDataResponse } from '../../api/bff'
+import { isScoresInferenceRowDetail } from '../../api/bff'
 import type { ScoresAnalyticDiagnostics } from '../../stores/analyticDiagnostics'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -76,7 +73,7 @@ export function scoresDiagnosticsFromTable(
 
   const players = data.rows.flatMap((row, rowIndex) => {
     const detail = inferenceByRow[rowIndex]
-    if (detail == null) {
+    if (detail == null || !isScoresInferenceRowDetail(detail)) {
       return []
     }
     const parsed = playerDiagnosticsFromRow(String(row[0] ?? ''), detail, rowIndex)

--- a/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
+++ b/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
@@ -1,0 +1,92 @@
+import type {
+  AnalyticShellScope,
+  ScoresInferenceRowDetail,
+  TableDataResponse,
+} from '../../api/bff'
+import type { ScoresAnalyticDiagnostics } from '../../stores/analyticDiagnostics'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readTurn(diagnostics: Record<string, unknown>): number | null {
+  if (typeof diagnostics.turn === 'number') {
+    return diagnostics.turn
+  }
+  const constraints = diagnostics.constraints
+  if (isRecord(constraints) && typeof constraints.turn === 'number') {
+    return constraints.turn
+  }
+  return null
+}
+
+function readSection(
+  diagnostics: Record<string, unknown>,
+  key: 'constraints' | 'actionCatalog' | 'solver'
+): Record<string, unknown> | undefined {
+  const direct = diagnostics[key]
+  if (isRecord(direct)) {
+    return direct
+  }
+  return undefined
+}
+
+function playerDiagnosticsFromRow(
+  racePlayer: string,
+  detail: ScoresInferenceRowDetail,
+  rowIndex: number
+): ScoresAnalyticDiagnostics['players'][number] | null {
+  const diagnostics = isRecord(detail.diagnostics) ? detail.diagnostics : {}
+  const turn = readTurn(diagnostics)
+  if (turn == null) {
+    return null
+  }
+
+  const playerId =
+    typeof detail.playerId === 'number'
+      ? detail.playerId
+      : isRecord(diagnostics.constraints) && typeof diagnostics.constraints.playerId === 'number'
+        ? diagnostics.constraints.playerId
+        : -(rowIndex + 1)
+
+  return {
+    playerId,
+    racePlayer,
+    status: detail.status,
+    summary: detail.summary,
+    turn,
+    constraints: readSection(diagnostics, 'constraints'),
+    actionCatalog: readSection(diagnostics, 'actionCatalog'),
+    solver: readSection(diagnostics, 'solver'),
+    diagnostics,
+  }
+}
+
+export function scoresDiagnosticsFromTable(
+  data: TableDataResponse,
+  scope: AnalyticShellScope
+): ScoresAnalyticDiagnostics | null {
+  if (data.analyticId !== 'scores' || data.includeBuildInference !== true) {
+    return null
+  }
+  const inferenceByRow = data.inferenceByRow
+  if (inferenceByRow == null) {
+    return null
+  }
+
+  const players = data.rows.flatMap((row, rowIndex) => {
+    const detail = inferenceByRow[rowIndex]
+    if (detail == null) {
+      return []
+    }
+    const parsed = playerDiagnosticsFromRow(String(row[0] ?? ''), detail, rowIndex)
+    return parsed != null ? [parsed] : []
+  })
+
+  return {
+    scope,
+    capturedAt: new Date().toISOString(),
+    includeBuildInference: true,
+    players,
+  }
+}

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatSignedDelta,
+  readInferenceConstraints,
+  readMilitaryScoreArithmetic,
+} from './inferenceConstraints'
+
+describe('readInferenceConstraints', () => {
+  it('reads constraint fields from diagnostics', () => {
+    const constraints = readInferenceConstraints({
+      constraints: {
+        turn: 8,
+        playerId: 3,
+        militaryDelta2x: 50,
+        warshipDelta: 1,
+        freighterDelta: -2,
+        requestedPriorityPointDelta: 10,
+        priorityPointConstraintNote: 'PP diagnostic only',
+        appliedEqualities: ['sum(scoreDelta2x * count) == 50'],
+      },
+    })
+    expect(constraints?.turn).toBe(8)
+    expect(constraints?.militaryDelta2x).toBe(50)
+    expect(constraints?.priorityPointConstraintNote).toBe('PP diagnostic only')
+    expect(constraints?.appliedEqualities).toHaveLength(1)
+  })
+})
+
+describe('readMilitaryScoreArithmetic', () => {
+  it('parses military score arithmetic payload', () => {
+    const arithmetic = readMilitaryScoreArithmetic({
+      observedMilitaryChange: 25,
+      observedMilitaryDelta2x: 50,
+      explainedMilitaryChange: 25,
+      explainedMilitaryDelta2x: 50,
+      matchesObserved: true,
+      lineItems: [
+        {
+          actionId: 'defense',
+          label: 'Defense post',
+          count: 2,
+          scoreDelta2xPerUnit: 22,
+          militaryChangePerUnit: 11,
+          scoreDelta2xSubtotal: 44,
+          militaryChangeSubtotal: 22,
+        },
+      ],
+    })
+    expect(arithmetic?.matchesObserved).toBe(true)
+    expect(arithmetic?.lineItems[0]?.militaryChangeSubtotal).toBe(22)
+  })
+})
+
+describe('formatSignedDelta', () => {
+  it('prefixes positive values', () => {
+    expect(formatSignedDelta(5)).toBe('+5')
+    expect(formatSignedDelta(-3)).toBe('-3')
+  })
+})

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatSignedDelta,
+  militaryChangeFromDelta2x,
   readInferenceConstraints,
   readMilitaryScoreArithmetic,
 } from './inferenceConstraints'
@@ -48,6 +49,15 @@ describe('readMilitaryScoreArithmetic', () => {
     })
     expect(arithmetic?.matchesObserved).toBe(true)
     expect(arithmetic?.lineItems[0]?.militaryChangeSubtotal).toBe(22)
+  })
+})
+
+describe('militaryChangeFromDelta2x', () => {
+  it('matches Python floor division for positive and negative 2× scale', () => {
+    expect(militaryChangeFromDelta2x(44)).toBe(22)
+    expect(militaryChangeFromDelta2x(45)).toBe(22)
+    expect(militaryChangeFromDelta2x(-107738)).toBe(-53869)
+    expect(militaryChangeFromDelta2x(-107737)).toBe(-53869)
   })
 })
 

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.ts
@@ -1,0 +1,126 @@
+export type InferenceConstraintsSection = {
+  turn?: number
+  playerId?: number
+  militaryDelta2x?: number
+  warshipDelta?: number
+  freighterDelta?: number
+  requestedPriorityPointDelta?: number
+  priorityPointConstraintNote?: string
+  appliedEqualities?: string[]
+}
+
+export type MilitaryScoreLineItem = {
+  actionId: string
+  label: string
+  count: number
+  scoreDelta2xPerUnit: number
+  militaryChangePerUnit: number
+  scoreDelta2xSubtotal: number
+  militaryChangeSubtotal: number
+}
+
+export type MilitaryScoreArithmetic = {
+  observedMilitaryChange: number
+  observedMilitaryDelta2x: number
+  explainedMilitaryChange: number
+  explainedMilitaryDelta2x: number
+  matchesObserved: boolean
+  lineItems: MilitaryScoreLineItem[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function readInferenceConstraints(
+  diagnostics: Record<string, unknown>
+): InferenceConstraintsSection | null {
+  const constraints = diagnostics.constraints
+  if (!isRecord(constraints)) {
+    return null
+  }
+  return {
+    turn: typeof constraints.turn === 'number' ? constraints.turn : undefined,
+    playerId:
+      typeof constraints.playerId === 'number' ? constraints.playerId : undefined,
+    militaryDelta2x:
+      typeof constraints.militaryDelta2x === 'number'
+        ? constraints.militaryDelta2x
+        : undefined,
+    warshipDelta:
+      typeof constraints.warshipDelta === 'number' ? constraints.warshipDelta : undefined,
+    freighterDelta:
+      typeof constraints.freighterDelta === 'number' ? constraints.freighterDelta : undefined,
+    requestedPriorityPointDelta:
+      typeof constraints.requestedPriorityPointDelta === 'number'
+        ? constraints.requestedPriorityPointDelta
+        : undefined,
+    priorityPointConstraintNote:
+      typeof constraints.priorityPointConstraintNote === 'string'
+        ? constraints.priorityPointConstraintNote
+        : undefined,
+    appliedEqualities: Array.isArray(constraints.appliedEqualities)
+      ? constraints.appliedEqualities.filter((item): item is string => typeof item === 'string')
+      : undefined,
+  }
+}
+
+export function readMilitaryScoreArithmetic(value: unknown): MilitaryScoreArithmetic | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const lineItemsRaw = value.lineItems
+  if (!Array.isArray(lineItemsRaw)) {
+    return null
+  }
+  const lineItems: MilitaryScoreLineItem[] = []
+  for (const item of lineItemsRaw) {
+    if (!isRecord(item)) {
+      continue
+    }
+    if (
+      typeof item.actionId !== 'string' ||
+      typeof item.label !== 'string' ||
+      typeof item.count !== 'number' ||
+      typeof item.scoreDelta2xPerUnit !== 'number' ||
+      typeof item.militaryChangePerUnit !== 'number' ||
+      typeof item.scoreDelta2xSubtotal !== 'number' ||
+      typeof item.militaryChangeSubtotal !== 'number'
+    ) {
+      continue
+    }
+    lineItems.push({
+      actionId: item.actionId,
+      label: item.label,
+      count: item.count,
+      scoreDelta2xPerUnit: item.scoreDelta2xPerUnit,
+      militaryChangePerUnit: item.militaryChangePerUnit,
+      scoreDelta2xSubtotal: item.scoreDelta2xSubtotal,
+      militaryChangeSubtotal: item.militaryChangeSubtotal,
+    })
+  }
+  if (
+    typeof value.observedMilitaryChange !== 'number' ||
+    typeof value.observedMilitaryDelta2x !== 'number' ||
+    typeof value.explainedMilitaryChange !== 'number' ||
+    typeof value.explainedMilitaryDelta2x !== 'number' ||
+    typeof value.matchesObserved !== 'boolean'
+  ) {
+    return null
+  }
+  return {
+    observedMilitaryChange: value.observedMilitaryChange,
+    observedMilitaryDelta2x: value.observedMilitaryDelta2x,
+    explainedMilitaryChange: value.explainedMilitaryChange,
+    explainedMilitaryDelta2x: value.explainedMilitaryDelta2x,
+    matchesObserved: value.matchesObserved,
+    lineItems,
+  }
+}
+
+export function formatSignedDelta(value: number): string {
+  if (value > 0) {
+    return `+${value}`
+  }
+  return String(value)
+}

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.ts
@@ -118,6 +118,11 @@ export function readMilitaryScoreArithmetic(value: unknown): MilitaryScoreArithm
   }
 }
 
+/** Scoreboard military change from solver 2× scale (matches Core `military_delta_2x // 2`). */
+export function militaryChangeFromDelta2x(militaryDelta2x: number): number {
+  return Math.floor(militaryDelta2x / 2)
+}
+
 export function formatSignedDelta(value: number): string {
   if (value > 0) {
     return `+${value}`

--- a/packages/frontend/src/analytics/scores/inferenceStatus.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceStatus.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { ScoresInferenceRowDetail } from '../../api/bff'
+import {
+  canOpenInferenceDetail,
+  inferenceAccessibleLabel,
+} from './inferenceStatus'
+
+function detail(
+  overrides: Partial<ScoresInferenceRowDetail> = {}
+): ScoresInferenceRowDetail {
+  return {
+    displayStatus: 'failure',
+    status: 'no_exact_solution',
+    summary: 'No feasible build explanation found',
+    solutionCount: 0,
+    isComplete: true,
+    solutions: [],
+    diagnostics: {},
+    ...overrides,
+  }
+}
+
+describe('inferenceAccessibleLabel', () => {
+  it('uses summary text for each display status', () => {
+    expect(inferenceAccessibleLabel(detail({ summary: 'Best: built one ship' }))).toBe(
+      'Best: built one ship'
+    )
+  })
+})
+
+describe('canOpenInferenceDetail', () => {
+  it('allows modal only for successful rows with solutions', () => {
+    expect(
+      canOpenInferenceDetail(
+        detail({
+          displayStatus: 'success',
+          solutionCount: 2,
+          solutions: [{ objectiveValue: 1, actions: [] }],
+        })
+      )
+    ).toBe(true)
+    expect(canOpenInferenceDetail(detail({ displayStatus: 'pending' }))).toBe(false)
+    expect(
+      canOpenInferenceDetail(detail({ displayStatus: 'success', solutionCount: 0 }))
+    ).toBe(false)
+  })
+})

--- a/packages/frontend/src/analytics/scores/inferenceStatus.ts
+++ b/packages/frontend/src/analytics/scores/inferenceStatus.ts
@@ -1,0 +1,17 @@
+import type { ScoresInferenceRowDetail } from '../../api/bff'
+
+export type InferenceDisplayStatus = ScoresInferenceRowDetail['displayStatus']
+
+export function inferenceAccessibleLabel(detail: ScoresInferenceRowDetail): string {
+  if (detail.displayStatus === 'success') {
+    return detail.summary || 'Feasible build explanation found'
+  }
+  if (detail.displayStatus === 'pending') {
+    return detail.summary || 'Build inference in progress'
+  }
+  return detail.summary || 'No build inference result'
+}
+
+export function canOpenInferenceDetail(detail: ScoresInferenceRowDetail): boolean {
+  return detail.displayStatus === 'success' && detail.solutionCount > 0
+}

--- a/packages/frontend/src/analytics/scores/scoresTableColumns.test.ts
+++ b/packages/frontend/src/analytics/scores/scoresTableColumns.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BUILD_INFERENCE_COLUMN,
+  scoresTableCellForColumn,
+} from './scoresTableColumns'
+
+describe('scoresTableCellForColumn', () => {
+  const row = [
+    'Federation (alice)',
+    '10 (+1)',
+    '5',
+    '3',
+    '2',
+    '1000 (-50)',
+    '217 (+54)',
+  ]
+
+  it('maps data columns by name, not by header position', () => {
+    expect(scoresTableCellForColumn(row, 'Priority Points')).toBe('217 (+54)')
+    expect(scoresTableCellForColumn(row, 'Military')).toBe('1000 (-50)')
+    expect(scoresTableCellForColumn(row, BUILD_INFERENCE_COLUMN)).toBe('')
+  })
+})

--- a/packages/frontend/src/analytics/scores/scoresTableColumns.ts
+++ b/packages/frontend/src/analytics/scores/scoresTableColumns.ts
@@ -1,0 +1,26 @@
+/** Column headers for Scores table data cells (matches BFF `TABLE_COLUMNS`). */
+export const SCORES_TABLE_DATA_COLUMNS = [
+  'Race (player)',
+  'Planets',
+  'Starbases',
+  'War Ships',
+  'Freighters',
+  'Military',
+  'Priority Points',
+] as const
+
+export const BUILD_INFERENCE_COLUMN = 'Build inference'
+
+export type ScoresTableDataColumn = (typeof SCORES_TABLE_DATA_COLUMNS)[number]
+
+export function scoresTableCellForColumn(row: string[], column: string): string {
+  const index = (SCORES_TABLE_DATA_COLUMNS as readonly string[]).indexOf(column)
+  if (index < 0) {
+    return ''
+  }
+  return row[index] ?? ''
+}
+
+export function isBuildInferenceColumn(column: string): boolean {
+  return column === BUILD_INFERENCE_COLUMN
+}

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -50,7 +50,7 @@ describe('useScoresInferenceByRow', () => {
   })
 
   it('merges settled inference independently per player', async () => {
-    vi.spyOn(bff, 'fetchScoresRowInference').mockImplementation(async (s, playerId) => {
+    vi.spyOn(bff, 'fetchScoresRowInference').mockImplementation(async (_scope, playerId) => {
       if (playerId === 8) {
         return {
           playerId: 8,

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { AnalyticShellScope, TableDataResponse } from '../../api/bff'
+import * as bff from '../../api/bff'
+import { useScoresInferenceByRow } from './useScoresInferenceByRow'
+
+const scope: AnalyticShellScope = {
+  gameId: '628580',
+  turn: 111,
+  perspective: 1,
+}
+
+const tableData: TableDataResponse = {
+  analyticId: 'scores',
+  includeBuildInference: true,
+  columns: ['Race (player)', 'Build inference'],
+  rows: [['Alice']],
+  inferenceByRow: [{ playerId: 8 }, { playerId: 9 }],
+}
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
+describe('useScoresInferenceByRow', () => {
+  it('returns pending while per-row inference requests are in flight', () => {
+    vi.spyOn(bff, 'fetchScoresRowInference').mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    const { result } = renderHook(
+      () => useScoresInferenceByRow(tableData, scope, true),
+      { wrapper: createWrapper() }
+    )
+
+    expect(result.current).toHaveLength(2)
+    expect(result.current?.[0]).toMatchObject({
+      playerId: 8,
+      displayStatus: 'pending',
+    })
+    expect(result.current?.[1]).toMatchObject({
+      playerId: 9,
+      displayStatus: 'pending',
+    })
+  })
+
+  it('merges settled inference independently per player', async () => {
+    vi.spyOn(bff, 'fetchScoresRowInference').mockImplementation(async (s, playerId) => {
+      if (playerId === 8) {
+        return {
+          playerId: 8,
+          displayStatus: 'success',
+          status: 'exact',
+          summary: 'Player 8 ok',
+          solutionCount: 1,
+          isComplete: true,
+          solutions: [],
+          diagnostics: { turn: 111 },
+        }
+      }
+      throw new Error('502 player 9 failed')
+    })
+
+    const { result } = renderHook(
+      () => useScoresInferenceByRow(tableData, scope, true),
+      { wrapper: createWrapper() }
+    )
+
+    await waitFor(() => {
+      expect(result.current?.[0]?.displayStatus).toBe('success')
+      expect(result.current?.[1]?.displayStatus).toBe('failure')
+    })
+    expect(result.current?.[0]?.summary).toBe('Player 8 ok')
+    expect(result.current?.[1]?.summary).toContain('502')
+  })
+})

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
@@ -1,0 +1,80 @@
+import { useQueries } from '@tanstack/react-query'
+import type { AnalyticShellScope, ScoresInferenceRowDetail, TableDataResponse } from '../../api/bff'
+import { fetchScoresRowInference } from '../../api/bff'
+import { scoresRowInferenceQueryKey } from './api'
+import { errorDetailFromUnknown } from '../../lib/queryRetry'
+
+function pendingDetail(playerId: number): ScoresInferenceRowDetail {
+  return {
+    playerId,
+    displayStatus: 'pending',
+    status: 'pending',
+    summary: 'Build inference in progress',
+    solutionCount: 0,
+    isComplete: false,
+    solutions: [],
+    diagnostics: {},
+  }
+}
+
+function failureDetail(playerId: number, summary: string): ScoresInferenceRowDetail {
+  return {
+    playerId,
+    displayStatus: 'failure',
+    status: 'fetch_error',
+    summary,
+    solutionCount: 0,
+    isComplete: true,
+    solutions: [],
+    diagnostics: {},
+  }
+}
+
+export function useScoresInferenceByRow(
+  tableData: TableDataResponse | undefined,
+  scope: AnalyticShellScope | null,
+  enabled: boolean
+): ScoresInferenceRowDetail[] | undefined {
+  const stubs =
+    enabled && tableData?.inferenceByRow != null ? tableData.inferenceByRow : []
+  const playerIds = stubs
+    .map((stub) => stub.playerId)
+    .filter((id): id is number => typeof id === 'number')
+
+  const queries = useQueries({
+    queries: playerIds.map((playerId) => ({
+      queryKey: scoresRowInferenceQueryKey(scope!, playerId),
+      queryFn: () => fetchScoresRowInference(scope!, playerId),
+      enabled: enabled && scope != null,
+    })),
+  })
+
+  const queryByPlayerId = new Map(
+    playerIds.map((playerId, index) => [playerId, queries[index]])
+  )
+
+  if (!enabled || tableData?.inferenceByRow == null) {
+    return undefined
+  }
+
+  return stubs.map((stub, rowIndex) => {
+    const playerId = stub.playerId
+    if (typeof playerId !== 'number') {
+      return failureDetail(-(rowIndex + 1), 'Missing player id for build inference')
+    }
+    const query = queryByPlayerId.get(playerId)
+    if (query == null) {
+      return pendingDetail(playerId)
+    }
+    if (query.isPending) {
+      return pendingDetail(playerId)
+    }
+    if (query.isError) {
+      return failureDetail(playerId, errorDetailFromUnknown(query.error))
+    }
+    if (query.data != null) {
+      return query.data
+    }
+    return pendingDetail(playerId)
+  })
+}

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -603,6 +603,22 @@ export async function fetchAnalyticTable(
   return r.json()
 }
 
+export async function fetchScoresRowInference(
+  scope: AnalyticShellScope,
+  playerId: number
+): Promise<ScoresInferenceRowDetail> {
+  const path = '/bff/analytics/scores/inference'
+  const params = analyticScopeParams(scope)
+  params.set('playerId', String(playerId))
+  const qs = `?${params.toString()}`
+  const endpointLabel = `GET ${path}`
+  const r = await bffRequest(`${path}${qs}`, undefined, endpointLabel)
+  if (!r.ok) {
+    throw new Error(withEndpointIfGeneric(String(r.status), endpointLabel))
+  }
+  return r.json()
+}
+
 export async function fetchAnalyticMap(
   analyticId: string,
   scope: AnalyticShellScope,

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -202,12 +202,17 @@ export type AnalyticsListResponse = {
   analytics: AnalyticItem[]
 }
 
+/** Initial table payload before per-row inference GETs complete. */
+export type ScoresInferenceRowStub = {
+  playerId?: number
+}
+
 export type TableDataResponse = {
   analyticId: string
   columns: string[]
   rows: string[][]
   includeBuildInference?: boolean
-  inferenceByRow?: ScoresInferenceRowDetail[]
+  inferenceByRow?: Array<ScoresInferenceRowStub | ScoresInferenceRowDetail>
 }
 
 export type ScoresInferenceSolutionAction = {
@@ -250,6 +255,21 @@ export type ScoresInferenceRowDetail = {
   isComplete: boolean
   solutions: ScoresInferenceSolution[]
   diagnostics: Record<string, unknown>
+}
+
+/** Scores table after per-row inference queries have been merged for display. */
+export type ScoresTableWithInferenceData = Omit<
+  TableDataResponse,
+  'includeBuildInference' | 'inferenceByRow'
+> & {
+  includeBuildInference: true
+  inferenceByRow: ScoresInferenceRowDetail[]
+}
+
+export function isScoresInferenceRowDetail(
+  row: ScoresInferenceRowStub | ScoresInferenceRowDetail
+): row is ScoresInferenceRowDetail {
+  return 'displayStatus' in row
 }
 
 export type StoredGameItem = {

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -216,9 +216,29 @@ export type ScoresInferenceSolutionAction = {
   count: number
 }
 
+export type ScoresInferenceMilitaryScoreLineItem = {
+  actionId: string
+  label: string
+  count: number
+  scoreDelta2xPerUnit: number
+  militaryChangePerUnit: number
+  scoreDelta2xSubtotal: number
+  militaryChangeSubtotal: number
+}
+
+export type ScoresInferenceMilitaryScoreArithmetic = {
+  observedMilitaryChange: number
+  observedMilitaryDelta2x: number
+  explainedMilitaryChange: number
+  explainedMilitaryDelta2x: number
+  matchesObserved: boolean
+  lineItems: ScoresInferenceMilitaryScoreLineItem[]
+}
+
 export type ScoresInferenceSolution = {
   objectiveValue: number
   actions: ScoresInferenceSolutionAction[]
+  militaryScoreArithmetic?: ScoresInferenceMilitaryScoreArithmetic
 }
 
 export type ScoresInferenceRowDetail = {

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -4,6 +4,8 @@
 
 import { appendConnectionsMapQueryParams } from '../analytics/connections/api'
 import type { ConnectionsMapParams } from '../analytics/connections/api'
+import { appendScoresTableQueryParams } from '../analytics/scores/api'
+import type { ScoresTableParams } from '../analytics/scores/api'
 import type {
   MapDataResponse,
   StellarCartographySampleResponse,
@@ -26,6 +28,8 @@ export type {
   ConnectionsFlareMode,
   ConnectionsMapParams,
 } from '../analytics/connections/api'
+
+export type { ScoresTableParams } from '../analytics/scores/api'
 
 export type {
   BlackHoleOverlayCircle,
@@ -202,6 +206,30 @@ export type TableDataResponse = {
   analyticId: string
   columns: string[]
   rows: string[][]
+  includeBuildInference?: boolean
+  inferenceByRow?: ScoresInferenceRowDetail[]
+}
+
+export type ScoresInferenceSolutionAction = {
+  actionId: string
+  label: string
+  count: number
+}
+
+export type ScoresInferenceSolution = {
+  objectiveValue: number
+  actions: ScoresInferenceSolutionAction[]
+}
+
+export type ScoresInferenceRowDetail = {
+  playerId?: number
+  displayStatus: 'success' | 'pending' | 'failure'
+  status: string
+  summary: string
+  solutionCount: number
+  isComplete: boolean
+  solutions: ScoresInferenceSolution[]
+  diagnostics: Record<string, unknown>
 }
 
 export type StoredGameItem = {
@@ -543,10 +571,19 @@ function analyticMapQueryString(
 
 export async function fetchAnalyticTable(
   analyticId: string,
-  scope: AnalyticShellScope
+  scope: AnalyticShellScope,
+  scoresTableParams?: ScoresTableParams
 ): Promise<TableDataResponse> {
   const path = `/bff/analytics/${encodeURIComponent(analyticId)}/table`
-  const qs = analyticScopeQuery(scope)
+  const params = new URLSearchParams({
+    gameId: scope.gameId,
+    turn: String(scope.turn),
+    perspective: String(scope.perspective),
+  })
+  if (analyticId === 'scores' && scoresTableParams != null) {
+    appendScoresTableQueryParams(params, scoresTableParams)
+  }
+  const qs = `?${params.toString()}`
   const endpointLabel = `GET ${path}`
   const r = await bffRequest(`${path}${qs}`, undefined, endpointLabel)
   if (!r.ok) {

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -544,13 +544,12 @@ export type AnalyticShellScope = {
   perspective: number
 }
 
-function analyticScopeQuery(scope: AnalyticShellScope): string {
-  const params = new URLSearchParams({
+function analyticScopeParams(scope: AnalyticShellScope): URLSearchParams {
+  return new URLSearchParams({
     gameId: scope.gameId,
     turn: String(scope.turn),
     perspective: String(scope.perspective),
   })
-  return `?${params.toString()}`
 }
 
 function analyticMapQueryString(
@@ -558,11 +557,7 @@ function analyticMapQueryString(
   analyticId: string,
   connectionsParams: ConnectionsMapParams | undefined
 ): string {
-  const params = new URLSearchParams({
-    gameId: scope.gameId,
-    turn: String(scope.turn),
-    perspective: String(scope.perspective),
-  })
+  const params = analyticScopeParams(scope)
   if (analyticId === 'connections' && connectionsParams != null) {
     appendConnectionsMapQueryParams(params, connectionsParams)
   }
@@ -575,11 +570,7 @@ export async function fetchAnalyticTable(
   scoresTableParams?: ScoresTableParams
 ): Promise<TableDataResponse> {
   const path = `/bff/analytics/${encodeURIComponent(analyticId)}/table`
-  const params = new URLSearchParams({
-    gameId: scope.gameId,
-    turn: String(scope.turn),
-    perspective: String(scope.perspective),
-  })
+  const params = analyticScopeParams(scope)
   if (analyticId === 'scores' && scoresTableParams != null) {
     appendScoresTableQueryParams(params, scoresTableParams)
   }

--- a/packages/frontend/src/api/schema-analytics.ts
+++ b/packages/frontend/src/api/schema-analytics.ts
@@ -44,6 +44,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/{analytic_id}/inference": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Analytic Inference
+         * @description Per-row military score build inference for the Scores analytic.
+         */
+        get: operations["get_analytic_inference_analytics__analytic_id__inference_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics/{analytic_id}/map": {
         parameters: {
             query?: never;
@@ -146,6 +166,43 @@ export interface operations {
                 turn: number;
                 perspective: number;
                 includeBuildInference?: boolean;
+                includeDiagnostics?: boolean;
+            };
+            header?: never;
+            path: {
+                analytic_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_analytic_inference_analytics__analytic_id__inference_get: {
+        parameters: {
+            query: {
+                gameId: number;
+                turn: number;
+                perspective: number;
+                playerId: number;
                 includeDiagnostics?: boolean;
             };
             header?: never;

--- a/packages/frontend/src/api/schema-analytics.ts
+++ b/packages/frontend/src/api/schema-analytics.ts
@@ -145,6 +145,7 @@ export interface operations {
                 gameId: number;
                 turn: number;
                 perspective: number;
+                includeBuildInference?: boolean;
                 includeDiagnostics?: boolean;
             };
             header?: never;

--- a/packages/frontend/src/components/AnalyticsBar.tsx
+++ b/packages/frontend/src/components/AnalyticsBar.tsx
@@ -1,9 +1,10 @@
 import { cn } from '../lib/utils'
 import { ConnectionsMapTile } from '../analytics/connections/ConnectionsMapTile'
+import { ScoresTableTile } from '../analytics/scores/ScoresTableTile'
 import { StellarCartographyMapTile } from '../analytics/stellar-cartography/StellarCartographyMapTile'
 import { tileClassName } from '../analytics/tileChrome'
 import type { StellarCartographySettingsGates } from '../analytics/stellar-cartography/layers'
-import type { AnalyticItem, ConnectionsMapParams } from '../api/bff'
+import type { AnalyticItem, ConnectionsMapParams, ScoresTableParams } from '../api/bff'
 
 type ViewMode = 'tabular' | 'map'
 
@@ -14,6 +15,8 @@ type AnalyticsBarProps = {
   viewMode: ViewMode
   connectionsMapParams: ConnectionsMapParams
   onConnectionsMapParamsChange: (next: ConnectionsMapParams) => void
+  scoresTableParams: ScoresTableParams
+  onScoresTableParamsChange: (next: ScoresTableParams) => void
   stellarCartographyGates: StellarCartographySettingsGates
   ionStormCount: number | null
 }
@@ -34,6 +37,8 @@ export function AnalyticsBar({
   viewMode,
   connectionsMapParams,
   onConnectionsMapParamsChange,
+  scoresTableParams,
+  onScoresTableParamsChange,
   stellarCartographyGates,
   ionStormCount,
 }: AnalyticsBarProps) {
@@ -49,7 +54,24 @@ export function AnalyticsBar({
           const supportsMode = supportsCurrentMode(a, viewMode)
           const depressed = enabled && supportsMode
           const isConnectionsMap = a.id === 'connections' && viewMode === 'map'
+          const isScoresTable = a.id === 'scores' && viewMode === 'tabular'
           const isStellarCartographyMap = a.id === 'stellar-cartography' && viewMode === 'map'
+
+          if (isScoresTable) {
+            return (
+              <li key={a.id} className="min-w-0">
+                <ScoresTableTile
+                  name={a.name}
+                  enabled={enabled}
+                  supportsMode={supportsMode}
+                  depressed={depressed}
+                  onToggle={() => onToggle(a.id)}
+                  scoresTableParams={scoresTableParams}
+                  onScoresTableParamsChange={onScoresTableParamsChange}
+                />
+              </li>
+            )
+          }
 
           if (isConnectionsMap) {
             return (

--- a/packages/frontend/src/components/DiagnosticsModal.tsx
+++ b/packages/frontend/src/components/DiagnosticsModal.tsx
@@ -2,34 +2,29 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { useQueryClient } from '@tanstack/react-query'
 import { ClipboardCopy } from 'lucide-react'
 import {
-  fetchDiagnosticsRecent,
   isIncludeDiagnosticsSessionEnabled,
   setIncludeDiagnosticsSessionEnabled,
-  type DiagnosticsRecentItem,
 } from '../api/bff'
 import { useModalKeydownFocusTrap } from '../lib/modalKeydownFocusTrap'
 import { restoreFocusToElementOrFallback } from '../lib/restoreFocus'
 import { cn } from '../lib/utils'
+import { useAnalyticDiagnosticsStore } from '../stores/analyticDiagnostics'
+import {
+  DiagnosticsRequestsTab,
+  formatAllDiagnosticsItems,
+  loadDiagnosticsRecentItems,
+} from './diagnostics/DiagnosticsRequestsTab'
+import { DiagnosticsScoresTab } from './diagnostics/DiagnosticsScoresTab'
+import {
+  DIAGNOSTICS_TAB_IDS,
+  DIAGNOSTICS_TAB_LABELS,
+  type DiagnosticsTabId,
+} from './diagnostics/diagnosticsTabs'
 
 type DiagnosticsModalProps = {
   isOpen: boolean
   onClose: () => void
   getFocusRestoreFallback?: () => HTMLElement | null
-}
-
-/** Newest `capturedAt` first (ISO-8601 strings compare lexicographically). */
-function _diagnosticsByNewestFirst(
-  list: DiagnosticsRecentItem[]
-): DiagnosticsRecentItem[] {
-  return [...list].sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
-}
-
-function formatBlob(item: DiagnosticsRecentItem): string {
-  return JSON.stringify(
-    { capturedAt: item.capturedAt, summary: item.summary, diagnostics: item.diagnostics },
-    null,
-    2
-  )
 }
 
 export function DiagnosticsModal({
@@ -40,10 +35,14 @@ export function DiagnosticsModal({
   const queryClient = useQueryClient()
   const dialogRef = useRef<HTMLDivElement>(null)
   const returnFocusRef = useRef<HTMLElement | null>(null)
-  const [items, setItems] = useState<DiagnosticsRecentItem[] | null>(null)
+  const [activeTab, setActiveTab] = useState<DiagnosticsTabId>('requests')
+  const [items, setItems] = useState<Awaited<
+    ReturnType<typeof loadDiagnosticsRecentItems>
+  > | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [clipboardError, setClipboardError] = useState<string | null>(null)
   const [recordBffDiagnostics, setRecordBffDiagnostics] = useState(false)
+  const scoresSnapshot = useAnalyticDiagnosticsStore((state) => state.scores)
 
   const closeAndReturnFocus = useCallback(() => {
     const target = returnFocusRef.current
@@ -77,10 +76,10 @@ export function DiagnosticsModal({
     setItems(null)
     setRecordBffDiagnostics(isIncludeDiagnosticsSessionEnabled())
     let cancelled = false
-    void fetchDiagnosticsRecent()
-      .then((r) => {
+    void loadDiagnosticsRecentItems()
+      .then((recentItems) => {
         if (cancelled) return
-        setItems(r.items)
+        setItems(recentItems)
       })
       .catch((e: unknown) => {
         if (cancelled) return
@@ -125,29 +124,21 @@ export function DiagnosticsModal({
       })
   }, [])
 
-  const copyOne = (item: DiagnosticsRecentItem) => {
-    runClipboardCopy(formatBlob(item))
-  }
-
-  const copyAll = () => {
-    if (!items?.length) return
-    const ordered = _diagnosticsByNewestFirst(items)
-    runClipboardCopy(
-      JSON.stringify(
-        {
-          items: ordered.map((i) => ({
-            capturedAt: i.capturedAt,
-            summary: i.summary,
-            diagnostics: i.diagnostics,
-          })),
-        },
-        null,
-        2
-      )
-    )
+  const copyActiveTab = () => {
+    if (activeTab === 'requests') {
+      if (!items?.length) return
+      runClipboardCopy(formatAllDiagnosticsItems(items))
+      return
+    }
+    if (scoresSnapshot != null) {
+      runClipboardCopy(JSON.stringify(scoresSnapshot, null, 2))
+    }
   }
 
   if (!isOpen) return null
+
+  const canCopyActiveTab =
+    activeTab === 'requests' ? Boolean(items?.length) : scoresSnapshot != null
 
   return (
     <div
@@ -162,7 +153,7 @@ export function DiagnosticsModal({
         aria-labelledby="diagnostics-title"
         tabIndex={-1}
         className={cn(
-          'flex max-h-[85vh] w-[min(42rem,100vw-2rem)] flex-col overflow-hidden',
+          'flex max-h-[85vh] w-[min(48rem,100vw-2rem)] flex-col overflow-hidden',
           'rounded-lg border border-[#52575d] bg-[#2d3136] shadow-xl',
           'outline-none focus-visible:ring-1 focus-visible:ring-slate-400'
         )}
@@ -174,15 +165,15 @@ export function DiagnosticsModal({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={copyAll}
-              disabled={!items?.length}
+              onClick={copyActiveTab}
+              disabled={!canCopyActiveTab}
               className={cn(
                 'inline-flex items-center gap-1 rounded p-1.5 text-slate-300',
                 'hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40',
                 'focus:outline-none focus:ring-1 focus:ring-slate-400'
               )}
-              title="Copy all to clipboard"
-              aria-label="Copy all diagnostics to clipboard"
+              title="Copy active tab to clipboard"
+              aria-label="Copy active tab to clipboard"
             >
               <ClipboardCopy className="h-4 w-4" aria-hidden />
             </button>
@@ -195,92 +186,68 @@ export function DiagnosticsModal({
             </button>
           </div>
         </div>
-        <div className="border-b border-[#52575d] px-4 py-2">
-          <label className="flex cursor-pointer select-none items-start gap-2 text-sm text-slate-300">
-            <input
-              type="checkbox"
-              className="mt-0.5 h-3.5 w-3.5 rounded border border-[#52575d] bg-[#2d3136] accent-slate-400"
-              checked={recordBffDiagnostics}
-              onChange={(e) => {
-                const on = e.target.checked
-                setIncludeDiagnosticsSessionEnabled(on)
-                setRecordBffDiagnostics(on)
-                // Session flag is not part of React Query keys; invalidate so map/shell requests
-                // re-run with ?includeDiagnostics=true and populate the server buffer (e.g.
-                // GET /analytics/connections/map connection_routes trees).
-                void queryClient.invalidateQueries({ queryKey: ['bff'] })
-                void queryClient.invalidateQueries({ queryKey: ['analytic'] })
-              }}
-            />
-            <span>
-              <span className="font-medium text-slate-200">Record BFF diagnostics</span>
-              <span className="mt-0.5 block text-xs text-slate-500">
-                Adds <code className="text-slate-400">includeDiagnostics=true</code> to BFF
-                calls from this tab (maps, games, shell, etc.). Then trigger a request — e.g.
-                Toggling this also refetches cached BFF data so new requests include diagnostics.
-                Or change a map control (e.g. flare depth) and open this panel again; recent trees
-                appear in the buffer below. Cleared when the tab ends.
-              </span>
-            </span>
-          </label>
+
+        <div
+          className="flex gap-1 border-b border-[#52575d] px-4 pt-2"
+          role="tablist"
+          aria-label="Diagnostics sections"
+        >
+          {DIAGNOSTICS_TAB_IDS.map((tabId) => (
+            <button
+              key={tabId}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tabId}
+              onClick={() => setActiveTab(tabId)}
+              className={cn(
+                'rounded-t px-3 py-2 text-xs font-medium',
+                activeTab === tabId
+                  ? 'bg-[#40454a] text-slate-100'
+                  : 'text-slate-400 hover:bg-white/5 hover:text-slate-200'
+              )}
+            >
+              {DIAGNOSTICS_TAB_LABELS[tabId]}
+            </button>
+          ))}
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+
+        {activeTab === 'requests' ? (
+          <div className="border-b border-[#52575d] px-4 py-2">
+            <label className="flex cursor-pointer select-none items-start gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                className="mt-0.5 h-3.5 w-3.5 rounded border border-[#52575d] bg-[#2d3136] accent-slate-400"
+                checked={recordBffDiagnostics}
+                onChange={(e) => {
+                  const on = e.target.checked
+                  setIncludeDiagnosticsSessionEnabled(on)
+                  setRecordBffDiagnostics(on)
+                  void queryClient.invalidateQueries({ queryKey: ['bff'] })
+                  void queryClient.invalidateQueries({ queryKey: ['analytic'] })
+                }}
+              />
+              <span>
+                <span className="font-medium text-slate-200">Record BFF diagnostics</span>
+                <span className="mt-0.5 block text-xs text-slate-500">
+                  Adds <code className="text-slate-400">includeDiagnostics=true</code> to BFF
+                  calls from this tab. Toggling refetches cached BFF data so new requests include
+                  timing trees in this tab.
+                </span>
+              </span>
+            </label>
+          </div>
+        ) : null}
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4" role="tabpanel">
           {clipboardError != null && (
             <p className="mb-2 text-sm text-red-400" role="alert">
               {clipboardError}
             </p>
           )}
-          {loadError != null && (
-            <p className="text-sm text-red-400" role="alert">
-              {loadError}
-            </p>
-          )}
-          {loadError == null && items == null && (
-            <p className="text-sm text-slate-400">Loading…</p>
-          )}
-          {loadError == null && items != null && items.length === 0 && (
-            <p className="text-sm text-slate-400">
-              No entries yet. Turn on <span className="font-medium text-slate-300">Record BFF diagnostics</span> above, then
-              trigger a BFF request in the console (or add{' '}
-              <code className="text-slate-300">includeDiagnostics=true</code> to a BFF URL yourself).
-            </p>
-          )}
-          {items != null && items.length > 0 && (
-            <ul className="flex flex-col gap-3">
-              {_diagnosticsByNewestFirst(items).map((item) => {
-                const label = item.summary || item.capturedAt
-                return (
-                  <li
-                    key={`${item.capturedAt}-${item.summary}`}
-                    className="rounded border border-[#52575d] bg-[#40454a] p-2"
-                  >
-                    <div className="mb-1 flex items-center justify-between gap-2">
-                      <span
-                        className="min-w-0 flex-1 truncate text-xs text-slate-200"
-                        title={label}
-                      >
-                        {label}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => copyOne(item)}
-                        className={cn(
-                          'shrink-0 inline-flex items-center gap-1 rounded p-1 text-slate-300',
-                          'hover:bg-white/10 focus:outline-none focus:ring-1 focus:ring-slate-400'
-                        )}
-                        title="Copy this entry"
-                        aria-label="Copy to clipboard"
-                      >
-                        <ClipboardCopy className="h-3.5 w-3.5" aria-hidden />
-                      </button>
-                    </div>
-                    <pre className="max-h-40 overflow-auto text-[10px] leading-snug text-slate-400 break-all whitespace-pre-wrap">
-                      {formatBlob(item)}
-                    </pre>
-                  </li>
-                )
-              })}
-            </ul>
+          {activeTab === 'requests' ? (
+            <DiagnosticsRequestsTab items={items} loadError={loadError} onCopy={runClipboardCopy} />
+          ) : (
+            <DiagnosticsScoresTab snapshot={scoresSnapshot} onCopy={runClipboardCopy} />
           )}
         </div>
       </div>

--- a/packages/frontend/src/components/MainArea.test.tsx
+++ b/packages/frontend/src/components/MainArea.test.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { ReactNode } from 'react'
 import type { AnalyticItem, AnalyticShellScope, ConnectionsMapParams } from '../api/bff'
+import type { ScoresTableParams } from '../analytics/scores/api'
 import { MainArea } from './MainArea'
 import { useMapAnalyticQueries } from '../lib/useMapAnalyticQueries'
 import { useRetainedMapDisplay } from '../lib/useRetainedMapDisplay'
@@ -75,6 +76,10 @@ function createWrapper() {
   }
 }
 
+const defaultScoresTableParams: ScoresTableParams = {
+  includeBuildInference: false,
+}
+
 function defaultMainAreaProps(viewMode: 'tabular' | 'map') {
   return {
     viewMode,
@@ -87,6 +92,7 @@ function defaultMainAreaProps(viewMode: 'tabular' | 'map') {
     turnEnsureError: null,
     turnBlockedNoLogin: false,
     connectionsMapParams: defaultConnectionsParams,
+    scoresTableParams: defaultScoresTableParams,
     futureTurnOffset: 0,
     onMapZoomChange: vi.fn(),
     onSetZoomReady: vi.fn(),

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -10,6 +10,7 @@ import type {
 import { scoresTableQueryKey } from '../analytics/scores/api'
 import { scoresDiagnosticsFromTable } from '../analytics/scores/diagnosticsFromTable'
 import { ScoresTableView } from '../analytics/scores/ScoresTableView'
+import { useScoresInferenceByRow } from '../analytics/scores/useScoresInferenceByRow'
 import { useAnalyticDiagnosticsStore } from '../stores/analyticDiagnostics'
 import { isStellarCartographyMapEnabled } from '../analytics/mapShellCartography'
 import {
@@ -62,6 +63,7 @@ function TableTile({
   scoresTableParams: ScoresTableParams
 }) {
   const isScores = analyticId === 'scores'
+  const inferenceEnabled = isScores && scoresTableParams.includeBuildInference
   const setScoresDiagnostics = useAnalyticDiagnosticsStore((state) => state.setScoresDiagnostics)
   const { data, isPending, error } = useQuery({
     queryKey: [
@@ -79,17 +81,28 @@ function TableTile({
       ),
     enabled: fetchEnabled,
   })
+  const inferenceByRow = useScoresInferenceByRow(
+    data,
+    analyticScope,
+    inferenceEnabled && fetchEnabled
+  )
+  const scoresTableData =
+    data != null && inferenceByRow != null
+      ? { ...data, inferenceByRow }
+      : data
 
   useEffect(() => {
     if (!isScores || analyticScope == null) {
       return
     }
-    if (data?.includeBuildInference === true) {
-      setScoresDiagnostics(scoresDiagnosticsFromTable(data, analyticScope))
+    if (scoresTableData?.includeBuildInference === true && inferenceByRow != null) {
+      setScoresDiagnostics(
+        scoresDiagnosticsFromTable({ ...scoresTableData, inferenceByRow }, analyticScope)
+      )
       return
     }
     setScoresDiagnostics(null)
-  }, [isScores, analyticScope, data, setScoresDiagnostics])
+  }, [isScores, analyticScope, scoresTableData, inferenceByRow, setScoresDiagnostics])
 
   if (analyticScope == null) {
     return (
@@ -107,8 +120,8 @@ function TableTile({
     )
   }
   if (!data) return null
-  if (isScores && data.includeBuildInference === true) {
-    return <ScoresTableView data={data} />
+  if (isScores && scoresTableData?.includeBuildInference === true && inferenceByRow != null) {
+    return <ScoresTableView data={{ ...scoresTableData, inferenceByRow }} />
   }
   return (
     <div className="overflow-auto">

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -5,7 +5,10 @@ import type {
   AnalyticItem,
   AnalyticShellScope,
   ConnectionsMapParams,
+  ScoresInferenceRowDetail,
   ScoresTableParams,
+  ScoresTableWithInferenceData,
+  TableDataResponse,
 } from '../api/bff'
 import { scoresTableQueryKey } from '../analytics/scores/api'
 import { scoresDiagnosticsFromTable } from '../analytics/scores/diagnosticsFromTable'
@@ -26,6 +29,19 @@ import { useRetainedMapDisplay } from '../lib/useRetainedMapDisplay'
 import { useStellarCartographyMapContext } from '../lib/useStellarCartographyMapContext'
 
 type ViewMode = 'tabular' | 'map'
+
+function buildScoresTableWithInference(
+  data: TableDataResponse,
+  inferenceByRow: ScoresInferenceRowDetail[]
+): ScoresTableWithInferenceData {
+  return {
+    analyticId: data.analyticId,
+    columns: data.columns,
+    rows: data.rows,
+    includeBuildInference: true,
+    inferenceByRow,
+  }
+}
 
 type MainAreaProps = {
   viewMode: ViewMode
@@ -86,23 +102,21 @@ function TableTile({
     analyticScope,
     inferenceEnabled && fetchEnabled
   )
-  const scoresTableData =
+  const scoresTableWithInference =
     data != null && inferenceByRow != null
-      ? { ...data, inferenceByRow }
-      : data
+      ? buildScoresTableWithInference(data, inferenceByRow)
+      : null
 
   useEffect(() => {
     if (!isScores || analyticScope == null) {
       return
     }
-    if (scoresTableData?.includeBuildInference === true && inferenceByRow != null) {
-      setScoresDiagnostics(
-        scoresDiagnosticsFromTable({ ...scoresTableData, inferenceByRow }, analyticScope)
-      )
+    if (scoresTableWithInference != null) {
+      setScoresDiagnostics(scoresDiagnosticsFromTable(scoresTableWithInference, analyticScope))
       return
     }
     setScoresDiagnostics(null)
-  }, [isScores, analyticScope, scoresTableData, inferenceByRow, setScoresDiagnostics])
+  }, [isScores, analyticScope, scoresTableWithInference, setScoresDiagnostics])
 
   if (analyticScope == null) {
     return (
@@ -120,8 +134,8 @@ function TableTile({
     )
   }
   if (!data) return null
-  if (isScores && scoresTableData?.includeBuildInference === true && inferenceByRow != null) {
-    return <ScoresTableView data={{ ...scoresTableData, inferenceByRow }} />
+  if (isScores && scoresTableWithInference != null) {
+    return <ScoresTableView data={scoresTableWithInference} />
   }
   return (
     <div className="overflow-auto">

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -1,11 +1,16 @@
-import { memo, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchAnalyticTable } from '../api/bff'
 import type {
   AnalyticItem,
   AnalyticShellScope,
   ConnectionsMapParams,
+  ScoresTableParams,
 } from '../api/bff'
+import { scoresTableQueryKey } from '../analytics/scores/api'
+import { scoresDiagnosticsFromTable } from '../analytics/scores/diagnosticsFromTable'
+import { ScoresTableView } from '../analytics/scores/ScoresTableView'
+import { useAnalyticDiagnosticsStore } from '../stores/analyticDiagnostics'
 import { isStellarCartographyMapEnabled } from '../analytics/mapShellCartography'
 import {
   DEFAULT_PLANET_LABEL_OPTIONS,
@@ -37,6 +42,8 @@ type MainAreaProps = {
   turnBlockedNoLogin: boolean
   /** Parameters for the Connections map analytic (refetch when these change). */
   connectionsMapParams: ConnectionsMapParams
+  /** Parameters for the Scores table analytic (refetch when these change). */
+  scoresTableParams: ScoresTableParams
   /** Turns beyond latest stored game turn for ion storm prediction. */
   futureTurnOffset: number
   onMapZoomChange: (zoom: number) => void
@@ -47,16 +54,43 @@ function TableTile({
   analyticId,
   analyticScope,
   fetchEnabled,
+  scoresTableParams,
 }: {
   analyticId: string
   analyticScope: AnalyticShellScope | null
   fetchEnabled: boolean
+  scoresTableParams: ScoresTableParams
 }) {
+  const isScores = analyticId === 'scores'
+  const setScoresDiagnostics = useAnalyticDiagnosticsStore((state) => state.setScoresDiagnostics)
   const { data, isPending, error } = useQuery({
-    queryKey: ['analytic', analyticId, 'table', analyticScope] as const,
-    queryFn: () => fetchAnalyticTable(analyticId, analyticScope!),
+    queryKey: [
+      'analytic',
+      analyticId,
+      'table',
+      analyticScope,
+      ...(isScores ? scoresTableQueryKey(scoresTableParams) : []),
+    ] as const,
+    queryFn: () =>
+      fetchAnalyticTable(
+        analyticId,
+        analyticScope!,
+        isScores ? scoresTableParams : undefined
+      ),
     enabled: fetchEnabled,
   })
+
+  useEffect(() => {
+    if (!isScores || analyticScope == null) {
+      return
+    }
+    if (data?.includeBuildInference === true) {
+      setScoresDiagnostics(scoresDiagnosticsFromTable(data, analyticScope))
+      return
+    }
+    setScoresDiagnostics(null)
+  }, [isScores, analyticScope, data, setScoresDiagnostics])
+
   if (analyticScope == null) {
     return (
       <div className="p-4 text-sm text-gray-400">
@@ -73,6 +107,9 @@ function TableTile({
     )
   }
   if (!data) return null
+  if (isScores && data.includeBuildInference === true) {
+    return <ScoresTableView data={data} />
+  }
   return (
     <div className="overflow-auto">
       <table className="min-w-full border-collapse text-sm">
@@ -210,6 +247,7 @@ export function MainArea({
   turnEnsureError,
   turnBlockedNoLogin,
   connectionsMapParams,
+  scoresTableParams,
   futureTurnOffset,
   onMapZoomChange,
   onSetZoomReady,
@@ -264,6 +302,7 @@ export function MainArea({
               analyticId={id}
               analyticScope={analyticScope}
               fetchEnabled={analyticFetchEnabled}
+              scoresTableParams={scoresTableParams}
             />
           </section>
         ))}

--- a/packages/frontend/src/components/diagnostics/DiagnosticsJsonBlock.test.tsx
+++ b/packages/frontend/src/components/diagnostics/DiagnosticsJsonBlock.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { CollapsibleJsonView } from './DiagnosticsJsonBlock'
+
+describe('CollapsibleJsonView', () => {
+  it('renders nested objects with collapsible sections', async () => {
+    const user = userEvent.setup()
+    render(
+      <CollapsibleJsonView
+        value={{
+          constraints: {
+            militaryDelta2x: -107738,
+            appliedEqualities: ['sum(scoreDelta2x * count) == -107738'],
+          },
+          actions: [{ id: 'planet_defense_posts_added_total' }],
+        }}
+      />
+    )
+
+    expect(screen.getByText(/constraints:/)).toBeTruthy()
+    expect(screen.getByText(/militaryDelta2x:/)).toBeTruthy()
+
+    const rootToggle = screen.getAllByRole('button', { name: /\{2\}/ })[0]
+    await user.click(rootToggle)
+    expect(screen.queryByText(/militaryDelta2x:/)).toBeNull()
+
+    await user.click(rootToggle)
+    expect(screen.getByText(/militaryDelta2x:/)).toBeTruthy()
+  })
+})

--- a/packages/frontend/src/components/diagnostics/DiagnosticsJsonBlock.tsx
+++ b/packages/frontend/src/components/diagnostics/DiagnosticsJsonBlock.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+type CollapsibleJsonViewProps = {
+  value: unknown
+  defaultExpandedDepth?: number
+  depth?: number
+  label?: string
+}
+
+function jsonPreview(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return `Array(${value.length})`
+  if (typeof value === 'object') return `Object(${Object.keys(value as object).length})`
+  return String(value)
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value == null) return true
+  if (Array.isArray(value)) return value.length === 0
+  if (typeof value === 'object') return Object.keys(value as object).length === 0
+  return false
+}
+
+export function CollapsibleJsonView({
+  value,
+  defaultExpandedDepth = 2,
+  depth = 0,
+  label,
+}: CollapsibleJsonViewProps) {
+  const [expanded, setExpanded] = useState(depth < defaultExpandedDepth)
+
+  if (value === null || typeof value !== 'object') {
+    return (
+      <span className="font-mono text-[10px] text-slate-300">
+        {label != null ? (
+          <>
+            <span className="text-slate-500">{label}: </span>
+            {jsonPreview(value)}
+          </>
+        ) : (
+          jsonPreview(value)
+        )}
+      </span>
+    )
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="font-mono text-[10px] text-slate-400">[]</span>
+    }
+    return (
+      <div className="font-mono text-[10px] text-slate-300">
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          className={cn(
+            'inline-flex items-center gap-1 rounded px-0.5 text-left text-slate-300',
+            'hover:bg-white/5 focus:outline-none focus:ring-1 focus:ring-slate-500'
+          )}
+          aria-expanded={expanded}
+        >
+          <ChevronDown
+            className={cn('h-3 w-3 shrink-0 text-slate-500', !expanded && '-rotate-90')}
+            aria-hidden
+          />
+          <span>{label != null ? `${label}: ` : ''}[{value.length}]</span>
+        </button>
+        {expanded ? (
+          <ul className="mt-1 space-y-1 border-l border-[#52575d]/70 pl-3">
+            {value.map((item, index) => (
+              <li key={index} className="min-w-0">
+                <CollapsibleJsonView
+                  value={item}
+                  defaultExpandedDepth={defaultExpandedDepth}
+                  depth={depth + 1}
+                  label={String(index)}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    )
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+  if (entries.length === 0) {
+    return <span className="font-mono text-[10px] text-slate-400">{'{}'}</span>
+  }
+
+  return (
+    <div className="font-mono text-[10px] text-slate-300">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        className={cn(
+          'inline-flex items-center gap-1 rounded px-0.5 text-left text-slate-300',
+          'hover:bg-white/5 focus:outline-none focus:ring-1 focus:ring-slate-500'
+        )}
+        aria-expanded={expanded}
+      >
+        <ChevronDown
+          className={cn('h-3 w-3 shrink-0 text-slate-500', !expanded && '-rotate-90')}
+          aria-hidden
+        />
+        <span>
+          {label != null ? `${label}: ` : ''}
+          {'{'}
+          {entries.length}
+          {'}'}
+        </span>
+      </button>
+      {expanded ? (
+        <ul className="mt-1 space-y-1 border-l border-[#52575d]/70 pl-3">
+          {entries.map(([entryKey, entryValue]) => (
+            <li key={entryKey} className="min-w-0">
+              <CollapsibleJsonView
+                value={entryValue}
+                defaultExpandedDepth={defaultExpandedDepth}
+                depth={depth + 1}
+                label={entryKey}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}
+
+type DiagnosticsJsonBlockProps = {
+  value: unknown
+  maxHeightClassName?: string
+  emptyLabel?: string
+}
+
+export function DiagnosticsJsonBlock({
+  value,
+  maxHeightClassName = 'max-h-96',
+  emptyLabel = 'No data',
+}: DiagnosticsJsonBlockProps) {
+  if (isEmptyValue(value)) {
+    return <p className="text-[10px] text-slate-500">{emptyLabel}</p>
+  }
+  return (
+    <div className={`overflow-auto rounded border border-[#52575d]/50 bg-[#2a2d30]/70 p-2 ${maxHeightClassName}`}>
+      <CollapsibleJsonView value={value} defaultExpandedDepth={2} />
+    </div>
+  )
+}

--- a/packages/frontend/src/components/diagnostics/DiagnosticsRequestsTab.tsx
+++ b/packages/frontend/src/components/diagnostics/DiagnosticsRequestsTab.tsx
@@ -1,0 +1,106 @@
+import { ClipboardCopy } from 'lucide-react'
+import {
+  fetchDiagnosticsRecent,
+  type DiagnosticsRecentItem,
+} from '../../api/bff'
+import { cn } from '../../lib/utils'
+import { DiagnosticsJsonBlock } from './DiagnosticsJsonBlock'
+
+type DiagnosticsRequestsTabProps = {
+  items: DiagnosticsRecentItem[] | null
+  loadError: string | null
+  onCopy: (text: string) => void
+}
+
+function diagnosticsByNewestFirst(list: DiagnosticsRecentItem[]): DiagnosticsRecentItem[] {
+  return [...list].sort((a, b) => b.capturedAt.localeCompare(a.capturedAt))
+}
+
+function formatBlob(item: DiagnosticsRecentItem): string {
+  return JSON.stringify(
+    { capturedAt: item.capturedAt, summary: item.summary, diagnostics: item.diagnostics },
+    null,
+    2
+  )
+}
+
+export function DiagnosticsRequestsTab({
+  items,
+  loadError,
+  onCopy,
+}: DiagnosticsRequestsTabProps) {
+  if (loadError != null) {
+    return (
+      <p className="text-sm text-red-400" role="alert">
+        {loadError}
+      </p>
+    )
+  }
+  if (items == null) {
+    return <p className="text-sm text-slate-400">Loading…</p>
+  }
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-slate-400">
+        No entries yet. Turn on{' '}
+        <span className="font-medium text-slate-300">Record BFF diagnostics</span> above, then
+        trigger a BFF request in the console.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {diagnosticsByNewestFirst(items).map((item) => {
+        const label = item.summary || item.capturedAt
+        return (
+          <li
+            key={`${item.capturedAt}-${item.summary}`}
+            className="rounded border border-[#52575d] bg-[#40454a] p-2"
+          >
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span
+                className="min-w-0 flex-1 truncate text-xs text-slate-200"
+                title={label}
+              >
+                {label}
+              </span>
+              <button
+                type="button"
+                onClick={() => onCopy(formatBlob(item))}
+                className={cn(
+                  'inline-flex shrink-0 items-center gap-1 rounded p-1 text-slate-300',
+                  'hover:bg-white/10 focus:outline-none focus:ring-1 focus:ring-slate-400'
+                )}
+                title="Copy this entry"
+                aria-label="Copy to clipboard"
+              >
+                <ClipboardCopy className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </div>
+            <DiagnosticsJsonBlock value={item} maxHeightClassName="max-h-40" />
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export async function loadDiagnosticsRecentItems(): Promise<DiagnosticsRecentItem[]> {
+  const response = await fetchDiagnosticsRecent()
+  return response.items
+}
+
+export function formatAllDiagnosticsItems(items: DiagnosticsRecentItem[]): string {
+  return JSON.stringify(
+    {
+      items: diagnosticsByNewestFirst(items).map((item) => ({
+        capturedAt: item.capturedAt,
+        summary: item.summary,
+        diagnostics: item.diagnostics,
+      })),
+    },
+    null,
+    2
+  )
+}

--- a/packages/frontend/src/components/diagnostics/DiagnosticsScoresTab.tsx
+++ b/packages/frontend/src/components/diagnostics/DiagnosticsScoresTab.tsx
@@ -1,0 +1,113 @@
+import { ClipboardCopy } from 'lucide-react'
+import type { ScoresAnalyticDiagnostics } from '../../stores/analyticDiagnostics'
+import { cn } from '../../lib/utils'
+import { DiagnosticsJsonBlock } from './DiagnosticsJsonBlock'
+
+type DiagnosticsScoresTabProps = {
+  snapshot: ScoresAnalyticDiagnostics | null
+  onCopy: (text: string) => void
+}
+
+export function DiagnosticsScoresTab({ snapshot, onCopy }: DiagnosticsScoresTabProps) {
+  if (snapshot == null) {
+    return (
+      <p className="text-sm text-slate-400">
+        No scores solver diagnostics yet. Enable{' '}
+        <span className="font-medium text-slate-300">Scores</span> with{' '}
+        <span className="font-medium text-slate-300">Include build inference</span>, then load
+        the scoreboard table.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded border border-[#52575d] bg-[#40454a] p-3 text-xs text-slate-300">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p>
+              Game <span className="font-medium text-slate-200">{snapshot.scope.gameId}</span>
+              {' · '}
+              Turn <span className="font-medium text-slate-200">{snapshot.scope.turn}</span>
+              {' · '}
+              Perspective{' '}
+              <span className="font-medium text-slate-200">{snapshot.scope.perspective}</span>
+            </p>
+            <p className="mt-1 text-slate-500">Captured {snapshot.capturedAt}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onCopy(JSON.stringify(snapshot, null, 2))}
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1 rounded p-1 text-slate-300',
+              'hover:bg-white/10 focus:outline-none focus:ring-1 focus:ring-slate-400'
+            )}
+            title="Copy scores diagnostics"
+            aria-label="Copy scores diagnostics"
+          >
+            <ClipboardCopy className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      {snapshot.players.map((player) => (
+        <section
+          key={player.playerId}
+          className="rounded border border-[#52575d] bg-[#40454a] p-3"
+        >
+          <div className="mb-2 flex items-start justify-between gap-2">
+            <div>
+              <h3 className="text-xs font-medium text-slate-200">{player.racePlayer}</h3>
+              <p className="mt-0.5 text-xs text-slate-400">
+                Player {player.playerId} · Turn {player.turn} · {player.status}
+              </p>
+              <p className="mt-1 text-xs text-slate-300">{player.summary}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onCopy(JSON.stringify(player, null, 2))}
+              className={cn(
+                'inline-flex shrink-0 items-center gap-1 rounded p-1 text-slate-300',
+                'hover:bg-white/10 focus:outline-none focus:ring-1 focus:ring-slate-400'
+              )}
+              title="Copy player diagnostics"
+              aria-label={`Copy diagnostics for ${player.racePlayer}`}
+            >
+              <ClipboardCopy className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <div>
+              <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                Constraints
+              </h4>
+              <DiagnosticsJsonBlock
+                value={player.constraints}
+                emptyLabel="No constraint data in the latest scores response."
+              />
+            </div>
+            <div>
+              <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                Action catalog
+              </h4>
+              <DiagnosticsJsonBlock
+                value={player.actionCatalog}
+                emptyLabel="No action catalog data in the latest scores response."
+              />
+            </div>
+            <div>
+              <h4 className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+                Solver
+              </h4>
+              <DiagnosticsJsonBlock
+                value={player.solver}
+                emptyLabel="No solver data in the latest scores response."
+              />
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/components/diagnostics/diagnosticsTabs.ts
+++ b/packages/frontend/src/components/diagnostics/diagnosticsTabs.ts
@@ -1,0 +1,8 @@
+export const DIAGNOSTICS_TAB_IDS = ['requests', 'scores'] as const
+
+export type DiagnosticsTabId = (typeof DIAGNOSTICS_TAB_IDS)[number]
+
+export const DIAGNOSTICS_TAB_LABELS: Record<DiagnosticsTabId, string> = {
+  requests: 'Requests',
+  scores: 'Scores',
+}

--- a/packages/frontend/src/stores/analyticDiagnostics.ts
+++ b/packages/frontend/src/stores/analyticDiagnostics.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import type { AnalyticShellScope } from '../api/bff'
+
+export type ScoresPlayerInferenceDiagnostics = {
+  playerId: number
+  racePlayer: string
+  status: string
+  summary: string
+  turn: number
+  constraints?: Record<string, unknown>
+  actionCatalog?: Record<string, unknown>
+  solver?: Record<string, unknown>
+  diagnostics: Record<string, unknown>
+}
+
+export type ScoresAnalyticDiagnostics = {
+  scope: AnalyticShellScope
+  capturedAt: string
+  includeBuildInference: boolean
+  players: ScoresPlayerInferenceDiagnostics[]
+}
+
+type AnalyticDiagnosticsState = {
+  scores: ScoresAnalyticDiagnostics | null
+  setScoresDiagnostics: (snapshot: ScoresAnalyticDiagnostics | null) => void
+}
+
+export const useAnalyticDiagnosticsStore = create<AnalyticDiagnosticsState>()((set) => ({
+  scores: null,
+  setScoresDiagnostics: (snapshot) => set({ scores: snapshot }),
+}))

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [manifest]
 members = [
@@ -8,6 +13,15 @@ members = [
     "bff",
     "planets-console",
     "server",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
 ]
 
 [[package]]
@@ -54,6 +68,7 @@ dependencies = [
     { name = "dacite" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "ortools" },
 ]
 
 [package.optional-dependencies]
@@ -66,6 +81,7 @@ requires-dist = [
     { name = "dacite", specifier = ">=1.8.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
 ]
 provides-extras = ["dev"]
@@ -211,6 +227,15 @@ wheels = [
 ]
 
 [[package]]
+name = "immutabledict"
+version = "4.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/e6/718471048fea0366c3e3d1df3acfd914ca66d571cdffcf6d37bbcd725708/immutabledict-4.3.1.tar.gz", hash = "sha256:f844a669106cfdc73f47b1a9da003782fb17dc955a54c80972e0d93d1c63c514", size = 7806, upload-time = "2026-02-15T10:32:34.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ce/f9018bf69ae91b273b6391a095e7c93fa5e1617f25b6ba81ad4b20c9df10/immutabledict-4.3.1-py3-none-any.whl", hash = "sha256:c9facdc0ff30fdb8e35bd16532026cac472a549e182c94fa201b51b25e4bf7bf", size = 5000, upload-time = "2026-02-15T10:32:33.672Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -241,6 +266,35 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
 name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -254,12 +308,63 @@ wheels = [
 ]
 
 [[package]]
+name = "ortools"
+version = "9.15.6755"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "immutabledict" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/ef/53a172ad12cf0d762b9a5af681b1f13f1b4105b38bf65c2b383d530ed97f/ortools-9.15.6755-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:acdf06a167933307608e7eba23a9490255933504df44c8de5f62c48656c29688", size = 23916963, upload-time = "2026-01-14T15:39:13.282Z" },
+    { url = "https://files.pythonhosted.org/packages/13/54/ed73ec00369fb6d6c71049d62e4b7c87c918b61f86ddd55a11c20ada395e/ortools-9.15.6755-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a0677270b0cd317a6b8dae42514264eaf5da5756c5bc7215eeea409424577df", size = 21923649, upload-time = "2026-01-14T15:39:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e0/ac57dd43eaadd73748bb542b30912e16c7dbf3a75f393f69efb8a1a2f032/ortools-9.15.6755-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:899b92afe3f775ab5867b9a8aa2850f81f2d95232db9b4ceec3456d69e6b8528", size = 27657273, upload-time = "2026-01-14T15:38:18.375Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e0/11144feb4ddadc491dc9d833d3a2080e6556245f912bebe2c0c7e174f2a1/ortools-9.15.6755-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7181183cdcafe2b0d83ca5505b65048c7953dc7b5ad479361dded607964cc1b3", size = 29843939, upload-time = "2026-01-14T15:38:21.457Z" },
+    { url = "https://files.pythonhosted.org/packages/96/97/771515ba3a05da3903b7da55a190d9f88f36a08c4bf848852e0ea4e3a731/ortools-9.15.6755-cp314-cp314-win_amd64.whl", hash = "sha256:afabb869e5fabeb704bd8147b22bf8139dee042e55fabd0d447a996428009e0c", size = 24673633, upload-time = "2026-01-14T15:39:51.212Z" },
+    { url = "https://files.pythonhosted.org/packages/46/99/0932d6d7d6ad326adf68f4ce9063ef07db7e9859859dddbcd200102aedff/ortools-9.15.6755-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9d07cddca201e25e2e219006a9d6cda10c7e9ee2c712c50d19d508f9ed8a888", size = 27682088, upload-time = "2026-01-14T15:38:25.174Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4d/bd75961e2c82db69bb41dd2c4a82131ca580e997485be2d5f59f8d26f31e/ortools-9.15.6755-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:990838ad66a052e72a50e69da500878710e3420e91717fe88bf3071995caba9e", size = 29851493, upload-time = "2026-01-14T15:38:28.168Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -293,6 +398,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -372,6 +492,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -478,6 +610,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -523,6 +664,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Delivers epic #39 Phase 1: infer likely per-turn military score changes from scoreboard deltas using OR-Tools CP-SAT, integrated into the existing **Scores** analytic (disabled by default, no new analytic ID).

- **Core:** `military_score_inference` package (scoring, bounded action catalog, CP-SAT exact solve, top-K, bucketed priors); per-player `get_scores_row_inference`; shared hard-constraint descriptors (`constraints.py`); priority points diagnostic-only (#50); per-solution military score arithmetic payload.
- **BFF:** Scores table with optional build-inference column stubs; `GET` per-row inference endpoint; thin shaping only.
- **Frontend:** "Include build inference" on Scores tile; status column with row-level hourglass via parallel TanStack Query; detail modal with observed constraints, score arithmetic, and PP-not-modeled warning; scores diagnostics tab; integer halving for negative military deltas aligned with Core.
- **Docs:** Design specs, inference corpus agent spec, CONTEXT glossary updates.

Closes the Phase 1 vertical slice (#40-#47). Includes Phase 1G starter (#50) and review remediation (catalog bound fix, column wiring, constraint single source, async per-row solve, modal arithmetic).

## Not in this PR

- Factored ship build combos / tiered search (#51-#55)
- Full #48/#53 modal polish for structured combos
- Inference corpus CI harness (#62+)
- Extended action families (#49)

## Test plan

- [x] `make lint && make test`
- [x] Scores table unchanged with inference off
- [x] With inference on: table loads quickly; rows show hourglass then tick/cross independently
- [x] Green tick modal: observed deltas, military score arithmetic (not solver objective), PP note when applicable
- [x] Diagnostics modal Scores tab shows per-player solver JSON after loading inference table
- [ ] Negative military change row displays integer halving (e.g. -53869, not -53869.5)


Made with [Cursor](https://cursor.com)