### PR TITLE
Unify analytic catalog and fix BFF CoreClient storage seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -128,8 +128,12 @@ _Avoid_: relying on reviewers to notice stale or monolithic generated types
 Application code imports the smallest matching `schema-<slice>.ts` module for types; `bff.ts` remains the facade for HTTP calls. Do not add a barrel `schema.ts` that re-exports every slice (that recreates a single monolith in git and in review).
 _Avoid_: `import from './schema'` as the default in feature folders
 
+**Turn analytic catalog**:
+Shared declarative list (`TURN_ANALYTIC_CATALOG` in `api/analytics/catalog.py`) of turn analytic ids and SPA-facing metadata (`name`, `supports_table`, `supports_map`, `type`). Core and BFF both import it; handler and descriptor registries are validated against it at import. Adding an analytic still requires three registrations: one **catalog** entry (identity + metadata), one Core `_HANDLERS_BY_ID` entry (computation), and one BFF `_BFF_DESCRIPTORS_BY_ID` entry (table/map shaping). The catalog does not replace handler or descriptor registration -- it prevents metadata and id drift between layers.
+_Avoid_: single registration list (handlers and shapers are still per-layer dicts)
+
 **Analytic descriptor**:
-The single BFF registration object for one **turn analytic** -- catalog fields plus optional table/map handlers and diagnostic hooks. Aggregated in `REGISTERED_ANALYTICS`; the SPA catalog comes from this list via `GET /bff/analytics`.
+The BFF registration object for one **turn analytic** -- optional table/map handlers and diagnostic hooks, with catalog metadata from `TURN_ANALYTIC_CATALOG` via `from_catalog_entry`. Aggregated in `REGISTERED_ANALYTICS`; the SPA catalog comes from this list via `GET /bff/analytics`.
 _Avoid_: METADATA dict, handler registry (when meaning the consolidated descriptor)
 
 **Base map**:

--- a/docs/design-adding-a-turn-analytic.md
+++ b/docs/design-adding-a-turn-analytic.md
@@ -40,21 +40,25 @@ Guidelines:
 - **Race-specific** mechanics (`raceid`, per-race caps, settings keyed to one race) go in **`api/concepts/races.py`** only -- do not add new race constants inside `api/analytics/<id>/`. See [design-analytics-structure.md](design-analytics-structure.md) (race-specific rules).
 - Attach **request diagnostics** at meaningful boundaries (`diagnostics.child(...)`) when work is non-trivial.
 
+### 2.1a Register in the shared catalog
+
+In `packages/api/api/analytics/catalog.py`, append a `TurnAnalyticCatalogEntry` to `TURN_ANALYTIC_CATALOG` (id, name, `supports_table`, `supports_map`, `type`).
+
 ### 2.2 Register in Core
 
-In `packages/api/api/analytics/registry.py`:
+In `packages/api/api/analytics/registry.py`, add the handler to `_HANDLERS_BY_ID`:
 
 ```python
 from api.analytics.my_analytic import ANALYTIC_ID as MY_ANALYTIC_ID
 from api.analytics.my_analytic import get_my_analytic
 
-TURN_ANALYTICS: dict[str, TurnAnalyticHandler] = {
+_HANDLERS_BY_ID: dict[str, TurnAnalyticHandler] = {
     ...
     MY_ANALYTIC_ID: get_my_analytic,
 }
 ```
 
-Core registration stays a **handler dict** only (no descriptor type). Metadata and SPA shaping belong in BFF.
+`TURN_ANALYTICS` is derived from the catalog at import; a missing or extra handler raises `RuntimeError` on startup.
 
 ### 2.3 Core tests
 
@@ -82,6 +86,7 @@ Add `packages/bff/bff/analytics/<id>.py` exporting **`DESCRIPTOR`**.
 **Table-only example (Scores pattern):**
 
 ```python
+from api.analytics.catalog import catalog_entry
 from bff.analytics.descriptor import AnalyticDescriptor
 
 ANALYTIC_ID = "my-table-analytic"
@@ -90,12 +95,8 @@ def get_table(scope, load_core, diagnostics) -> dict:
     core_data = load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
     return shape_for_spa(core_data)
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="My Table",
-    supports_table=True,
-    supports_map=False,
-    type="selectable",
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_table=get_table,
 )
 ```
@@ -106,12 +107,8 @@ DESCRIPTOR = AnalyticDescriptor(
 def get_map(scope, _query, load_core, diagnostics) -> dict:
     return load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="My Map",
-    supports_table=False,
-    supports_map=True,
-    type="selectable",  # or "base" if always-on like base-map
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_map=get_map,
 )
 ```
@@ -127,18 +124,16 @@ If a new analytic needs **different** query params (not an extension of the Conn
 
 ### 3.2 Register in BFF
 
-In `packages/bff/bff/analytics/registry.py`:
+In `packages/bff/bff/analytics/registry.py`, add the module descriptor to `_BFF_DESCRIPTORS_BY_ID`:
 
 ```python
-from . import my_analytic
-
-REGISTERED_ANALYTICS: tuple[AnalyticDescriptor, ...] = (
+_BFF_DESCRIPTORS_BY_ID: dict[str, AnalyticDescriptor] = {
     ...
-    my_analytic.DESCRIPTOR,
-)
+    my_analytic.DESCRIPTOR.id: my_analytic.DESCRIPTOR,
+}
 ```
 
-That is the **only** BFF registration edit. Metadata, table dispatch, map dispatch, and optional diagnostic hooks come from the descriptor.
+`REGISTERED_ANALYTICS` is ordered from `TURN_ANALYTIC_CATALOG` at import. Catalog metadata comes from `from_catalog_entry`; handlers stay in the BFF module.
 
 ### 3.3 BFF tests
 
@@ -151,7 +146,7 @@ Add or extend tests under `packages/bff/tests/`:
 
 Registry tests should mock `load_core` rather than hitting storage when testing shaping only.
 
-`test_bff_descriptors_match_core_turn_analytics_registry` asserts BFF `REGISTERED_ANALYTICS` ids match Core `TURN_ANALYTICS` keys in both directions. Update both registries when adding an analytic.
+Registry tests assert each layer follows `TURN_ANALYTIC_CATALOG` order; catalog/handler/descriptor mismatch fails at import or in those tests.
 
 ### 3.4 Verify catalog
 
@@ -233,9 +228,10 @@ When triggered, prefer a small registry refactor over accumulating `MainArea` br
 
 Use this before opening a PR:
 
-- [ ] **Core:** module + `TURN_ANALYTICS` entry + unit tests
+- [ ] **Catalog:** `TurnAnalyticCatalogEntry` in `TURN_ANALYTIC_CATALOG`
+- [ ] **Core:** module + `_HANDLERS_BY_ID` entry + unit tests
 - [ ] **Core:** router query params and `TurnAnalyticsOptions` (if applicable)
-- [ ] **BFF:** module with `DESCRIPTOR` + `REGISTERED_ANALYTICS` entry
+- [ ] **BFF:** module with `from_catalog_entry` descriptor + `_BFF_DESCRIPTORS_BY_ID` entry
 - [ ] **BFF:** unit/integration tests for dispatch and HTTP shape
 - [ ] **Frontend:** only if generic shells insufficient; query wire names aligned with BFF
 - [ ] **Frontend:** if adding a `MainArea` map-fetch branch, confirm [§4.1 re-examination triggers](#41-map-fetch-orchestration-current-vs-future) are not met
@@ -249,7 +245,7 @@ Use this before opening a PR:
 
 | Mistake | Symptom | Fix |
 |---------|---------|-----|
-| Core handler registered, BFF descriptor missing | 422 on BFF GET; analytic absent from sidebar list | Add BFF module + `REGISTERED_ANALYTICS` |
+| Core handler registered, BFF descriptor missing | Startup `RuntimeError` or 422 on BFF GET | Add catalog entry + BFF module + `_BFF_DESCRIPTORS_BY_ID` |
 | BFF lists analytic, Core handler missing | 422 from Core when BFF forwards | Add Core registry entry |
 | `supportsMap: true` but no `get_map` | Registry validation test fails | Set handler on descriptor |
 | Frontend query param names drift from BFF | Silent wrong results or ignored params | Share wire names via `api/transport/` |

--- a/docs/design-analytics-structure.md
+++ b/docs/design-analytics-structure.md
@@ -25,11 +25,12 @@ Related docs:
   - `scores.py`
   - `connections.py`
   - `stellar_cartography.py`
-  - `registry.py` -- `TURN_ANALYTICS` id-to-handler map
+  - `catalog.py` -- `TURN_ANALYTIC_CATALOG` (shared ids and SPA catalog metadata)
+  - `registry.py` -- `TURN_ANALYTICS` id-to-handler map (aligned with the catalog at import)
 
 `TurnAnalyticService` loads `TurnInfo`, builds `TurnAnalyticsOptions`, and delegates to `get_turn_analytic(...)` in the registry.
 
-**Core registry shape:** a flat `TURN_ANALYTICS` dict (id → handler). Core does not use BFF-style descriptors -- it only computes from `TurnInfo`. Catalog metadata and response shaping stay in BFF. The parity test in `test_analytics_registry.py` keeps Core ids aligned with BFF `REGISTERED_ANALYTICS`.
+**Shared catalog:** `TURN_ANALYTIC_CATALOG` is the single declarative list of turn analytic ids and SPA metadata. Core attaches computation handlers; BFF attaches table/map shaping via `AnalyticDescriptor.from_catalog_entry(...)`. `dict_aligned_with_turn_analytic_catalog` / `tuple_aligned_with_turn_analytic_catalog` in `catalog.py` validate each layer's registry keys and preserve catalog order at import. Id or metadata drift raises `RuntimeError` on startup. Handlers and descriptors are still registered separately (see [Registration touch points](#registration-touch-points)).
 
 ### Race-specific rules vs analytic modules
 
@@ -67,7 +68,7 @@ Each BFF analytic module exports a single `DESCRIPTOR: AnalyticDescriptor` (`bff
 
 | Field | Purpose |
 |-------|---------|
-| `id`, `name`, `supports_table`, `supports_map`, `type` | Catalog entry (`type` is `base` or `selectable`) |
+| `id`, `name`, `supports_table`, `supports_map`, `type` | From `TurnAnalyticCatalogEntry` via `from_catalog_entry` (`type` is `base` or `selectable`) |
 | `get_table` | Optional handler: Core fetch + BFF table shaping |
 | `get_map` | Optional handler: Core fetch + BFF map shaping (receives `ConnectionsMapQuery`; ignore when unused) |
 | `map_diagnostic_values` | Optional hook for request diagnostics on map GETs |
@@ -75,14 +76,13 @@ Each BFF analytic module exports a single `DESCRIPTOR: AnalyticDescriptor` (`bff
 
 Adding a new analytic to the BFF requires:
 
-1. Create `bff/analytics/<id>.py` with handlers and `DESCRIPTOR`.
-2. Append `module.DESCRIPTOR` to `REGISTERED_ANALYTICS` in `registry.py`.
+1. Add a `TurnAnalyticCatalogEntry` to `TURN_ANALYTIC_CATALOG` in `api/analytics/catalog.py`.
+2. Create `bff/analytics/<id>.py` with handlers and `DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(catalog_entry(...), ...)`.
+3. Register the module descriptor in `_BFF_DESCRIPTORS_BY_ID` in `bff/analytics/registry.py`.
 
 Dispatch is descriptor-driven -- no per-id `if/elif` chains in `registry.py`.
 
 Unknown analytic ids and unsupported view modes return **422** (`BFFValidationError`).
-
-**Registry parity:** `packages/bff/tests/test_analytics_registry.py` asserts BFF descriptor ids match Core `TURN_ANALYTICS` keys. Keep both registries in sync when adding or removing analytics.
 
 ### Map route query params (intentional gap)
 
@@ -94,12 +94,13 @@ This is deliberate for now: one route, one OpenAPI shape, Connections works with
 
 **Possible future direction (not implemented):** descriptor-driven query parsing -- e.g. each `AnalyticDescriptor` declares whether it uses map query params (and optionally a parser type); the router only binds/forwards params when declared. Alternatively, analytic-specific map sub-routes if contracts diverge sharply. Until then, new parametric map analytics follow the Connections pattern: extend the shared `ConnectionsMapQuery` / router params only when wire names are shared; otherwise trigger this re-examination.
 
-## Registration touch points (target model)
+## Registration touch points
 
-Adding a **turn analytic** intentionally touches **two** registration points:
+Adding a **turn analytic** touches:
 
-1. **Core** -- module + one line in `TURN_ANALYTICS`
-2. **BFF** -- module + one line in `REGISTERED_ANALYTICS`
+1. **Catalog** -- one `TurnAnalyticCatalogEntry` in `TURN_ANALYTIC_CATALOG`
+2. **Core** -- module + handler in `_HANDLERS_BY_ID` (`registry.py`)
+3. **BFF** -- module with `from_catalog_entry` descriptor + entry in `_BFF_DESCRIPTORS_BY_ID` (`registry.py`)
 
 Frontend registration is **optional** and only needed when generic shells are insufficient (custom sidebar controls, non-default query keys, bespoke map merge logic). See [design-adding-a-turn-analytic.md](design-adding-a-turn-analytic.md).
 

--- a/packages/api/api/analytics/__init__.py
+++ b/packages/api/api/analytics/__init__.py
@@ -1,6 +1,13 @@
 """Core turn analytics."""
 
+from api.analytics.catalog import TURN_ANALYTIC_CATALOG, TurnAnalyticCatalogEntry
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.registry import TURN_ANALYTICS, get_turn_analytic
 
-__all__ = ["TURN_ANALYTICS", "TurnAnalyticsOptions", "get_turn_analytic"]
+__all__ = [
+    "TURN_ANALYTIC_CATALOG",
+    "TURN_ANALYTICS",
+    "TurnAnalyticCatalogEntry",
+    "TurnAnalyticsOptions",
+    "get_turn_analytic",
+]

--- a/packages/api/api/analytics/catalog.py
+++ b/packages/api/api/analytics/catalog.py
@@ -1,0 +1,86 @@
+"""Declarative catalog for turn analytics (ids and SPA-facing metadata)."""
+
+from dataclasses import dataclass
+from typing import Literal, TypeVar
+
+AnalyticType = Literal["base", "selectable"]
+
+
+@dataclass(frozen=True)
+class TurnAnalyticCatalogEntry:
+    """One turn analytic in the shared catalog."""
+
+    id: str
+    name: str
+    supports_table: bool
+    supports_map: bool
+    type: AnalyticType
+
+
+TURN_ANALYTIC_CATALOG: tuple[TurnAnalyticCatalogEntry, ...] = (
+    TurnAnalyticCatalogEntry(
+        id="base-map",
+        name="Map",
+        supports_table=False,
+        supports_map=True,
+        type="base",
+    ),
+    TurnAnalyticCatalogEntry(
+        id="scores",
+        name="Scores",
+        supports_table=True,
+        supports_map=False,
+        type="selectable",
+    ),
+    TurnAnalyticCatalogEntry(
+        id="connections",
+        name="Connections",
+        supports_table=False,
+        supports_map=True,
+        type="selectable",
+    ),
+    TurnAnalyticCatalogEntry(
+        id="stellar-cartography",
+        name="Stellar Cartography",
+        supports_table=False,
+        supports_map=True,
+        type="selectable",
+    ),
+)
+
+_CATALOG_BY_ID: dict[str, TurnAnalyticCatalogEntry] = {
+    entry.id: entry for entry in TURN_ANALYTIC_CATALOG
+}
+
+T = TypeVar("T")
+
+
+def _validate_registry_ids_match_catalog(registered_ids: set[str], *, role: str) -> None:
+    catalog_ids = {entry.id for entry in TURN_ANALYTIC_CATALOG}
+    if catalog_ids == registered_ids:
+        return
+    missing = sorted(catalog_ids - registered_ids)
+    extra = sorted(registered_ids - catalog_ids)
+    raise RuntimeError(
+        f"Turn analytic catalog and {role} are out of sync: "
+        f"catalog without registration={missing!r}, registration without catalog={extra!r}"
+    )
+
+
+def dict_aligned_with_turn_analytic_catalog(by_id: dict[str, T], *, role: str) -> dict[str, T]:
+    """Return *by_id* in catalog order after verifying its keys match the catalog exactly."""
+    _validate_registry_ids_match_catalog(set(by_id), role=role)
+    return {entry.id: by_id[entry.id] for entry in TURN_ANALYTIC_CATALOG}
+
+
+def tuple_aligned_with_turn_analytic_catalog(by_id: dict[str, T], *, role: str) -> tuple[T, ...]:
+    """Return *by_id* values in catalog order after verifying its keys match the catalog exactly."""
+    _validate_registry_ids_match_catalog(set(by_id), role=role)
+    return tuple(by_id[entry.id] for entry in TURN_ANALYTIC_CATALOG)
+
+
+def catalog_entry(analytic_id: str) -> TurnAnalyticCatalogEntry:
+    try:
+        return _CATALOG_BY_ID[analytic_id]
+    except KeyError as err:
+        raise KeyError(f"Unknown turn analytic catalog id: {analytic_id!r}") from err

--- a/packages/api/api/analytics/registry.py
+++ b/packages/api/api/analytics/registry.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 
 from api.analytics.base_map import ANALYTIC_ID as BASE_MAP_ID
 from api.analytics.base_map import get_base_map
+from api.analytics.catalog import dict_aligned_with_turn_analytic_catalog
 from api.analytics.connections import ANALYTIC_ID as CONNECTIONS_ID
 from api.analytics.connections import get_connections_map
 from api.analytics.options import TurnAnalyticsOptions
@@ -25,12 +26,18 @@ def _scores_handler(turn: TurnInfo, options: TurnAnalyticsOptions) -> dict:
     return get_scores_table(turn, options)
 
 
-TURN_ANALYTICS: dict[str, TurnAnalyticHandler] = {
+_HANDLERS_BY_ID: dict[str, TurnAnalyticHandler] = {
     BASE_MAP_ID: _base_map_handler,
     SCORES_ID: _scores_handler,
     CONNECTIONS_ID: get_connections_map,
     STELLAR_CARTOGRAPHY_ID: get_stellar_cartography_map,
 }
+
+
+TURN_ANALYTICS: dict[str, TurnAnalyticHandler] = dict_aligned_with_turn_analytic_catalog(
+    _HANDLERS_BY_ID,
+    role="Core handlers",
+)
 
 
 def get_turn_analytic(analytic_id: str, turn: TurnInfo, options: TurnAnalyticsOptions) -> dict:

--- a/packages/api/api/services/game_service.py
+++ b/packages/api/api/services/game_service.py
@@ -2,7 +2,7 @@
 
 from dacite.exceptions import DaciteError
 
-from api.errors import ValidationError
+from api.errors import NotFoundError, ValidationError
 from api.models.enums import GameStatus
 from api.models.game import GameInfo
 from api.models.game_info_operations import GameInfoUpdateOperation
@@ -13,6 +13,16 @@ from api.services.credential_service import CredentialService
 from api.services.storage_json import require_dict
 from api.storage.base import StorageBackend
 from api.transport.game_info_update import GameInfoUpdateRequest, RefreshGameInfoParams
+from api.transport.sector_display import (
+    sector_display_name_from_game_info,
+    sector_display_name_from_stored_payload,
+)
+
+_sector_title_by_stored_game_id: dict[str, str | None] = {}
+
+
+def clear_sector_title_cache() -> None:
+    _sector_title_by_stored_game_id.clear()
 
 
 class GameService:
@@ -92,7 +102,43 @@ class GameService:
 
         store_key = f"games/{game_id}/info"
         self._storage.put(store_key, remote)
+        self.remember_sector_title_for_game(game_id, info)
         return info
+
+    def remember_sector_title_for_game(self, game_id: int, info: GameInfo) -> None:
+        title = sector_display_name_from_game_info(info)
+        _sector_title_by_stored_game_id[str(game_id)] = title
+
+    def list_stored_games(self) -> dict[str, list[dict[str, str]]]:
+        """Stored game ids with optional sector titles (cache or stored info)."""
+        try:
+            children = self._storage.list("games")
+        except NotFoundError:
+            return {"games": []}
+        games: list[dict[str, str]] = []
+        for child in children:
+            game_id = str(child)
+            entry: dict[str, str] = {"id": game_id}
+            sector = self._resolved_sector_title_for_listed_game(game_id)
+            if sector is not None:
+                entry["sectorName"] = sector
+            games.append(entry)
+        return {"games": games}
+
+    def _resolved_sector_title_for_listed_game(self, game_id: str) -> str | None:
+        cached = _sector_title_by_stored_game_id.get(game_id)
+        if cached is not None or game_id in _sector_title_by_stored_game_id:
+            return cached
+
+        try:
+            raw = self._storage.get(f"games/{game_id}/info")
+        except NotFoundError:
+            title = None
+        else:
+            title = sector_display_name_from_stored_payload(raw)
+
+        _sector_title_by_stored_game_id[game_id] = title
+        return title
 
     def get_game_info(self, game_id: int) -> GameInfo:
         data = self._storage.get(f"games/{game_id}/info")

--- a/packages/api/api/services/stack.py
+++ b/packages/api/api/services/stack.py
@@ -25,3 +25,16 @@ def build_service_stack(
     concepts = TurnConceptService(turns)
     analytics = TurnAnalyticService(turns)
     return games, turns, load_all, concepts, analytics
+
+
+def build_default_service_stack() -> tuple[
+    GameService,
+    TurnLoadService,
+    LoadAllTurnsService,
+    TurnConceptService,
+    TurnAnalyticService,
+]:
+    """Service graph for the active process storage backend (BFF in-process adapter, tests)."""
+    from api.storage import get_storage
+
+    return build_service_stack(get_storage())

--- a/packages/api/tests/test_analytics_registry.py
+++ b/packages/api/tests/test_analytics_registry.py
@@ -4,8 +4,9 @@ import json
 from pathlib import Path
 
 import pytest
-from api.analytics import TurnAnalyticsOptions, get_turn_analytic
+from api.analytics import TURN_ANALYTIC_CATALOG, TurnAnalyticsOptions, get_turn_analytic
 from api.analytics.base_map import get_base_map
+from api.analytics.registry import TURN_ANALYTICS
 from api.analytics.scores import get_scores_table
 from api.errors import ValidationError
 from api.serialization.turn import turn_info_from_json
@@ -44,3 +45,18 @@ def test_registry_scores_dispatch_unchanged_without_inference_option(sample_turn
 def test_registry_rejects_unknown_analytic(sample_turn):
     with pytest.raises(ValidationError, match="Unknown analytic_id"):
         get_turn_analytic("missing", sample_turn, TurnAnalyticsOptions())
+
+
+def test_turn_analytics_registry_follows_catalog():
+    assert list(TURN_ANALYTICS) == [entry.id for entry in TURN_ANALYTIC_CATALOG]
+    assert set(TURN_ANALYTICS) == {entry.id for entry in TURN_ANALYTIC_CATALOG}
+
+
+def test_dict_aligned_with_turn_analytic_catalog_reports_mismatch():
+    from api.analytics.catalog import dict_aligned_with_turn_analytic_catalog
+
+    with pytest.raises(RuntimeError, match="Core handlers"):
+        dict_aligned_with_turn_analytic_catalog(
+            {"not-in-catalog": object()},
+            role="Core handlers",
+        )

--- a/packages/api/tests/test_game_service.py
+++ b/packages/api/tests/test_game_service.py
@@ -8,7 +8,7 @@ import pytest
 from api.errors import LoginCredentialsRequiredError, NotFoundError, ValidationError
 from api.models.game import GameInfo
 from api.models.game_info_operations import GameInfoUpdateOperation
-from api.services.game_service import GameService
+from api.services.game_service import GameService, clear_sector_title_cache
 from api.services.stack import build_service_stack
 from api.storage.memory_asset import MemoryAssetBackend
 from api.transport.game_info_update import GameInfoUpdateRequest
@@ -37,6 +37,59 @@ def seeded_backend():
 def service(seeded_backend):
     games, _, _, _, _ = build_service_stack(seeded_backend)
     return games
+
+
+@pytest.fixture(autouse=True)
+def _clear_sector_title_cache():
+    clear_sector_title_cache()
+    yield
+    clear_sector_title_cache()
+
+
+class TestListStoredGames:
+    def test_returns_empty_when_games_path_missing(self):
+        backend = MemoryAssetBackend(initial={})
+        games, _, _, _, _ = build_service_stack(backend)
+        assert games.list_stored_games() == {"games": []}
+
+    def test_includes_sector_name_from_stored_info(self, service):
+        result = service.list_stored_games()
+        hit = next(g for g in result["games"] if g["id"] == "628580")
+        assert hit.get("sectorName") == "Serada 9 Sector"
+
+    def test_remember_sector_title_avoids_re_read_on_second_list(self):
+        backend = MemoryAssetBackend(initial={})
+        with open(ASSETS_DIR / "game_info_sample.json") as f:
+            payload = json.load(f)
+        backend.put("games/111/info", payload)
+        backend.put("games/222/info", payload)
+        games, _, _, _, _ = build_service_stack(backend)
+
+        info_reads: list[str] = []
+        original_get = backend.get
+
+        def counting_get(path: str) -> object:
+            if path.startswith("games/") and path.endswith("/info"):
+                info_reads.append(path)
+            return original_get(path)
+
+        backend.get = counting_get  # type: ignore[method-assign]
+        games.list_stored_games()
+        games.list_stored_games()
+        assert info_reads == ["games/111/info", "games/222/info"]
+
+    def test_refresh_updates_sector_title_cache(self, game_info_sample_data):
+        backend = MemoryAssetBackend(initial={})
+        games, _, _, _, _ = build_service_stack(backend)
+        planets = FakePlanetsNu(game_info_sample_data, login_returns="key")
+        body = GameInfoUpdateRequest(
+            operation=GameInfoUpdateOperation.REFRESH,
+            params={"username": "player1", "password": "secret"},
+        )
+        games.update_game_info(628580, body, planets)
+        result = games.list_stored_games()
+        hit = next(g for g in result["games"] if g["id"] == "628580")
+        assert hit.get("sectorName") == "Serada 9 Sector"
 
 
 class TestGetGameInfo:

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -332,9 +332,10 @@ def test_row_inference_includes_structured_solver_diagnostics(sample_turn):
 
 
 def test_registry_still_exposes_only_scores_analytic(sample_turn):
+    from api.analytics.catalog import TURN_ANALYTIC_CATALOG
     from api.analytics.registry import TURN_ANALYTICS
 
-    assert set(TURN_ANALYTICS) == {"base-map", "connections", "scores", "stellar-cartography"}
+    assert set(TURN_ANALYTICS) == {entry.id for entry in TURN_ANALYTIC_CATALOG}
     data = get_turn_analytic(
         "scores",
         sample_turn,

--- a/packages/bff/bff/analytics/base_map.py
+++ b/packages/bff/bff/analytics/base_map.py
@@ -1,5 +1,6 @@
 """BFF base-map analytic handler."""
 
+from api.analytics.catalog import catalog_entry
 from api.diagnostics import Diagnostics
 
 from bff.analytics.descriptor import AnalyticDescriptor
@@ -22,11 +23,7 @@ def get_map(
     return load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
 
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="Map",
-    supports_table=False,
-    supports_map=True,
-    type="base",
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_map=get_map,
 )

--- a/packages/bff/bff/analytics/connections.py
+++ b/packages/bff/bff/analytics/connections.py
@@ -1,5 +1,6 @@
 """BFF Connections map analytic handler."""
 
+from api.analytics.catalog import catalog_entry
 from api.diagnostics import Diagnostics
 from api.transport.connections_options import (
     FLARE_DEPTH_QUERY,
@@ -49,12 +50,8 @@ def get_map(
     )
 
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="Connections",
-    supports_table=False,
-    supports_map=True,
-    type="selectable",
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_map=get_map,
     map_diagnostic_values=diagnostic_values,
 )

--- a/packages/bff/bff/analytics/descriptor.py
+++ b/packages/bff/bff/analytics/descriptor.py
@@ -2,13 +2,12 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any
 
+from api.analytics.catalog import AnalyticType, TurnAnalyticCatalogEntry
 from api.diagnostics import Diagnostics
 
 from bff.analytics.models import ConnectionsMapQuery, CoreAnalyticsLoader, TurnScope
-
-AnalyticType = Literal["base", "selectable"]
 
 TableHandler = Callable[[TurnScope, CoreAnalyticsLoader, Diagnostics], dict]
 
@@ -42,3 +41,25 @@ class AnalyticDescriptor:
             "supportsMap": self.supports_map,
             "type": self.type,
         }
+
+    @classmethod
+    def from_catalog_entry(
+        cls,
+        entry: TurnAnalyticCatalogEntry,
+        *,
+        get_table: TableHandler | None = None,
+        get_map: MapHandler | None = None,
+        map_diagnostic_values: MapDiagnosticValuesHook | None = None,
+        map_timing_section: str = "turn_analytics_from_core",
+    ) -> "AnalyticDescriptor":
+        return cls(
+            id=entry.id,
+            name=entry.name,
+            supports_table=entry.supports_table,
+            supports_map=entry.supports_map,
+            type=entry.type,
+            get_table=get_table,
+            get_map=get_map,
+            map_diagnostic_values=map_diagnostic_values,
+            map_timing_section=map_timing_section,
+        )

--- a/packages/bff/bff/analytics/registry.py
+++ b/packages/bff/bff/analytics/registry.py
@@ -1,5 +1,6 @@
 """BFF analytics catalog and dispatch."""
 
+from api.analytics.catalog import tuple_aligned_with_turn_analytic_catalog
 from api.diagnostics import Diagnostics
 
 from bff.analytics.descriptor import AnalyticDescriptor
@@ -8,11 +9,17 @@ from bff.errors import BFFValidationError
 
 from . import base_map, connections, scores, stellar_cartography
 
-REGISTERED_ANALYTICS: tuple[AnalyticDescriptor, ...] = (
-    base_map.DESCRIPTOR,
-    scores.DESCRIPTOR,
-    connections.DESCRIPTOR,
-    stellar_cartography.DESCRIPTOR,
+_BFF_DESCRIPTORS_BY_ID: dict[str, AnalyticDescriptor] = {
+    base_map.DESCRIPTOR.id: base_map.DESCRIPTOR,
+    scores.DESCRIPTOR.id: scores.DESCRIPTOR,
+    connections.DESCRIPTOR.id: connections.DESCRIPTOR,
+    stellar_cartography.DESCRIPTOR.id: stellar_cartography.DESCRIPTOR,
+}
+
+
+REGISTERED_ANALYTICS: tuple[AnalyticDescriptor, ...] = tuple_aligned_with_turn_analytic_catalog(
+    _BFF_DESCRIPTORS_BY_ID,
+    role="BFF descriptors",
 )
 
 _BY_ID: dict[str, AnalyticDescriptor] = {

--- a/packages/bff/bff/analytics/scores.py
+++ b/packages/bff/bff/analytics/scores.py
@@ -1,5 +1,6 @@
 """BFF Scores table analytic handler."""
 
+from api.analytics.catalog import catalog_entry
 from api.diagnostics import Diagnostics
 
 from bff.analytics.descriptor import AnalyticDescriptor
@@ -140,11 +141,7 @@ def inference_from_core(core_inference: object, *, player_id: int) -> dict[str, 
     return _shape_inference_detail(core_inference, player_id=player_id)
 
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="Scores",
-    supports_table=True,
-    supports_map=False,
-    type="selectable",
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_table=get_table,
 )

--- a/packages/bff/bff/analytics/stellar_cartography.py
+++ b/packages/bff/bff/analytics/stellar_cartography.py
@@ -1,5 +1,6 @@
 """BFF Stellar Cartography map analytic handler."""
 
+from api.analytics.catalog import catalog_entry
 from api.diagnostics import Diagnostics
 
 from bff.analytics.descriptor import AnalyticDescriptor
@@ -22,11 +23,7 @@ def get_map(
     return load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
 
 
-DESCRIPTOR = AnalyticDescriptor(
-    id=ANALYTIC_ID,
-    name="Stellar Cartography",
-    supports_table=False,
-    supports_map=True,
-    type="selectable",
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
     get_map=get_map,
 )

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -18,13 +18,10 @@ from api.models.game import GameInfo, TurnInfo
 from api.planets_nu import PlanetsNuClient
 from api.services.game_service import GameService
 from api.services.load_all_turns import LoadAllTurnsService
-from api.services.stack import build_service_stack
-from api.services.store_service import StoreService
+from api.services.stack import build_default_service_stack
 from api.services.turn_analytic_service import TurnAnalyticService
 from api.services.turn_concept_service import TurnConceptService
 from api.services.turn_load_service import TurnLoadService
-from api.storage import get_storage
-from api.storage.base import StorageBackend
 from api.transport.concept_stellar_cartography import (
     StellarCartographySampleResponse,
     StellarCartographyTurnSummaryResponse,
@@ -37,10 +34,6 @@ from api.transport.concept_warp_well import (
 )
 from api.transport.game_info_update import GameInfoUpdateRequest, RefreshGameInfoParams
 from api.transport.load_all_turns import LoadAllStreamItem
-from api.transport.sector_display import (
-    sector_display_name_from_game_info,
-    sector_display_name_from_stored_payload,
-)
 from api.transport.turn_ensure import TurnEnsureRequest
 from fastapi import HTTPException
 
@@ -53,8 +46,6 @@ from bff.transport.game_responses import (
 
 T = TypeVar("T")
 
-_sector_title_by_stored_game_id: dict[str, str | None] = {}
-
 
 class CoreClient:
     """Allowed Core surface for BFF routers: services only, no direct storage in routes."""
@@ -62,23 +53,18 @@ class CoreClient:
     def __init__(
         self,
         *,
-        game_service: GameService | None = None,
-        turn_load_service: TurnLoadService | None = None,
-        load_all_turns_service: LoadAllTurnsService | None = None,
-        turn_concept_service: TurnConceptService | None = None,
-        turn_analytic_service: TurnAnalyticService | None = None,
-        store_service: StoreService | None = None,
+        game_service: GameService,
+        turn_load_service: TurnLoadService,
+        load_all_turns_service: LoadAllTurnsService,
+        turn_concept_service: TurnConceptService,
+        turn_analytic_service: TurnAnalyticService,
         planets_client_factory: Callable[[], PlanetsNuClient] | None = None,
-        storage: StorageBackend | None = None,
     ) -> None:
-        backend = storage or get_storage()
-        games, turns, load_all, concepts, analytics = build_service_stack(backend)
-        self._games = game_service or games
-        self._turns = turn_load_service or turns
-        self._load_all = load_all_turns_service or load_all
-        self._concepts = turn_concept_service or concepts
-        self._analytics = turn_analytic_service or analytics
-        self._store = store_service or StoreService(backend)
+        self._games = game_service
+        self._turns = turn_load_service
+        self._load_all = load_all_turns_service
+        self._concepts = turn_concept_service
+        self._analytics = turn_analytic_service
         self._planets_client_factory = planets_client_factory or PlanetsNuClient.from_config
 
     def _invoke(self, fn: Callable[[], T]) -> T:
@@ -91,43 +77,7 @@ class CoreClient:
             ) from exc
 
     def list_stored_games(self) -> dict[str, list[dict[str, str]]]:
-        def work() -> dict[str, list[dict[str, str]]]:
-            try:
-                shallow = self._store.read_shallow("games")
-            except NotFoundError:
-                return {"games": []}
-            children = shallow.get("children") or []
-            games: list[dict[str, str]] = []
-            for child in children:
-                game_id = str(child)
-                entry: dict[str, str] = {"id": game_id}
-                sector = self._resolved_sector_title_for_listed_game(game_id)
-                if sector is not None:
-                    entry["sectorName"] = sector
-                games.append(entry)
-            return {"games": games}
-
-        return self._invoke(work)
-
-    def _resolved_sector_title_for_listed_game(self, game_id: str) -> str | None:
-        cached = _sector_title_by_stored_game_id.get(game_id)
-        if cached is not None or game_id in _sector_title_by_stored_game_id:
-            return cached
-
-        def read_title() -> str | None:
-            try:
-                raw = self._store.read(f"games/{game_id}/info")
-            except NotFoundError:
-                return None
-            return sector_display_name_from_stored_payload(raw)
-
-        title = self._invoke(read_title)
-        _sector_title_by_stored_game_id[game_id] = title
-        return title
-
-    def remember_sector_title_for_game(self, game_id: int, info: GameInfo) -> None:
-        title = sector_display_name_from_game_info(info)
-        _sector_title_by_stored_game_id[str(game_id)] = title
+        return self._invoke(self._games.list_stored_games)
 
     def list_stored_turn_perspectives(
         self,
@@ -148,9 +98,7 @@ class CoreClient:
         def work() -> GameInfo:
             return self._games.update_game_info(game_id, body, planets)
 
-        updated = self._invoke(work)
-        self.remember_sector_title_for_game(game_id, updated)
-        return updated
+        return self._invoke(work)
 
     def load_all_turns_status(self, game_id: int, username: str) -> BffLoadAllTurnsStatusResponse:
         def work() -> BffLoadAllTurnsStatusResponse:
@@ -289,9 +237,29 @@ class CoreClient:
         )
 
 
+_core_client_singleton: CoreClient | None = None
+
+
+def clear_core_client_cache() -> None:
+    """Drop the cached client (tests after ``clear_backend_cache`` / config change)."""
+    global _core_client_singleton
+    _core_client_singleton = None
+
+
+def _build_core_client() -> CoreClient:
+    games, turns, load_all, concepts, analytics = build_default_service_stack()
+    return CoreClient(
+        game_service=games,
+        turn_load_service=turns,
+        load_all_turns_service=load_all,
+        turn_concept_service=concepts,
+        turn_analytic_service=analytics,
+    )
+
+
 def get_core_client() -> CoreClient:
-    return CoreClient()
-
-
-def clear_sector_title_cache() -> None:
-    _sector_title_by_stored_game_id.clear()
+    """Process-singleton in-process Core facade (one service stack per storage backend)."""
+    global _core_client_singleton
+    if _core_client_singleton is None:
+        _core_client_singleton = _build_core_client()
+    return _core_client_singleton

--- a/packages/bff/bff/routers/games.py
+++ b/packages/bff/bff/routers/games.py
@@ -1,21 +1,17 @@
-"""Games list for the console shell: stored game ids from the Core store (shallow read).
+"""Games routes for the console shell.
 
-This router is mounted on the BFF sub-app at prefix `/games`, so **GET /games** is the path
-when using `TestClient(bff.app)` or OpenAPI for the BFF app alone. The root server mounts the
-BFF under `/bff`, so the SPA and full-stack docs use **GET /bff/games**.
+Mounted at prefix `/games` on the BFF sub-app (**GET /games**). The root server mounts the
+BFF at `/bff`, so the SPA uses **GET /bff/games**.
 
-The handler maps Core store path `games` shallow children to `{"games": [{"id": "..."}, ...]}`.
-Each item may include `sectorName` when `games/{id}/info` has a title (`game.name` or
-`settings.name`). Titles are memoized in-process per game id so repeated list requests avoid
-re-reading every `games/{id}/info`. If `games` does not exist (`NotFoundError` from the store),
-returns an empty list.
+Routes delegate to the process-singleton ``CoreClient`` (``get_core_client``), which calls
+Core services only -- no direct storage access in this router.
 
-**POST /games/{game_id}/info** forwards the SPA refresh payload to Core via ``CoreClient``.
+**GET /games** uses ``GameService.list_stored_games()``: stored game ids under ``games/``,
+optional ``sectorName`` from in-process memo or ``games/{id}/info`` (empty list when the
+``games`` prefix is absent).
 
-**POST /games/{game_id}/turns/ensure** ensures turn data is in storage (Planets.nu loadturn
-when missing), using the same credential rules as game info refresh.
-
-**Warp wells** -- turn-scoped concept routes delegate to shared Core handlers via ``CoreClient``.
+**POST /games/{game_id}/info** refreshes game info from Planets.nu. **POST .../turns/ensure**
+loads a turn when missing. Warp-well and Stellar Cartography routes use shared Core handlers.
 """
 
 from __future__ import annotations
@@ -32,10 +28,10 @@ from api.transport.concept_warp_well import (
 from api.transport.game_info_update import GameInfoUpdateRequest
 from api.transport.load_all_turns import stream_load_all_turns
 from api.transport.turn_ensure import TurnEnsureRequest
-from fastapi import APIRouter, Path, Query
+from fastapi import APIRouter, Depends, Path, Query
 from fastapi.responses import StreamingResponse
 
-from bff.core_client import get_core_client
+from bff.core_client import CoreClient, get_core_client
 from bff.diagnostics_dep import (
     IncludeDiagnostics,
     finish_response,
@@ -53,18 +49,19 @@ from bff.transport.game_responses import (
 
 router = APIRouter()
 
+CoreClientDep = Annotated[CoreClient, Depends(get_core_client)]
+
 
 @router.get("")
 def list_stored_games(
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ):
-    """Return game ids present under store path `games` (next-hop segment names).
+    """Return stored game ids (optional sector names) via Core ``GameService``.
 
-    Route: **GET /games** on the BFF app; **GET /bff/games** when the BFF is mounted at `/bff`.
-
-    Uses the same shallow enumeration as GET /api/v1/store/games?view=shallow.
+    Route: **GET /games** on the BFF app; **GET /bff/games** when mounted at `/bff`.
     """
-    core = get_core_client()
     root = optional_request_root(include, "GET", "/games", handler="list_stored_games")
     body = with_timed_child(root, "list_stored_games", "total", core.list_stored_games)
     return finish_response(body, root)
@@ -78,9 +75,10 @@ def get_stored_turn_perspectives(
     game_id: int,
     turn_number: int = Path(..., ge=1),
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Return perspective slots that already have turn data in storage (no Planets.nu)."""
-    core = get_core_client()
     root = optional_request_root(
         include,
         "GET",
@@ -99,9 +97,13 @@ def get_stored_turn_perspectives(
 
 
 @router.get("/{game_id}/info", response_model=BffGameInfoResponse)
-def get_stored_game_info(game_id: int, include: IncludeDiagnostics = False) -> object:
+def get_stored_game_info(
+    game_id: int,
+    include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
+) -> object:
     """Return game info already in storage (no Planets.nu refresh)."""
-    core = get_core_client()
     root = optional_request_root(
         include,
         "GET",
@@ -123,9 +125,10 @@ def post_game_info(
     game_id: int,
     body: GameInfoUpdateRequest,
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Refresh game info from Planets.nu (`refresh`); returns updated `GameInfo`."""
-    core = get_core_client()
     root = optional_request_root(
         include,
         "POST",
@@ -147,9 +150,10 @@ def get_load_all_turns_status(
     game_id: int,
     username: Annotated[str, Query()] = "",
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Whether storage already has every turn expected after a bulk load."""
-    core = get_core_client()
     root = optional_request_root(
         include,
         "GET",
@@ -188,9 +192,10 @@ def get_load_all_turns_status(
 def post_load_all_turns_stream(
     game_id: int,
     body: LoadAllTurnsRequest,
+    *,
+    core: CoreClientDep,
 ) -> StreamingResponse:
     """Load all turns, streaming NDJSON progress events."""
-    core = get_core_client()
     return StreamingResponse(
         stream_load_all_turns(
             lambda: core.iter_load_all_turns(game_id, body.username, body.password)
@@ -204,9 +209,10 @@ def post_ensure_turn(
     game_id: int,
     body: TurnEnsureRequest,
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Ensure turn data exists in storage; fetch from Planets.nu when absent."""
-    core = get_core_client()
     root = optional_request_root(
         include,
         "POST",
@@ -235,9 +241,10 @@ def post_warp_well_coordinate_in_well(
     turn_number: int,
     body: CoordinateInWarpWellRequest,
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Turn-scoped warp-well point test via ``CoreClient`` (shared handler with Core REST)."""
-    core = get_core_client()
     bff_path = (
         f"/games/{game_id}/{perspective}/turns/{turn_number}/concepts/warp-wells/coordinate-in-well"
     )
@@ -271,9 +278,10 @@ def get_warp_well_cells(
     planet_id: int = Query(..., ge=1),
     well_type: WarpWellTypeParam = Query(...),
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Turn-scoped warp-well cells via ``CoreClient`` (shared handler with Core REST)."""
-    core = get_core_client()
     bff_path = f"/games/{game_id}/{perspective}/turns/{turn_number}/concepts/warp-wells/cells"
     root = optional_request_root(
         include,
@@ -306,9 +314,10 @@ def get_stellar_cartography_sample(
     x: int = Query(..., ge=0),
     y: int = Query(..., ge=0),
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Turn-scoped Stellar Cartography cell sample via ``CoreClient``."""
-    core = get_core_client()
     bff_path = (
         f"/games/{game_id}/{perspective}/turns/{turn_number}/concepts/stellar-cartography/sample"
     )
@@ -341,9 +350,10 @@ def get_stellar_cartography_turn_summary(
     perspective: int,
     turn_number: int,
     include: IncludeDiagnostics = False,
+    *,
+    core: CoreClientDep,
 ) -> object:
     """Turn-scoped lightweight Stellar Cartography facts via ``CoreClient``."""
-    core = get_core_client()
     bff_path = (
         f"/games/{game_id}/{perspective}/turns/{turn_number}/concepts/stellar-cartography/summary"
     )

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -10,6 +10,7 @@ from api.config import set_config as set_api_config
 from api.storage import clear_backend_cache, get_storage
 from bff.analytics import ANALYTICS_LIST
 from bff.app import app
+from bff.core_client import clear_core_client_cache
 from fastapi.testclient import TestClient
 
 client = TestClient(app)
@@ -24,6 +25,7 @@ ASSETS_DIR = REPO_PACKAGES_DIR / "api" / "api" / "storage" / "assets"
 def _setup_storage_for_core_calls():
     """Seed Core storage so BFF can call Core via ASGI transport."""
     clear_backend_cache()
+    clear_core_client_cache()
     set_api_config(
         ApiConfig(
             storage_backend="ephemeral",
@@ -38,6 +40,7 @@ def _setup_storage_for_core_calls():
         storage.put("games/628580/1/turns/111", json.load(f))
     yield
     clear_backend_cache()
+    clear_core_client_cache()
 
 
 def test_list_analytics_returns_analytics_list():

--- a/packages/bff/tests/test_analytics_registry.py
+++ b/packages/bff/tests/test_analytics_registry.py
@@ -1,6 +1,7 @@
 """Tests for BFF analytics modules and registry dispatch."""
 
 import pytest
+from api.analytics.catalog import TURN_ANALYTIC_CATALOG
 from api.diagnostics import NOOP_DIAGNOSTICS
 from api.transport.connections_options import derive_include_illustrative_routes
 from bff.analytics import (
@@ -16,6 +17,12 @@ from bff.analytics.registry import REGISTERED_ANALYTICS
 from bff.errors import BFFValidationError
 
 
+def test_registered_analytics_follow_catalog_order():
+    assert [descriptor.id for descriptor in REGISTERED_ANALYTICS] == [
+        entry.id for entry in TURN_ANALYTIC_CATALOG
+    ]
+
+
 def test_registered_analytics_have_unique_ids_and_handlers():
     ids = [descriptor.id for descriptor in REGISTERED_ANALYTICS]
     assert len(ids) == len(set(ids))
@@ -24,18 +31,6 @@ def test_registered_analytics_have_unique_ids_and_handlers():
             assert descriptor.get_table is not None
         if descriptor.supports_map:
             assert descriptor.get_map is not None
-
-
-def test_bff_descriptors_match_core_turn_analytics_registry():
-    """BFF catalog ids must match Core TURN_ANALYTICS keys (both directions)."""
-    from api.analytics.registry import TURN_ANALYTICS
-
-    bff_ids = {descriptor.id for descriptor in REGISTERED_ANALYTICS}
-    core_ids = set(TURN_ANALYTICS)
-    assert bff_ids == core_ids, (
-        f"Registry mismatch: BFF-only={sorted(bff_ids - core_ids)!r}, "
-        f"Core-only={sorted(core_ids - bff_ids)!r}"
-    )
 
 
 def test_registry_metadata_keeps_scores_selectable_table_only():

--- a/packages/bff/tests/test_core_client.py
+++ b/packages/bff/tests/test_core_client.py
@@ -5,24 +5,45 @@ from unittest.mock import MagicMock
 import pytest
 from api.errors import NotFoundError, ValidationError
 from api.models.game_info_operations import GameInfoUpdateOperation
+from api.services.game_service import GameService, clear_sector_title_cache
 from api.transport.concept_warp_well import CoordinateInWarpWellRequest, WarpWellTypeParam
 from api.transport.game_info_update import GameInfoUpdateRequest
 from api.transport.turn_ensure import TurnEnsureRequest
-from bff.core_client import CoreClient, clear_sector_title_cache
+from bff.core_client import CoreClient, clear_core_client_cache, get_core_client
 from fastapi import HTTPException
+
+
+def _core_client(**overrides: object) -> CoreClient:
+    defaults: dict[str, object] = {
+        "game_service": MagicMock(spec=GameService),
+        "turn_load_service": MagicMock(),
+        "load_all_turns_service": MagicMock(),
+        "turn_concept_service": MagicMock(),
+        "turn_analytic_service": MagicMock(),
+    }
+    defaults.update(overrides)
+    return CoreClient(**defaults)  # type: ignore[arg-type]
 
 
 @pytest.fixture(autouse=True)
 def _clear_sector_cache():
     clear_sector_title_cache()
+    clear_core_client_cache()
     yield
     clear_sector_title_cache()
+    clear_core_client_cache()
+
+
+def test_get_core_client_returns_process_singleton():
+    first = get_core_client()
+    second = get_core_client()
+    assert first is second
 
 
 def test_get_turn_analytics_maps_core_errors_to_http():
     analytics = MagicMock()
     analytics.get_turn_analytics.side_effect = ValidationError("bad scope")
-    client = CoreClient(turn_analytic_service=analytics, store_service=MagicMock())
+    client = _core_client(turn_analytic_service=analytics)
 
     with pytest.raises(HTTPException) as exc:
         client.get_turn_analytics(1, 1, 1, "connections")
@@ -31,18 +52,19 @@ def test_get_turn_analytics_maps_core_errors_to_http():
     assert exc.value.detail == "bad scope"
 
 
-def test_list_stored_games_returns_empty_when_games_path_missing():
-    store = MagicMock()
-    store.read_shallow.side_effect = NotFoundError("missing")
-    client = CoreClient(store_service=store)
+def test_list_stored_games_delegates_to_game_service():
+    games = MagicMock()
+    games.list_stored_games.return_value = {"games": []}
+    client = _core_client(game_service=games)
 
     assert client.list_stored_games() == {"games": []}
+    games.list_stored_games.assert_called_once()
 
 
-def test_list_stored_games_maps_store_errors_to_http():
-    store = MagicMock()
-    store.read_shallow.side_effect = ValidationError("bad games path")
-    client = CoreClient(store_service=store)
+def test_list_stored_games_maps_game_service_errors_to_http():
+    games = MagicMock()
+    games.list_stored_games.side_effect = ValidationError("bad games path")
+    client = _core_client(game_service=games)
 
     with pytest.raises(HTTPException) as exc:
         client.list_stored_games()
@@ -51,22 +73,10 @@ def test_list_stored_games_maps_store_errors_to_http():
     assert exc.value.detail == "bad games path"
 
 
-def test_resolved_sector_title_maps_store_read_errors_to_http():
-    store = MagicMock()
-    store.read.side_effect = ValidationError("bad info payload")
-    client = CoreClient(store_service=store)
-
-    with pytest.raises(HTTPException) as exc:
-        client._resolved_sector_title_for_listed_game("628580")
-
-    assert exc.value.status_code == 422
-    assert exc.value.detail == "bad info payload"
-
-
 def test_warp_well_coordinate_in_well_delegates_to_shared_handler():
     concepts = MagicMock()
     concepts.warp_well_coordinate_in_well.return_value = True
-    client = CoreClient(turn_concept_service=concepts, store_service=MagicMock())
+    client = _core_client(turn_concept_service=concepts)
     body = CoordinateInWarpWellRequest(
         planet_id=1,
         map_x=10.0,
@@ -80,15 +90,12 @@ def test_warp_well_coordinate_in_well_delegates_to_shared_handler():
     concepts.warp_well_coordinate_in_well.assert_called_once()
 
 
-def test_refresh_game_info_updates_sector_title_cache():
+def test_refresh_game_info_delegates_to_game_service():
     games = MagicMock()
     info = MagicMock()
-    info.game.name = "Cached Sector"
-    info.settings.name = None
     games.update_game_info.return_value = info
-    client = CoreClient(
+    client = _core_client(
         game_service=games,
-        store_service=MagicMock(),
         planets_client_factory=lambda: MagicMock(),
     )
     body = GameInfoUpdateRequest(
@@ -96,9 +103,10 @@ def test_refresh_game_info_updates_sector_title_cache():
         params={"username": "player1"},
     )
 
-    client.refresh_game_info(628580, body)
+    result = client.refresh_game_info(628580, body)
 
-    assert client._resolved_sector_title_for_listed_game("628580") == "Cached Sector"
+    assert result is info
+    games.update_game_info.assert_called_once()
 
 
 def test_ensure_turn_returns_stored_turn_without_planets_client():
@@ -106,9 +114,8 @@ def test_ensure_turn_returns_stored_turn_without_planets_client():
     turn = MagicMock()
     turns.get_turn_info.return_value = turn
     factory = MagicMock()
-    client = CoreClient(
+    client = _core_client(
         turn_load_service=turns,
-        store_service=MagicMock(),
         planets_client_factory=factory,
     )
     body = TurnEnsureRequest(turn=111, perspective=1, username="player1")
@@ -127,9 +134,8 @@ def test_ensure_turn_delegates_with_refresh_params():
     turns.get_turn_info.side_effect = NotFoundError("missing")
     turns.ensure_turn_loaded.return_value = turn
     planets = MagicMock()
-    client = CoreClient(
+    client = _core_client(
         turn_load_service=turns,
-        store_service=MagicMock(),
         planets_client_factory=lambda: planets,
     )
     body = TurnEnsureRequest(turn=111, perspective=1, username="player1")

--- a/packages/bff/tests/test_diagnostics.py
+++ b/packages/bff/tests/test_diagnostics.py
@@ -7,6 +7,7 @@ from api.storage import clear_backend_cache
 from bff.app import app
 from bff.config import BffConfig
 from bff.config import set_config as set_bff_config
+from bff.core_client import clear_core_client_cache
 from bff.diagnostics_buffer import get_diagnostics_buffer
 from fastapi.testclient import TestClient
 
@@ -16,6 +17,7 @@ client = TestClient(app)
 @pytest.fixture(autouse=True)
 def _reset():
     clear_backend_cache()
+    clear_core_client_cache()
     set_bff_config(BffConfig(diagnostics_buffer_size=10))
     get_diagnostics_buffer().clear()
     set_api_config(
@@ -27,6 +29,7 @@ def _reset():
     )
     yield
     clear_backend_cache()
+    clear_core_client_cache()
 
 
 def test_diagnostics_recent_empty_by_default():

--- a/packages/bff/tests/test_games.py
+++ b/packages/bff/tests/test_games.py
@@ -7,12 +7,12 @@ from unittest.mock import patch
 import pytest
 from api.config import ApiConfig
 from api.config import set_config as set_api_config
-from api.services.store_service import StoreService
+from api.services.game_service import clear_sector_title_cache
 from api.storage import clear_backend_cache, get_storage
 from bff.app import app
 from bff.config import BffConfig
 from bff.config import set_config as set_bff_config
-from bff.core_client import clear_sector_title_cache
+from bff.core_client import clear_core_client_cache
 from bff.diagnostics_buffer import get_diagnostics_buffer
 from fastapi.testclient import TestClient
 
@@ -24,6 +24,7 @@ ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "api" / "api" / "st
 @pytest.fixture(autouse=True)
 def _reset_storage():
     clear_backend_cache()
+    clear_core_client_cache()
     clear_sector_title_cache()
     set_bff_config(BffConfig())
     get_diagnostics_buffer().clear()
@@ -36,6 +37,7 @@ def _reset_storage():
     )
     yield
     clear_backend_cache()
+    clear_core_client_cache()
 
 
 def test_list_games_empty_when_no_games_path():
@@ -82,14 +84,14 @@ def test_list_games_does_not_re_read_info_when_sector_titles_are_cached():
     storage.put("games/222/info", payload)
 
     info_reads: list[str] = []
-    original_read = StoreService.read
+    original_get = storage.get
 
-    def counting_read(self, path: str) -> object:
+    def counting_get(path: str) -> object:
         if path.startswith("games/") and path.endswith("/info"):
             info_reads.append(path)
-        return original_read(self, path)
+        return original_get(path)
 
-    with patch.object(StoreService, "read", counting_read):
+    with patch.object(storage, "get", counting_get):
         r1 = client.get("/games")
         r2 = client.get("/games")
 

--- a/packages/bff/tests/test_shell.py
+++ b/packages/bff/tests/test_shell.py
@@ -7,6 +7,7 @@ from api.storage import clear_backend_cache
 from bff.app import app
 from bff.config import BffConfig
 from bff.config import set_config as set_bff_config
+from bff.core_client import clear_core_client_cache
 from bff.diagnostics_buffer import get_diagnostics_buffer
 from fastapi.testclient import TestClient
 
@@ -16,6 +17,7 @@ client = TestClient(app)
 @pytest.fixture(autouse=True)
 def _reset():
     clear_backend_cache()
+    clear_core_client_cache()
     set_bff_config(BffConfig())
     get_diagnostics_buffer().clear()
     set_api_config(
@@ -27,6 +29,7 @@ def _reset():
     )
     yield
     clear_backend_cache()
+    clear_core_client_cache()
 
 
 def test_shell_bootstrap_null_when_unconfigured():

--- a/packages/frontend/src/api/schema-games.ts
+++ b/packages/frontend/src/api/schema-games.ts
@@ -13,11 +13,9 @@ export interface paths {
         };
         /**
          * List Stored Games
-         * @description Return game ids present under store path `games` (next-hop segment names).
+         * @description Return stored game ids (optional sector names) via Core ``GameService``.
          *
-         *     Route: **GET /games** on the BFF app; **GET /bff/games** when the BFF is mounted at `/bff`.
-         *
-         *     Uses the same shallow enumeration as GET /api/v1/store/games?view=shallow.
+         *     Route: **GET /games** on the BFF app; **GET /bff/games** when mounted at `/bff`.
          */
         get: operations["list_stored_games_games_get"];
         put?: never;


### PR DESCRIPTION
## Summary

- Add a shared `AnalyticCatalog` in Core API so turn analytic ids, handlers, and BFF descriptors register once instead of maintaining parallel registries with sync tests.
- Remove `StorageBackend` / `StoreService` usage from `CoreClient`: move `list_stored_games` and sector title memoization into `GameService`, inject required Core services, and use a process-singleton `get_core_client()` with `Depends` on games routes.
- Regenerate `schema-games.ts` for the updated OpenAPI surface.

## Test plan

- [x] `make ci` (lint, frontend API slices, typecheck, full test suite)
- [ ] Smoke `GET /bff/games` and game info refresh in dev


Made with [Cursor](https://cursor.com)