### PR TITLE
Fix accelerated-start GT scope vs cumulative observation (#74)

### DIFF
--- a/docs/design-inference-corpus.md
+++ b/docs/design-inference-corpus.md
@@ -291,6 +291,8 @@ GroundTruth = tuple[tuple[str, int], ...]  # (action_id, count) ascending by act
 
 Extract only when **adjunct** is false and complexity <= `heavy`. Otherwise set `groundTruthAvailable: false` and skip coverage/ranking/Tier 2.
 
+**Turn-pair residual scope:** Ground truth is built from inventory deltas between the manifest's `priorTurnPath` and `scoreTurnPath` snapshots (host turn pair). Residual validation compares the explained multiset to **`2 * score.militarychange`** on the score row -- not `build_inference_observation(...).military_delta_2x`. On the first reliable accelerated-start scoreboard row, inference observation is cumulative since homeworld baseline (`observation_deltas_from_score`), while `militarychange` on that row is still the delta for host turn N-1 only. Comparing turn-pair GT to cumulative observation falsely marks explainable cases as `residual_unexplained` (e.g. `628580-p1-host2`). Accelerated-window activity before host turn N-1 is out of scope for turn-pair GT unless extraction is extended to include it explicitly.
+
 **Ship builds (combo catalog, #51+):**
 
 - New ship ids at N+1 not at N, `ownerid == playerId`, `turnkilled == 0`.
@@ -318,7 +320,7 @@ If residual cannot be assigned without deferred effects, set `groundTruthAvailab
 
 ### 9.3 Catalog coverage (v1)
 
-After `build_action_catalog_from_turn(observation, scoreTurn)`:
+When `groundTruthAvailable: true`, for each `(action_id, count)` in ground truth, check against `build_action_catalog_from_turn(observation, scoreTurn)` at escalating `ship_build_tier` values (0 through max), matching solver tier progression. Ship-build combos such as Missouri may only appear at higher tiers.
 
 When `groundTruthAvailable: true`, for each `(action_id, count)` in ground truth:
 

--- a/packages/api/tests/fixtures/inference_corpus/manifest.json
+++ b/packages/api/tests/fixtures/inference_corpus/manifest.json
@@ -16,7 +16,7 @@
       "requireTopK": false,
       "expectCoverage": false,
       "requiredPerspectives": [],
-      "notes": "Perspective 1 (dead); host turn 2 Missouri build; strict ground truth unavailable (110 score residual after construction; turn snapshot vs scoreboard timing)."
+      "notes": "Perspective 1 (dead); host turn 2 Missouri build; strict ground truth is Missouri combo (turn-pair scope; Tier 1 inference uses cumulative accel observation on turn 3)."
     },
     {
       "id": "628580-p1-host51",

--- a/packages/api/tests/inference_corpus/catalog_coverage.py
+++ b/packages/api/tests/inference_corpus/catalog_coverage.py
@@ -2,8 +2,20 @@
 
 from dataclasses import dataclass
 
-from api.analytics.military_score_inference.actions import ActionCatalog
-from api.analytics.military_score_inference.models import CandidateAction, ShipBuildCombo
+from api.analytics.military_score_inference.actions import (
+    ActionCatalog,
+    build_action_catalog_from_turn,
+)
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    ShipBuildCombo,
+)
+from api.analytics.military_score_inference.ship_build_combos import (
+    MAX_SHIP_BUILD_TIER,
+    START_SHIP_BUILD_TIER,
+)
+from api.models.game import TurnInfo
 
 from tests.inference_corpus.ground_truth import GroundTruth, GroundTruthExtraction
 
@@ -92,12 +104,38 @@ def evaluate_catalog_coverage(
     return CatalogCoverageResult(in_search_space=True)
 
 
+def evaluate_ground_truth_catalog_coverage(
+    *,
+    ground_truth: GroundTruth,
+    observation: InferenceObservation,
+    score_turn: TurnInfo,
+) -> CatalogCoverageResult:
+    """Check GT against escalating ship-build tiers, matching solver tier progression."""
+    last_result = CatalogCoverageResult(
+        in_search_space=False,
+        coverage_reason=COVERAGE_REASON_COMBO_NOT_IN_CATALOG,
+    )
+    for tier in range(START_SHIP_BUILD_TIER, MAX_SHIP_BUILD_TIER + 1):
+        catalog = build_action_catalog_from_turn(
+            observation,
+            score_turn,
+            ship_build_tier=tier,
+        )
+        result = evaluate_catalog_coverage(ground_truth, catalog)
+        if result.in_search_space:
+            return result
+        last_result = result
+    return last_result
+
+
 def resolve_coverage_for_case(
     *,
     extraction: GroundTruthExtraction,
     ground_truth: GroundTruth,
     catalog: ActionCatalog,
     complexity_reasons: tuple[str, ...],
+    observation: InferenceObservation | None = None,
+    score_turn: TurnInfo | None = None,
 ) -> CatalogCoverageResult | None:
     """Evaluate catalog coverage when ground truth is available; otherwise skip (Tier 1 may run)."""
     if not extraction.available:
@@ -107,4 +145,10 @@ def resolve_coverage_for_case(
     if deferred_reason is not None:
         return CatalogCoverageResult(in_search_space=False, coverage_reason=deferred_reason)
 
+    if observation is not None and score_turn is not None:
+        return evaluate_ground_truth_catalog_coverage(
+            ground_truth=ground_truth,
+            observation=observation,
+            score_turn=score_turn,
+        )
     return evaluate_catalog_coverage(ground_truth, catalog)

--- a/packages/api/tests/inference_corpus/ground_truth.py
+++ b/packages/api/tests/inference_corpus/ground_truth.py
@@ -3,7 +3,6 @@
 from collections import Counter
 from dataclasses import dataclass
 
-from api.analytics.military_score_inference.analytic import build_inference_observation
 from api.analytics.military_score_inference.scoring import (
     LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
     loaded_ship_torpedo_score_delta_2x,
@@ -78,12 +77,11 @@ def extract_ground_truth_v1(
         multiset[action_id] += 1
     multiset.update(new_ship_load_action_counts(new_ships, score_turn))
 
-    observation = build_inference_observation(score, score_turn)
     explained_2x = sum(
         _catalog_score_delta_2x_for_action_id(action_id, score_turn) * multiset[action_id]
         for action_id in multiset
     )
-    residual_2x = observation.military_delta_2x - explained_2x
+    residual_2x = _ground_truth_military_delta_2x(score) - explained_2x
     if residual_2x < 0:
         return GroundTruthExtraction(
             available=False,
@@ -222,6 +220,17 @@ def format_unavailable_ground_truth(
     if activity == "no inventory changes detected":
         return f"ground truth unavailable ({reason})"
     return f"{activity} (strict ground truth unavailable: {reason})"
+
+
+def _ground_truth_military_delta_2x(score: Score) -> int:
+    """Turn-pair military delta for residual checks against inventory-derived GT.
+
+    Ground truth is built from inventory deltas between ``prior_turn`` and
+    ``score_turn`` files. That scope matches ``score.militarychange`` on the
+    score row (including accelerated-start games on the first reliable row,
+    where inference uses cumulative totals since homeworld baseline instead).
+    """
+    return 2 * score.militarychange
 
 
 def _sorted_multiset(counter: Counter[str]) -> GroundTruth:

--- a/packages/api/tests/inference_corpus/run.py
+++ b/packages/api/tests/inference_corpus/run.py
@@ -254,6 +254,8 @@ def run_loaded_case(loaded: LoadedCorpusCase) -> CorpusCaseResult:
         ground_truth=extraction.ground_truth,
         catalog=catalog,
         complexity_reasons=loaded.complexity_reasons,
+        observation=observation,
+        score_turn=loaded.score_turn,
     )
 
     if loaded.expect_coverage:

--- a/packages/api/tests/test_inference_corpus_coverage.py
+++ b/packages/api/tests/test_inference_corpus_coverage.py
@@ -16,6 +16,7 @@ from tests.inference_corpus.catalog_coverage import (
     COVERAGE_REASON_COUNT_ABOVE_UPPER_BOUND,
     COVERAGE_REASON_GROUND_TRUTH_UNAVAILABLE,
     evaluate_catalog_coverage,
+    evaluate_ground_truth_catalog_coverage,
     resolve_coverage_for_case,
 )
 from tests.inference_corpus.fixtures import load_turn_fixture
@@ -126,7 +127,7 @@ def test_host2_missouri_combo_id_and_summary_label():
     assert "Mark 4 Photon" in summary
 
 
-def test_seed_host2_strict_ground_truth_unavailable():
+def test_seed_host2_strict_ground_truth_available():
     _, cases = load_manifest()
     host2 = next(case for case in cases if case.id == "628580-p1-host2")
     prior = load_turn_fixture(host2.prior_turn_path, fixtures_root=FIXTURES_ROOT)
@@ -140,8 +141,10 @@ def test_seed_host2_strict_ground_truth_unavailable():
         score=score,
         complexity="minimal",
     )
-    assert extraction.available is False
-    assert extraction.unavailable_reason == "residual_unexplained"
+    new_ship = new_owned_ships(prior, score_turn, player_id)[0]
+    combo_id = ship_to_build_combo_id(new_ship, score_turn)
+    assert extraction.available is True
+    assert extraction.ground_truth == ((combo_id, 1),)
 
 
 def test_host51_manifest_case_coverage_passes_tier1():
@@ -154,19 +157,57 @@ def test_host51_manifest_case_coverage_passes_tier1():
     assert result.status == "exact"
 
 
+def test_host2_ground_truth_passes_catalog_coverage_with_tier_escalation():
+    _, cases = load_manifest()
+    host2 = next(case for case in cases if case.id == "628580-p1-host2")
+    prior = load_turn_fixture(host2.prior_turn_path, fixtures_root=FIXTURES_ROOT)
+    score_turn = load_turn_fixture(host2.score_turn_path, fixtures_root=FIXTURES_ROOT)
+    player_id = resolve_player_id(host2, fixtures_root=FIXTURES_ROOT)
+    score = score_for_player(score_turn.scores, player_id, host2.id)
+    extraction = extract_ground_truth_v1(
+        prior_turn=prior,
+        score_turn=score_turn,
+        player_id=player_id,
+        score=score,
+        complexity="minimal",
+    )
+    observation = build_inference_observation(score, score_turn)
+    tier0_catalog = build_action_catalog_from_turn(observation, score_turn)
+    tier0_coverage = evaluate_catalog_coverage(extraction.ground_truth, tier0_catalog)
+    assert tier0_coverage.in_search_space is False
+    assert (
+        evaluate_ground_truth_catalog_coverage(
+            ground_truth=extraction.ground_truth,
+            observation=observation,
+            score_turn=score_turn,
+        ).in_search_space
+        is True
+    )
+
+
 def test_host2_manifest_runs_tier1_without_coverage_gate():
     _, cases = load_manifest()
     host2 = next(case for case in cases if case.id == "628580-p1-host2")
     result = run_manifest_case(host2)
     assert result.outcome == CaseOutcome.PASSED
-    assert result.ground_truth_available is False
+    assert result.ground_truth_available is True
 
 
 def test_expect_coverage_fails_without_solver_when_ground_truth_unavailable():
     _, cases = load_manifest()
-    host2 = next(case for case in cases if case.id == "628580-p1-host2")
-    coverage_required = host2.__class__(**{**host2.__dict__, "expect_coverage": True})
-    with patch("tests.inference_corpus.run.run_inference_with_artifacts") as run_inference:
+    host51 = next(case for case in cases if case.id == "628580-p1-host51")
+    coverage_required = host51.__class__(**{**host51.__dict__, "expect_coverage": True})
+    unavailable_extraction = GroundTruthExtraction(
+        available=False,
+        unavailable_reason="residual_unexplained",
+    )
+    with (
+        patch(
+            "tests.inference_corpus.run.extract_ground_truth_v1",
+            return_value=unavailable_extraction,
+        ),
+        patch("tests.inference_corpus.run.run_inference_with_artifacts") as run_inference,
+    ):
         result = run_manifest_case(coverage_required)
         run_inference.assert_not_called()
     assert result.outcome == CaseOutcome.FAILED
@@ -193,6 +234,19 @@ def test_available_ground_truth_action_not_in_catalog_out_of_search_without_expe
     assert result.outcome == CaseOutcome.OUT_OF_SEARCH_SPACE
     assert result.ground_truth_available is True
     assert result.coverage_reason == COVERAGE_REASON_ACTION_NOT_IN_CATALOG
+
+
+def test_host2_ground_truth_residual_uses_turn_pair_not_cumulative_observation():
+    _, cases = load_manifest()
+    host2 = next(case for case in cases if case.id == "628580-p1-host2")
+    score_turn = load_turn_fixture(host2.score_turn_path, fixtures_root=FIXTURES_ROOT)
+    player_id = resolve_player_id(host2, fixtures_root=FIXTURES_ROOT)
+    score = score_for_player(score_turn.scores, player_id, host2.id)
+    observation = build_inference_observation(score, score_turn)
+    assert score.militarychange == 4275
+    assert observation.military_delta_2x == 8660
+    assert 2 * score.militarychange == 8550
+    assert observation.military_delta_2x != 2 * score.militarychange
 
 
 def test_host51_fixture_ground_truth_in_catalog():

--- a/packages/api/tests/test_inference_corpus_discover_list.py
+++ b/packages/api/tests/test_inference_corpus_discover_list.py
@@ -77,5 +77,5 @@ def test_discover_case_listings_human_readable(listing_storage):
     lines = format_listing_report(listings, game_id=628580)
     joined = "\n".join(lines)
     assert "perspective 1" in joined
-    assert "built 1x" in joined
+    assert "Missouri Class Battleship" in joined
     assert listings[0].summary


### PR DESCRIPTION
## Summary

- Align ground truth residual validation with turn-pair inventory scope by using `2 * score.militarychange` instead of cumulative `build_inference_observation` military delta on first reliable accelerated-start rows.
- Escalate ship-build catalog tiers when checking ground truth coverage so Missouri-class combos (tier 3) are found without blocking Tier 1.
- Document accelerated-start GT rules in `docs/design-inference-corpus.md` §9.2/§9.3 and update `628580-p1-host2` manifest notes.

Fixes #74.

## Test plan

- [x] `make test_api` (542 passed)
- [x] `uv run ruff check` and `uv run ruff format --check`
- [x] `628580-p1-host2` strict ground truth available with Missouri combo
- [x] Fixed corpus Tier 1 still passes


Made with [Cursor](https://cursor.com)