### PR TITLE
Military score inference: YAML tier policy ladder with slack deferral (#77)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -285,7 +285,7 @@ Core **turn analytic** behavior (optional on the **Scores** analytic) that expla
 _Avoid_: build solver, score guesser
 
 **Inference search tier**:
-One staged step in **military score build inference** catalog construction and solving. The ladder has no fixed length; each tier declares how much of the action inventory is in play for that attempt. Later tiers are strict supersets of earlier ones on every dimension they control (permitted actions, per-action caps, ship-build component eligibility, constraint strictness). The solver walks the list until time runs out or a tier adds no new distinct exact explanation signatures to the merged top-K.
+One staged step in **military score build inference** catalog construction and solving. The ladder has no fixed length; each tier declares how much of the action inventory is in play for that attempt. Later tiers are strict supersets of earlier ones on every dimension they control (permitted actions, per-action caps, ship-build component eligibility, constraint strictness). The solver walks the list until time runs out or a tier adds no new distinct exact explanation signatures to **inference merged top-K** (the ladder continues when K is full; see K-best retention there).
 _Avoid_: ship build tier (too narrow; implies only hull combos), phase
 
 **Fine-grained slack action**:
@@ -309,8 +309,20 @@ A band-feasible action multiset from tier *n* (exact pass at that tier was infea
 _Avoid_: warm start, hint
 
 **Inference score band**:
-Relaxed military-score constraint `explained_2x >= observed_2x - alpha` with `alpha` from the tier policy. Warship and freighter equalities stay exact. The final **inference search tier** always uses `alpha = 0`. Each tier tries exact constraints first; **inference score band** applies only on retry after an infeasible exact pass at that tier. Band-feasible results seed the next tier only; they are never user-facing explanations. **Exact** solutions from any tier merge into top-K (green tick). If the full ladder yields zero exact solutions, status is `no_exact_solution` with band residual in diagnostics.
+Relaxed military-score constraint `explained_2x >= observed_2x - alpha` with `alpha` from the tier policy. Warship and freighter equalities stay exact. The final **inference search tier** always uses `alpha = 0`. Each tier tries exact constraints first; **inference score band** applies only on retry after an infeasible exact pass at that tier. Band-feasible results seed the next tier only; they are never user-facing explanations. **Exact** solutions from any tier merge into **inference merged top-K**. If the full ladder yields zero exact solutions, status is `no_exact_solution` with band residual in diagnostics.
 _Avoid_: slack constraint, approximate solve
+
+**Inference explanation signature**:
+Identity of one feasible explanation as the sorted multiset of aggregate action ids with counts plus ship-build combo ids with counts. Two ranked rows with the same signature are the same explanation for merge dedup and **inference solution streaming** -- regardless of display labels or which **inference search tier** found them. Re-discovery at a later tier is suppressed; first discovery wins.
+_Avoid_: solution hash, fingerprint
+
+**Inference merged top-K**:
+Up to K distinct exact explanations held across the full **inference search tier** ladder, ranked by **inference solution rank weight**. When K is full the ladder still climbs: a new signature evicts the current worst held row only if its weight is higher. Distinctness is by **inference explanation signature**.
+_Avoid_: per-tier top-K, solution buffer
+
+**Inference solution rank weight**:
+The solver likelihood objective attached to one explanation. Orders the merged top-K and each streamed `solution` event; the consumer may maintain final ranked order incrementally from this weight without waiting for the full ladder to finish.
+_Avoid_: probability score, objective value (implementation field name)
 
 **Inference tier policy overlay** (follow-on):
 Solver-side merge of injected parameters into the static **inference tier policy asset** at solve time (e.g. extra launcher torpedo tech levels, earlier beam tech bands). Defines how overlays combine with the base YAML -- not which upstream features produce overlay values (fleet histogram, prior builds, user settings, etc.). Separate ticket from the static-policy refactor.
@@ -321,8 +333,12 @@ Static YAML ladder under `assets/analytics/military_score_build_inference/` (rep
 _Avoid_: tier_policy.yaml (filename in prose only when citing path)
 
 **Inference solution streaming**:
-Planned NDJSON wire protocol (**#71**, Phase 1H) that emits each ranked explanation for one scoreboard row as the CP-SAT top-K loop discovers it, so the hourglass clears before enumeration finishes. Follows the load-all progress stream pattern (Zod-owned events). Batch JSON remains for the inference corpus harness until stream parity is proven.
+Planned NDJSON wire protocol (**#71**, Phase 1H) that emits each new exact explanation for one scoreboard row as soon as any **inference search tier** finds it -- within-tier enumeration and cross-tier ladder progress -- so the hourglass clears before top-K is full. Each `solution` event carries **inference solution rank weight**; the consumer dedupes on **inference explanation signature** and applies final ordering. Follows the load-all progress stream pattern (Zod-owned events). Batch JSON remains for the inference corpus harness until stream parity is proven.
 _Avoid_: websocket inference, whole-table stream
+
+**Inference solution count indicator**:
+Per scoreboard row chrome replacing the binary green tick: a green outlined badge showing **N** = the number of rows currently held in **inference merged top-K** (not cumulative discoveries above K). **N > 0** as soon as the first exact explanation is held; rises toward K then plateaus while eviction swaps membership. Hourglass while **N = 0** and search is in flight; red cross when the row completes with no exact explanation. Click opens the ranked modal.
+_Avoid_: green tick, checkmark column
 
 **Inference host turn**:
 The host turn whose activity is being explained. Scoreboard deltas are read from the **later** stored **TurnInfo** document (turn *N+1*); the **earlier** document (turn *N*) supplies inventory ground truth for complexity grading and Tier 2 checks.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint ci typecheck_frontend check_frontend_api_slices check_frontend_api_no_monolithic_schema test_bff test_api test_server test_scripts test_frontend generate generate_frontend_api inference_corpus inference_corpus_discover
+.PHONY: test lint ci typecheck_frontend check_frontend_api_slices check_frontend_api_no_monolithic_schema test_bff test_api test_server test_scripts test_frontend generate generate_frontend_api inference_corpus inference_corpus_discover inference_corpus_probe
 
 # Use workspace venv (Python 3.14) and ensure dev deps (pytest, ruff) are installed.
 # `test` runs lint and unit tests. `ci` also runs the full frontend `tsc -b` (see `typecheck_frontend`).
@@ -65,3 +65,19 @@ ifndef GAME_ID
 	$(error GAME_ID is required, e.g. make inference_corpus_discover GAME_ID=628580)
 endif
 	uv run python scripts/run_inference_corpus.py discover --game-id $(GAME_ID) $(if $(STORAGE_ROOT),--storage-root $(STORAGE_ROOT),) $(if $(FROM_TURN),--from-turn $(FROM_TURN),) $(if $(TO_TURN),--to-turn $(TO_TURN),)
+
+# Walk stored turn pairs for a finished game (default 628580) in host-turn order; stop once
+# the solver accumulates STOP_AFTER_FAILURES inference failures (default 10) or
+# PROBE_TIME_LIMIT_SECONDS elapses (default 300). Skips do not count toward the failure budget.
+# Cases run in a process pool of PROBE_WORKERS (default 4).
+inference_corpus_probe:
+	uv sync --extra dev
+	PYTHONPATH=packages/api uv run python scripts/run_inference_corpus.py \
+		--game-id $(or $(GAME_ID),628580) \
+		--stop-after-failures $(or $(STOP_AFTER_FAILURES),10) \
+		--probe-time-limit-seconds $(or $(PROBE_TIME_LIMIT_SECONDS),300) \
+		--workers $(or $(PROBE_WORKERS),4) \
+		$(if $(STORAGE_ROOT),--storage-root $(STORAGE_ROOT),) \
+		$(if $(FROM_TURN),--from-turn $(FROM_TURN),) \
+		$(if $(TO_TURN),--to-turn $(TO_TURN),) \
+		$(if $(MAX_COMPLEXITY),--max-complexity $(MAX_COMPLEXITY),)

--- a/assets/analytics/military_score_build_inference/tier_policy.yaml
+++ b/assets/analytics/military_score_build_inference/tier_policy.yaml
@@ -1,0 +1,153 @@
+# Inference search tier ladder (sketch A, section 8.5.3).
+# filters.*.all widens eligibility (see tier_policy.py module docstring).
+# filters.*.techLevels narrows by component techlevel; ids derived at runtime.
+version: 1
+steps:
+  - id: early_game_bands
+    filters:
+      hulls:
+        techLevels: [1, 2, 3, 4, 5, 6]
+      engines:
+        all: true
+      beams:
+        techLevels: [1, 2, 3, 4, 5]
+      launchers:
+        techLevels: [1, 2, 3, 4, 5]
+    beamSlotCounts: none
+    launcherSlotCounts: none
+    aggregateAllowlist: {}
+    alpha: 50
+    maxSeeds: 5
+
+  - id: widen_launchers
+    filters:
+      hulls:
+        techLevels: [1, 2, 3, 4, 5, 6]
+      engines:
+        all: true
+      beams:
+        techLevels: [1, 2, 3, 4, 5]
+      launchers:
+        techLevels: [1, 2, 3, 4, 5, 6, 7, 8]
+    beamSlotCounts: none
+    launcherSlotCounts: none
+    aggregateAllowlist: {}
+    alpha: 50
+    maxSeeds: 5
+
+  - id: widen_hulls
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        techLevels: [1, 2, 3, 4, 5]
+      launchers:
+        techLevels: [1, 2, 3, 4, 5, 6, 7, 8]
+    beamSlotCounts: none
+    launcherSlotCounts: none
+    aggregateAllowlist: {}
+    alpha: 50
+    maxSeeds: 5
+
+  - id: full_components
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist: {}
+    alpha: 50
+    maxSeeds: 5
+
+  - id: full_components_planet_defense
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist:
+      planet_defense_posts_added_total: 16
+      starbase_fighters_added_total: 50
+      ship_fighters_added_total: 20
+      fighter_transfers_per_direction: 50
+    alpha: 50
+    maxSeeds: 5
+
+  - id: admit_starbase_defense_posts
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist:
+      planet_defense_posts_added_total: 16
+      starbase_defense_posts_added_total: 5
+      starbase_fighters_added_total: 50
+      ship_fighters_added_total: 20
+      fighter_transfers_per_direction: 50
+    alpha: 30
+    maxSeeds: 5
+
+  - id: admit_ship_torpedoes
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist:
+      planet_defense_posts_added_total: 16
+      starbase_defense_posts_added_total: 5
+      ship_torps_per_type: 10
+      starbase_fighters_added_total: 50
+      ship_fighters_added_total: 20
+      fighter_transfers_per_direction: 50
+    alpha: 30
+    maxSeeds: 5
+
+  - id: full_catalog_exact
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist:
+      planet_defense_posts_added_total: 100
+      starbase_defense_posts_added_total: 100
+      ship_torps_per_type: 200
+      starbase_fighters_added_total: 200
+      ship_fighters_added_total: 500
+      fighter_transfers_per_direction: 100
+    alpha: 0
+    maxSeeds: 5

--- a/docs/design-inference-corpus.md
+++ b/docs/design-inference-corpus.md
@@ -192,6 +192,57 @@ PYTHONPATH=packages/api uv run python scripts/run_inference_corpus.py \
 
 **Finished game:** Script does not require load-all completeness; sparse pairs are valid. Optionally warn if `games/{id}/info.json` missing.
 
+### 5.1 Local probe (`make inference_corpus_probe`)
+
+Quick scan of a stored game (default `628580`) in **host-turn discovery order**. Stops when either:
+
+- `--stop-after-failures` inference failures accumulate (default **10**), or
+- `--probe-time-limit-seconds` elapses (default **300**).
+
+Inference failures = `failed`, `out_of_search_space`, or `ranking_miss`. Skips do not count.
+
+```bash
+make inference_corpus_probe GAME_ID=628580 STORAGE_ROOT=.data
+# overrides: STOP_AFTER_FAILURES, PROBE_TIME_LIMIT_SECONDS, PROBE_WORKERS (default 4)
+```
+
+Save machine-readable output on the first run you intend to analyze:
+
+```bash
+PYTHONPATH=packages/api uv run python scripts/run_inference_corpus.py \
+  --game-id 628580 --storage-root .data \
+  --stop-after-failures 100 --probe-time-limit-seconds 300 --workers 4 \
+  --json > /tmp/probe.json
+```
+
+### 5.2 Investigating probe failures (do not re-run the probe)
+
+When an agent needs **which cases failed** and **what ground truth says**, a prior probe JSON plus ground-truth extraction is enough. **Do not re-run the probe** for that question.
+
+**What probe output includes**
+
+| Source | Case ids | `coverageReason` / status | Ground truth |
+|--------|----------|---------------------------|--------------|
+| Text summary | Only `failed` (solver mismatch) rows | No | No |
+| `--json` per-case records | Yes | Yes (`outcome`, `status`, `coverageReason`, ...) | **No** |
+
+Most probe budget stops are **`out_of_search_space`** (catalog coverage gaps). They appear in JSON but **not** in the text summary.
+
+**Better path (two steps)**
+
+1. **Failure list** -- parse saved `--json` (or one full run with a high `--stop-after-failures` budget). Filter `outcome` in `failed`, `out_of_search_space`, `ranking_miss`. Cases appear in **discovery order**; the first *N* failures match a probe stopped at `--stop-after-failures N`.
+
+2. **Ground truth** -- probe JSON does not carry GT. For each `caseId`, use either:
+   - **`discover` subcommand** (human-readable inventory summaries, no solver):
+
+     ```bash
+     make inference_corpus_discover GAME_ID=628580 FROM_TURN=2 TO_TURN=12 STORAGE_ROOT=.data
+     ```
+
+   - **Harness APIs** (multiset + `format_ground_truth_summary`): `discover_cases_for_game`, `extract_ground_truth_v1`, `format_ground_truth_summary` in `tests/inference_corpus/ground_truth.py` (see `discover_list.py` for the listing wrapper).
+
+**When to re-run the probe:** only after changing inference, tier policy, coverage rules, or corpus harness code -- not to look up failures or ground truth from an existing run.
+
 ---
 
 ## 6. Complexity classification
@@ -291,7 +342,7 @@ GroundTruth = tuple[tuple[str, int], ...]  # (action_id, count) ascending by act
 
 Extract only when **adjunct** is false and complexity <= `heavy`. Otherwise set `groundTruthAvailable: false` and skip coverage/ranking/Tier 2.
 
-**Turn-pair residual scope:** Ground truth is built from inventory deltas between the manifest's `priorTurnPath` and `scoreTurnPath` snapshots (host turn pair). Residual validation compares the explained multiset to **`2 * score.militarychange`** on the score row -- not `build_inference_observation(...).military_delta_2x`. On the first reliable accelerated-start scoreboard row, inference observation is cumulative since homeworld baseline (`observation_deltas_from_score`), while `militarychange` on that row is still the delta for host turn N-1 only. Comparing turn-pair GT to cumulative observation falsely marks explainable cases as `residual_unexplained` (e.g. `628580-p1-host2`). Accelerated-window activity before host turn N-1 is out of scope for turn-pair GT unless extraction is extended to include it explicitly.
+**Inventory-only scope:** Ground truth is built entirely from inventory deltas between the manifest's `priorTurnPath` and `scoreTurnPath` snapshots (host turn pair). Scoreboard fields such as ``militarychange`` are **not** used for extraction or validation -- during accelerated start those scoreboard rows are unreliable while ship, planet, and starbase inventory remain authoritative. The same new ship may therefore appear in consecutive turn-pair extractions (e.g. Cat's Paw on both host turns 1 and 2 in game 628580 player 9) when earlier scoreboard rows omit reliable totals but inventory diffs still reveal the build.
 
 **Ship builds (combo catalog, #51+):**
 
@@ -301,26 +352,28 @@ Extract only when **adjunct** is false and complexity <= `heavy`. Otherwise set 
 
 **Ammo on newly built ships:** do not attribute fighters or torpedoes loaded onto **new** ships to aggregate load actions. Turn snapshots reflect post-order ship state while scoreboard military deltas reflect pre-order totals; client-side build/transfer actions create a systematic mismatch. Loads on **existing** ships still use inventory deltas (with new-ship ids excluded).
 
-**Aggregate loads (score-derived v1):**
+**Aggregate loads (inventory-derived v1):**
 
-When ship builds alone do not explain `militarychange`, allocate residual scaled delta to aggregate action ids in priority order (first fit):
+When inventory shows activity on **existing** ships, planets, or starbases, map deltas directly to aggregate catalog action ids:
 
 | Action id | When |
 |-----------|------|
 | `ship_fighters_added_total` | Positive fighter load delta on **existing** ships (new-ship ids excluded) |
 | `ship_torps_loaded_{torpedoId}` | Torp load delta on **existing** ships (new-ship ids excluded) |
-| `starbase_fighters_added_total` | Starbase fighter remainder |
-| `starbase_defense_posts_added_total` | Starbase defense remainder |
-| `planet_defense_posts_added_total` | Planet defense remainder |
+| `starbase_fighters_added_total` | Positive starbase fighter inventory delta |
+| `starbase_defense_posts_added_total` | Positive starbase defense inventory delta |
+| `planet_defense_posts_added_total` | Positive planet defense inventory delta |
 | `fighters_starbase_to_ship` / `fighters_ship_to_starbase` | Only when inventory shows starbase vs ship fighter counts support transfer |
 
-If residual cannot be assigned without deferred effects, set `groundTruthAvailable: false`.
+If a new ship cannot be mapped to a combo id, set `groundTruthAvailable: false`. An empty inventory delta yields an empty ground-truth multiset (still available).
 
 **Follow-on:** edge cases from other client-side actions (starbase torp builds, transfers) that appear in turn snapshots but not scoreboard deltas -- see tracker issue.
 
 ### 9.3 Catalog coverage (v1)
 
 When `groundTruthAvailable: true`, for each `(action_id, count)` in ground truth, check against `build_action_catalog_from_turn(observation, scoreTurn)` at escalating `ship_build_tier` values (0 through max), matching solver tier progression. Ship-build combos such as Missouri may only appear at higher tiers.
+
+**Accelerated context:** Coverage must use the same resolved observation and ``TurnInfo`` as inference for the case host turn. Unreliable accelerated scoreboard rows (score turn `< acceleratedturns`) backfill from the first reliable split via ``resolve_inference_target_for_host_turn``; the first reliable row selects the matching accelerated segment. Do not evaluate coverage against the raw unreliable score row alone.
 
 When `groundTruthAvailable: true`, for each `(action_id, count)` in ground truth:
 
@@ -388,7 +441,7 @@ Skip Tier 2 when `groundTruthAvailable: false`.
 - `0` -- no `failed` cases
 - `1` -- one or more `failed`
 
-Print summary counts and optional `--json` array of per-case records (`caseId`, `outcome`, `status`, `complexity`, `coverageReason`, ...).
+Print summary counts and optional `--json` array of per-case records (`caseId`, `outcome`, `status`, `complexity`, `coverageReason`, ...). JSON does **not** include ground truth; see **section 5.2** for investigating failures without re-running the probe.
 
 ---
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -449,7 +449,7 @@ Aggregate actions where location detail is not yet known:
 
 These variables still have exact score contributions, but they avoid one variable per planet or starbase in the initial version.
 
-**#77 deferral:** interim code includes all of section 8.3 at every search step. Target behavior (section 8.5.2): only **fine-grained slack actions** enter via cumulative **tier aggregate allowlist** on higher policy steps; large-increment fighter loads and race-specific actions follow separate rules.
+**#77 deferral:** aggregate noisy actions from section 8.3 enter only via cumulative **tier aggregate allowlist** on higher policy steps (section 8.5.2). `evil_empire_free_starbase_fighters` remains outside the allowlist.
 
 ### 8.4 Negative actions
 
@@ -482,25 +482,32 @@ Per-step fields (informal schema; exact YAML shape is implementation-owned):
 | Field | Meaning |
 |-------|---------|
 | `id` | Stable step id for diagnostics |
-| `hullTechLevels` | Explicit allowlist of hull tech levels; component ids derived at runtime |
-| `engineTechLevels` | Same for engines |
-| `beamTechLevels` | Same for beams |
-| `launcherTorpTechLevels` | Launcher **torpedo type** tech levels (`Torpedo` catalog); not hull launcher **slot** counts |
-| `usePlayerActiveLists` | When set, widen an axis from player `activeengines` / `activebeams` / `activetorps` intersect turn catalog; **empty active list jumps to full turn catalog** for that axis (existing rule) |
+| `filters` | Catalog constraints for all four ship-build axes (see below) |
 | `beamSlotCounts` / `launcherSlotCounts` | `none` (0 or max only) vs `partial` (niche intermediate counts); dedicated policy step before `partial` |
 | `aggregateAllowlist` | Cumulative **tier aggregate allowlist**: action id -> max count |
 | `alpha` | Military-score band tolerance in **2x** units; **final step must be `0`** |
 | `maxSeeds` | Band near-solutions to carry to next step (default **5**) |
 
-**Tech levels, not component ids:** YAML lists tech levels per axis. Runtime intersects with `turn.*` catalogs and player actives. Static YAML steps widen by **strict superset on tech-level lists** unless `usePlayerActiveLists` is explicitly enabled on that step (mode switch, not necessarily a literal id superset).
+**`filters` object:** required keys `hulls`, `engines`, `beams`, `launchers`. Each value uses the same shape:
+
+| Subfield | Meaning |
+|----------|---------|
+| `all: true` | **Widened** eligibility on that axis (not "every turn-catalog id"). **hulls:** all buildable hull ids for the player, no tech band. **engines / beams / launchers:** player `active*` intersect turn catalog; **empty active list jumps to full turn catalog** for that axis. Mutually exclusive with `techLevels`. |
+| `techLevels: [...]` | Non-empty tech-level allowlist; component ids derived at runtime. **hulls:** intersect buildable hull set. **Other axes:** filter turn catalog by `techlevel`. Required when `all` is false or absent. |
+| `componentIds: [...]` | Optional future refinement: further restrict resolved ids (e.g. when multiple ids share a tech level). Parsed but unused in v1 eligibility unless non-empty. |
+
+Static YAML steps widen by **strict superset on `techLevels` lists** or by switching an axis from `techLevels` to `all: true` (one-way; cannot narrow back).
 
 **Fine-grained slack deferral:** v1 **tier aggregate allowlist** admits only:
 
 - `planet_defense_posts_added_total`
 - `starbase_defense_posts_added_total`
+- `starbase_fighters_added_total`
+- `ship_fighters_added_total`
 - `ship_torps_loaded_{torpedo_id}` (per type, with per-type caps)
+- `fighters_starbase_to_ship` / `fighters_ship_to_starbase` (via `fighter_transfers_per_direction`)
 
-Not deferred as fine-grained slack by default: `starbase_fighters_added_total`, `ship_fighters_added_total` (large per-unit score increments). `fighters_*_transfer` and `evil_empire_free_starbase_fighters` stay governed by existing aggregate rules unless a future policy step adds them explicitly.
+**Not** deferred: `evil_empire_free_starbase_fighters` (race-specific, high-probability informational action when EE resources allow).
 
 #### 8.5.3 v1 ladder (sketch A)
 
@@ -508,15 +515,13 @@ Tunable constants in YAML; illustrative starting point from design review:
 
 | Step | Ship-build scope | Aggregate allowlist (cumulative caps) | `alpha` |
 |------|------------------|---------------------------------------|---------|
-| 0 | Early-game tech bands on all four axes | none | 50 |
-| 1 | Widen engine tech / `usePlayerActiveLists` for engines | none | 50 |
-| 2 | Widen beam tech | none | 50 |
-| 3 | Widen launcher torpedo tech | none | 50 |
-| 4 | Enable partial beam/launcher **slot** counts on hulls | none | 50 |
-| 5 | + planet defense posts | max 5 | 50 |
-| 6 | + starbase defense posts | max 5 | 30 |
-| 7 | + ship torpedoes per type | max 10 each | 30 |
-| 8 | Full ship-build catalog; slack at full policy caps | full | 0 |
+| 0 | Early game: hulls tech 1--6, engines all, beams/launchers tech 1--5 | none | 50 |
+| 1 | Widen launchers to tech 1--8 | none | 50 |
+| 2 | Widen hulls (`filters.hulls.all`) | none | 50 |
+| 3 | All component axes; partial beam/launcher **slot** counts | planet defense max 16; starbase/ship fighters max 50/20; fighter transfers max 50/dir | 50 |
+| 4 | + starbase defense posts | + starbase defense max 5 | 30 |
+| 5 | + ship torpedoes per type | + ship torps max 10 each | 30 |
+| 6 | Full ship-build catalog; slack at full policy caps | full (fighters 200/500, transfers 100/dir) | 0 |
 
 #### 8.5.4 Per-player solve loop
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -52,14 +52,20 @@ Start with a small Core API subpackage so the solver and scoring model do not cr
 ```text
 packages/api/api/analytics/military_score_inference/
 |-- __init__.py
-|-- accelerated_start.py  # accelerated scoreboard baselines and observation deltas
-|-- actions.py            # aggregate noisy actions (defense, ammo load, transfers)
-|-- ship_build_combos.py  # eligible hull/engine/beam/torp combos (Phase 1G+)
-|-- tier_policy.py        # YAML policy load, resolve, optional overlay hook (#77, #78)
-|-- models.py             # dataclasses for observations, actions, problems, solutions
-|-- scoring.py            # scaled military-score contribution formulas
-|-- solver.py             # OR-Tools CP-SAT adapter
-`-- analytic.py           # turn-level analytic assembly
+|-- accelerated_start.py    # accelerated scoreboard baselines, segment split, observation deltas
+|-- actions.py              # aggregate noisy actions (defense, ammo load, transfers)
+|-- ship_build_combos.py    # eligible hull/engine/beam/torp combos (Phase 1G+)
+|-- component_eligibility.py # hull/component id resolution for policy filters and catalog build
+|-- tier_policy.py          # YAML policy load, resolve, optional overlay hook (#77, #78)
+|-- policy_ladder.py        # walk YAML policy steps, seed carry-forward, merge top-K
+|-- inference_path.py       # prior-turn gate and InferencePath resolve-then-dispatch
+|-- inference_target.py     # observation/catalog context; accelerated backfill source loading
+|-- constraints.py          # hard equality targets and band-retry slack for observations
+|-- models.py               # dataclasses for observations, actions, problems, solutions
+|-- scoring.py              # scaled military-score contribution formulas
+|-- score_arithmetic.py     # solution score breakdown for API diagnostics
+|-- solver.py               # OR-Tools CP-SAT adapter
+`-- analytic.py             # run_inference_with_artifacts entry; path dispatch to solver paths
 ```
 
 Phase 1F shipped an interim flat `build_{hull}_{preset}` catalog in `actions.py`. Phase 1G moves ship builds into `ship_build_combos.py` and leaves aggregate actions in `actions.py`.
@@ -70,8 +76,26 @@ Phase 1F shipped an interim flat `build_{hull}_{preset}` catalog in `actions.py`
 
 When `settings.acceleratedturns = N` with `N > 0`:
 
-- `prior_turn_score_data_available(turn)` in `analytic.py` returns false for `turn < N` (and turn 1), so `infer_military_score_build` emits `no_prior_turn` without calling the solver.
-- `build_inference_observation` uses `observation_deltas_from_score(score, turn)` instead of raw `militarychange` / `shipchange` / `freighterchange` on the first reliable row (`turn == N`).
+- **Unreliable rows** (`1 <= turn < N`): scoreboard deltas are not trustworthy for a single-host-turn solve. `prior_turn_score_data_available(turn)` in `inference_path.py` returns false for these rows (and for turn 1).
+- **First reliable row** (`turn == N`): `accelerated_inference_segments(score, turn)` splits activity into an optional `accel_window` segment (host turn `N-2`) and a `reported_host_turn` segment (host turn `N-1`). Each segment gets its own observation and a full YAML **policy ladder** solve via `policy_ladder.py` (`ACCELERATED_SPLIT` path).
+- **Later rows** (`turn > N`): use normal scoreboard deltas through `observation_deltas_from_score(score, turn)` and the single-row policy ladder (`POLICY_LADDER` path).
+
+**Resolve-then-dispatch:** `run_inference_with_artifacts` in `analytic.py` calls `resolve_inference_path` in `inference_path.py` before any solver work. The `InferencePath` enum selects orchestration:
+
+| Path | When | Solver behavior |
+|------|------|-----------------|
+| `NO_PRIOR_TURN` | Turn 1, or unreliable accelerated row with no backfill | Return `no_prior_turn` without CP-SAT |
+| `ACCELERATED_BACKFILL` | Unreliable accelerated row; first reliable turn stored | Re-run split inference from stored turn `N`; return the segment matching this row's host turn |
+| `ACCELERATED_SPLIT` | First reliable row (`turn == N`) | Per-segment policy ladders; primary API payload from `reported_host_turn` |
+| `POLICY_LADDER` | Normal rows with a prior scoreboard row | Single `solve_with_policy_ladder` call |
+| `CORPUS_PREBUILT` | Corpus harness passes a prebuilt catalog | Single solve on supplied catalog |
+
+**Accelerated backfill:** Unreliable accelerated rows (`turn < N`) can still produce inference when the game store holds turn `N`. `inference_target.py` loads the first reliable scoreboard turn via `load_scoreboard_turn`, recomputes `accelerated_inference_segments` from that stored row, and `analytic.py` runs the same split solve once. The row's host turn (`turn - 1`) selects which segment's solutions and catalog are returned. Diagnostics include `accelerated_backfill`, `accelerated_backfill_source_turn`, and `accelerated_backfill_host_turn`. The scores analytic supplies `load_scoreboard_turn` when storage is available; callers without it (e.g. bare `infer_military_score_build`) cannot backfill.
+
+**When `no_prior_turn` still applies:**
+
+- **Turn 1** -- no prior host turn (`diagnostics.reason`: `first_turn`).
+- **Unreliable accelerated row** (`turn < N`) when backfill cannot run: no `load_scoreboard_turn`, first reliable turn not stored, player missing on source turn, or no segment for the target host turn (`diagnostics.reason`: `accelerated_backfill_unavailable`).
 
 **Homeworld baseline:** `starting_scoreboard_snapshot(settings)` derives turn-1 military totals from Starmap flags (e.g. `homeworldhasstarbase`, standard homeworld starbase fighters and defense posts, one starting freighter). Shared homeworld constants used by the action catalog (e.g. Evil Empire free starbase fighter caps) also live in this module.
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -65,6 +65,7 @@ packages/api/api/analytics/military_score_inference/
 |-- scoring.py              # scaled military-score contribution formulas
 |-- score_arithmetic.py     # solution score breakdown for API diagnostics
 |-- solver.py               # OR-Tools CP-SAT adapter
+|-- inference_api_payload.py # inference result and solution API payload serialization
 `-- analytic.py             # run_inference_with_artifacts entry; path dispatch to solver paths
 ```
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -833,12 +833,28 @@ Files:
 
 - `assets/analytics/military_score_build_inference/tier_policy.yaml` (new),
 - `packages/api/api/analytics/military_score_inference/tier_policy.py` (new),
+- `packages/api/api/analytics/military_score_inference/policy_ladder.py` (ladder walk and top-K merge),
 - refactors to `actions.py`, `ship_build_combos.py`, `component_eligibility.py`, `analytic.py`, `constraints.py` (band retry only; warship/freighter stay exact).
 
 Done when:
 
 - acceptance criteria in #77 are met,
 - section 8.5 is authoritative over interim Phase 1G tier code paths.
+
+#### Branch composition and merge planning
+
+The **Issue_77** branch may bundle tier policy, accelerated-start inference, corpus probe tooling, and frontend diagnostics in one PR. The slices below are **logical review units** for attribution and merge discussion -- not a mandate to split git history unless explicitly requested.
+
+| Slice | Role | Primary ownership |
+|-------|------|-------------------|
+| **A** (merge gate) | Tier policy core per section 8.5; satisfies **#77** acceptance criteria | `tier_policy.yaml`, `tier_policy.py`, `policy_ladder.py`, `component_eligibility.py`; refactors to `actions.py`, `constraints.py` (band retry), `ship_build_combos.py`, `solver.py`, `analytic.py`; `test_military_score_inference_tier_policy.py` and related inference tests |
+| **B** (companion) | Accelerated-start inference dispatch | `accelerated_start.py`, `inference_target.py`, `inference_path.py`; scoreboard wiring in `scores.py`, `turn_analytic_service.py`; `test_accelerated_start_scoreboard.py` |
+| **C** (companion, optional split) | Corpus probe harness; inventory-only ground truth | `Makefile` targets (`inference_corpus`, `inference_corpus_discover`, `inference_corpus_probe`), `scripts/run_inference_corpus.py`, `packages/api/tests/inference_corpus/` (`worker.py`, `ground_truth.py`, `run.py`, `verify.py`, discovery/coverage/report), `test_inference_corpus_*.py`; spec touch-ups in `docs/design-inference-corpus.md` |
+| **D** (companion, optional split) | Frontend accelerated segments and wire parsing | `acceleratedInferenceSegments.ts`, `scoresWireParsers.ts`, `diagnosticsFromTable.ts`, `inferenceConstraints.ts`, `InferenceDetailModal.tsx`; matching `*.test.ts(x)` |
+
+**Merge gate:** slice **A** closes **#77**. Slices **B--D** are companion changes on the same branch that depend on or exercise the ladder but are not required to meet **#77** acceptance criteria.
+
+**Review recommendation:** approve **A + B** as one unit (backend tier policy plus accelerated-start solve dispatch). **C** and **D** can ship with the branch or split into follow-on PRs under epic **#39** (corpus harness **#62--#66**, frontend diagnostic polish) without blocking **#77** merge once **A** (and typically **B**) pass.
 
 ### Phase 1H: Per-row solution streaming (NDJSON)
 

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -306,7 +306,7 @@ Use repeated optimization:
 
 A no-good cut can be encoded with indicator variables that detect whether each action count differs from its previous value, then require at least one difference. Keep this inside `solver.py` so the rest of the analytic only sees top-K results.
 
-**Phase 1H (#71):** the same top-K loop can emit each discovered solution on the wire before the row is complete, so the UI can show a green tick (and open a partial modal) while later alternatives are still enumerating. Until that ships, the batch JSON path returns only after top-K or time budget.
+**Phase 1H (#71):** the policy ladder and per-tier top-K loop can emit each newly discovered exact explanation on the wire before the row is complete, so the UI can show an **inference solution count indicator** (and open a partial modal) while later alternatives are still enumerating. Until that ships, the batch JSON path returns only after top-K or time budget.
 
 The solver should return:
 
@@ -339,15 +339,15 @@ When inference is enabled, add one extra column to the existing scoreboard table
 
 | Icon | Meaning | Hover text | Click behavior |
 |------|---------|------------|----------------|
-| Green tick | At least one feasible solution found (search may continue until `isComplete`) | summarize top solution and alternative count | open modal with ranked solutions (grows while streaming) |
-| Hourglass | No feasible solution yet for this player row | show that inference is still running | no modal until at least one solution arrives |
+| **Inference solution count indicator** | Green outlined badge with **N** = rows currently held in **inference merged top-K** (`N > 0`). Search may continue until `isComplete`. | summarize top solution; note when search is still running | open modal with ranked held solutions (grows while streaming until plateau at K) |
+| Hourglass | No exact explanation held yet for this player row (`N = 0`) | show that inference is still running | no modal until the first held exact arrives |
 | Red cross | no solution, timeout, invalid problem, or solver failure | summarize failure status and key diagnostics | optionally open diagnostic modal if details exist |
 
-The row-level hourglass means the frontend should track inference status per player, not block the whole scoreboard table until all rows are solved. The table should remain useful while slower rows are still pending. With Phase 1H streaming (#71), the hourglass clears when the first `solution` event arrives, not when top-K enumeration finishes.
+The row-level hourglass means the frontend should track inference status per player, not block the whole scoreboard table until all rows are solved. The table should remain useful while slower rows are still pending. With Phase 1H streaming (#71), the hourglass clears when the first `solution` event is admitted to the held top-K (`N` becomes 1), not when top-K enumeration or the full policy ladder finishes.
 
 ### 7.3 Modal details
 
-The modal for a green tick should show:
+The modal for a row with **N > 0** should show:
 
 - player and turn transition,
 - observed deltas used as constraints,
@@ -373,7 +373,9 @@ Keep the Core solver as an internal component. The Core `scores` analytic should
 
 The BFF fetches inference **per scoreboard row** (`GET .../scores/inference?playerId=...`). The initial batch JSON response returns only after top-K enumeration or the per-row time budget.
 
-**Planned (Phase 1H, #71):** NDJSON stream per row (`solution`, optional `progress`, terminal `complete` / `error`), following the load-all progress pattern (`readNdjsonStream`, Zod-owned event shapes). The hourglass clears on the first `solution`; the modal can list partial results while search continues. Keep the batch JSON path for the inference corpus harness until the stream is proven.
+**Planned (Phase 1H, #71):** NDJSON stream per row (`solution`, optional `progress`, terminal `complete` / `error`), following the load-all progress pattern (`readNdjsonStream`, Zod-owned event shapes). Each `solution` event carries one newly admitted exact explanation plus **inference solution rank weight**; the consumer dedupes on **inference explanation signature** and maintains **inference merged top-K** ordering. The hourglass clears when the first `solution` is admitted (`N = 1`); the count badge and modal grow while search continues. Keep the batch JSON path for the inference corpus harness until the stream is proven.
+
+**#77 batch path (before #71):** same merge semantics (section 8.5.4) without wire events; `solutionCount` in the batch payload reflects final held top-K size.
 
 ---
 
@@ -555,7 +557,11 @@ Replace `_solve_with_tier_retry` hardcoded 0--4 with policy-driven loop:
 2. Build catalog: policy constraints intersect turn catalog intersect player actives; apply **tier aggregate allowlist** and caps.
 3. **Exact solve first** (military, warship, freighter equalities -- section constraints module).
 4. If INFEASIBLE and `alpha > 0`, **band retry** on military score only: `explained_2x >= observed_2x - alpha`; warship and freighter stay exact.
-5. **Exact solutions** from any step merge into top-K immediately (user-facing). **Do not** carry exact solutions forward as seeds -- no remainder to refine.
+5. **Exact solutions** from any step merge into **inference merged top-K** immediately (user-facing). **Do not** carry exact solutions forward as seeds -- no remainder to refine. Merge rules:
+   - **Accumulate across the full ladder.** Catalog widen at a step (new ship-build combo ids and/or newly admitted aggregate action ids) does **not** discard previously merged exact solutions. Later tiers are strict supersets on every dimension they control; an explanation exact at step *N* remains valid for the observation when re-checked against the final catalog reached.
+   - **Dedup:** identity is **inference explanation signature** (sorted multiset of aggregate action ids with counts plus ship-build combo ids with counts). Re-discovery at a later step is suppressed; first discovery wins. The same rule applies to batch merge and to stream emission in #71.
+   - **K-best retention:** default top-K is 20. When *K* distinct signatures are held, the ladder **continues** climbing tiers (do not stop solely because the buffer is full). A new signature is admitted only if its **inference solution rank weight** exceeds the current worst held row, which is then evicted.
+   - **Batch terminal status:** `exact` when **any** held row satisfies hard equalities (military, warship, freighter) against the **final** catalog at ladder end. Do not emit `exact` when rank-1 alone fails hard equalities but another held row would pass.
 6. **Band near-solutions** (up to `maxSeeds` distinct per step) seed the **next** step only:
    - **Fix** ship-build combo counts from the seed.
    - Admit newly unlocked aggregate actions to close residual military score.
@@ -569,9 +575,11 @@ Record in diagnostics: policy step `id`, index, `tiersAttempted`, resolved const
 
 | Outcome | UI |
 |---------|-----|
-| At least one **exact** solution from any policy step | Green tick; merged top-K across steps |
+| At least one **exact** solution from any policy step | **Inference solution count indicator** with **N** = held top-K size; merged top-K across steps |
 | Full ladder, zero exact | Red cross / `no_exact_solution`; diagnostics include best band residual from internal retries |
 | Band near-solution | Never shown directly; seeds next step only |
+
+While search is in flight (#71), **N** rises from 1 toward K as new signatures are admitted, then plateaus at K when the buffer is full (eviction swaps membership without changing **N**). Hourglass until **N > 0**; red cross only after terminal `complete` / batch response with zero held exact.
 
 Do not emit `exact-with-deferred-risk` for band-feasible multisets in #77; that status remains for future deferred-effect modeling (#49).
 
@@ -834,29 +842,32 @@ Done when:
 
 ### Phase 1H: Per-row solution streaming (NDJSON)
 
-Goal: expose ranked solutions **within each scoreboard row** as they are discovered, so the UI is not blocked on full top-K enumeration.
+Goal: expose exact explanations **within each scoreboard row** as they are admitted to **inference merged top-K**, so the UI is not blocked on full top-K enumeration or full policy-ladder completion.
 
-GitHub: **#71**.
+GitHub: **#71**. Depends on **#77** ladder merge semantics (section 8.5.4): cross-tier accumulation, signature dedup, K-best eviction.
 
 Files:
 
-- `packages/api/api/analytics/military_score_inference/solver.py` (yield/callback per solution),
+- `packages/api/api/analytics/military_score_inference/policy_ladder.py` (emit hook on merge admit),
+- `packages/api/api/analytics/military_score_inference/solver.py` (yield/callback per within-tier solution),
 - Core + BFF inference routes (NDJSON stream alongside existing batch JSON),
 - `packages/frontend/src/api/` (Zod schemas + parser for stream events),
-- `packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts` (consume stream, partial modal),
+- `packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts` (consume stream, count badge, partial modal),
 - tests at API, BFF, and frontend layers.
 
 Steps:
 
 1. Define NDJSON event types: `solution`, optional `progress`, terminal `complete` / `error`.
-2. Refactor the top-K loop to flush each feasible solution before the next no-good cut.
-3. Add stream endpoint on Core and BFF; document in BFF OpenAPI for visibility; treat Zod as authoritative for frontend parsing.
-4. Update row UI: hourglass until first `solution`; tick when `solutionCount >= 1`; `isComplete` when `complete` arrives; abort on game/turn/perspective change.
-5. Retain batch JSON for corpus harness (`infer_military_score_build`) until stream parity is verified; then revisit `max_solutions=1` combo-count fallback.
+2. Emit `solution` when the ladder admits a **new** **inference explanation signature** to held top-K (within-tier enumeration and cross-tier ladder progress). Payload includes full explanation rows plus **inference solution rank weight**. Do not re-emit suppressed re-discoveries.
+3. Refactor the within-tier top-K loop to flush each feasible solution to the emit hook before the next no-good cut.
+4. Add stream endpoint on Core and BFF; document in BFF OpenAPI for visibility; treat Zod as authoritative for frontend parsing.
+5. Update row UI: hourglass until first admitted `solution` (`N = 0`); **inference solution count indicator** with **N** = held top-K size once `N > 0`; subtle in-progress affordance while `!isComplete`; `complete` sets terminal `status` (`exact` when any held row passes final-catalog hard equalities). Abort on game/turn/perspective change.
+6. Retain batch JSON for corpus harness (`infer_military_score_build`) until stream parity is verified; then revisit `max_solutions=1` combo-count fallback.
 
 Done when:
 
-- first solution appears before top-K completes on large catalogs,
+- first admitted solution appears before top-K enumeration and policy-ladder completion on large catalogs,
+- count badge **N** always matches modal row count (held top-K, not cumulative discoveries above K),
 - partial rows are not misclassified as failure,
 - `make lint` and relevant package tests pass.
 
@@ -940,7 +951,7 @@ Steps:
 1. Add a checkbox labeled `Include build inference` to the Scores analytic controls.
 2. Include the checkbox state in the scores query key.
 3. Render the inference column only when enabled.
-4. Render green tick, hourglass, or red cross based on row status.
+4. Render inference solution count indicator, hourglass, or red cross based on row status.
 5. Add hover text with the row summary.
 6. Keep the normal scoreboard table fast and unchanged when the checkbox is off.
 
@@ -968,7 +979,7 @@ Files:
 
 Steps:
 
-1. Open the modal when the user clicks a green tick.
+1. Open the modal when the user clicks a row with **N > 0**.
 2. Show solutions in descending objective/probability order.
 3. Show observed deltas, action breakdown, score arithmetic, and warnings.
 4. Do not open a solution modal for hourglass rows.
@@ -976,7 +987,7 @@ Steps:
 
 Tests:
 
-- clicking a green tick opens the modal,
+- clicking a count badge opens the modal,
 - solutions are displayed in order,
 - hourglass rows are non-clickable or explain that solving is pending,
 - modal closes cleanly and does not reset the Scores checkbox.
@@ -1135,6 +1146,6 @@ The user-facing scoreboard integration should be considered complete when:
 - the existing Scores table contract is unchanged when inference is disabled,
 - the Scores tile includes an `Include build inference` checkbox,
 - enabling inference adds an inference column with row-level status,
-- green tick rows open a modal with ranked solution details,
+- rows with **N > 0** open a modal with ranked held solution details,
 - BFF and frontend code never import OR-Tools or encode solver rules directly,
 - `make lint` and the relevant API, BFF, and frontend tests pass.

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -384,9 +384,9 @@ The inference engine should return a per-player list of explanations that can en
 - warnings about ignored deferred effects,
 - a compact summary suitable for a scoreboard cell.
 
-The user-facing feature should be an optional capability of the existing Scores analytic rather than a separate analytic. When enabled, the scoreboard adds an inference column with row-level status: green tick for at least one solution, hourglass while a row has no solution yet, and red cross for no solution or solver failure. Hover text should summarize the result. Clicking a green tick should open a modal with the detailed ranked explanations, including action vectors and score arithmetic.
+The user-facing feature should be an optional capability of the existing Scores analytic rather than a separate analytic. When enabled, the scoreboard adds an inference column with row-level status: an **inference solution count indicator** (green outlined badge with **N** = held top-K size) when **N > 0**, hourglass while **N = 0** and search is in flight, and red cross when the row completes with no exact explanation or on solver failure. Hover text should summarize the result. Clicking the badge opens a modal with the detailed ranked held explanations, including action vectors and score arithmetic.
 
-**Streaming (#71):** each row's solver should eventually stream ranked solutions over NDJSON as they are found (hourglass clears on the first solution; the modal can grow while top-K enumeration continues). Until that ships, the UI waits for the full per-row JSON response. See [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md) Phase 1H.
+**Streaming (#71):** each row's policy ladder should stream newly admitted exact explanations over NDJSON as they are found (hourglass clears when **N** becomes 1; the badge and modal grow while search continues). Until that ships, the UI waits for the full per-row JSON response. See [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md) Phase 1H and section 8.5.4.
 
 ---
 

--- a/packages/api/api/analytics/military_score_inference/accelerated_start.py
+++ b/packages/api/api/analytics/military_score_inference/accelerated_start.py
@@ -2,9 +2,7 @@
 
 During accelerated start (``settings.acceleratedturns`` = N), scoreboard rows on
 turns 1..N-1 are not filled in correctly. The first reliable score row is on
-host turn N. Inference on that turn explains activity since game start, so the
-effective prior military total is the standard homeworld starting score, not the
-zeroed prior-turn row.
+host turn N.
 
 On turn N the row shows **current totals** and **deltas for host turn N-1 only**
 (not cumulative over the accelerated window). Example (N=3, one starting
@@ -12,6 +10,14 @@ freighter): a freighter built on host turn 1 and a warship on host turn 2 appear
 as ``Freighters 2 (+0)``, ``Military 1 (+1)`` -- the ``+0`` is relative to
 inferred turn-2 totals (2 freighters already), while turn-1 freighter construction
 is recovered by comparing inferred turn N-1 counts to the turn-1 baseline.
+
+Build inference on the first reliable row runs **two separate solves**:
+
+1. **Reported host turn** (N-1): ``militarychange`` / ``shipchange`` / ``freighterchange``
+   on the turn N score row.
+2. **Accelerated window** (host turns before N-1): military residual
+   ``(militaryscore - baseline) - militarychange`` plus ship counts from
+   ``infer_accelerated_window_ship_builds()``.
 """
 
 from dataclasses import dataclass, replace
@@ -33,6 +39,11 @@ HOMEBASE_STARTING_CAPITAL_SHIPS = 0
 HOMEBASE_STARTING_STARBASES = 1
 STANDARD_STARBASE_MAX_FIGHTERS = 60
 
+# Scoreboard ``militarychange`` is stored in 1x integer units. Half-point military
+# components (starbase fighters, defense posts) can lose up to one 2x unit when a host-turn
+# delta is rounded or when an accelerated-start segment partition subtracts 1x values.
+SCOREBOARD_MILITARY_PARTITION_SLACK_2X = 1
+
 
 @dataclass(frozen=True)
 class ScoreboardSnapshot:
@@ -43,6 +54,18 @@ class ScoreboardSnapshot:
     freighters: int
     starbases: int
     prioritypoints: int = 0
+
+
+@dataclass(frozen=True)
+class AcceleratedInferenceSegment:
+    """One accelerated-start inference target (accel window or reported host turn)."""
+
+    segment_id: str
+    host_turn: int
+    military_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    priority_point_delta: int
 
 
 @dataclass(frozen=True)
@@ -74,6 +97,37 @@ def is_first_reliable_scoreboard_turn(turn_number: int, settings: GameSettings) 
     return accelerated > 0 and turn_number == accelerated
 
 
+def first_reliable_accelerated_scoreboard_turn(settings: GameSettings) -> int | None:
+    """Scoreboard turn that runs the accelerated split solve, when accelerated start is enabled."""
+    accelerated = accelerated_turn_count(settings)
+    return accelerated if accelerated > 0 else None
+
+
+def scoreboard_host_turn(scoreboard_turn: int) -> int | None:
+    """Host turn whose delta is shown on a scoreboard row (row turn N shows host turn N-1)."""
+    if scoreboard_turn <= 1:
+        return None
+    return scoreboard_turn - 1
+
+
+def needs_accelerated_backfill(scoreboard_turn: int, settings: GameSettings) -> bool:
+    """Whether this unreliable accelerated row should be filled from the first reliable split."""
+    if not is_unreliable_accelerated_scoreboard_turn(scoreboard_turn, settings):
+        return False
+    return scoreboard_host_turn(scoreboard_turn) is not None
+
+
+def homeworld_baseline_military_2x(settings: GameSettings) -> int:
+    """Homeworld starting military score in 2x integer units (no per-component truncation)."""
+    if not settings.homeworldhasstarbase:
+        return 0
+    return (
+        starbase_defense_post_score_delta_2x(HOMEBASE_STARBASE_DEFENSE_POSTS)
+        + starbase_fighter_score_delta_2x(HOMEBASE_STARBASE_FIGHTERS)
+        + planet_defense_post_score_delta_2x(HOMEBASE_PLANET_DEFENSE_POSTS)
+    )
+
+
 def starting_scoreboard_snapshot(settings: GameSettings) -> ScoreboardSnapshot:
     """Homeworld baseline totals at game start (turn 1) under normal Starmap settings."""
     if not settings.homeworldhasstarbase:
@@ -84,16 +138,30 @@ def starting_scoreboard_snapshot(settings: GameSettings) -> ScoreboardSnapshot:
             starbases=0,
         )
 
-    militaryscore = (
-        starbase_defense_post_score_delta_2x(HOMEBASE_STARBASE_DEFENSE_POSTS) // 2
-        + starbase_fighter_score_delta_2x(HOMEBASE_STARBASE_FIGHTERS) // 2
-        + planet_defense_post_score_delta_2x(HOMEBASE_PLANET_DEFENSE_POSTS) // 2
-    )
     return ScoreboardSnapshot(
-        militaryscore=militaryscore,
+        militaryscore=homeworld_baseline_military_2x(settings) // 2,
         capitalships=HOMEBASE_STARTING_CAPITAL_SHIPS,
         freighters=HOMEBASE_STARTING_FREIGHTERS,
         starbases=HOMEBASE_STARTING_STARBASES,
+    )
+
+
+def cumulative_military_delta_2x(score: Score, settings: GameSettings) -> int:
+    """Military score gained since homeworld baseline, in 2x integer units."""
+    return 2 * score.militaryscore - homeworld_baseline_military_2x(settings)
+
+
+def reported_host_military_delta_2x(score: Score) -> int:
+    """Reported host-turn military delta on a scoreboard row, in 2x integer units."""
+    return 2 * score.militarychange
+
+
+def accelerated_window_military_delta_2x(score: Score, turn: TurnInfo) -> int:
+    """Military score increase in the accelerated window before the reported host turn (2x)."""
+    if not is_first_reliable_scoreboard_turn(turn.settings.turn, turn.settings):
+        return 0
+    return cumulative_military_delta_2x(score, turn.settings) - reported_host_military_delta_2x(
+        score
     )
 
 
@@ -149,29 +217,67 @@ def observation_deltas_from_score(
     score: Score,
     turn: TurnInfo,
 ) -> tuple[int, int, int, int]:
-    """Return (military_delta_2x, warship_delta, freighter_delta, priority_point_delta)."""
-    settings = turn.settings
-    turn_number = settings.turn
-    if is_first_reliable_scoreboard_turn(turn_number, settings):
-        baseline = starting_scoreboard_snapshot(settings)
-        military_change = score.militaryscore - baseline.militaryscore
-        # Warships since turn-1 baseline; ``shipchange`` is only host turn N-1.
-        warship_delta = score.capitalships - baseline.capitalships
-        # Freighters do not affect military score; keep scoreboard freighterchange
-        # (host N-1 only). Use infer_accelerated_window_ship_builds() for accel-window
-        # freighter construction inferred from totals vs baseline.
-        freighter_delta = score.freighterchange
-        return (
-            2 * military_change,
-            warship_delta,
-            freighter_delta,
-            score.prioritypointchange,
-        )
+    """Return scoreboard-row deltas for the reported host turn on this row."""
+    del turn
     return (
-        2 * score.militarychange,
+        reported_host_military_delta_2x(score),
         score.shipchange,
         score.freighterchange,
         score.prioritypointchange,
+    )
+
+
+def accelerated_window_military_change(score: Score, turn: TurnInfo) -> int:
+    """Military score increase in the accelerated window before the reported host turn (1x)."""
+    return accelerated_window_military_delta_2x(score, turn) // 2
+
+
+def accelerated_inference_segments(
+    score: Score,
+    turn: TurnInfo,
+) -> tuple[AcceleratedInferenceSegment, ...] | None:
+    """Split first reliable accelerated row into accel-window and reported-host-turn targets."""
+    if not is_first_reliable_scoreboard_turn(turn.settings.turn, turn.settings):
+        return None
+
+    builds = infer_accelerated_window_ship_builds(score, turn)
+    if builds is None:
+        return None
+
+    reported_host_turn = turn.settings.turn - 1
+    accel_host_turn = turn.settings.turn - 2
+    segments: list[AcceleratedInferenceSegment] = []
+
+    accel_segment = AcceleratedInferenceSegment(
+        segment_id="accel_window",
+        host_turn=accel_host_turn,
+        military_delta_2x=accelerated_window_military_delta_2x(score, turn),
+        warship_delta=builds.warships_built_before_reported_host_turn,
+        freighter_delta=builds.freighters_built_before_reported_host_turn,
+        priority_point_delta=0,
+    )
+    if _segment_has_inference_targets(accel_segment):
+        segments.append(accel_segment)
+
+    segments.append(
+        AcceleratedInferenceSegment(
+            segment_id="reported_host_turn",
+            host_turn=reported_host_turn,
+            military_delta_2x=reported_host_military_delta_2x(score),
+            warship_delta=score.shipchange,
+            freighter_delta=score.freighterchange,
+            priority_point_delta=score.prioritypointchange,
+        )
+    )
+    return tuple(segments)
+
+
+def _segment_has_inference_targets(segment: AcceleratedInferenceSegment) -> bool:
+    return (
+        segment.military_delta_2x != 0
+        or segment.warship_delta != 0
+        or segment.freighter_delta != 0
+        or segment.priority_point_delta != 0
     )
 
 

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -1,6 +1,6 @@
 """Bounded aggregate action catalog for military score build inference."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from api.analytics.military_score_inference.accelerated_start import (
     HOMEBASE_STARBASE_FIGHTERS,
@@ -8,7 +8,7 @@ from api.analytics.military_score_inference.accelerated_start import (
 )
 from api.analytics.military_score_inference.component_eligibility import (
     player_by_id,
-    turn_catalog_context_for_tier,
+    turn_catalog_context_for_policy_step,
 )
 from api.analytics.military_score_inference.models import (
     CandidateAction,
@@ -26,9 +26,13 @@ from api.analytics.military_score_inference.scoring import (
     starbase_fighter_score_delta_2x,
 )
 from api.analytics.military_score_inference.ship_build_combos import (
-    DEFAULT_SHIP_BUILD_TIER,
     ShipBuildComboConfig,
     generate_ship_build_combos,
+)
+from api.analytics.military_score_inference.tier_policy import (
+    InferenceTierPolicyStep,
+    resolve_tier_policies,
+    resolved_aggregate_cap,
 )
 from api.concepts.races import (
     evil_empire_free_starbase_fighters_per_host_turn,
@@ -94,7 +98,8 @@ class ActionCatalog:
     aggregate_actions: tuple[CandidateAction, ...]
     ship_build_combos: tuple[ShipBuildCombo, ...]
     probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]]
-    ship_build_tier: int = DEFAULT_SHIP_BUILD_TIER
+    policy_step_id: str = ""
+    policy_step_index: int = 0
 
     @property
     def catalog_size(self) -> int:
@@ -105,7 +110,8 @@ class ActionCatalog:
             "catalog_size": self.catalog_size,
             "aggregate_action_count": len(self.aggregate_actions),
             "ship_build_combo_count": len(self.ship_build_combos),
-            "ship_build_tier": self.ship_build_tier,
+            "policy_step_id": self.policy_step_id,
+            "policy_step_index": self.policy_step_index,
             "bucketed_action_count": sum(
                 1 for action in self.aggregate_actions if action.id in BUCKETED_ACTION_IDS
             ),
@@ -118,15 +124,28 @@ def build_inference_problem(
     *,
     max_solutions: int | None = None,
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
+    military_score_alpha: int = 0,
+    fixed_combo_counts: dict[str, int] | None = None,
+    combo_count_neighborhood: int = 0,
 ) -> InferenceProblem:
+    aggregate_actions = catalog.aggregate_actions
+    ship_build_combos = catalog.ship_build_combos
+    if fixed_combo_counts:
+        ship_build_combos = _apply_combo_count_constraints(
+            ship_build_combos,
+            fixed_combo_counts=fixed_combo_counts,
+            neighborhood=combo_count_neighborhood,
+        )
     return InferenceProblem(
         observation=observation,
-        aggregate_actions=catalog.aggregate_actions,
-        ship_build_combos=catalog.ship_build_combos,
-        ship_build_tier=catalog.ship_build_tier,
+        aggregate_actions=aggregate_actions,
+        ship_build_combos=ship_build_combos,
+        policy_step_id=catalog.policy_step_id,
+        policy_step_index=catalog.policy_step_index,
         probability_buckets_by_action_id=catalog.probability_buckets_by_action_id,
         max_solutions=20 if max_solutions is None else max_solutions,
         time_limit_seconds=time_limit_seconds,
+        military_score_alpha=military_score_alpha,
     )
 
 
@@ -135,12 +154,16 @@ def build_action_catalog_from_turn(
     turn: TurnInfo,
     *,
     config: ActionCatalogConfig | None = None,
-    ship_build_tier: int = DEFAULT_SHIP_BUILD_TIER,
+    policy_step: InferenceTierPolicyStep | None = None,
+    policy_step_index: int = 0,
 ) -> ActionCatalog:
-    catalog_context = turn_catalog_context_for_tier(
+    resolved_policy_step = policy_step
+    if resolved_policy_step is None:
+        resolved_policy_step = resolve_tier_policies()[0]
+    catalog_context = turn_catalog_context_for_policy_step(
         turn,
         observation.player_id,
-        ship_build_tier,
+        resolved_policy_step,
     )
     return build_action_catalog(
         observation,
@@ -154,7 +177,8 @@ def build_action_catalog_from_turn(
         eligible_torp_ids=catalog_context.eligible_torp_ids,
         config=config,
         turn=turn,
-        ship_build_tier=ship_build_tier,
+        policy_step=resolved_policy_step,
+        policy_step_index=policy_step_index,
     )
 
 
@@ -171,20 +195,26 @@ def build_action_catalog(
     eligible_torp_ids: frozenset[int],
     config: ActionCatalogConfig | None = None,
     turn: TurnInfo | None = None,
-    ship_build_tier: int = DEFAULT_SHIP_BUILD_TIER,
+    policy_step: InferenceTierPolicyStep | None = None,
+    policy_step_index: int = 0,
 ) -> ActionCatalog:
+    resolved_policy_step = policy_step or resolve_tier_policies()[-1]
     catalog_config = config or ActionCatalogConfig()
     actions: list[CandidateAction] = []
     probability_buckets: dict[str, tuple[ProbabilityBucket, ...]] = {}
 
-    actions.extend(_aggregate_noisy_actions(observation, catalog_config, torpedos_by_id))
+    actions.extend(
+        _aggregate_noisy_actions(
+            observation,
+            catalog_config,
+            torpedos_by_id,
+            resolved_policy_step.aggregate_allowlist,
+        )
+    )
     if turn is not None:
         actions.extend(
             _evil_empire_free_starbase_fighter_actions(observation, turn, catalog_config)
         )
-    actions.extend(
-        _fighter_transfer_actions(observation, catalog_config),
-    )
 
     kept_actions: list[CandidateAction] = []
     for action in actions:
@@ -207,15 +237,38 @@ def build_action_catalog(
         eligible_beam_ids=eligible_beam_ids,
         eligible_torp_ids=eligible_torp_ids,
         config=catalog_config.ship_build_combo_config,
-        ship_build_tier=ship_build_tier,
+        beam_slot_counts=resolved_policy_step.beam_slot_counts,
+        launcher_slot_counts=resolved_policy_step.launcher_slot_counts,
     )
 
     return ActionCatalog(
         aggregate_actions=tuple(kept_actions),
         ship_build_combos=ship_build_combos,
         probability_buckets_by_action_id=probability_buckets,
-        ship_build_tier=ship_build_tier,
+        policy_step_id=resolved_policy_step.id,
+        policy_step_index=policy_step_index,
     )
+
+
+def _apply_combo_count_constraints(
+    combos: tuple[ShipBuildCombo, ...],
+    *,
+    fixed_combo_counts: dict[str, int],
+    neighborhood: int,
+) -> tuple[ShipBuildCombo, ...]:
+    constrained: list[ShipBuildCombo] = []
+    for combo in combos:
+        if combo.combo_id not in fixed_combo_counts:
+            constrained.append(replace(combo, lower_bound=0, upper_bound=0))
+            continue
+        seed_count = fixed_combo_counts[combo.combo_id]
+        if neighborhood <= 0:
+            constrained.append(replace(combo, lower_bound=seed_count, upper_bound=seed_count))
+            continue
+        lower_bound = max(combo.lower_bound, max(0, seed_count - neighborhood))
+        upper_bound = min(combo.upper_bound, seed_count + neighborhood)
+        constrained.append(replace(combo, lower_bound=lower_bound, upper_bound=upper_bound))
+    return tuple(constrained)
 
 
 def _residual_count_bound(
@@ -229,7 +282,7 @@ def _residual_count_bound(
         return 0
 
     abs_score = abs(score_delta_2x)
-    abs_residual = abs(observation.military_delta_2x)
+    abs_residual = abs(observation.military_delta_2x) + observation.military_partition_slack_2x
     return min(configured_cap, abs_residual // abs_score)
 
 
@@ -279,8 +332,11 @@ def _aggregate_noisy_actions(
     observation: InferenceObservation,
     config: ActionCatalogConfig,
     torpedos_by_id: dict[int, Torpedo],
+    aggregate_allowlist: dict[str, int],
 ) -> list[CandidateAction]:
-    actions = [
+    actions: list[CandidateAction] = []
+
+    fine_grained_candidates = [
         CandidateAction(
             id="planet_defense_posts_added_total",
             label="Planet defense posts added",
@@ -329,7 +385,7 @@ def _aggregate_noisy_actions(
     for torpedo_id in sorted(torpedos_by_id):
         torpedo = torpedos_by_id[torpedo_id]
         per_torpedo_score = loaded_ship_torpedo_score_delta_2x(torpedo.torpedocost)
-        actions.append(
+        fine_grained_candidates.append(
             CandidateAction(
                 id=f"ship_torps_loaded_{torpedo_id}",
                 label=f"Ship torpedoes loaded ({torpedo.name})",
@@ -342,13 +398,7 @@ def _aggregate_noisy_actions(
                 probability_weight=config.noisy_action_probability_weight,
             )
         )
-    return actions
 
-
-def _fighter_transfer_actions(
-    observation: InferenceObservation,
-    config: ActionCatalogConfig,
-) -> list[CandidateAction]:
     transfer_cap = min(
         config.max_fighter_transfers,
         _residual_count_bound(
@@ -357,22 +407,35 @@ def _fighter_transfer_actions(
             config.max_fighter_transfers,
         ),
     )
-    return [
-        CandidateAction(
-            id="fighters_starbase_to_ship",
-            label="Fighters transferred starbase to ship",
-            score_delta_2x=STARBASE_FIGHTER_SCORE_DELTA_2X,
-            upper_bound=transfer_cap,
-            probability_weight=config.fighter_transfer_probability_weight,
-        ),
-        CandidateAction(
-            id="fighters_ship_to_starbase",
-            label="Fighters transferred ship to starbase",
-            score_delta_2x=-STARBASE_FIGHTER_SCORE_DELTA_2X,
-            upper_bound=transfer_cap,
-            probability_weight=config.fighter_transfer_probability_weight,
-        ),
-    ]
+    fine_grained_candidates.extend(
+        [
+            CandidateAction(
+                id="fighters_starbase_to_ship",
+                label="Fighters transferred starbase to ship",
+                score_delta_2x=STARBASE_FIGHTER_SCORE_DELTA_2X,
+                upper_bound=transfer_cap,
+                probability_weight=config.fighter_transfer_probability_weight,
+            ),
+            CandidateAction(
+                id="fighters_ship_to_starbase",
+                label="Fighters transferred ship to starbase",
+                score_delta_2x=-STARBASE_FIGHTER_SCORE_DELTA_2X,
+                upper_bound=transfer_cap,
+                probability_weight=config.fighter_transfer_probability_weight,
+            ),
+        ]
+    )
+
+    for action in fine_grained_candidates:
+        allowlist_cap = resolved_aggregate_cap(action.id, aggregate_allowlist)
+        if allowlist_cap is None:
+            continue
+        capped_upper = min(action.upper_bound, allowlist_cap)
+        if capped_upper <= 0:
+            continue
+        actions.append(replace(action, upper_bound=capped_upper))
+
+    return actions
 
 
 def _probability_buckets_for_action(action_id: str) -> tuple[ProbabilityBucket, ...]:

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -2,8 +2,6 @@
 
 from api.analytics.military_score_inference.accelerated_start import (
     AcceleratedInferenceSegment,
-    accelerated_inference_segments,
-    accelerated_turn_count,
     needs_accelerated_backfill,
     observation_deltas_from_score,
     scoreboard_host_turn,
@@ -20,14 +18,10 @@ from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
     observation_to_constraints_payload,
 )
-from api.analytics.military_score_inference.models import (
-    InferenceObservation,
-    InferenceProblem,
-    InferenceResult,
-    InferenceSolution,
-)
-from api.analytics.military_score_inference.score_arithmetic import (
-    solution_military_score_arithmetic_payload,
+from api.analytics.military_score_inference.inference_path import (
+    InferencePath,
+    prior_turn_score_data_available,
+    resolve_inference_path,
 )
 from api.analytics.military_score_inference.inference_target import (
     ScoreboardTurnLoader,
@@ -36,7 +30,16 @@ from api.analytics.military_score_inference.inference_target import (
     observation_from_accelerated_segment,
     observation_from_deltas,
 )
+from api.analytics.military_score_inference.models import (
+    InferenceObservation,
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+)
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
+from api.analytics.military_score_inference.score_arithmetic import (
+    solution_military_score_arithmetic_payload,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
@@ -50,18 +53,13 @@ from api.models.player import Score
 STATUS_NO_PRIOR_TURN = "no_prior_turn"
 STATUS_SOLVER_ERROR = "solver_error"
 
+__all__ = [
+    "is_after_ship_limit",
+    "prior_turn_score_data_available",
+    "run_inference_with_artifacts",
+]
+
 AcceleratedSegmentArtifacts = tuple[InferenceObservation, ActionCatalog]
-
-
-def prior_turn_score_data_available(turn: TurnInfo) -> bool:
-    """Return whether this turn has a prior scoreboard row to infer from."""
-    turn_number = turn.settings.turn
-    if turn_number <= 1:
-        return False
-    accelerated = accelerated_turn_count(turn.settings)
-    if accelerated > 0 and turn_number < accelerated:
-        return False
-    return True
 
 
 def _no_prior_turn_reason(turn: TurnInfo) -> str:
@@ -183,67 +181,125 @@ def build_inference_solver_diagnostics(
     return payload
 
 
-def run_inference_with_artifacts(
+def _no_prior_turn_inference_result(
+    turn: TurnInfo,
+    resolved_observation: InferenceObservation,
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
+    return (
+        _inference_api_payload(
+            status=STATUS_NO_PRIOR_TURN,
+            summary="Prior turn score data unavailable",
+            solutions=(),
+            diagnostics=build_inference_solver_diagnostics(
+                turn=turn.settings.turn,
+                observation=resolved_observation,
+                turn_info=turn,
+                extra={"reason": _no_prior_turn_reason(turn)},
+            ),
+        ),
+        resolved_observation,
+        None,
+    )
+
+
+def _run_accelerated_backfill_inference(
     score: Score,
     turn: TurnInfo,
+    resolved_observation: InferenceObservation,
     *,
-    observation: InferenceObservation | None = None,
-    catalog: ActionCatalog | None = None,
-    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+    load_scoreboard_turn: ScoreboardTurnLoader | None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
-    """Run inference once; return API payload plus observation and catalog for re-checks.
-
-    When ``observation`` and ``catalog`` are supplied (e.g. corpus harness), they are
-    reused for solving and returned unchanged so constraint re-check uses the same
-    catalog instance as coverage evaluation.
-    """
-    turn_number = turn.settings.turn
-    resolved_observation = (
-        observation if observation is not None else build_inference_observation(score, turn)
+    backfill = _try_accelerated_backfill_inference(
+        score,
+        turn,
+        load_scoreboard_turn=load_scoreboard_turn,
     )
-    if not prior_turn_score_data_available(turn):
-        backfill = _try_accelerated_backfill_inference(
-            score,
-            turn,
-            load_scoreboard_turn=load_scoreboard_turn,
-        )
-        if backfill is not None:
-            return backfill
-        return (
-            _inference_api_payload(
-                status=STATUS_NO_PRIOR_TURN,
-                summary="Prior turn score data unavailable",
-                solutions=(),
-                diagnostics=build_inference_solver_diagnostics(
-                    turn=turn_number,
-                    observation=resolved_observation,
-                    turn_info=turn,
-                    extra={"reason": _no_prior_turn_reason(turn)},
-                ),
+    if backfill is not None:
+        return backfill
+    return _no_prior_turn_inference_result(turn, resolved_observation)
+
+
+def _run_accelerated_split_inference_path(
+    score: Score,
+    turn: TurnInfo,
+    segments: tuple[AcceleratedInferenceSegment, ...],
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
+    payload, reported_observation, reported_catalog, _ = _run_accelerated_split_inference(
+        score,
+        turn,
+        segments,
+    )
+    return payload, reported_observation, reported_catalog
+
+
+def _run_policy_ladder_inference(
+    resolved_observation: InferenceObservation,
+    turn: TurnInfo,
+) -> tuple[InferenceResult, ActionCatalog, InferenceProblem, list[str], list[dict[str, object]]]:
+    return solve_with_policy_ladder(
+        resolved_observation,
+        turn,
+    )
+
+
+def _run_corpus_prebuilt_inference(
+    resolved_observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> tuple[InferenceResult, ActionCatalog, InferenceProblem, list[str], list[dict[str, object]]]:
+    problem = build_inference_problem(resolved_observation, catalog)
+    result = solve_inference_problem(problem)
+    return result, catalog, problem, [catalog.policy_step_id], []
+
+
+def _solver_error_inference_result(
+    turn: TurnInfo,
+    resolved_observation: InferenceObservation,
+    solve_catalog: ActionCatalog | None,
+    exc: Exception,
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
+    return (
+        _inference_api_payload(
+            status=STATUS_SOLVER_ERROR,
+            summary="Build inference failed",
+            solutions=(),
+            diagnostics=build_inference_solver_diagnostics(
+                turn=turn.settings.turn,
+                observation=resolved_observation,
+                catalog=solve_catalog,
+                turn_info=turn,
+                extra={"error": str(exc)},
             ),
-            resolved_observation,
-            None,
-        )
+        ),
+        resolved_observation,
+        solve_catalog,
+    )
+
+
+def _run_solver_inference_path(
+    path: InferencePath,
+    score: Score,
+    turn: TurnInfo,
+    resolved_observation: InferenceObservation,
+    *,
+    catalog: ActionCatalog | None,
+    accelerated_segments: tuple[AcceleratedInferenceSegment, ...] | None,
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
+    if path == InferencePath.ACCELERATED_SPLIT:
+        assert accelerated_segments is not None
+        return _run_accelerated_split_inference_path(score, turn, accelerated_segments)
 
     solve_catalog = catalog
     try:
-        if solve_catalog is None:
-            segments = accelerated_inference_segments(score, turn)
-            if segments is not None:
-                split_result = _run_accelerated_split_inference(score, turn, segments)
-                payload, reported_observation, reported_catalog, _ = split_result
-                return payload, reported_observation, reported_catalog
+        if path == InferencePath.POLICY_LADDER:
             result, solve_catalog, problem, policy_steps_attempted, step_diagnostics = (
-                solve_with_policy_ladder(
-                    resolved_observation,
-                    turn,
-                )
+                _run_policy_ladder_inference(resolved_observation, turn)
             )
         else:
-            policy_steps_attempted = [solve_catalog.policy_step_id]
-            step_diagnostics = []
-            problem = build_inference_problem(resolved_observation, solve_catalog)
-            result = solve_inference_problem(problem)
+            assert path == InferencePath.CORPUS_PREBUILT
+            assert solve_catalog is not None
+            result, solve_catalog, problem, policy_steps_attempted, step_diagnostics = (
+                _run_corpus_prebuilt_inference(resolved_observation, solve_catalog)
+            )
         return (
             inference_result_to_api_payload(
                 result,
@@ -258,22 +314,50 @@ def run_inference_with_artifacts(
             solve_catalog,
         )
     except Exception as exc:
-        return (
-            _inference_api_payload(
-                status=STATUS_SOLVER_ERROR,
-                summary="Build inference failed",
-                solutions=(),
-                diagnostics=build_inference_solver_diagnostics(
-                    turn=turn_number,
-                    observation=resolved_observation,
-                    catalog=solve_catalog,
-                    turn_info=turn,
-                    extra={"error": str(exc)},
-                ),
-            ),
+        return _solver_error_inference_result(turn, resolved_observation, solve_catalog, exc)
+
+
+def run_inference_with_artifacts(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    observation: InferenceObservation | None = None,
+    catalog: ActionCatalog | None = None,
+    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
+    """Run inference once; return API payload plus observation and catalog for re-checks.
+
+    When ``observation`` and ``catalog`` are supplied (e.g. corpus harness), they are
+    reused for solving and returned unchanged so constraint re-check uses the same
+    catalog instance as coverage evaluation.
+    """
+    resolved_observation = (
+        observation if observation is not None else build_inference_observation(score, turn)
+    )
+    path, accelerated_segments = resolve_inference_path(
+        score,
+        turn,
+        catalog=catalog,
+        load_scoreboard_turn=load_scoreboard_turn,
+    )
+
+    if path == InferencePath.NO_PRIOR_TURN:
+        return _no_prior_turn_inference_result(turn, resolved_observation)
+    if path == InferencePath.ACCELERATED_BACKFILL:
+        return _run_accelerated_backfill_inference(
+            score,
+            turn,
             resolved_observation,
-            solve_catalog,
+            load_scoreboard_turn=load_scoreboard_turn,
         )
+    return _run_solver_inference_path(
+        path,
+        score,
+        turn,
+        resolved_observation,
+        catalog=catalog,
+        accelerated_segments=accelerated_segments,
+    )
 
 
 def _try_accelerated_backfill_inference(

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -18,6 +18,13 @@ from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
     observation_to_constraints_payload,
 )
+from api.analytics.military_score_inference.inference_api_payload import (
+    STATUS_NO_PRIOR_TURN,
+    STATUS_SOLVER_ERROR,
+    _inference_api_payload,
+    _serialize_solution_with_arithmetic,
+    inference_result_to_api_payload,
+)
 from api.analytics.military_score_inference.inference_path import (
     InferencePath,
     prior_turn_score_data_available,
@@ -34,12 +41,8 @@ from api.analytics.military_score_inference.models import (
     InferenceObservation,
     InferenceProblem,
     InferenceResult,
-    InferenceSolution,
 )
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
-from api.analytics.military_score_inference.score_arithmetic import (
-    solution_military_score_arithmetic_payload,
-)
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
@@ -49,9 +52,6 @@ from api.analytics.military_score_inference.solver import (
 )
 from api.models.game import TurnInfo
 from api.models.player import Score
-
-STATUS_NO_PRIOR_TURN = "no_prior_turn"
-STATUS_SOLVER_ERROR = "solver_error"
 
 __all__ = [
     "is_after_ship_limit",
@@ -658,171 +658,3 @@ def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object
     """Run build inference for one scoreboard row, isolating failures to that row."""
     payload, _, _ = run_inference_with_artifacts(score, turn)
     return payload
-
-
-def inference_result_to_api_payload(
-    result: InferenceResult,
-    catalog: ActionCatalog,
-    observation: InferenceObservation,
-    turn: TurnInfo,
-    problem: InferenceProblem,
-    *,
-    policy_steps_attempted: list[str] | None = None,
-    step_diagnostics: list[dict[str, object]] | None = None,
-    extra_diagnostics: dict[str, object] | None = None,
-) -> dict[str, object]:
-    """Shape a solver result into the Core scores row inference object."""
-    solver_diagnostics = {
-        "status": result.status,
-        **result.diagnostics,
-    }
-    diagnostics = build_inference_solver_diagnostics(
-        turn=turn.settings.turn,
-        observation=observation,
-        problem=problem,
-        catalog=catalog,
-        turn_info=turn,
-        solver=solver_diagnostics,
-        extra={
-            "policy_steps_attempted": policy_steps_attempted or [catalog.policy_step_id],
-            "policy_step_attempts": step_diagnostics or [],
-            **(extra_diagnostics or {}),
-        },
-    )
-    return _inference_api_payload(
-        status=result.status,
-        summary=format_inference_summary(result),
-        solutions=result.solutions,
-        diagnostics=diagnostics,
-        observation=observation,
-        catalog=catalog,
-    )
-
-
-def format_inference_summary(result: InferenceResult) -> str:
-    """Return compact row-level summary text for the inference column."""
-    if result.status == STATUS_NO_PRIOR_TURN:
-        return "Prior turn score data unavailable"
-    if result.status == STATUS_INVALID_PROBLEM:
-        reason = result.diagnostics.get("reason")
-        if isinstance(reason, str) and reason:
-            return f"Invalid inference problem: {reason}"
-        return "Invalid inference problem"
-    if result.status == STATUS_NO_EXACT_SOLUTION:
-        return "No feasible build explanation found"
-    if result.status == STATUS_SOLVER_ERROR:
-        return "Build inference failed"
-    if result.status == STATUS_TIME_LIMITED and not result.solutions:
-        return "Inference timed out before finding a solution"
-    if not result.solutions:
-        return "No feasible build explanation found"
-
-    best_summary = _format_solution_brief(result.solutions[0])
-    alternative_count = len(result.solutions) - 1
-    if alternative_count == 0:
-        return f"Best: {best_summary}"
-    if alternative_count == 1:
-        return f"Best: {best_summary}; 1 alternative"
-    return f"Best: {best_summary}; {alternative_count} alternatives"
-
-
-def _format_solution_brief(solution: InferenceSolution) -> str:
-    parts: list[str] = []
-    for action in solution.actions:
-        if action.count == 1:
-            parts.append(action.label)
-        else:
-            parts.append(f"{action.count}x {action.label}")
-    for ship_build in solution.ship_builds:
-        if ship_build.count == 1:
-            parts.append(ship_build.label)
-        else:
-            parts.append(f"{ship_build.count}x {ship_build.label}")
-    return "; ".join(parts) if parts else "no actions"
-
-
-def _inference_api_payload(
-    *,
-    status: str,
-    summary: str,
-    solutions: tuple[InferenceSolution, ...],
-    diagnostics: dict[str, object],
-    observation: InferenceObservation | None = None,
-    catalog: ActionCatalog | None = None,
-) -> dict[str, object]:
-    return {
-        "status": status,
-        "summary": summary,
-        "solutionCount": len(solutions),
-        "isComplete": status != STATUS_TIME_LIMITED,
-        "solutions": (
-            [
-                _serialize_solution_with_arithmetic(observation, catalog, solution)
-                for solution in solutions
-            ]
-            if observation is not None and catalog is not None
-            else [_serialize_solution_without_arithmetic(solution) for solution in solutions]
-        ),
-        "diagnostics": diagnostics,
-    }
-
-
-def _serialize_solution_actions(
-    solution: InferenceSolution,
-) -> list[dict[str, object]]:
-    return [
-        {
-            "actionId": action.action_id,
-            "label": action.label,
-            "count": action.count,
-        }
-        for action in solution.actions
-    ]
-
-
-def _serialize_solution_ship_builds(
-    solution: InferenceSolution,
-) -> list[dict[str, object]]:
-    return [
-        {
-            "comboId": ship_build.combo_id,
-            "label": ship_build.label,
-            "count": ship_build.count,
-            "hullId": ship_build.hull_id,
-            "engineId": ship_build.engine_id,
-            "beamId": ship_build.beam_id,
-            "torpId": ship_build.torp_id,
-            "beamCount": ship_build.beam_count,
-            "launcherCount": ship_build.launcher_count,
-        }
-        for ship_build in solution.ship_builds
-    ]
-
-
-def _serialize_solution_core(solution: InferenceSolution) -> dict[str, object]:
-    return {
-        "objectiveValue": solution.objective_value,
-        "actions": _serialize_solution_actions(solution),
-        "shipBuilds": _serialize_solution_ship_builds(solution),
-    }
-
-
-def _serialize_solution_with_arithmetic(
-    observation: InferenceObservation,
-    catalog: ActionCatalog,
-    solution: InferenceSolution,
-) -> dict[str, object]:
-    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
-    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
-    payload = _serialize_solution_core(solution)
-    payload["militaryScoreArithmetic"] = solution_military_score_arithmetic_payload(
-        solution,
-        observation,
-        actions_by_id,
-        combos_by_id,
-    )
-    return payload
-
-
-def _serialize_solution_without_arithmetic(solution: InferenceSolution) -> dict[str, object]:
-    return _serialize_solution_core(solution)

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,14 +1,9 @@
 """Scores analytic integration for military score build inference."""
 
-from collections.abc import Callable
-from dataclasses import dataclass
-
 from api.analytics.military_score_inference.accelerated_start import (
-    SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
     AcceleratedInferenceSegment,
     accelerated_inference_segments,
     accelerated_turn_count,
-    first_reliable_accelerated_scoreboard_turn,
     needs_accelerated_backfill,
     observation_deltas_from_score,
     scoreboard_host_turn,
@@ -34,6 +29,13 @@ from api.analytics.military_score_inference.models import (
 from api.analytics.military_score_inference.score_arithmetic import (
     solution_military_score_arithmetic_payload,
 )
+from api.analytics.military_score_inference.inference_target import (
+    ScoreboardTurnLoader,
+    is_after_ship_limit,
+    load_accelerated_backfill_source_for_host_turn,
+    observation_from_accelerated_segment,
+    observation_from_deltas,
+)
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
@@ -48,114 +50,7 @@ from api.models.player import Score
 STATUS_NO_PRIOR_TURN = "no_prior_turn"
 STATUS_SOLVER_ERROR = "solver_error"
 
-ScoreboardTurnLoader = Callable[[int], TurnInfo | None]
-
 AcceleratedSegmentArtifacts = tuple[InferenceObservation, ActionCatalog]
-
-
-@dataclass(frozen=True)
-class ResolvedInferenceTarget:
-    """Observation and turn snapshot used to build the action catalog for one host turn."""
-
-    observation: InferenceObservation
-    turn_info: TurnInfo
-    score: Score
-
-
-def resolve_inference_target_for_host_turn(
-    score: Score,
-    turn: TurnInfo,
-    *,
-    host_turn: int,
-    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
-) -> ResolvedInferenceTarget | None:
-    """Resolve catalog context for a host-turn target using inference-equivalent rules.
-
-    Unreliable accelerated scoreboard rows backfill from the first reliable split;
-    the first reliable row uses accelerated segments; later rows use score deltas.
-    Returns None when accelerated context is required but cannot be loaded.
-    """
-    if needs_accelerated_backfill(turn.settings.turn, turn.settings):
-        return _resolve_backfill_inference_target(
-            score,
-            turn,
-            host_turn=host_turn,
-            load_scoreboard_turn=load_scoreboard_turn,
-        )
-
-    segments = accelerated_inference_segments(score, turn)
-    if segments is not None:
-        segment = _accelerated_segment_for_host_turn(segments, host_turn)
-        if segment is None:
-            return None
-        return ResolvedInferenceTarget(
-            observation=_observation_from_accelerated_segment(score, turn, segment),
-            turn_info=turn,
-            score=score,
-        )
-
-    expected_host_turn = scoreboard_host_turn(turn.settings.turn)
-    if expected_host_turn is None or expected_host_turn != host_turn:
-        return None
-    return ResolvedInferenceTarget(
-        observation=build_inference_observation(score, turn),
-        turn_info=turn,
-        score=score,
-    )
-
-
-def _resolve_backfill_inference_target(
-    score: Score,
-    turn: TurnInfo,
-    *,
-    host_turn: int,
-    load_scoreboard_turn: ScoreboardTurnLoader | None,
-) -> ResolvedInferenceTarget | None:
-    if load_scoreboard_turn is None:
-        return None
-
-    scoreboard_turn_host = scoreboard_host_turn(turn.settings.turn)
-    if scoreboard_turn_host is None or scoreboard_turn_host != host_turn:
-        return None
-
-    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
-    if source_turn_number is None:
-        return None
-
-    source_turn = load_scoreboard_turn(source_turn_number)
-    if source_turn is None:
-        return None
-
-    source_score = next(
-        (row for row in source_turn.scores if row.ownerid == score.ownerid),
-        None,
-    )
-    if source_score is None:
-        return None
-
-    segments = accelerated_inference_segments(source_score, source_turn)
-    if segments is None:
-        return None
-
-    segment = _accelerated_segment_for_host_turn(segments, host_turn)
-    if segment is None:
-        return None
-
-    return ResolvedInferenceTarget(
-        observation=_observation_from_accelerated_segment(source_score, source_turn, segment),
-        turn_info=source_turn,
-        score=source_score,
-    )
-
-
-def _accelerated_segment_for_host_turn(
-    segments: tuple[AcceleratedInferenceSegment, ...],
-    host_turn: int,
-) -> AcceleratedInferenceSegment | None:
-    for segment in segments:
-        if segment.host_turn == host_turn:
-            return segment
-    return None
 
 
 def prior_turn_score_data_available(turn: TurnInfo) -> bool:
@@ -177,67 +72,12 @@ def _no_prior_turn_reason(turn: TurnInfo) -> str:
     return "first_turn"
 
 
-def is_after_ship_limit(turn: TurnInfo, score: Score) -> bool:
-    """Return whether ship-limit queue rules apply for this player on this turn."""
-    settings = turn.settings
-    player_ships = score.capitalships + score.freighters
-    if settings.shiplimittype != 0:
-        player_limit = (
-            settings.plsminships
-            + settings.plsextraships
-            + settings.plsshipsperplanet * score.planets
-        )
-        return player_ships >= player_limit
-    total_ships = sum(
-        other_score.capitalships + other_score.freighters for other_score in turn.scores
-    )
-    return total_ships >= settings.shiplimit
-
-
 def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObservation:
     """Build solver observation for the reported host turn on this scoreboard row."""
-    return _observation_from_deltas(
+    return observation_from_deltas(
         score,
         turn,
         observation_deltas_from_score(score, turn),
-    )
-
-
-def _observation_from_deltas(
-    score: Score,
-    turn: TurnInfo,
-    deltas: tuple[int, int, int, int],
-    *,
-    military_partition_slack_2x: int = SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
-) -> InferenceObservation:
-    military_delta_2x, warship_delta, freighter_delta, priority_point_delta = deltas
-    return InferenceObservation(
-        player_id=score.ownerid,
-        turn=turn.settings.turn,
-        military_delta_2x=military_delta_2x,
-        warship_delta=warship_delta,
-        freighter_delta=freighter_delta,
-        priority_point_delta=priority_point_delta,
-        starbases_owned=score.starbases,
-        is_after_ship_limit=is_after_ship_limit(turn, score),
-        military_partition_slack_2x=military_partition_slack_2x,
-    )
-
-
-def _observation_from_accelerated_segment(
-    score: Score,
-    turn: TurnInfo,
-    segment: AcceleratedInferenceSegment,
-) -> InferenceObservation:
-    return _observation_from_deltas(
-        score,
-        turn,
-        (
-            segment.military_delta_2x,
-            segment.warship_delta,
-            segment.freighter_delta,
-            segment.priority_point_delta,
-        ),
     )
 
 
@@ -445,33 +285,24 @@ def _try_accelerated_backfill_inference(
     """Fill unreliable accelerated rows from the first reliable split when that turn is stored."""
     if load_scoreboard_turn is None:
         return None
-    if not needs_accelerated_backfill(turn.settings.turn, turn.settings):
-        return None
 
     target_host_turn = scoreboard_host_turn(turn.settings.turn)
-    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
-    if target_host_turn is None or source_turn_number is None:
+    if target_host_turn is None:
         return None
 
-    source_turn = load_scoreboard_turn(source_turn_number)
-    if source_turn is None:
-        return None
-
-    source_score = next(
-        (row for row in source_turn.scores if row.ownerid == score.ownerid),
-        None,
+    backfill_source = load_accelerated_backfill_source_for_host_turn(
+        score,
+        turn,
+        host_turn=target_host_turn,
+        load_scoreboard_turn=load_scoreboard_turn,
     )
-    if source_score is None:
-        return None
-
-    segments = accelerated_inference_segments(source_score, source_turn)
-    if segments is None:
+    if backfill_source is None:
         return None
 
     payload, _, _, segment_artifacts = _run_accelerated_split_inference(
-        source_score,
-        source_turn,
-        segments,
+        backfill_source.source_score,
+        backfill_source.source_turn,
+        backfill_source.segments,
     )
     segment_payload = _segment_payload_for_host_turn(
         payload,
@@ -509,10 +340,10 @@ def _try_accelerated_backfill_inference(
                 turn=turn.settings.turn,
                 observation=segment_observation,
                 catalog=segment_catalog,
-                turn_info=source_turn,
+                turn_info=backfill_source.source_turn,
                 extra={
                     "accelerated_backfill": True,
-                    "accelerated_backfill_source_turn": source_turn_number,
+                    "accelerated_backfill_source_turn": backfill_source.source_turn_number,
                     "accelerated_backfill_host_turn": target_host_turn,
                     "accelerated_backfill_segment_id": segment_payload.get("segmentId"),
                     "accelerated_segments": accelerated_segments,
@@ -608,7 +439,7 @@ def _run_accelerated_split_inference(
     combined_time_limited = False
 
     for segment in segments:
-        segment_observation = _observation_from_accelerated_segment(score, turn, segment)
+        segment_observation = observation_from_accelerated_segment(score, turn, segment)
         if segment.segment_id == "reported_host_turn":
             reported_observation = segment_observation
 

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,10 +1,19 @@
 """Scores analytic integration for military score build inference."""
 
 import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
 
 from api.analytics.military_score_inference.accelerated_start import (
+    SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+    AcceleratedInferenceSegment,
+    accelerated_inference_segments,
     accelerated_turn_count,
+    first_reliable_accelerated_scoreboard_turn,
+    needs_accelerated_backfill,
     observation_deltas_from_score,
+    scoreboard_host_turn,
 )
 from api.analytics.military_score_inference.actions import (
     DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
@@ -14,6 +23,7 @@ from api.analytics.military_score_inference.actions import (
 )
 from api.analytics.military_score_inference.component_eligibility import (
     buildable_hull_ids_for_player,
+    turn_catalog_context_for_policy_step,
 )
 from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
@@ -28,10 +38,6 @@ from api.analytics.military_score_inference.models import (
 from api.analytics.military_score_inference.score_arithmetic import (
     solution_military_score_arithmetic_payload,
 )
-from api.analytics.military_score_inference.ship_build_combos import (
-    MAX_SHIP_BUILD_TIER,
-    START_SHIP_BUILD_TIER,
-)
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
@@ -40,11 +46,124 @@ from api.analytics.military_score_inference.solver import (
     solution_signature,
     solve_inference_problem,
 )
+from api.analytics.military_score_inference.tier_policy import (
+    InferenceTierPolicyStep,
+    resolve_tier_policies,
+)
 from api.models.game import TurnInfo
 from api.models.player import Score
 
 STATUS_NO_PRIOR_TURN = "no_prior_turn"
 STATUS_SOLVER_ERROR = "solver_error"
+
+ScoreboardTurnLoader = Callable[[int], TurnInfo | None]
+
+AcceleratedSegmentArtifacts = tuple[InferenceObservation, ActionCatalog]
+
+
+@dataclass(frozen=True)
+class ResolvedInferenceTarget:
+    """Observation and turn snapshot used to build the action catalog for one host turn."""
+
+    observation: InferenceObservation
+    turn_info: TurnInfo
+    score: Score
+
+
+def resolve_inference_target_for_host_turn(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    host_turn: int,
+    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+) -> ResolvedInferenceTarget | None:
+    """Resolve catalog context for a host-turn target using inference-equivalent rules.
+
+    Unreliable accelerated scoreboard rows backfill from the first reliable split;
+    the first reliable row uses accelerated segments; later rows use score deltas.
+    Returns None when accelerated context is required but cannot be loaded.
+    """
+    if needs_accelerated_backfill(turn.settings.turn, turn.settings):
+        return _resolve_backfill_inference_target(
+            score,
+            turn,
+            host_turn=host_turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )
+
+    segments = accelerated_inference_segments(score, turn)
+    if segments is not None:
+        segment = _accelerated_segment_for_host_turn(segments, host_turn)
+        if segment is None:
+            return None
+        return ResolvedInferenceTarget(
+            observation=_observation_from_accelerated_segment(score, turn, segment),
+            turn_info=turn,
+            score=score,
+        )
+
+    expected_host_turn = scoreboard_host_turn(turn.settings.turn)
+    if expected_host_turn is None or expected_host_turn != host_turn:
+        return None
+    return ResolvedInferenceTarget(
+        observation=build_inference_observation(score, turn),
+        turn_info=turn,
+        score=score,
+    )
+
+
+def _resolve_backfill_inference_target(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    host_turn: int,
+    load_scoreboard_turn: ScoreboardTurnLoader | None,
+) -> ResolvedInferenceTarget | None:
+    if load_scoreboard_turn is None:
+        return None
+
+    scoreboard_turn_host = scoreboard_host_turn(turn.settings.turn)
+    if scoreboard_turn_host is None or scoreboard_turn_host != host_turn:
+        return None
+
+    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
+    if source_turn_number is None:
+        return None
+
+    source_turn = load_scoreboard_turn(source_turn_number)
+    if source_turn is None:
+        return None
+
+    source_score = next(
+        (row for row in source_turn.scores if row.ownerid == score.ownerid),
+        None,
+    )
+    if source_score is None:
+        return None
+
+    segments = accelerated_inference_segments(source_score, source_turn)
+    if segments is None:
+        return None
+
+    segment = _accelerated_segment_for_host_turn(segments, host_turn)
+    if segment is None:
+        return None
+
+    return ResolvedInferenceTarget(
+        observation=_observation_from_accelerated_segment(source_score, source_turn, segment),
+        turn_info=source_turn,
+        score=source_score,
+    )
+
+
+def _accelerated_segment_for_host_turn(
+    segments: tuple[AcceleratedInferenceSegment, ...],
+    host_turn: int,
+) -> AcceleratedInferenceSegment | None:
+    for segment in segments:
+        if segment.host_turn == host_turn:
+            return segment
+    return None
 
 
 def prior_turn_score_data_available(turn: TurnInfo) -> bool:
@@ -56,6 +175,14 @@ def prior_turn_score_data_available(turn: TurnInfo) -> bool:
     if accelerated > 0 and turn_number < accelerated:
         return False
     return True
+
+
+def _no_prior_turn_reason(turn: TurnInfo) -> str:
+    if turn.settings.turn <= 1:
+        return "first_turn"
+    if needs_accelerated_backfill(turn.settings.turn, turn.settings):
+        return "accelerated_backfill_unavailable"
+    return "first_turn"
 
 
 def is_after_ship_limit(turn: TurnInfo, score: Score) -> bool:
@@ -76,10 +203,22 @@ def is_after_ship_limit(turn: TurnInfo, score: Score) -> bool:
 
 
 def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObservation:
-    """Build solver observation from one scoreboard row and turn context."""
-    military_delta_2x, warship_delta, freighter_delta, priority_point_delta = (
-        observation_deltas_from_score(score, turn)
+    """Build solver observation for the reported host turn on this scoreboard row."""
+    return _observation_from_deltas(
+        score,
+        turn,
+        observation_deltas_from_score(score, turn),
     )
+
+
+def _observation_from_deltas(
+    score: Score,
+    turn: TurnInfo,
+    deltas: tuple[int, int, int, int],
+    *,
+    military_partition_slack_2x: int = SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+) -> InferenceObservation:
+    military_delta_2x, warship_delta, freighter_delta, priority_point_delta = deltas
     return InferenceObservation(
         player_id=score.ownerid,
         turn=turn.settings.turn,
@@ -89,6 +228,24 @@ def build_inference_observation(score: Score, turn: TurnInfo) -> InferenceObserv
         priority_point_delta=priority_point_delta,
         starbases_owned=score.starbases,
         is_after_ship_limit=is_after_ship_limit(turn, score),
+        military_partition_slack_2x=military_partition_slack_2x,
+    )
+
+
+def _observation_from_accelerated_segment(
+    score: Score,
+    turn: TurnInfo,
+    segment: AcceleratedInferenceSegment,
+) -> InferenceObservation:
+    return _observation_from_deltas(
+        score,
+        turn,
+        (
+            segment.military_delta_2x,
+            segment.warship_delta,
+            segment.freighter_delta,
+            segment.priority_point_delta,
+        ),
     )
 
 
@@ -103,7 +260,8 @@ def catalog_to_actions_payload(
         "catalogSize": catalog.catalog_size,
         "aggregateActionCount": len(catalog.aggregate_actions),
         "shipBuildComboCount": len(catalog.ship_build_combos),
-        "shipBuildTier": catalog.ship_build_tier,
+        "policyStepId": catalog.policy_step_id,
+        "policyStepIndex": catalog.policy_step_index,
         "actions": [
             {
                 "id": action.id,
@@ -173,6 +331,11 @@ def build_inference_solver_diagnostics(
         payload["constraints"] = observation_to_constraints_payload(
             observation,
             hard_constraints=hard_constraints,
+            aggregate_action_ids=(
+                frozenset(action.id for action in problem.aggregate_actions)
+                if problem is not None
+                else None
+            ),
         )
     if catalog is not None:
         payload["actionCatalog"] = catalog_to_actions_payload(
@@ -194,6 +357,7 @@ def run_inference_with_artifacts(
     *,
     observation: InferenceObservation | None = None,
     catalog: ActionCatalog | None = None,
+    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
 
@@ -206,6 +370,13 @@ def run_inference_with_artifacts(
         observation if observation is not None else build_inference_observation(score, turn)
     )
     if not prior_turn_score_data_available(turn):
+        backfill = _try_accelerated_backfill_inference(
+            score,
+            turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )
+        if backfill is not None:
+            return backfill
         return (
             _inference_api_payload(
                 status=STATUS_NO_PRIOR_TURN,
@@ -215,7 +386,7 @@ def run_inference_with_artifacts(
                     turn=turn_number,
                     observation=resolved_observation,
                     turn_info=turn,
-                    extra={"reason": "first_turn"},
+                    extra={"reason": _no_prior_turn_reason(turn)},
                 ),
             ),
             resolved_observation,
@@ -225,12 +396,20 @@ def run_inference_with_artifacts(
     solve_catalog = catalog
     try:
         if solve_catalog is None:
-            result, solve_catalog, problem, tiers_attempted = _solve_with_tier_retry(
-                resolved_observation,
-                turn,
+            segments = accelerated_inference_segments(score, turn)
+            if segments is not None:
+                split_result = _run_accelerated_split_inference(score, turn, segments)
+                payload, reported_observation, reported_catalog, _ = split_result
+                return payload, reported_observation, reported_catalog
+            result, solve_catalog, problem, policy_steps_attempted, step_diagnostics = (
+                _solve_with_policy_ladder(
+                    resolved_observation,
+                    turn,
+                )
             )
         else:
-            tiers_attempted = [solve_catalog.ship_build_tier]
+            policy_steps_attempted = [solve_catalog.policy_step_id]
+            step_diagnostics = []
             problem = build_inference_problem(resolved_observation, solve_catalog)
             result = solve_inference_problem(problem)
         return (
@@ -240,7 +419,8 @@ def run_inference_with_artifacts(
                 resolved_observation,
                 turn,
                 problem,
-                tiers_attempted=tiers_attempted,
+                policy_steps_attempted=policy_steps_attempted,
+                step_diagnostics=step_diagnostics,
             ),
             resolved_observation,
             solve_catalog,
@@ -264,31 +444,463 @@ def run_inference_with_artifacts(
         )
 
 
+def _try_accelerated_backfill_inference(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    load_scoreboard_turn: ScoreboardTurnLoader | None,
+) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None] | None:
+    """Fill unreliable accelerated rows from the first reliable split when that turn is stored."""
+    if load_scoreboard_turn is None:
+        return None
+    if not needs_accelerated_backfill(turn.settings.turn, turn.settings):
+        return None
+
+    target_host_turn = scoreboard_host_turn(turn.settings.turn)
+    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
+    if target_host_turn is None or source_turn_number is None:
+        return None
+
+    source_turn = load_scoreboard_turn(source_turn_number)
+    if source_turn is None:
+        return None
+
+    source_score = next(
+        (row for row in source_turn.scores if row.ownerid == score.ownerid),
+        None,
+    )
+    if source_score is None:
+        return None
+
+    segments = accelerated_inference_segments(source_score, source_turn)
+    if segments is None:
+        return None
+
+    payload, _, _, segment_artifacts = _run_accelerated_split_inference(
+        source_score,
+        source_turn,
+        segments,
+    )
+    segment_payload = _segment_payload_for_host_turn(
+        payload,
+        host_turn=target_host_turn,
+    )
+    if segment_payload is None:
+        return None
+
+    artifacts = segment_artifacts.get(target_host_turn)
+    if artifacts is None:
+        return None
+    segment_observation, segment_catalog = artifacts
+    segment_status = segment_payload.get("status")
+    if not isinstance(segment_status, str):
+        return None
+
+    solutions_raw = segment_payload.get("solutions")
+    solution_count_raw = segment_payload.get("solutionCount", 0)
+    solution_count = solution_count_raw if isinstance(solution_count_raw, int) else 0
+
+    split_diagnostics = payload.get("diagnostics")
+    accelerated_segments = (
+        split_diagnostics.get("accelerated_segments")
+        if isinstance(split_diagnostics, dict)
+        else None
+    )
+    return (
+        {
+            "status": segment_status,
+            "summary": _summary_from_segment_payload(segment_payload),
+            "solutionCount": solution_count,
+            "isComplete": segment_status != STATUS_TIME_LIMITED,
+            "solutions": solutions_raw if isinstance(solutions_raw, list) else [],
+            "diagnostics": build_inference_solver_diagnostics(
+                turn=turn.settings.turn,
+                observation=segment_observation,
+                catalog=segment_catalog,
+                turn_info=source_turn,
+                extra={
+                    "accelerated_backfill": True,
+                    "accelerated_backfill_source_turn": source_turn_number,
+                    "accelerated_backfill_host_turn": target_host_turn,
+                    "accelerated_backfill_segment_id": segment_payload.get("segmentId"),
+                    "accelerated_segments": accelerated_segments,
+                },
+            ),
+        },
+        segment_observation,
+        segment_catalog,
+    )
+
+
+def _segment_payload_for_host_turn(
+    split_payload: dict[str, object],
+    *,
+    host_turn: int,
+) -> dict[str, object] | None:
+    diagnostics = split_payload.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return None
+    segments_raw = diagnostics.get("accelerated_segments")
+    if not isinstance(segments_raw, list):
+        return None
+    for entry in segments_raw:
+        if not isinstance(entry, dict):
+            continue
+        entry_host_turn = entry.get("hostTurn")
+        if entry_host_turn == host_turn:
+            return entry
+    return None
+
+
+def _summary_from_segment_payload(segment_payload: dict[str, object]) -> str:
+    status = segment_payload.get("status")
+    if status == STATUS_NO_EXACT_SOLUTION:
+        return "No feasible build explanation found"
+    if status == STATUS_INVALID_PROBLEM:
+        return "Invalid inference problem"
+    solutions_raw = segment_payload.get("solutions")
+    if not isinstance(solutions_raw, list) or not solutions_raw:
+        return "No feasible build explanation found"
+    first = solutions_raw[0]
+    if not isinstance(first, dict):
+        return "No feasible build explanation found"
+    parts: list[str] = []
+    actions = first.get("actions")
+    if isinstance(actions, list):
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            label = action.get("label")
+            count = action.get("count")
+            if not isinstance(label, str) or not isinstance(count, int) or count <= 0:
+                continue
+            parts.append(label if count == 1 else f"{count}x {label}")
+    ship_builds = first.get("shipBuilds")
+    if isinstance(ship_builds, list):
+        for build in ship_builds:
+            if not isinstance(build, dict):
+                continue
+            label = build.get("label")
+            count = build.get("count")
+            if not isinstance(label, str) or not isinstance(count, int) or count <= 0:
+                continue
+            parts.append(label if count == 1 else f"{count}x {label}")
+    if not parts:
+        return "No feasible build explanation found"
+    return f"Best: {'; '.join(parts)}"
+
+
+def _run_accelerated_split_inference(
+    score: Score,
+    turn: TurnInfo,
+    segments: tuple[AcceleratedInferenceSegment, ...],
+) -> tuple[
+    dict[str, object],
+    InferenceObservation,
+    ActionCatalog | None,
+    dict[int, AcceleratedSegmentArtifacts],
+]:
+    """Solve accel-window and reported-host-turn targets independently."""
+    segment_count = len(segments)
+    per_segment_time = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS / segment_count
+    per_segment_max_solutions = max(1, 20 // segment_count)
+
+    segment_payloads: list[dict[str, object]] = []
+    segment_artifacts: dict[int, AcceleratedSegmentArtifacts] = {}
+    reported_observation: InferenceObservation | None = None
+    reported_catalog: ActionCatalog | None = None
+    reported_problem: InferenceProblem | None = None
+    reported_result: InferenceResult | None = None
+    reported_policy_steps: list[str] = []
+    reported_step_diagnostics: list[dict[str, object]] = []
+    combined_time_limited = False
+
+    for segment in segments:
+        segment_observation = _observation_from_accelerated_segment(score, turn, segment)
+        if segment.segment_id == "reported_host_turn":
+            reported_observation = segment_observation
+
+        result, catalog, problem, policy_steps_attempted, step_diagnostics = (
+            _solve_with_policy_ladder(
+                segment_observation,
+                turn,
+                max_solutions=per_segment_max_solutions,
+                time_limit_seconds=per_segment_time,
+            )
+        )
+        segment_artifacts[segment.host_turn] = (segment_observation, catalog)
+        if segment.segment_id == "reported_host_turn":
+            reported_catalog = catalog
+            reported_problem = problem
+            reported_result = result
+            reported_policy_steps = policy_steps_attempted
+            reported_step_diagnostics = step_diagnostics
+        if result.status == STATUS_TIME_LIMITED:
+            combined_time_limited = True
+
+        segment_payloads.append(
+            {
+                "segmentId": segment.segment_id,
+                "hostTurn": segment.host_turn,
+                "status": result.status,
+                "solutionCount": len(result.solutions),
+                "militaryDelta2x": segment.military_delta_2x,
+                "warshipDelta": segment.warship_delta,
+                "freighterDelta": segment.freighter_delta,
+                "policyStepsAttempted": policy_steps_attempted,
+                "policyStepAttempts": step_diagnostics,
+                "solutions": [
+                    _serialize_solution_with_arithmetic(segment_observation, catalog, solution)
+                    for solution in result.solutions
+                ],
+            }
+        )
+
+    assert reported_observation is not None
+    assert reported_catalog is not None
+    assert reported_problem is not None
+    assert reported_result is not None
+
+    overall_status = _accelerated_split_status(segment_payloads, combined_time_limited)
+    primary_result = InferenceResult(
+        status=overall_status,
+        solutions=reported_result.solutions,
+        diagnostics={
+            **reported_result.diagnostics,
+            "accelerated_segments": segment_payloads,
+        },
+    )
+
+    return (
+        inference_result_to_api_payload(
+            primary_result,
+            reported_catalog,
+            reported_observation,
+            turn,
+            reported_problem,
+            policy_steps_attempted=reported_policy_steps,
+            step_diagnostics=reported_step_diagnostics,
+            extra_diagnostics={"accelerated_segments": segment_payloads},
+        ),
+        reported_observation,
+        reported_catalog,
+        segment_artifacts,
+    )
+
+
+def _accelerated_split_status(
+    segment_payloads: list[dict[str, object]],
+    combined_time_limited: bool,
+) -> str:
+    statuses = [
+        payload["status"] for payload in segment_payloads if isinstance(payload["status"], str)
+    ]
+    if any(status == STATUS_NO_EXACT_SOLUTION for status in statuses):
+        return STATUS_NO_EXACT_SOLUTION
+    if any(status == STATUS_INVALID_PROBLEM for status in statuses):
+        return STATUS_INVALID_PROBLEM
+    if combined_time_limited or any(status == STATUS_TIME_LIMITED for status in statuses):
+        return STATUS_TIME_LIMITED
+    return STATUS_EXACT
+
+
 def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object]:
     """Run build inference for one scoreboard row, isolating failures to that row."""
     payload, _, _ = run_inference_with_artifacts(score, turn)
     return payload
 
 
-def _solve_with_tier_retry(
+def _combo_counts_from_solution(solution: InferenceSolution) -> dict[str, int]:
+    return {ship_build.combo_id: ship_build.count for ship_build in solution.ship_builds}
+
+
+def _solution_fully_explained_by_ship_builds_only(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> bool:
+    if solution.actions:
+        return False
+    return _solution_satisfies_exact_hard_equalities(solution, observation, catalog)
+
+
+def _solution_satisfies_exact_hard_equalities(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> bool:
+    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
+    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
+    military_sum = 0
+    warship_sum = 0
+    freighter_sum = 0
+    for action in solution.actions:
+        catalog_action = actions_by_id.get(action.action_id)
+        if catalog_action is None:
+            return False
+        military_sum += catalog_action.score_delta_2x * action.count
+        warship_sum += catalog_action.warship_delta * action.count
+        freighter_sum += catalog_action.freighter_delta * action.count
+    for ship_build in solution.ship_builds:
+        combo = combos_by_id.get(ship_build.combo_id)
+        if combo is None:
+            return False
+        military_sum += combo.score_delta_2x * ship_build.count
+        warship_sum += combo.warship_delta * ship_build.count
+        freighter_sum += combo.freighter_delta * ship_build.count
+    return (
+        abs(military_sum - observation.military_delta_2x) <= observation.military_partition_slack_2x
+        and warship_sum == observation.warship_delta
+        and freighter_sum == observation.freighter_delta
+    )
+
+
+def _explained_military_score_2x(
+    solution: InferenceSolution,
+    catalog: ActionCatalog,
+) -> int:
+    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
+    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
+    explained = 0
+    for action in solution.actions:
+        catalog_action = actions_by_id[action.action_id]
+        explained += catalog_action.score_delta_2x * action.count
+    for ship_build in solution.ship_builds:
+        combo = combos_by_id[ship_build.combo_id]
+        explained += combo.score_delta_2x * ship_build.count
+    return explained
+
+
+def _merge_exact_solutions(
+    merged_solutions: list[InferenceSolution],
+    seen_signatures: set[tuple[tuple[str, int], ...]],
+    candidates: tuple[InferenceSolution, ...],
+    *,
+    resolved_max_solutions: int,
+) -> int:
+    new_solutions = 0
+    for solution in candidates:
+        signature = solution_signature(solution)
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        merged_solutions.append(solution)
+        new_solutions += 1
+        if len(merged_solutions) >= resolved_max_solutions:
+            break
+    return new_solutions
+
+
+def _solve_catalog(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    *,
+    max_solutions: int,
+    time_limit_seconds: float,
+    military_score_alpha: int = 0,
+    fixed_combo_counts: dict[str, int] | None = None,
+    combo_count_neighborhood: int = 0,
+) -> tuple[InferenceResult, InferenceProblem]:
+    problem = build_inference_problem(
+        observation,
+        catalog,
+        max_solutions=max_solutions,
+        time_limit_seconds=time_limit_seconds,
+        military_score_alpha=military_score_alpha,
+        fixed_combo_counts=fixed_combo_counts,
+        combo_count_neighborhood=combo_count_neighborhood,
+    )
+    return solve_inference_problem(problem), problem
+
+
+def _solve_seed_progression(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    seed: InferenceSolution,
+    *,
+    max_solutions: int,
+    time_limit_seconds: float,
+) -> tuple[InferenceResult | None, InferenceProblem | None]:
+    fixed_counts = _combo_counts_from_solution(seed)
+    if not fixed_counts:
+        return None, None
+
+    remaining_slots = max_solutions
+    for neighborhood in (0, 1):
+        if remaining_slots <= 0 or time_limit_seconds <= 0:
+            break
+        result, problem = _solve_catalog(
+            observation,
+            catalog,
+            max_solutions=remaining_slots,
+            time_limit_seconds=time_limit_seconds,
+            fixed_combo_counts=fixed_counts,
+            combo_count_neighborhood=neighborhood,
+        )
+        if result.solutions:
+            return result, problem
+
+    result, problem = _solve_catalog(
+        observation,
+        catalog,
+        max_solutions=remaining_slots,
+        time_limit_seconds=time_limit_seconds,
+    )
+    if result.solutions:
+        return result, problem
+    return None, None
+
+
+def _policy_step_diagnostics(
+    *,
+    policy_step: InferenceTierPolicyStep,
+    policy_step_index: int,
+    catalog: ActionCatalog,
+    turn: TurnInfo,
+    observation: InferenceObservation,
+    seed_count: int,
+    band_residual_2x: int | None,
+) -> dict[str, object]:
+    catalog_context = turn_catalog_context_for_policy_step(
+        turn,
+        observation.player_id,
+        policy_step,
+    )
+    return {
+        "policyStepId": policy_step.id,
+        "policyStepIndex": policy_step_index,
+        "policyStepsAttempted": policy_step_index + 1,
+        "constraintSnapshot": policy_step.constraint_snapshot(),
+        "resolvedEligibleEngineIds": sorted(catalog_context.eligible_engine_ids),
+        "resolvedEligibleBeamIds": sorted(catalog_context.eligible_beam_ids),
+        "resolvedEligibleTorpIds": sorted(catalog_context.eligible_torp_ids),
+        "resolvedBuildableHullIds": sorted(catalog_context.buildable_hull_ids),
+        "alpha": policy_step.alpha,
+        "comboCount": len(catalog.ship_build_combos),
+        "seedCount": seed_count,
+        "bandResidual2x": band_residual_2x,
+    }
+
+
+def _solve_with_policy_ladder(
     observation: InferenceObservation,
     turn: TurnInfo,
     *,
+    policy_path: Path | None = None,
     max_solutions: int | None = None,
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
-) -> tuple[InferenceResult, ActionCatalog, InferenceProblem, list[int]]:
-    """Try ship-build tiers from narrow to wide, accumulating distinct feasible solutions.
-
-    Continues while each tier adds at least one new feasible solution (by action/combo
-    counts). Stops when a tier is feasible but contributes no new signatures, when a
-    tier is infeasible and no further tiers remain, on invalid problem, or when time
-    budget is exhausted.
-
-    Higher tiers may surface solutions ranked above earlier tiers once build
-    probability weights are refined; merged results are sorted by objective value.
-    """
+) -> tuple[
+    InferenceResult,
+    ActionCatalog,
+    InferenceProblem,
+    list[str],
+    list[dict[str, object]],
+]:
+    """Walk the YAML inference search tier ladder with band seed carry-forward."""
     started_at = time.monotonic()
-    tiers_attempted: list[int] = []
+    policy_steps = resolve_tier_policies(policy_path)
+    policy_steps_attempted: list[str] = []
+    step_diagnostics: list[dict[str, object]] = []
     merged_solutions: list[InferenceSolution] = []
     seen_signatures: set[tuple[tuple[str, int], ...]] = set()
     catalog: ActionCatalog | None = None
@@ -297,87 +909,212 @@ def _solve_with_tier_retry(
     last_diagnostics: dict[str, object] = {}
     resolved_max_solutions = max_solutions if max_solutions is not None else 20
     time_limited = False
+    band_seeds: list[InferenceSolution] = []
+    best_band_residual_2x: int | None = None
+    prior_combo_ids: frozenset[str] | None = None
+    prior_aggregate_action_ids: frozenset[str] | None = None
+    ladder_early_stop_reason: str | None = None
 
-    for tier in range(START_SHIP_BUILD_TIER, MAX_SHIP_BUILD_TIER + 1):
+    for step_index, policy_step in enumerate(policy_steps):
         remaining = time_limit_seconds - (time.monotonic() - started_at)
         if remaining <= 0:
             time_limited = True
             break
-        tiers_attempted.append(tier)
+
+        policy_steps_attempted.append(policy_step.id)
         catalog = build_action_catalog_from_turn(
             observation,
             turn,
-            ship_build_tier=tier,
+            policy_step=policy_step,
+            policy_step_index=step_index,
         )
+        current_combo_ids = frozenset(combo.combo_id for combo in catalog.ship_build_combos)
+        added_combo_ids = (
+            current_combo_ids if prior_combo_ids is None else current_combo_ids - prior_combo_ids
+        )
+        if added_combo_ids:
+            merged_solutions.clear()
+            seen_signatures.clear()
+        prior_combo_ids = current_combo_ids
+        current_aggregate_action_ids = frozenset(action.id for action in catalog.aggregate_actions)
+        added_aggregate_action_ids = (
+            current_aggregate_action_ids
+            if prior_aggregate_action_ids is None
+            else current_aggregate_action_ids - prior_aggregate_action_ids
+        )
+        prior_aggregate_action_ids = current_aggregate_action_ids
+
         remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
         if remaining_slots == 0:
             break
-        problem = build_inference_problem(
+
+        new_exact_before_step = len(merged_solutions)
+        seeds_for_step = list(band_seeds)
+        band_seeds = []
+
+        for seed in seeds_for_step[: policy_step.max_seeds]:
+            seed_remaining = time_limit_seconds - (time.monotonic() - started_at)
+            if seed_remaining <= 0:
+                time_limited = True
+                break
+            seed_result, seed_problem = _solve_seed_progression(
+                observation,
+                catalog,
+                seed,
+                max_solutions=remaining_slots,
+                time_limit_seconds=seed_remaining,
+            )
+            if seed_result is None or seed_problem is None:
+                continue
+            if seed_result.status == STATUS_INVALID_PROBLEM:
+                last_status = seed_result.status
+                last_diagnostics = dict(seed_result.diagnostics)
+                problem = seed_problem
+                break
+            remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
+            if remaining_slots == 0:
+                break
+            _merge_exact_solutions(
+                merged_solutions,
+                seen_signatures,
+                seed_result.solutions,
+                resolved_max_solutions=resolved_max_solutions,
+            )
+            problem = seed_problem
+            if seed_result.status == STATUS_TIME_LIMITED:
+                time_limited = True
+
+        if last_status == STATUS_INVALID_PROBLEM:
+            break
+
+        remaining = time_limit_seconds - (time.monotonic() - started_at)
+        if remaining <= 0:
+            time_limited = True
+            break
+        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
+        if remaining_slots == 0:
+            break
+
+        exact_result, problem = _solve_catalog(
             observation,
             catalog,
             max_solutions=remaining_slots,
             time_limit_seconds=remaining,
         )
-        tier_result = solve_inference_problem(problem)
-        last_status = tier_result.status
-        last_diagnostics = dict(tier_result.diagnostics)
-        if tier_result.status == STATUS_INVALID_PROBLEM:
+        last_status = exact_result.status
+        last_diagnostics = dict(exact_result.diagnostics)
+        if exact_result.status == STATUS_INVALID_PROBLEM:
             break
-        if not tier_result.solutions:
-            continue
 
-        new_solutions = 0
-        for solution in tier_result.solutions:
-            signature = solution_signature(solution)
-            if signature in seen_signatures:
-                continue
-            seen_signatures.add(signature)
-            merged_solutions.append(solution)
-            new_solutions += 1
-            if len(merged_solutions) >= resolved_max_solutions:
-                break
+        if exact_result.solutions:
+            _merge_exact_solutions(
+                merged_solutions,
+                seen_signatures,
+                exact_result.solutions,
+                resolved_max_solutions=resolved_max_solutions,
+            )
+            if exact_result.status == STATUS_TIME_LIMITED:
+                time_limited = True
 
-        if new_solutions == 0:
+        band_residual_2x: int | None = None
+        if not exact_result.solutions and policy_step.alpha > 0:
+            remaining = time_limit_seconds - (time.monotonic() - started_at)
+            if remaining > 0:
+                band_result, band_problem = _solve_catalog(
+                    observation,
+                    catalog,
+                    max_solutions=policy_step.max_seeds,
+                    time_limit_seconds=remaining,
+                    military_score_alpha=policy_step.alpha,
+                )
+                problem = band_problem
+                last_diagnostics = dict(band_result.diagnostics)
+                if band_result.solutions:
+                    band_seeds = list(band_result.solutions[: policy_step.max_seeds])
+                    best_solution = band_result.solutions[0]
+                    explained = _explained_military_score_2x(best_solution, catalog)
+                    band_residual_2x = observation.military_delta_2x - explained
+                    if best_band_residual_2x is None or band_residual_2x < best_band_residual_2x:
+                        best_band_residual_2x = band_residual_2x
+                elif band_result.status == STATUS_INVALID_PROBLEM:
+                    last_status = band_result.status
+                    break
+
+        step_diagnostics.append(
+            _policy_step_diagnostics(
+                policy_step=policy_step,
+                policy_step_index=step_index,
+                catalog=catalog,
+                turn=turn,
+                observation=observation,
+                seed_count=len(seeds_for_step),
+                band_residual_2x=band_residual_2x,
+            )
+        )
+
+        if merged_solutions and _solution_fully_explained_by_ship_builds_only(
+            merged_solutions[0],
+            observation,
+            catalog,
+        ):
             break
-        if tier_result.status == STATUS_TIME_LIMITED:
-            time_limited = True
+
+        if (
+            len(merged_solutions) == new_exact_before_step
+            and len(merged_solutions) > 0
+            and not added_combo_ids
+            and not added_aggregate_action_ids
+        ):
+            ladder_early_stop_reason = "no_new_exact_signatures"
+            break
 
     if catalog is None or problem is None:
-        tiers_attempted.append(START_SHIP_BUILD_TIER)
+        first_step = policy_steps[0]
+        policy_steps_attempted.append(first_step.id)
         catalog = build_action_catalog_from_turn(
             observation,
             turn,
-            ship_build_tier=START_SHIP_BUILD_TIER,
+            policy_step=first_step,
+            policy_step_index=0,
         )
         problem = build_inference_problem(observation, catalog, max_solutions=max_solutions)
         tier_result = solve_inference_problem(problem)
         last_status = tier_result.status
         last_diagnostics = dict(tier_result.diagnostics)
-        for solution in tier_result.solutions:
-            signature = solution_signature(solution)
-            if signature not in seen_signatures:
-                seen_signatures.add(signature)
-                merged_solutions.append(solution)
+        _merge_exact_solutions(
+            merged_solutions,
+            seen_signatures,
+            tier_result.solutions,
+            resolved_max_solutions=resolved_max_solutions,
+        )
 
     merged_solutions.sort(key=lambda solution: solution.objective_value, reverse=True)
     if merged_solutions:
-        status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
+        if _solution_satisfies_exact_hard_equalities(
+            merged_solutions[0],
+            observation,
+            catalog,
+        ):
+            status = STATUS_EXACT
+        else:
+            status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
     else:
         status = STATUS_TIME_LIMITED if time_limited else last_status
 
+    stopped_reason = ladder_early_stop_reason or last_diagnostics.get("stopped_reason", "exhausted")
     result = InferenceResult(
         status=status,
         solutions=tuple(merged_solutions),
         diagnostics={
             **last_diagnostics,
-            "ship_build_tier": catalog.ship_build_tier,
+            "policy_step_id": catalog.policy_step_id,
+            "policy_step_index": catalog.policy_step_index,
             "solution_count": len(merged_solutions),
-            "stopped_reason": "no_new_solutions_at_tier"
-            if merged_solutions and len(tiers_attempted) > 1
-            else last_diagnostics.get("stopped_reason", "exhausted"),
+            "best_band_residual_2x": best_band_residual_2x,
+            "stopped_reason": stopped_reason,
         },
     )
-    return result, catalog, problem, tiers_attempted
+    return result, catalog, problem, policy_steps_attempted, step_diagnostics
 
 
 def inference_result_to_api_payload(
@@ -387,7 +1124,9 @@ def inference_result_to_api_payload(
     turn: TurnInfo,
     problem: InferenceProblem,
     *,
-    tiers_attempted: list[int] | None = None,
+    policy_steps_attempted: list[str] | None = None,
+    step_diagnostics: list[dict[str, object]] | None = None,
+    extra_diagnostics: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Shape a solver result into the Core scores row inference object."""
     solver_diagnostics = {
@@ -402,7 +1141,9 @@ def inference_result_to_api_payload(
         turn_info=turn,
         solver=solver_diagnostics,
         extra={
-            "tiers_attempted": tiers_attempted or [catalog.ship_build_tier],
+            "policy_steps_attempted": policy_steps_attempted or [catalog.policy_step_id],
+            "policy_step_attempts": step_diagnostics or [],
+            **(extra_diagnostics or {}),
         },
     )
     return _inference_api_payload(
@@ -472,7 +1213,10 @@ def _inference_api_payload(
         "solutionCount": len(solutions),
         "isComplete": status != STATUS_TIME_LIMITED,
         "solutions": (
-            [_serialize_solution(solution, observation, catalog) for solution in solutions]
+            [
+                _serialize_solution_with_arithmetic(observation, catalog, solution)
+                for solution in solutions
+            ]
             if observation is not None and catalog is not None
             else [_serialize_solution_without_arithmetic(solution) for solution in solutions]
         ),
@@ -520,10 +1264,10 @@ def _serialize_solution_core(solution: InferenceSolution) -> dict[str, object]:
     }
 
 
-def _serialize_solution(
-    solution: InferenceSolution,
+def _serialize_solution_with_arithmetic(
     observation: InferenceObservation,
     catalog: ActionCatalog,
+    solution: InferenceSolution,
 ) -> dict[str, object]:
     actions_by_id = {action.id: action for action in catalog.aggregate_actions}
     combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -202,6 +202,41 @@ def _no_prior_turn_inference_result(
     )
 
 
+def _accelerated_split_missing_reported_segment_result(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    segment_payloads: list[dict[str, object]],
+    segment_artifacts: dict[int, AcceleratedSegmentArtifacts],
+) -> tuple[
+    dict[str, object],
+    InferenceObservation,
+    ActionCatalog | None,
+    dict[int, AcceleratedSegmentArtifacts],
+]:
+    reason = "accelerated_split_missing_reported_segment"
+    fallback_observation = build_inference_observation(score, turn)
+    return (
+        _inference_api_payload(
+            status=STATUS_INVALID_PROBLEM,
+            summary=f"Invalid inference problem: {reason}",
+            solutions=(),
+            diagnostics=build_inference_solver_diagnostics(
+                turn=turn.settings.turn,
+                observation=fallback_observation,
+                turn_info=turn,
+                extra={
+                    "reason": reason,
+                    "accelerated_segments": segment_payloads,
+                },
+            ),
+        ),
+        fallback_observation,
+        None,
+        segment_artifacts,
+    )
+
+
 def _run_accelerated_backfill_inference(
     score: Score,
     turn: TurnInfo,
@@ -563,10 +598,18 @@ def _run_accelerated_split_inference(
             }
         )
 
-    assert reported_observation is not None
-    assert reported_catalog is not None
-    assert reported_problem is not None
-    assert reported_result is not None
+    if (
+        reported_observation is None
+        or reported_catalog is None
+        or reported_problem is None
+        or reported_result is None
+    ):
+        return _accelerated_split_missing_reported_segment_result(
+            score,
+            turn,
+            segment_payloads=segment_payloads,
+            segment_artifacts=segment_artifacts,
+        )
 
     overall_status = _accelerated_split_status(segment_payloads, combined_time_limited)
     primary_result = InferenceResult(

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,9 +1,7 @@
 """Scores analytic integration for military score build inference."""
 
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
 
 from api.analytics.military_score_inference.accelerated_start import (
     SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
@@ -18,12 +16,10 @@ from api.analytics.military_score_inference.accelerated_start import (
 from api.analytics.military_score_inference.actions import (
     DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     ActionCatalog,
-    build_action_catalog_from_turn,
     build_inference_problem,
 )
 from api.analytics.military_score_inference.component_eligibility import (
     buildable_hull_ids_for_player,
-    turn_catalog_context_for_policy_step,
 )
 from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
@@ -38,17 +34,13 @@ from api.analytics.military_score_inference.models import (
 from api.analytics.military_score_inference.score_arithmetic import (
     solution_military_score_arithmetic_payload,
 )
+from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
     STATUS_TIME_LIMITED,
-    solution_signature,
     solve_inference_problem,
-)
-from api.analytics.military_score_inference.tier_policy import (
-    InferenceTierPolicyStep,
-    resolve_tier_policies,
 )
 from api.models.game import TurnInfo
 from api.models.player import Score
@@ -402,7 +394,7 @@ def run_inference_with_artifacts(
                 payload, reported_observation, reported_catalog, _ = split_result
                 return payload, reported_observation, reported_catalog
             result, solve_catalog, problem, policy_steps_attempted, step_diagnostics = (
-                _solve_with_policy_ladder(
+                solve_with_policy_ladder(
                     resolved_observation,
                     turn,
                 )
@@ -621,7 +613,7 @@ def _run_accelerated_split_inference(
             reported_observation = segment_observation
 
         result, catalog, problem, policy_steps_attempted, step_diagnostics = (
-            _solve_with_policy_ladder(
+            solve_with_policy_ladder(
                 segment_observation,
                 turn,
                 max_solutions=per_segment_max_solutions,
@@ -708,413 +700,6 @@ def infer_military_score_build(score: Score, turn: TurnInfo) -> dict[str, object
     """Run build inference for one scoreboard row, isolating failures to that row."""
     payload, _, _ = run_inference_with_artifacts(score, turn)
     return payload
-
-
-def _combo_counts_from_solution(solution: InferenceSolution) -> dict[str, int]:
-    return {ship_build.combo_id: ship_build.count for ship_build in solution.ship_builds}
-
-
-def _solution_fully_explained_by_ship_builds_only(
-    solution: InferenceSolution,
-    observation: InferenceObservation,
-    catalog: ActionCatalog,
-) -> bool:
-    if solution.actions:
-        return False
-    return _solution_satisfies_exact_hard_equalities(solution, observation, catalog)
-
-
-def _solution_satisfies_exact_hard_equalities(
-    solution: InferenceSolution,
-    observation: InferenceObservation,
-    catalog: ActionCatalog,
-) -> bool:
-    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
-    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
-    military_sum = 0
-    warship_sum = 0
-    freighter_sum = 0
-    for action in solution.actions:
-        catalog_action = actions_by_id.get(action.action_id)
-        if catalog_action is None:
-            return False
-        military_sum += catalog_action.score_delta_2x * action.count
-        warship_sum += catalog_action.warship_delta * action.count
-        freighter_sum += catalog_action.freighter_delta * action.count
-    for ship_build in solution.ship_builds:
-        combo = combos_by_id.get(ship_build.combo_id)
-        if combo is None:
-            return False
-        military_sum += combo.score_delta_2x * ship_build.count
-        warship_sum += combo.warship_delta * ship_build.count
-        freighter_sum += combo.freighter_delta * ship_build.count
-    return (
-        abs(military_sum - observation.military_delta_2x) <= observation.military_partition_slack_2x
-        and warship_sum == observation.warship_delta
-        and freighter_sum == observation.freighter_delta
-    )
-
-
-def _explained_military_score_2x(
-    solution: InferenceSolution,
-    catalog: ActionCatalog,
-) -> int:
-    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
-    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
-    explained = 0
-    for action in solution.actions:
-        catalog_action = actions_by_id[action.action_id]
-        explained += catalog_action.score_delta_2x * action.count
-    for ship_build in solution.ship_builds:
-        combo = combos_by_id[ship_build.combo_id]
-        explained += combo.score_delta_2x * ship_build.count
-    return explained
-
-
-def _merge_exact_solutions(
-    merged_solutions: list[InferenceSolution],
-    seen_signatures: set[tuple[tuple[str, int], ...]],
-    candidates: tuple[InferenceSolution, ...],
-    *,
-    resolved_max_solutions: int,
-) -> int:
-    new_solutions = 0
-    for solution in candidates:
-        signature = solution_signature(solution)
-        if signature in seen_signatures:
-            continue
-        seen_signatures.add(signature)
-        merged_solutions.append(solution)
-        new_solutions += 1
-        if len(merged_solutions) >= resolved_max_solutions:
-            break
-    return new_solutions
-
-
-def _solve_catalog(
-    observation: InferenceObservation,
-    catalog: ActionCatalog,
-    *,
-    max_solutions: int,
-    time_limit_seconds: float,
-    military_score_alpha: int = 0,
-    fixed_combo_counts: dict[str, int] | None = None,
-    combo_count_neighborhood: int = 0,
-) -> tuple[InferenceResult, InferenceProblem]:
-    problem = build_inference_problem(
-        observation,
-        catalog,
-        max_solutions=max_solutions,
-        time_limit_seconds=time_limit_seconds,
-        military_score_alpha=military_score_alpha,
-        fixed_combo_counts=fixed_combo_counts,
-        combo_count_neighborhood=combo_count_neighborhood,
-    )
-    return solve_inference_problem(problem), problem
-
-
-def _solve_seed_progression(
-    observation: InferenceObservation,
-    catalog: ActionCatalog,
-    seed: InferenceSolution,
-    *,
-    max_solutions: int,
-    time_limit_seconds: float,
-) -> tuple[InferenceResult | None, InferenceProblem | None]:
-    fixed_counts = _combo_counts_from_solution(seed)
-    if not fixed_counts:
-        return None, None
-
-    remaining_slots = max_solutions
-    for neighborhood in (0, 1):
-        if remaining_slots <= 0 or time_limit_seconds <= 0:
-            break
-        result, problem = _solve_catalog(
-            observation,
-            catalog,
-            max_solutions=remaining_slots,
-            time_limit_seconds=time_limit_seconds,
-            fixed_combo_counts=fixed_counts,
-            combo_count_neighborhood=neighborhood,
-        )
-        if result.solutions:
-            return result, problem
-
-    result, problem = _solve_catalog(
-        observation,
-        catalog,
-        max_solutions=remaining_slots,
-        time_limit_seconds=time_limit_seconds,
-    )
-    if result.solutions:
-        return result, problem
-    return None, None
-
-
-def _policy_step_diagnostics(
-    *,
-    policy_step: InferenceTierPolicyStep,
-    policy_step_index: int,
-    catalog: ActionCatalog,
-    turn: TurnInfo,
-    observation: InferenceObservation,
-    seed_count: int,
-    band_residual_2x: int | None,
-) -> dict[str, object]:
-    catalog_context = turn_catalog_context_for_policy_step(
-        turn,
-        observation.player_id,
-        policy_step,
-    )
-    return {
-        "policyStepId": policy_step.id,
-        "policyStepIndex": policy_step_index,
-        "policyStepsAttempted": policy_step_index + 1,
-        "constraintSnapshot": policy_step.constraint_snapshot(),
-        "resolvedEligibleEngineIds": sorted(catalog_context.eligible_engine_ids),
-        "resolvedEligibleBeamIds": sorted(catalog_context.eligible_beam_ids),
-        "resolvedEligibleTorpIds": sorted(catalog_context.eligible_torp_ids),
-        "resolvedBuildableHullIds": sorted(catalog_context.buildable_hull_ids),
-        "alpha": policy_step.alpha,
-        "comboCount": len(catalog.ship_build_combos),
-        "seedCount": seed_count,
-        "bandResidual2x": band_residual_2x,
-    }
-
-
-def _solve_with_policy_ladder(
-    observation: InferenceObservation,
-    turn: TurnInfo,
-    *,
-    policy_path: Path | None = None,
-    max_solutions: int | None = None,
-    time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
-) -> tuple[
-    InferenceResult,
-    ActionCatalog,
-    InferenceProblem,
-    list[str],
-    list[dict[str, object]],
-]:
-    """Walk the YAML inference search tier ladder with band seed carry-forward."""
-    started_at = time.monotonic()
-    policy_steps = resolve_tier_policies(policy_path)
-    policy_steps_attempted: list[str] = []
-    step_diagnostics: list[dict[str, object]] = []
-    merged_solutions: list[InferenceSolution] = []
-    seen_signatures: set[tuple[tuple[str, int], ...]] = set()
-    catalog: ActionCatalog | None = None
-    problem: InferenceProblem | None = None
-    last_status = STATUS_NO_EXACT_SOLUTION
-    last_diagnostics: dict[str, object] = {}
-    resolved_max_solutions = max_solutions if max_solutions is not None else 20
-    time_limited = False
-    band_seeds: list[InferenceSolution] = []
-    best_band_residual_2x: int | None = None
-    prior_combo_ids: frozenset[str] | None = None
-    prior_aggregate_action_ids: frozenset[str] | None = None
-    ladder_early_stop_reason: str | None = None
-
-    for step_index, policy_step in enumerate(policy_steps):
-        remaining = time_limit_seconds - (time.monotonic() - started_at)
-        if remaining <= 0:
-            time_limited = True
-            break
-
-        policy_steps_attempted.append(policy_step.id)
-        catalog = build_action_catalog_from_turn(
-            observation,
-            turn,
-            policy_step=policy_step,
-            policy_step_index=step_index,
-        )
-        current_combo_ids = frozenset(combo.combo_id for combo in catalog.ship_build_combos)
-        added_combo_ids = (
-            current_combo_ids if prior_combo_ids is None else current_combo_ids - prior_combo_ids
-        )
-        if added_combo_ids:
-            merged_solutions.clear()
-            seen_signatures.clear()
-        prior_combo_ids = current_combo_ids
-        current_aggregate_action_ids = frozenset(action.id for action in catalog.aggregate_actions)
-        added_aggregate_action_ids = (
-            current_aggregate_action_ids
-            if prior_aggregate_action_ids is None
-            else current_aggregate_action_ids - prior_aggregate_action_ids
-        )
-        prior_aggregate_action_ids = current_aggregate_action_ids
-
-        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-        if remaining_slots == 0:
-            break
-
-        new_exact_before_step = len(merged_solutions)
-        seeds_for_step = list(band_seeds)
-        band_seeds = []
-
-        for seed in seeds_for_step[: policy_step.max_seeds]:
-            seed_remaining = time_limit_seconds - (time.monotonic() - started_at)
-            if seed_remaining <= 0:
-                time_limited = True
-                break
-            seed_result, seed_problem = _solve_seed_progression(
-                observation,
-                catalog,
-                seed,
-                max_solutions=remaining_slots,
-                time_limit_seconds=seed_remaining,
-            )
-            if seed_result is None or seed_problem is None:
-                continue
-            if seed_result.status == STATUS_INVALID_PROBLEM:
-                last_status = seed_result.status
-                last_diagnostics = dict(seed_result.diagnostics)
-                problem = seed_problem
-                break
-            remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-            if remaining_slots == 0:
-                break
-            _merge_exact_solutions(
-                merged_solutions,
-                seen_signatures,
-                seed_result.solutions,
-                resolved_max_solutions=resolved_max_solutions,
-            )
-            problem = seed_problem
-            if seed_result.status == STATUS_TIME_LIMITED:
-                time_limited = True
-
-        if last_status == STATUS_INVALID_PROBLEM:
-            break
-
-        remaining = time_limit_seconds - (time.monotonic() - started_at)
-        if remaining <= 0:
-            time_limited = True
-            break
-        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-        if remaining_slots == 0:
-            break
-
-        exact_result, problem = _solve_catalog(
-            observation,
-            catalog,
-            max_solutions=remaining_slots,
-            time_limit_seconds=remaining,
-        )
-        last_status = exact_result.status
-        last_diagnostics = dict(exact_result.diagnostics)
-        if exact_result.status == STATUS_INVALID_PROBLEM:
-            break
-
-        if exact_result.solutions:
-            _merge_exact_solutions(
-                merged_solutions,
-                seen_signatures,
-                exact_result.solutions,
-                resolved_max_solutions=resolved_max_solutions,
-            )
-            if exact_result.status == STATUS_TIME_LIMITED:
-                time_limited = True
-
-        band_residual_2x: int | None = None
-        if not exact_result.solutions and policy_step.alpha > 0:
-            remaining = time_limit_seconds - (time.monotonic() - started_at)
-            if remaining > 0:
-                band_result, band_problem = _solve_catalog(
-                    observation,
-                    catalog,
-                    max_solutions=policy_step.max_seeds,
-                    time_limit_seconds=remaining,
-                    military_score_alpha=policy_step.alpha,
-                )
-                problem = band_problem
-                last_diagnostics = dict(band_result.diagnostics)
-                if band_result.solutions:
-                    band_seeds = list(band_result.solutions[: policy_step.max_seeds])
-                    best_solution = band_result.solutions[0]
-                    explained = _explained_military_score_2x(best_solution, catalog)
-                    band_residual_2x = observation.military_delta_2x - explained
-                    if best_band_residual_2x is None or band_residual_2x < best_band_residual_2x:
-                        best_band_residual_2x = band_residual_2x
-                elif band_result.status == STATUS_INVALID_PROBLEM:
-                    last_status = band_result.status
-                    break
-
-        step_diagnostics.append(
-            _policy_step_diagnostics(
-                policy_step=policy_step,
-                policy_step_index=step_index,
-                catalog=catalog,
-                turn=turn,
-                observation=observation,
-                seed_count=len(seeds_for_step),
-                band_residual_2x=band_residual_2x,
-            )
-        )
-
-        if merged_solutions and _solution_fully_explained_by_ship_builds_only(
-            merged_solutions[0],
-            observation,
-            catalog,
-        ):
-            break
-
-        if (
-            len(merged_solutions) == new_exact_before_step
-            and len(merged_solutions) > 0
-            and not added_combo_ids
-            and not added_aggregate_action_ids
-        ):
-            ladder_early_stop_reason = "no_new_exact_signatures"
-            break
-
-    if catalog is None or problem is None:
-        first_step = policy_steps[0]
-        policy_steps_attempted.append(first_step.id)
-        catalog = build_action_catalog_from_turn(
-            observation,
-            turn,
-            policy_step=first_step,
-            policy_step_index=0,
-        )
-        problem = build_inference_problem(observation, catalog, max_solutions=max_solutions)
-        tier_result = solve_inference_problem(problem)
-        last_status = tier_result.status
-        last_diagnostics = dict(tier_result.diagnostics)
-        _merge_exact_solutions(
-            merged_solutions,
-            seen_signatures,
-            tier_result.solutions,
-            resolved_max_solutions=resolved_max_solutions,
-        )
-
-    merged_solutions.sort(key=lambda solution: solution.objective_value, reverse=True)
-    if merged_solutions:
-        if _solution_satisfies_exact_hard_equalities(
-            merged_solutions[0],
-            observation,
-            catalog,
-        ):
-            status = STATUS_EXACT
-        else:
-            status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
-    else:
-        status = STATUS_TIME_LIMITED if time_limited else last_status
-
-    stopped_reason = ladder_early_stop_reason or last_diagnostics.get("stopped_reason", "exhausted")
-    result = InferenceResult(
-        status=status,
-        solutions=tuple(merged_solutions),
-        diagnostics={
-            **last_diagnostics,
-            "policy_step_id": catalog.policy_step_id,
-            "policy_step_index": catalog.policy_step_index,
-            "solution_count": len(merged_solutions),
-            "best_band_residual_2x": best_band_residual_2x,
-            "stopped_reason": stopped_reason,
-        },
-    )
-    return result, catalog, problem, policy_steps_attempted, step_diagnostics
 
 
 def inference_result_to_api_payload(

--- a/packages/api/api/analytics/military_score_inference/component_eligibility.py
+++ b/packages/api/api/analytics/military_score_inference/component_eligibility.py
@@ -2,8 +2,11 @@
 
 from dataclasses import dataclass
 
-from api.analytics.military_score_inference.ship_build_combos import MAX_SHIP_BUILD_TIER
-from api.analytics.military_score_inference.ship_build_scoring import default_build_components
+from api.analytics.military_score_inference.tier_policy import (
+    ComponentFilter,
+    InferenceCatalogFilters,
+    InferenceTierPolicyStep,
+)
 from api.models.components import Beam, Engine, Hull, Torpedo
 from api.models.game import TurnInfo
 from api.models.player import Player, Race
@@ -44,18 +47,22 @@ def race_by_id_or_none(turn: TurnInfo, race_id: int) -> Race | None:
 
 
 def buildable_hull_ids_for_player(turn: TurnInfo, player_id: int) -> frozenset[int]:
+    """Return hull ids buildable for the viewpoint race on this turn snapshot.
+
+    ``turn.racehulls`` is the game-specific buildable set for the loaded perspective.
+    ``player.activehulls`` reflects campaign activation state and is not used here.
+    """
+    catalog_hull_ids = frozenset(hull.id for hull in turn.hulls)
+    turn_race_hull_ids = frozenset(turn.racehulls)
+    if turn_race_hull_ids:
+        return turn_race_hull_ids & catalog_hull_ids
+
     player = player_by_id(turn, player_id)
     race = race_by_id_or_none(turn, player.raceid)
-    active_hull_ids = parse_component_id_csv(player.activehulls)
     if race is not None:
-        eligible_hull_ids = active_hull_ids & (
-            parse_component_id_csv(race.hulls) | parse_component_id_csv(race.basehulls)
-        )
-    else:
-        eligible_hull_ids = active_hull_ids
-    turn_hull_ids = frozenset(turn.racehulls)
-    catalog_hull_ids = frozenset(hull.id for hull in turn.hulls)
-    return eligible_hull_ids & turn_hull_ids & catalog_hull_ids
+        race_hull_ids = parse_component_id_csv(race.hulls) | parse_component_id_csv(race.basehulls)
+        return race_hull_ids & catalog_hull_ids
+    return catalog_hull_ids
 
 
 def eligible_component_ids_for_player(
@@ -70,76 +77,107 @@ def eligible_component_ids_for_player(
     return active_ids & turn_catalog_ids
 
 
-def _default_component_id_set(component) -> frozenset[int]:
-    if component is None:
-        return frozenset()
-    return frozenset({component.id})
+def _apply_component_id_allowlist(
+    eligible_ids: frozenset[int],
+    component_filter: ComponentFilter,
+) -> frozenset[int]:
+    if not component_filter.component_ids:
+        return eligible_ids
+    allowed = frozenset(component_filter.component_ids)
+    return eligible_ids & allowed
 
 
-def turn_catalog_context_for_tier(
+def _component_ids_for_tech_levels(
+    components_by_id: dict[int, Hull | Engine | Beam | Torpedo],
+    *,
+    tech_levels: tuple[int, ...],
+) -> frozenset[int]:
+    return frozenset(
+        component_id
+        for component_id, component in components_by_id.items()
+        if component.techlevel in tech_levels
+    )
+
+
+def eligible_hull_ids_for_filter(
     turn: TurnInfo,
     player_id: int,
-    tier: int,
-) -> TurnCatalogContext:
-    if tier < 0 or tier > MAX_SHIP_BUILD_TIER:
-        raise ValueError(f"ship build tier must be between 0 and {MAX_SHIP_BUILD_TIER}, got {tier}")
+    hull_filter: ComponentFilter,
+) -> frozenset[int]:
+    """Resolve hull ids from a policy ``filters.hulls`` entry."""
+    if hull_filter.all:
+        eligible_ids = buildable_hull_ids_for_player(turn, player_id)
+    else:
+        buildable_hull_ids = buildable_hull_ids_for_player(turn, player_id)
+        hulls_by_id = {hull.id: hull for hull in turn.hulls}
+        eligible_ids = frozenset(
+            hull_id
+            for hull_id in buildable_hull_ids
+            if hull_id in hulls_by_id and hulls_by_id[hull_id].techlevel in hull_filter.tech_levels
+        )
+    return _apply_component_id_allowlist(eligible_ids, hull_filter)
 
+
+def eligible_component_ids_for_filter(
+    component_filter: ComponentFilter,
+    *,
+    active_component_csv: str,
+    components_by_id: dict[int, Engine | Beam | Torpedo],
+) -> frozenset[int]:
+    """Resolve engine, beam, or launcher torpedo ids from a policy filter entry."""
+    turn_catalog_ids = frozenset(components_by_id)
+    if component_filter.all:
+        eligible_ids = eligible_component_ids_for_player(
+            active_component_csv=active_component_csv,
+            turn_catalog_ids=turn_catalog_ids,
+        )
+    else:
+        eligible_ids = _component_ids_for_tech_levels(
+            components_by_id,
+            tech_levels=component_filter.tech_levels,
+        )
+    return _apply_component_id_allowlist(eligible_ids, component_filter)
+
+
+def turn_catalog_context_for_policy_step(
+    turn: TurnInfo,
+    player_id: int,
+    policy_step: InferenceTierPolicyStep,
+) -> TurnCatalogContext:
     hulls_by_id = {hull.id: hull for hull in turn.hulls}
     engines_by_id = {engine.id: engine for engine in turn.engines}
     beams_by_id = {beam.id: beam for beam in turn.beams}
     torpedos_by_id = {torpedo.id: torpedo for torpedo in turn.torpedos}
     player = player_by_id(turn, player_id)
-    defaults = default_build_components(
-        engines_by_id=engines_by_id,
-        beams_by_id=beams_by_id,
-        torpedos_by_id=torpedos_by_id,
-    )
-    turn_engine_ids = frozenset(engines_by_id)
-    turn_beam_ids = frozenset(beams_by_id)
-    turn_torp_ids = frozenset(torpedos_by_id)
-
-    if tier == 0:
-        eligible_engine_ids = _default_component_id_set(defaults.engine)
-    elif tier >= MAX_SHIP_BUILD_TIER:
-        eligible_engine_ids = turn_engine_ids
-    else:
-        eligible_engine_ids = eligible_component_ids_for_player(
-            active_component_csv=player.activeengines,
-            turn_catalog_ids=turn_engine_ids,
-        )
-
-    if tier <= 1:
-        eligible_beam_ids = _default_component_id_set(defaults.beam)
-    elif tier >= MAX_SHIP_BUILD_TIER:
-        eligible_beam_ids = turn_beam_ids
-    else:
-        eligible_beam_ids = eligible_component_ids_for_player(
-            active_component_csv=player.activebeams,
-            turn_catalog_ids=turn_beam_ids,
-        )
-
-    if tier <= 2:
-        eligible_torp_ids = _default_component_id_set(defaults.torpedo)
-    elif tier >= MAX_SHIP_BUILD_TIER:
-        eligible_torp_ids = turn_torp_ids
-    else:
-        eligible_torp_ids = eligible_component_ids_for_player(
-            active_component_csv=player.activetorps,
-            turn_catalog_ids=turn_torp_ids,
-        )
+    filters: InferenceCatalogFilters = policy_step.filters
 
     return TurnCatalogContext(
         hulls_by_id=hulls_by_id,
         engines_by_id=engines_by_id,
         beams_by_id=beams_by_id,
         torpedos_by_id=torpedos_by_id,
-        buildable_hull_ids=buildable_hull_ids_for_player(turn, player_id),
-        eligible_engine_ids=eligible_engine_ids,
-        eligible_beam_ids=eligible_beam_ids,
-        eligible_torp_ids=eligible_torp_ids,
+        buildable_hull_ids=eligible_hull_ids_for_filter(turn, player_id, filters.hulls),
+        eligible_engine_ids=eligible_component_ids_for_filter(
+            filters.engines,
+            active_component_csv=player.activeengines,
+            components_by_id=engines_by_id,
+        ),
+        eligible_beam_ids=eligible_component_ids_for_filter(
+            filters.beams,
+            active_component_csv=player.activebeams,
+            components_by_id=beams_by_id,
+        ),
+        eligible_torp_ids=eligible_component_ids_for_filter(
+            filters.launchers,
+            active_component_csv=player.activetorps,
+            components_by_id=torpedos_by_id,
+        ),
     )
 
 
 def turn_catalog_context_for_player(turn: TurnInfo, player_id: int) -> TurnCatalogContext:
-    """Full active-or-jump eligibility (tier 3 semantics)."""
-    return turn_catalog_context_for_tier(turn, player_id, tier=3)
+    """Full active-or-jump eligibility using the final policy step semantics."""
+    from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
+
+    policy_steps = resolve_tier_policies()
+    return turn_catalog_context_for_policy_step(turn, player_id, policy_steps[-1])

--- a/packages/api/api/analytics/military_score_inference/constraints.py
+++ b/packages/api/api/analytics/military_score_inference/constraints.py
@@ -16,6 +16,39 @@ PRIORITY_POINT_DIAGNOSTIC_NOTE = (
     "semantics assign per-build priority_point_delta values."
 )
 
+FIGHTERS_STARBASE_TO_SHIP_ID = "fighters_starbase_to_ship"
+FIGHTERS_SHIP_TO_STARBASE_ID = "fighters_ship_to_starbase"
+FIGHTER_TRANSFER_DIRECTIONS_EXCLUSIVE_DIAGNOSTIC = (
+    "at most one of fighters_starbase_to_ship and fighters_ship_to_starbase counts may be non-zero"
+)
+
+
+def _fighter_transfer_actions_both_present(
+    aggregate_action_ids: frozenset[str],
+) -> bool:
+    return (
+        FIGHTERS_STARBASE_TO_SHIP_ID in aggregate_action_ids
+        and FIGHTERS_SHIP_TO_STARBASE_ID in aggregate_action_ids
+    )
+
+
+def _add_fighter_transfer_direction_exclusivity(
+    model: cp_model.CpModel,
+    action_count_vars: dict[str, cp_model.IntVar],
+) -> None:
+    """Forbid using both transfer directions in one explanation."""
+    starbase_to_ship = action_count_vars[FIGHTERS_STARBASE_TO_SHIP_ID]
+    ship_to_starbase = action_count_vars[FIGHTERS_SHIP_TO_STARBASE_ID]
+
+    uses_starbase_to_ship = model.new_bool_var("fighter_transfer_starbase_to_ship_active")
+    uses_ship_to_starbase = model.new_bool_var("fighter_transfer_ship_to_starbase_active")
+
+    model.add(starbase_to_ship >= 1).only_enforce_if(uses_starbase_to_ship)
+    model.add(starbase_to_ship == 0).only_enforce_if(uses_starbase_to_ship.negated())
+    model.add(ship_to_starbase >= 1).only_enforce_if(uses_ship_to_starbase)
+    model.add(ship_to_starbase == 0).only_enforce_if(uses_ship_to_starbase.negated())
+    model.add(uses_starbase_to_ship + uses_ship_to_starbase <= 1)
+
 
 @dataclass(frozen=True)
 class _SumEqualityConstraint:
@@ -35,19 +68,29 @@ class _SumEqualityConstraint:
         action_count_vars: dict[str, cp_model.IntVar],
         combo_count_vars: dict[str, cp_model.IntVar],
         observation: InferenceObservation,
+        *,
+        military_score_alpha: int = 0,
     ) -> None:
         rhs = getattr(observation, self.observation_attr)
-        model.add(
-            sum(
-                getattr(action, self.coefficient_attr) * action_count_vars[action.id]
-                for action in aggregate_actions
-            )
-            + sum(
-                getattr(combo, self.coefficient_attr) * combo_count_vars[combo.combo_id]
-                for combo in ship_build_combos
-            )
-            == rhs
+        lhs = sum(
+            getattr(action, self.coefficient_attr) * action_count_vars[action.id]
+            for action in aggregate_actions
+        ) + sum(
+            getattr(combo, self.coefficient_attr) * combo_count_vars[combo.combo_id]
+            for combo in ship_build_combos
         )
+        if self.coefficient_attr != "score_delta_2x":
+            model.add(lhs == rhs)
+            return
+        partition_slack = observation.military_partition_slack_2x
+        if partition_slack > 0:
+            model.add(lhs >= rhs - partition_slack)
+            model.add(lhs <= rhs + partition_slack)
+            return
+        if military_score_alpha > 0:
+            model.add(lhs >= rhs - military_score_alpha)
+            return
+        model.add(lhs == rhs)
 
 
 _MILITARY_SCORE_EQUALITY = _SumEqualityConstraint(
@@ -71,22 +114,49 @@ class InferenceHardConstraints:
     """Which hard equalities and inequalities apply for one inference solve."""
 
     enforce_priority_point_constraint: bool = False
+    military_score_alpha: int = 0
 
     @classmethod
     def from_problem(cls, problem: InferenceProblem) -> InferenceHardConstraints:
-        return cls(enforce_priority_point_constraint=problem.enforce_priority_point_constraint)
+        return cls(
+            enforce_priority_point_constraint=problem.enforce_priority_point_constraint,
+            military_score_alpha=problem.military_score_alpha,
+        )
 
     def enforced_equalities(self) -> tuple[_SumEqualityConstraint, ...]:
         if self.enforce_priority_point_constraint:
             return _ALWAYS_ENFORCED_EQUALITIES + (_PRIORITY_POINT_EQUALITY,)
         return _ALWAYS_ENFORCED_EQUALITIES
 
-    def applied_equalities(self, observation: InferenceObservation) -> list[str]:
-        strings = [
-            constraint.applied_equality_string(observation)
-            for constraint in self.enforced_equalities()
-        ]
+    def applied_equalities(
+        self,
+        observation: InferenceObservation,
+        *,
+        aggregate_action_ids: frozenset[str] | None = None,
+    ) -> list[str]:
+        strings: list[str] = []
+        for constraint in self.enforced_equalities():
+            if (
+                constraint.coefficient_attr == "score_delta_2x"
+                and observation.military_partition_slack_2x > 0
+            ):
+                slack = observation.military_partition_slack_2x
+                strings.append(
+                    f"{observation.military_delta_2x - slack} <= "
+                    f"sum(scoreDelta2x * count) <= {observation.military_delta_2x + slack}"
+                )
+            elif constraint.coefficient_attr == "score_delta_2x" and self.military_score_alpha > 0:
+                strings.append(
+                    "sum(scoreDelta2x * count) >= "
+                    f"{observation.military_delta_2x - self.military_score_alpha}"
+                )
+            else:
+                strings.append(constraint.applied_equality_string(observation))
         strings.append(f"sum(buildSlotUsage * count) <= {observation.starbases_owned}")
+        if aggregate_action_ids is not None and _fighter_transfer_actions_both_present(
+            aggregate_action_ids
+        ):
+            strings.append(FIGHTER_TRANSFER_DIRECTIONS_EXCLUSIVE_DIAGNOSTIC)
         return strings
 
     def add_to_model(
@@ -105,6 +175,7 @@ class InferenceHardConstraints:
                 action_count_vars,
                 combo_count_vars,
                 observation,
+                military_score_alpha=self.military_score_alpha,
             )
         model.add(
             sum(
@@ -117,12 +188,16 @@ class InferenceHardConstraints:
             )
             <= observation.starbases_owned
         )
+        aggregate_action_ids = frozenset(action.id for action in problem.aggregate_actions)
+        if _fighter_transfer_actions_both_present(aggregate_action_ids):
+            _add_fighter_transfer_direction_exclusivity(model, action_count_vars)
 
 
 def observation_to_constraints_payload(
     observation: InferenceObservation,
     *,
     hard_constraints: InferenceHardConstraints | None = None,
+    aggregate_action_ids: frozenset[str] | None = None,
 ) -> dict[str, object]:
     """Serialize hard solver constraints for diagnostics."""
     constraints = hard_constraints or InferenceHardConstraints()
@@ -130,13 +205,18 @@ def observation_to_constraints_payload(
         "turn": observation.turn,
         "playerId": observation.player_id,
         "militaryDelta2x": observation.military_delta_2x,
+        "militaryPartitionSlack2x": observation.military_partition_slack_2x,
         "warshipDelta": observation.warship_delta,
         "freighterDelta": observation.freighter_delta,
         "requestedPriorityPointDelta": observation.priority_point_delta,
         "priorityPointConstraintEnforced": constraints.enforce_priority_point_constraint,
         "starbasesOwned": observation.starbases_owned,
         "isAfterShipLimit": observation.is_after_ship_limit,
-        "appliedEqualities": constraints.applied_equalities(observation),
+        "militaryScoreAlpha": constraints.military_score_alpha,
+        "appliedEqualities": constraints.applied_equalities(
+            observation,
+            aggregate_action_ids=aggregate_action_ids,
+        ),
     }
     if not constraints.enforce_priority_point_constraint:
         payload["priorityPointConstraintNote"] = PRIORITY_POINT_DIAGNOSTIC_NOTE

--- a/packages/api/api/analytics/military_score_inference/inference_api_payload.py
+++ b/packages/api/api/analytics/military_score_inference/inference_api_payload.py
@@ -1,0 +1,193 @@
+"""API payload serialization for military score build inference results."""
+
+from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.models import (
+    InferenceObservation,
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+)
+from api.analytics.military_score_inference.score_arithmetic import (
+    solution_military_score_arithmetic_payload,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_INVALID_PROBLEM,
+    STATUS_NO_EXACT_SOLUTION,
+    STATUS_TIME_LIMITED,
+)
+from api.models.game import TurnInfo
+
+STATUS_NO_PRIOR_TURN = "no_prior_turn"
+STATUS_SOLVER_ERROR = "solver_error"
+
+
+def inference_result_to_api_payload(
+    result: InferenceResult,
+    catalog: ActionCatalog,
+    observation: InferenceObservation,
+    turn: TurnInfo,
+    problem: InferenceProblem,
+    *,
+    policy_steps_attempted: list[str] | None = None,
+    step_diagnostics: list[dict[str, object]] | None = None,
+    extra_diagnostics: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Shape a solver result into the Core scores row inference object."""
+    from api.analytics.military_score_inference.analytic import (
+        build_inference_solver_diagnostics,
+    )
+
+    solver_diagnostics = {
+        "status": result.status,
+        **result.diagnostics,
+    }
+    diagnostics = build_inference_solver_diagnostics(
+        turn=turn.settings.turn,
+        observation=observation,
+        problem=problem,
+        catalog=catalog,
+        turn_info=turn,
+        solver=solver_diagnostics,
+        extra={
+            "policy_steps_attempted": policy_steps_attempted or [catalog.policy_step_id],
+            "policy_step_attempts": step_diagnostics or [],
+            **(extra_diagnostics or {}),
+        },
+    )
+    return _inference_api_payload(
+        status=result.status,
+        summary=format_inference_summary(result),
+        solutions=result.solutions,
+        diagnostics=diagnostics,
+        observation=observation,
+        catalog=catalog,
+    )
+
+
+def format_inference_summary(result: InferenceResult) -> str:
+    """Return compact row-level summary text for the inference column."""
+    if result.status == STATUS_NO_PRIOR_TURN:
+        return "Prior turn score data unavailable"
+    if result.status == STATUS_INVALID_PROBLEM:
+        reason = result.diagnostics.get("reason")
+        if isinstance(reason, str) and reason:
+            return f"Invalid inference problem: {reason}"
+        return "Invalid inference problem"
+    if result.status == STATUS_NO_EXACT_SOLUTION:
+        return "No feasible build explanation found"
+    if result.status == STATUS_SOLVER_ERROR:
+        return "Build inference failed"
+    if result.status == STATUS_TIME_LIMITED and not result.solutions:
+        return "Inference timed out before finding a solution"
+    if not result.solutions:
+        return "No feasible build explanation found"
+
+    best_summary = _format_solution_brief(result.solutions[0])
+    alternative_count = len(result.solutions) - 1
+    if alternative_count == 0:
+        return f"Best: {best_summary}"
+    if alternative_count == 1:
+        return f"Best: {best_summary}; 1 alternative"
+    return f"Best: {best_summary}; {alternative_count} alternatives"
+
+
+def _format_solution_brief(solution: InferenceSolution) -> str:
+    parts: list[str] = []
+    for action in solution.actions:
+        if action.count == 1:
+            parts.append(action.label)
+        else:
+            parts.append(f"{action.count}x {action.label}")
+    for ship_build in solution.ship_builds:
+        if ship_build.count == 1:
+            parts.append(ship_build.label)
+        else:
+            parts.append(f"{ship_build.count}x {ship_build.label}")
+    return "; ".join(parts) if parts else "no actions"
+
+
+def _inference_api_payload(
+    *,
+    status: str,
+    summary: str,
+    solutions: tuple[InferenceSolution, ...],
+    diagnostics: dict[str, object],
+    observation: InferenceObservation | None = None,
+    catalog: ActionCatalog | None = None,
+) -> dict[str, object]:
+    return {
+        "status": status,
+        "summary": summary,
+        "solutionCount": len(solutions),
+        "isComplete": status != STATUS_TIME_LIMITED,
+        "solutions": (
+            [
+                _serialize_solution_with_arithmetic(observation, catalog, solution)
+                for solution in solutions
+            ]
+            if observation is not None and catalog is not None
+            else [_serialize_solution_without_arithmetic(solution) for solution in solutions]
+        ),
+        "diagnostics": diagnostics,
+    }
+
+
+def _serialize_solution_actions(
+    solution: InferenceSolution,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "actionId": action.action_id,
+            "label": action.label,
+            "count": action.count,
+        }
+        for action in solution.actions
+    ]
+
+
+def _serialize_solution_ship_builds(
+    solution: InferenceSolution,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "comboId": ship_build.combo_id,
+            "label": ship_build.label,
+            "count": ship_build.count,
+            "hullId": ship_build.hull_id,
+            "engineId": ship_build.engine_id,
+            "beamId": ship_build.beam_id,
+            "torpId": ship_build.torp_id,
+            "beamCount": ship_build.beam_count,
+            "launcherCount": ship_build.launcher_count,
+        }
+        for ship_build in solution.ship_builds
+    ]
+
+
+def _serialize_solution_core(solution: InferenceSolution) -> dict[str, object]:
+    return {
+        "objectiveValue": solution.objective_value,
+        "actions": _serialize_solution_actions(solution),
+        "shipBuilds": _serialize_solution_ship_builds(solution),
+    }
+
+
+def _serialize_solution_with_arithmetic(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    solution: InferenceSolution,
+) -> dict[str, object]:
+    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
+    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
+    payload = _serialize_solution_core(solution)
+    payload["militaryScoreArithmetic"] = solution_military_score_arithmetic_payload(
+        solution,
+        observation,
+        actions_by_id,
+        combos_by_id,
+    )
+    return payload
+
+
+def _serialize_solution_without_arithmetic(solution: InferenceSolution) -> dict[str, object]:
+    return _serialize_solution_core(solution)

--- a/packages/api/api/analytics/military_score_inference/inference_path.py
+++ b/packages/api/api/analytics/military_score_inference/inference_path.py
@@ -1,0 +1,89 @@
+"""Resolve which inference orchestration path applies for a scoreboard row."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from api.analytics.military_score_inference.accelerated_start import (
+    AcceleratedInferenceSegment,
+    accelerated_inference_segments,
+    accelerated_turn_count,
+    scoreboard_host_turn,
+)
+from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.inference_target import (
+    ScoreboardTurnLoader,
+    load_accelerated_backfill_source_for_host_turn,
+)
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+
+class InferencePath(Enum):
+    """High-level inference orchestration path for one scoreboard row."""
+
+    CORPUS_PREBUILT = "corpus_prebuilt"
+    ACCELERATED_BACKFILL = "accelerated_backfill"
+    ACCELERATED_SPLIT = "accelerated_split"
+    POLICY_LADDER = "policy_ladder"
+    NO_PRIOR_TURN = "no_prior_turn"
+
+
+def prior_turn_score_data_available(turn: TurnInfo) -> bool:
+    """Return whether this turn has a prior scoreboard row to infer from."""
+    turn_number = turn.settings.turn
+    if turn_number <= 1:
+        return False
+    accelerated = accelerated_turn_count(turn.settings)
+    if accelerated > 0 and turn_number < accelerated:
+        return False
+    return True
+
+
+def _can_attempt_accelerated_backfill(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    load_scoreboard_turn: ScoreboardTurnLoader | None,
+) -> bool:
+    if load_scoreboard_turn is None:
+        return False
+    target_host_turn = scoreboard_host_turn(turn.settings.turn)
+    if target_host_turn is None:
+        return False
+    return (
+        load_accelerated_backfill_source_for_host_turn(
+            score,
+            turn,
+            host_turn=target_host_turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )
+        is not None
+    )
+
+
+def resolve_inference_path(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    catalog: ActionCatalog | None = None,
+    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+) -> tuple[InferencePath, tuple[AcceleratedInferenceSegment, ...] | None]:
+    """Pick the inference orchestration path and any pre-resolved accelerated segments."""
+    if not prior_turn_score_data_available(turn):
+        if _can_attempt_accelerated_backfill(
+            score,
+            turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        ):
+            return InferencePath.ACCELERATED_BACKFILL, None
+        return InferencePath.NO_PRIOR_TURN, None
+
+    if catalog is not None:
+        return InferencePath.CORPUS_PREBUILT, None
+
+    segments = accelerated_inference_segments(score, turn)
+    if segments is not None:
+        return InferencePath.ACCELERATED_SPLIT, segments
+
+    return InferencePath.POLICY_LADDER, None

--- a/packages/api/api/analytics/military_score_inference/inference_target.py
+++ b/packages/api/api/analytics/military_score_inference/inference_target.py
@@ -1,0 +1,209 @@
+"""Resolve inference catalog context for a host turn, including accelerated backfill."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from api.analytics.military_score_inference.accelerated_start import (
+    SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+    AcceleratedInferenceSegment,
+    accelerated_inference_segments,
+    first_reliable_accelerated_scoreboard_turn,
+    needs_accelerated_backfill,
+    observation_deltas_from_score,
+    scoreboard_host_turn,
+)
+from api.analytics.military_score_inference.models import InferenceObservation
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+ScoreboardTurnLoader = Callable[[int], TurnInfo | None]
+
+
+@dataclass(frozen=True)
+class ResolvedInferenceTarget:
+    """Observation and turn snapshot used to build the action catalog for one host turn."""
+
+    observation: InferenceObservation
+    turn_info: TurnInfo
+    score: Score
+
+
+@dataclass(frozen=True)
+class AcceleratedBackfillSource:
+    """First reliable scoreboard turn and accelerated segments for backfill."""
+
+    source_turn: TurnInfo
+    source_score: Score
+    segments: tuple[AcceleratedInferenceSegment, ...]
+    source_turn_number: int
+
+
+def is_after_ship_limit(turn: TurnInfo, score: Score) -> bool:
+    """Return whether ship-limit queue rules apply for this player on this turn."""
+    settings = turn.settings
+    player_ships = score.capitalships + score.freighters
+    if settings.shiplimittype != 0:
+        player_limit = (
+            settings.plsminships
+            + settings.plsextraships
+            + settings.plsshipsperplanet * score.planets
+        )
+        return player_ships >= player_limit
+    total_ships = sum(
+        other_score.capitalships + other_score.freighters for other_score in turn.scores
+    )
+    return total_ships >= settings.shiplimit
+
+
+def observation_from_deltas(
+    score: Score,
+    turn: TurnInfo,
+    deltas: tuple[int, int, int, int],
+    *,
+    military_partition_slack_2x: int = SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+) -> InferenceObservation:
+    military_delta_2x, warship_delta, freighter_delta, priority_point_delta = deltas
+    return InferenceObservation(
+        player_id=score.ownerid,
+        turn=turn.settings.turn,
+        military_delta_2x=military_delta_2x,
+        warship_delta=warship_delta,
+        freighter_delta=freighter_delta,
+        priority_point_delta=priority_point_delta,
+        starbases_owned=score.starbases,
+        is_after_ship_limit=is_after_ship_limit(turn, score),
+        military_partition_slack_2x=military_partition_slack_2x,
+    )
+
+
+def observation_from_accelerated_segment(
+    score: Score,
+    turn: TurnInfo,
+    segment: AcceleratedInferenceSegment,
+) -> InferenceObservation:
+    return observation_from_deltas(
+        score,
+        turn,
+        (
+            segment.military_delta_2x,
+            segment.warship_delta,
+            segment.freighter_delta,
+            segment.priority_point_delta,
+        ),
+    )
+
+
+def accelerated_segment_for_host_turn(
+    segments: tuple[AcceleratedInferenceSegment, ...],
+    host_turn: int,
+) -> AcceleratedInferenceSegment | None:
+    for segment in segments:
+        if segment.host_turn == host_turn:
+            return segment
+    return None
+
+
+def load_accelerated_backfill_source_for_host_turn(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    host_turn: int,
+    load_scoreboard_turn: ScoreboardTurnLoader,
+) -> AcceleratedBackfillSource | None:
+    """Load accelerated segments from the first reliable scoreboard turn for backfill."""
+    if not needs_accelerated_backfill(turn.settings.turn, turn.settings):
+        return None
+
+    scoreboard_turn_host = scoreboard_host_turn(turn.settings.turn)
+    if scoreboard_turn_host is None or scoreboard_turn_host != host_turn:
+        return None
+
+    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
+    if source_turn_number is None:
+        return None
+
+    source_turn = load_scoreboard_turn(source_turn_number)
+    if source_turn is None:
+        return None
+
+    source_score = next(
+        (row for row in source_turn.scores if row.ownerid == score.ownerid),
+        None,
+    )
+    if source_score is None:
+        return None
+
+    segments = accelerated_inference_segments(source_score, source_turn)
+    if segments is None:
+        return None
+
+    return AcceleratedBackfillSource(
+        source_turn=source_turn,
+        source_score=source_score,
+        segments=segments,
+        source_turn_number=source_turn_number,
+    )
+
+
+def resolve_inference_target_for_host_turn(
+    score: Score,
+    turn: TurnInfo,
+    *,
+    host_turn: int,
+    load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+) -> ResolvedInferenceTarget | None:
+    """Resolve catalog context for a host-turn target using inference-equivalent rules.
+
+    Unreliable accelerated scoreboard rows backfill from the first reliable split;
+    the first reliable row uses accelerated segments; later rows use score deltas.
+    Returns None when accelerated context is required but cannot be loaded.
+    """
+    if needs_accelerated_backfill(turn.settings.turn, turn.settings):
+        if load_scoreboard_turn is None:
+            return None
+        backfill_source = load_accelerated_backfill_source_for_host_turn(
+            score,
+            turn,
+            host_turn=host_turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )
+        if backfill_source is None:
+            return None
+        segment = accelerated_segment_for_host_turn(backfill_source.segments, host_turn)
+        if segment is None:
+            return None
+        return ResolvedInferenceTarget(
+            observation=observation_from_accelerated_segment(
+                backfill_source.source_score,
+                backfill_source.source_turn,
+                segment,
+            ),
+            turn_info=backfill_source.source_turn,
+            score=backfill_source.source_score,
+        )
+
+    segments = accelerated_inference_segments(score, turn)
+    if segments is not None:
+        segment = accelerated_segment_for_host_turn(segments, host_turn)
+        if segment is None:
+            return None
+        return ResolvedInferenceTarget(
+            observation=observation_from_accelerated_segment(score, turn, segment),
+            turn_info=turn,
+            score=score,
+        )
+
+    expected_host_turn = scoreboard_host_turn(turn.settings.turn)
+    if expected_host_turn is None or expected_host_turn != host_turn:
+        return None
+    return ResolvedInferenceTarget(
+        observation=observation_from_deltas(
+            score,
+            turn,
+            observation_deltas_from_score(score, turn),
+        ),
+        turn_info=turn,
+        score=score,
+    )

--- a/packages/api/api/analytics/military_score_inference/models.py
+++ b/packages/api/api/analytics/military_score_inference/models.py
@@ -13,6 +13,7 @@ class InferenceObservation:
     priority_point_delta: int
     starbases_owned: int
     is_after_ship_limit: bool
+    military_partition_slack_2x: int = 0
 
 
 @dataclass(frozen=True)
@@ -61,13 +62,15 @@ class InferenceProblem:
     observation: InferenceObservation
     aggregate_actions: tuple[CandidateAction, ...]
     ship_build_combos: tuple[ShipBuildCombo, ...] = ()
-    ship_build_tier: int = 0
+    policy_step_id: str = ""
+    policy_step_index: int = 0
     probability_buckets_by_action_id: dict[str, tuple[ProbabilityBucket, ...]] = field(
         default_factory=dict
     )
     max_solutions: int = 20
     time_limit_seconds: float = 20.0
     enforce_priority_point_constraint: bool = False
+    military_score_alpha: int = 0
 
 
 @dataclass(frozen=True)

--- a/packages/api/api/analytics/military_score_inference/policy_ladder.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder.py
@@ -96,6 +96,13 @@ def _explained_military_score_2x(
     return explained
 
 
+def _catalog_solve_max_solutions(merged_count: int, resolved_max_solutions: int) -> int:
+    remaining_slots = max(0, resolved_max_solutions - merged_count)
+    if remaining_slots > 0:
+        return remaining_slots
+    return resolved_max_solutions
+
+
 def _merge_exact_solutions(
     merged_solutions: list[InferenceSolution],
     seen_signatures: set[tuple[tuple[str, int], ...]],
@@ -108,11 +115,22 @@ def _merge_exact_solutions(
         signature = solution_signature(solution)
         if signature in seen_signatures:
             continue
+        if len(merged_solutions) < resolved_max_solutions:
+            seen_signatures.add(signature)
+            merged_solutions.append(solution)
+            new_solutions += 1
+            continue
+        worst_index = min(
+            range(len(merged_solutions)),
+            key=lambda index: merged_solutions[index].objective_value,
+        )
+        worst_solution = merged_solutions[worst_index]
+        if solution.objective_value <= worst_solution.objective_value:
+            continue
+        seen_signatures.remove(solution_signature(worst_solution))
         seen_signatures.add(signature)
-        merged_solutions.append(solution)
+        merged_solutions[worst_index] = solution
         new_solutions += 1
-        if len(merged_solutions) >= resolved_max_solutions:
-            break
     return new_solutions
 
 
@@ -257,9 +275,6 @@ def solve_with_policy_ladder(
         added_combo_ids = (
             current_combo_ids if prior_combo_ids is None else current_combo_ids - prior_combo_ids
         )
-        if added_combo_ids:
-            merged_solutions.clear()
-            seen_signatures.clear()
         prior_combo_ids = current_combo_ids
         current_aggregate_action_ids = frozenset(action.id for action in catalog.aggregate_actions)
         added_aggregate_action_ids = (
@@ -269,9 +284,10 @@ def solve_with_policy_ladder(
         )
         prior_aggregate_action_ids = current_aggregate_action_ids
 
-        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-        if remaining_slots == 0:
-            break
+        catalog_solve_max = _catalog_solve_max_solutions(
+            len(merged_solutions),
+            resolved_max_solutions,
+        )
 
         new_exact_before_step = len(merged_solutions)
         seeds_for_step = list(band_seeds)
@@ -286,7 +302,7 @@ def solve_with_policy_ladder(
                 observation,
                 catalog,
                 seed,
-                max_solutions=remaining_slots,
+                max_solutions=catalog_solve_max,
                 time_limit_seconds=seed_remaining,
             )
             if seed_result is None or seed_problem is None:
@@ -296,9 +312,10 @@ def solve_with_policy_ladder(
                 last_diagnostics = dict(seed_result.diagnostics)
                 problem = seed_problem
                 break
-            remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-            if remaining_slots == 0:
-                break
+            catalog_solve_max = _catalog_solve_max_solutions(
+                len(merged_solutions),
+                resolved_max_solutions,
+            )
             _merge_exact_solutions(
                 merged_solutions,
                 seen_signatures,
@@ -316,14 +333,15 @@ def solve_with_policy_ladder(
         if remaining <= 0:
             time_limited = True
             break
-        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
-        if remaining_slots == 0:
-            break
+        catalog_solve_max = _catalog_solve_max_solutions(
+            len(merged_solutions),
+            resolved_max_solutions,
+        )
 
         exact_result, problem = _solve_catalog(
             observation,
             catalog,
-            max_solutions=remaining_slots,
+            max_solutions=catalog_solve_max,
             time_limit_seconds=remaining,
         )
         last_status = exact_result.status
@@ -415,14 +433,15 @@ def solve_with_policy_ladder(
 
     merged_solutions.sort(key=lambda solution: solution.objective_value, reverse=True)
     if merged_solutions:
-        if _solution_satisfies_exact_hard_equalities(
-            merged_solutions[0],
-            observation,
-            catalog,
+        if any(
+            _solution_satisfies_exact_hard_equalities(solution, observation, catalog)
+            for solution in merged_solutions
         ):
             status = STATUS_EXACT
+        elif time_limited:
+            status = STATUS_TIME_LIMITED
         else:
-            status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
+            status = STATUS_NO_EXACT_SOLUTION
     else:
         status = STATUS_TIME_LIMITED if time_limited else last_status
 

--- a/packages/api/api/analytics/military_score_inference/policy_ladder.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder.py
@@ -1,0 +1,442 @@
+"""YAML tier policy ladder execution: walk steps, seed carry-forward, merge solutions."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from api.analytics.military_score_inference.actions import (
+    DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
+    ActionCatalog,
+    build_action_catalog_from_turn,
+    build_inference_problem,
+)
+from api.analytics.military_score_inference.component_eligibility import (
+    turn_catalog_context_for_policy_step,
+)
+from api.analytics.military_score_inference.models import (
+    InferenceObservation,
+    InferenceProblem,
+    InferenceResult,
+    InferenceSolution,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_INVALID_PROBLEM,
+    STATUS_NO_EXACT_SOLUTION,
+    STATUS_TIME_LIMITED,
+    solution_signature,
+    solve_inference_problem,
+)
+from api.analytics.military_score_inference.tier_policy import (
+    InferenceTierPolicyStep,
+    resolve_tier_policies,
+)
+from api.models.game import TurnInfo
+
+
+def _combo_counts_from_solution(solution: InferenceSolution) -> dict[str, int]:
+    return {ship_build.combo_id: ship_build.count for ship_build in solution.ship_builds}
+
+
+def _solution_fully_explained_by_ship_builds_only(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> bool:
+    if solution.actions:
+        return False
+    return _solution_satisfies_exact_hard_equalities(solution, observation, catalog)
+
+
+def _solution_satisfies_exact_hard_equalities(
+    solution: InferenceSolution,
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+) -> bool:
+    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
+    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
+    military_sum = 0
+    warship_sum = 0
+    freighter_sum = 0
+    for action in solution.actions:
+        catalog_action = actions_by_id.get(action.action_id)
+        if catalog_action is None:
+            return False
+        military_sum += catalog_action.score_delta_2x * action.count
+        warship_sum += catalog_action.warship_delta * action.count
+        freighter_sum += catalog_action.freighter_delta * action.count
+    for ship_build in solution.ship_builds:
+        combo = combos_by_id.get(ship_build.combo_id)
+        if combo is None:
+            return False
+        military_sum += combo.score_delta_2x * ship_build.count
+        warship_sum += combo.warship_delta * ship_build.count
+        freighter_sum += combo.freighter_delta * ship_build.count
+    return (
+        abs(military_sum - observation.military_delta_2x) <= observation.military_partition_slack_2x
+        and warship_sum == observation.warship_delta
+        and freighter_sum == observation.freighter_delta
+    )
+
+
+def _explained_military_score_2x(
+    solution: InferenceSolution,
+    catalog: ActionCatalog,
+) -> int:
+    actions_by_id = {action.id: action for action in catalog.aggregate_actions}
+    combos_by_id = {combo.combo_id: combo for combo in catalog.ship_build_combos}
+    explained = 0
+    for action in solution.actions:
+        catalog_action = actions_by_id[action.action_id]
+        explained += catalog_action.score_delta_2x * action.count
+    for ship_build in solution.ship_builds:
+        combo = combos_by_id[ship_build.combo_id]
+        explained += combo.score_delta_2x * ship_build.count
+    return explained
+
+
+def _merge_exact_solutions(
+    merged_solutions: list[InferenceSolution],
+    seen_signatures: set[tuple[tuple[str, int], ...]],
+    candidates: tuple[InferenceSolution, ...],
+    *,
+    resolved_max_solutions: int,
+) -> int:
+    new_solutions = 0
+    for solution in candidates:
+        signature = solution_signature(solution)
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        merged_solutions.append(solution)
+        new_solutions += 1
+        if len(merged_solutions) >= resolved_max_solutions:
+            break
+    return new_solutions
+
+
+def _solve_catalog(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    *,
+    max_solutions: int,
+    time_limit_seconds: float,
+    military_score_alpha: int = 0,
+    fixed_combo_counts: dict[str, int] | None = None,
+    combo_count_neighborhood: int = 0,
+) -> tuple[InferenceResult, InferenceProblem]:
+    problem = build_inference_problem(
+        observation,
+        catalog,
+        max_solutions=max_solutions,
+        time_limit_seconds=time_limit_seconds,
+        military_score_alpha=military_score_alpha,
+        fixed_combo_counts=fixed_combo_counts,
+        combo_count_neighborhood=combo_count_neighborhood,
+    )
+    return solve_inference_problem(problem), problem
+
+
+def _solve_seed_progression(
+    observation: InferenceObservation,
+    catalog: ActionCatalog,
+    seed: InferenceSolution,
+    *,
+    max_solutions: int,
+    time_limit_seconds: float,
+) -> tuple[InferenceResult | None, InferenceProblem | None]:
+    fixed_counts = _combo_counts_from_solution(seed)
+    if not fixed_counts:
+        return None, None
+
+    remaining_slots = max_solutions
+    for neighborhood in (0, 1):
+        if remaining_slots <= 0 or time_limit_seconds <= 0:
+            break
+        result, problem = _solve_catalog(
+            observation,
+            catalog,
+            max_solutions=remaining_slots,
+            time_limit_seconds=time_limit_seconds,
+            fixed_combo_counts=fixed_counts,
+            combo_count_neighborhood=neighborhood,
+        )
+        if result.solutions:
+            return result, problem
+
+    result, problem = _solve_catalog(
+        observation,
+        catalog,
+        max_solutions=remaining_slots,
+        time_limit_seconds=time_limit_seconds,
+    )
+    if result.solutions:
+        return result, problem
+    return None, None
+
+
+def _policy_step_diagnostics(
+    *,
+    policy_step: InferenceTierPolicyStep,
+    policy_step_index: int,
+    catalog: ActionCatalog,
+    turn: TurnInfo,
+    observation: InferenceObservation,
+    seed_count: int,
+    band_residual_2x: int | None,
+) -> dict[str, object]:
+    catalog_context = turn_catalog_context_for_policy_step(
+        turn,
+        observation.player_id,
+        policy_step,
+    )
+    return {
+        "policyStepId": policy_step.id,
+        "policyStepIndex": policy_step_index,
+        "policyStepsAttempted": policy_step_index + 1,
+        "constraintSnapshot": policy_step.constraint_snapshot(),
+        "resolvedEligibleEngineIds": sorted(catalog_context.eligible_engine_ids),
+        "resolvedEligibleBeamIds": sorted(catalog_context.eligible_beam_ids),
+        "resolvedEligibleTorpIds": sorted(catalog_context.eligible_torp_ids),
+        "resolvedBuildableHullIds": sorted(catalog_context.buildable_hull_ids),
+        "alpha": policy_step.alpha,
+        "comboCount": len(catalog.ship_build_combos),
+        "seedCount": seed_count,
+        "bandResidual2x": band_residual_2x,
+    }
+
+
+def solve_with_policy_ladder(
+    observation: InferenceObservation,
+    turn: TurnInfo,
+    *,
+    policy_path: Path | None = None,
+    max_solutions: int | None = None,
+    time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
+) -> tuple[
+    InferenceResult,
+    ActionCatalog,
+    InferenceProblem,
+    list[str],
+    list[dict[str, object]],
+]:
+    """Walk the YAML inference search tier ladder with band seed carry-forward."""
+    started_at = time.monotonic()
+    policy_steps = resolve_tier_policies(policy_path)
+    policy_steps_attempted: list[str] = []
+    step_diagnostics: list[dict[str, object]] = []
+    merged_solutions: list[InferenceSolution] = []
+    seen_signatures: set[tuple[tuple[str, int], ...]] = set()
+    catalog: ActionCatalog | None = None
+    problem: InferenceProblem | None = None
+    last_status = STATUS_NO_EXACT_SOLUTION
+    last_diagnostics: dict[str, object] = {}
+    resolved_max_solutions = max_solutions if max_solutions is not None else 20
+    time_limited = False
+    band_seeds: list[InferenceSolution] = []
+    best_band_residual_2x: int | None = None
+    prior_combo_ids: frozenset[str] | None = None
+    prior_aggregate_action_ids: frozenset[str] | None = None
+    ladder_early_stop_reason: str | None = None
+
+    for step_index, policy_step in enumerate(policy_steps):
+        remaining = time_limit_seconds - (time.monotonic() - started_at)
+        if remaining <= 0:
+            time_limited = True
+            break
+
+        policy_steps_attempted.append(policy_step.id)
+        catalog = build_action_catalog_from_turn(
+            observation,
+            turn,
+            policy_step=policy_step,
+            policy_step_index=step_index,
+        )
+        current_combo_ids = frozenset(combo.combo_id for combo in catalog.ship_build_combos)
+        added_combo_ids = (
+            current_combo_ids if prior_combo_ids is None else current_combo_ids - prior_combo_ids
+        )
+        if added_combo_ids:
+            merged_solutions.clear()
+            seen_signatures.clear()
+        prior_combo_ids = current_combo_ids
+        current_aggregate_action_ids = frozenset(action.id for action in catalog.aggregate_actions)
+        added_aggregate_action_ids = (
+            current_aggregate_action_ids
+            if prior_aggregate_action_ids is None
+            else current_aggregate_action_ids - prior_aggregate_action_ids
+        )
+        prior_aggregate_action_ids = current_aggregate_action_ids
+
+        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
+        if remaining_slots == 0:
+            break
+
+        new_exact_before_step = len(merged_solutions)
+        seeds_for_step = list(band_seeds)
+        band_seeds = []
+
+        for seed in seeds_for_step[: policy_step.max_seeds]:
+            seed_remaining = time_limit_seconds - (time.monotonic() - started_at)
+            if seed_remaining <= 0:
+                time_limited = True
+                break
+            seed_result, seed_problem = _solve_seed_progression(
+                observation,
+                catalog,
+                seed,
+                max_solutions=remaining_slots,
+                time_limit_seconds=seed_remaining,
+            )
+            if seed_result is None or seed_problem is None:
+                continue
+            if seed_result.status == STATUS_INVALID_PROBLEM:
+                last_status = seed_result.status
+                last_diagnostics = dict(seed_result.diagnostics)
+                problem = seed_problem
+                break
+            remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
+            if remaining_slots == 0:
+                break
+            _merge_exact_solutions(
+                merged_solutions,
+                seen_signatures,
+                seed_result.solutions,
+                resolved_max_solutions=resolved_max_solutions,
+            )
+            problem = seed_problem
+            if seed_result.status == STATUS_TIME_LIMITED:
+                time_limited = True
+
+        if last_status == STATUS_INVALID_PROBLEM:
+            break
+
+        remaining = time_limit_seconds - (time.monotonic() - started_at)
+        if remaining <= 0:
+            time_limited = True
+            break
+        remaining_slots = max(0, resolved_max_solutions - len(merged_solutions))
+        if remaining_slots == 0:
+            break
+
+        exact_result, problem = _solve_catalog(
+            observation,
+            catalog,
+            max_solutions=remaining_slots,
+            time_limit_seconds=remaining,
+        )
+        last_status = exact_result.status
+        last_diagnostics = dict(exact_result.diagnostics)
+        if exact_result.status == STATUS_INVALID_PROBLEM:
+            break
+
+        if exact_result.solutions:
+            _merge_exact_solutions(
+                merged_solutions,
+                seen_signatures,
+                exact_result.solutions,
+                resolved_max_solutions=resolved_max_solutions,
+            )
+            if exact_result.status == STATUS_TIME_LIMITED:
+                time_limited = True
+
+        band_residual_2x: int | None = None
+        if not exact_result.solutions and policy_step.alpha > 0:
+            remaining = time_limit_seconds - (time.monotonic() - started_at)
+            if remaining > 0:
+                band_result, band_problem = _solve_catalog(
+                    observation,
+                    catalog,
+                    max_solutions=policy_step.max_seeds,
+                    time_limit_seconds=remaining,
+                    military_score_alpha=policy_step.alpha,
+                )
+                problem = band_problem
+                last_diagnostics = dict(band_result.diagnostics)
+                if band_result.solutions:
+                    band_seeds = list(band_result.solutions[: policy_step.max_seeds])
+                    best_solution = band_result.solutions[0]
+                    explained = _explained_military_score_2x(best_solution, catalog)
+                    band_residual_2x = observation.military_delta_2x - explained
+                    if best_band_residual_2x is None or band_residual_2x < best_band_residual_2x:
+                        best_band_residual_2x = band_residual_2x
+                elif band_result.status == STATUS_INVALID_PROBLEM:
+                    last_status = band_result.status
+                    break
+
+        step_diagnostics.append(
+            _policy_step_diagnostics(
+                policy_step=policy_step,
+                policy_step_index=step_index,
+                catalog=catalog,
+                turn=turn,
+                observation=observation,
+                seed_count=len(seeds_for_step),
+                band_residual_2x=band_residual_2x,
+            )
+        )
+
+        if merged_solutions and _solution_fully_explained_by_ship_builds_only(
+            merged_solutions[0],
+            observation,
+            catalog,
+        ):
+            break
+
+        if (
+            len(merged_solutions) == new_exact_before_step
+            and len(merged_solutions) > 0
+            and not added_combo_ids
+            and not added_aggregate_action_ids
+        ):
+            ladder_early_stop_reason = "no_new_exact_signatures"
+            break
+
+    if catalog is None or problem is None:
+        first_step = policy_steps[0]
+        policy_steps_attempted.append(first_step.id)
+        catalog = build_action_catalog_from_turn(
+            observation,
+            turn,
+            policy_step=first_step,
+            policy_step_index=0,
+        )
+        problem = build_inference_problem(observation, catalog, max_solutions=max_solutions)
+        tier_result = solve_inference_problem(problem)
+        last_status = tier_result.status
+        last_diagnostics = dict(tier_result.diagnostics)
+        _merge_exact_solutions(
+            merged_solutions,
+            seen_signatures,
+            tier_result.solutions,
+            resolved_max_solutions=resolved_max_solutions,
+        )
+
+    merged_solutions.sort(key=lambda solution: solution.objective_value, reverse=True)
+    if merged_solutions:
+        if _solution_satisfies_exact_hard_equalities(
+            merged_solutions[0],
+            observation,
+            catalog,
+        ):
+            status = STATUS_EXACT
+        else:
+            status = STATUS_TIME_LIMITED if time_limited else STATUS_EXACT
+    else:
+        status = STATUS_TIME_LIMITED if time_limited else last_status
+
+    stopped_reason = ladder_early_stop_reason or last_diagnostics.get("stopped_reason", "exhausted")
+    result = InferenceResult(
+        status=status,
+        solutions=tuple(merged_solutions),
+        diagnostics={
+            **last_diagnostics,
+            "policy_step_id": catalog.policy_step_id,
+            "policy_step_index": catalog.policy_step_index,
+            "solution_count": len(merged_solutions),
+            "best_band_residual_2x": best_band_residual_2x,
+            "stopped_reason": stopped_reason,
+        },
+    )
+    return result, catalog, problem, policy_steps_attempted, step_diagnostics

--- a/packages/api/api/analytics/military_score_inference/score_arithmetic.py
+++ b/packages/api/api/analytics/military_score_inference/score_arithmetic.py
@@ -61,11 +61,13 @@ def solution_military_score_arithmetic_payload(
     observed_military_delta_2x = observation.military_delta_2x
     observed_military_change = observed_military_delta_2x // 2
     explained_military_change = explained_military_delta_2x // 2
+    slack = observation.military_partition_slack_2x
     return {
         "observedMilitaryChange": observed_military_change,
         "observedMilitaryDelta2x": observed_military_delta_2x,
         "explainedMilitaryChange": explained_military_change,
         "explainedMilitaryDelta2x": explained_military_delta_2x,
-        "matchesObserved": explained_military_delta_2x == observed_military_delta_2x,
+        "militaryPartitionSlack2x": slack,
+        "matchesObserved": abs(explained_military_delta_2x - observed_military_delta_2x) <= slack,
         "lineItems": line_items,
     }

--- a/packages/api/api/analytics/military_score_inference/ship_build_combos.py
+++ b/packages/api/api/analytics/military_score_inference/ship_build_combos.py
@@ -5,13 +5,10 @@ from dataclasses import dataclass
 from api.analytics.military_score_inference.models import InferenceObservation, ShipBuildCombo
 from api.analytics.military_score_inference.ship_build_scoring import (
     is_military_hull,
-    ship_build_score_delta_2x,
+    ship_build_military_score_delta_2x,
 )
+from api.analytics.military_score_inference.tier_policy import SlotCountMode
 from api.models.components import Beam, Engine, Hull, Torpedo
-
-START_SHIP_BUILD_TIER = 0
-MAX_SHIP_BUILD_TIER = 4
-DEFAULT_SHIP_BUILD_TIER = START_SHIP_BUILD_TIER
 
 
 @dataclass(frozen=True)
@@ -57,18 +54,18 @@ def ship_build_combo_label(
     return f"Build {hull.name} (unarmed)"
 
 
-def beam_count_options_for_tier(hull: Hull, tier: int) -> tuple[int, ...]:
+def beam_count_options_for_slot_mode(hull: Hull, slot_mode: SlotCountMode) -> tuple[int, ...]:
     if hull.beams == 0:
         return (0,)
-    if tier >= MAX_SHIP_BUILD_TIER:
+    if slot_mode == "partial":
         return tuple(range(0, hull.beams + 1))
     return (0, hull.beams)
 
 
-def launcher_count_options_for_tier(hull: Hull, tier: int) -> tuple[int, ...]:
+def launcher_count_options_for_slot_mode(hull: Hull, slot_mode: SlotCountMode) -> tuple[int, ...]:
     if hull.launchers == 0:
         return (0,)
-    if tier >= MAX_SHIP_BUILD_TIER:
+    if slot_mode == "partial":
         return tuple(range(0, hull.launchers + 1))
     return (0, hull.launchers)
 
@@ -100,7 +97,8 @@ def generate_ship_build_combos(
     eligible_beam_ids: frozenset[int],
     eligible_torp_ids: frozenset[int],
     config: ShipBuildComboConfig | None = None,
-    ship_build_tier: int = DEFAULT_SHIP_BUILD_TIER,
+    beam_slot_counts: SlotCountMode = "none",
+    launcher_slot_counts: SlotCountMode = "none",
 ) -> tuple[ShipBuildCombo, ...]:
     combo_config = config or ShipBuildComboConfig()
     combos: list[ShipBuildCombo] = []
@@ -120,8 +118,8 @@ def generate_ship_build_combos(
         if build_upper_bound <= 0:
             continue
 
-        beam_count_options = beam_count_options_for_tier(hull, ship_build_tier)
-        launcher_count_options = launcher_count_options_for_tier(hull, ship_build_tier)
+        beam_count_options = beam_count_options_for_slot_mode(hull, beam_slot_counts)
+        launcher_count_options = launcher_count_options_for_slot_mode(hull, launcher_slot_counts)
 
         for engine_id in sorted(eligible_engine_ids):
             engine = engines_by_id.get(engine_id)
@@ -156,7 +154,7 @@ def generate_ship_build_combos(
 
                     for beam in beam_choices:
                         for torpedo in torp_choices:
-                            score_delta_2x = ship_build_score_delta_2x(
+                            score_delta_2x = ship_build_military_score_delta_2x(
                                 hull,
                                 engine,
                                 beam,
@@ -164,7 +162,7 @@ def generate_ship_build_combos(
                                 beam_count=beam_count,
                                 launcher_count=launcher_count,
                             )
-                            if score_delta_2x == 0:
+                            if score_delta_2x == 0 and not is_warship and not is_freighter:
                                 continue
 
                             armed = beam_count > 0 or launcher_count > 0
@@ -225,11 +223,22 @@ def prune_combos_for_observation(
     if observation.military_delta_2x <= 0:
         return combos
     abs_military_delta = observation.military_delta_2x
-    kept = [combo for combo in combos if combo.upper_bound > 0 and combo.score_delta_2x > 0]
+    kept = [
+        combo
+        for combo in combos
+        if combo.upper_bound > 0
+        and (combo.score_delta_2x > 0 or combo.warship_delta > 0 or combo.freighter_delta > 0)
+    ]
     required_builds = observation.warship_delta + observation.freighter_delta
     if required_builds > 0 and max_aggregate_residual_when_ship_builds is not None:
         score_floor = abs_military_delta - max_aggregate_residual_when_ship_builds
-        narrowed = [combo for combo in kept if combo.score_delta_2x >= score_floor]
+        narrowed = [
+            combo
+            for combo in kept
+            if combo.score_delta_2x >= score_floor
+            or combo.warship_delta > 0
+            or combo.freighter_delta > 0
+        ]
         if narrowed:
             kept = narrowed
     return tuple(kept)

--- a/packages/api/api/analytics/military_score_inference/ship_build_scoring.py
+++ b/packages/api/api/analytics/military_score_inference/ship_build_scoring.py
@@ -66,5 +66,27 @@ def ship_build_score_delta_2x(
     )
 
 
+def ship_build_military_score_delta_2x(
+    hull: Hull,
+    engine: Engine,
+    beam: Beam | None,
+    torpedo: Torpedo | None,
+    *,
+    beam_count: int,
+    launcher_count: int,
+) -> int:
+    """Military-score contribution for a ship build; pure freighters contribute zero."""
+    if not is_military_hull(hull):
+        return 0
+    return ship_build_score_delta_2x(
+        hull,
+        engine,
+        beam,
+        torpedo,
+        beam_count=beam_count,
+        launcher_count=launcher_count,
+    )
+
+
 def _component_minerals(component: Hull | Engine | Beam | Torpedo) -> int:
     return component.tritanium + component.duranium + component.molybdenum

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -1,5 +1,6 @@
 """OR-Tools CP-SAT adapter for military score build inference."""
 
+import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass, replace
@@ -24,6 +25,15 @@ STATUS_NO_EXACT_SOLUTION = "no_exact_solution"
 STATUS_TIME_LIMITED = "time_limited"
 
 _SUCCESS_STATUSES = (cp_model.OPTIMAL, cp_model.FEASIBLE)
+
+
+def _configured_num_search_workers(combo_count: int) -> int | None:
+    raw = os.environ.get("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS")
+    if raw is not None:
+        return int(raw)
+    if combo_count > 100:
+        return 8
+    return None
 
 
 @dataclass(frozen=True)
@@ -139,14 +149,18 @@ def _merge_score_equivalent_combos(
     )
 
 
-def _observation_has_no_deltas(problem: InferenceProblem) -> bool:
+def _observation_is_solver_idle(problem: InferenceProblem) -> bool:
+    """True when the solver has no modeled deltas to explain."""
     observation = problem.observation
-    return (
-        observation.military_delta_2x == 0
-        and observation.warship_delta == 0
-        and observation.freighter_delta == 0
-        and observation.priority_point_delta == 0
-    )
+    if (
+        observation.military_delta_2x != 0
+        or observation.warship_delta != 0
+        or observation.freighter_delta != 0
+    ):
+        return False
+    if observation.priority_point_delta == 0:
+        return True
+    return not problem.enforce_priority_point_constraint
 
 
 def _problem_has_catalog_entries(problem: InferenceProblem) -> bool:
@@ -394,7 +408,7 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
         )
 
     if not _problem_has_catalog_entries(problem):
-        if _observation_has_no_deltas(problem):
+        if _observation_is_solver_idle(problem):
             return InferenceResult(
                 status=STATUS_EXACT,
                 solutions=(InferenceSolution(objective_value=0, actions=()),),
@@ -430,8 +444,9 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
             break
 
         solver.parameters.max_time_in_seconds = remaining_seconds
-        if len(problem.ship_build_combos) > 100:
-            solver.parameters.num_search_workers = 8
+        num_search_workers = _configured_num_search_workers(len(problem.ship_build_combos))
+        if num_search_workers is not None:
+            solver.parameters.num_search_workers = num_search_workers
         last_solver_status = solver.solve(model)
         if last_solver_status not in _SUCCESS_STATUSES:
             if last_solver_status == cp_model.UNKNOWN and solutions:
@@ -497,7 +512,9 @@ def solve_inference_problem(problem: InferenceProblem) -> InferenceResult:
         "solution_count": len(solutions),
         "stopped_reason": stopped_reason,
         "wall_time_seconds": time.monotonic() - started_at,
-        "ship_build_tier": problem.ship_build_tier,
+        "policy_step_id": problem.policy_step_id,
+        "policy_step_index": problem.policy_step_index,
+        "military_score_alpha": problem.military_score_alpha,
     }
     if time_limited:
         diagnostics["time_limited"] = True

--- a/packages/api/api/analytics/military_score_inference/tier_policy.py
+++ b/packages/api/api/analytics/military_score_inference/tier_policy.py
@@ -1,0 +1,386 @@
+"""YAML inference search tier policy load, validation, and optional overlay hook."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+SlotCountMode = Literal["none", "partial"]
+FilterAxis = Literal["hulls", "engines", "beams", "launchers"]
+FILTER_AXES: tuple[FilterAxis, ...] = ("hulls", "engines", "beams", "launchers")
+
+FINE_GRAINED_SLACK_ACTION_IDS = frozenset(
+    {
+        "planet_defense_posts_added_total",
+        "starbase_defense_posts_added_total",
+        "starbase_fighters_added_total",
+        "ship_fighters_added_total",
+        "fighters_starbase_to_ship",
+        "fighters_ship_to_starbase",
+    }
+)
+SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY = "ship_torps_per_type"
+FIGHTER_TRANSFERS_PER_DIRECTION_ALLOWLIST_KEY = "fighter_transfers_per_direction"
+DEFAULT_MAX_SEEDS = 5
+
+# ``all: true`` widens eligibility on that axis. It does **not** mean "every component id
+# in the turn catalog regardless of player state."
+#
+# - hulls: all buildable hull ids for the player (turn.racehulls ∩ turn hull catalog),
+#   with no additional tech-level band.
+# - engines / beams / launchers: player active* list intersect turn catalog; when the active
+#   list is empty, jump to the full turn catalog for that axis (existing Planets.nu rule).
+#
+# ``techLevels: [...]`` narrows to components whose ``techlevel`` is in the list. Hull tech
+# bands apply on top of the buildable-hull set; other axes filter the turn catalog directly.
+
+
+@dataclass(frozen=True)
+class ComponentFilter:
+    """Catalog filter for one ship-build component axis.
+
+    Exactly one primary mode: ``all=True`` (widened) or non-empty ``tech_levels`` (tech band).
+    Optional ``component_ids`` further restricts the resolved set (reserved for future overlay
+    and policy refinement when multiple ids share a tech level).
+    """
+
+    all: bool = False
+    tech_levels: tuple[int, ...] = ()
+    component_ids: tuple[int, ...] = ()
+
+    def to_snapshot(self) -> dict[str, object]:
+        if self.all:
+            snapshot: dict[str, object] = {"all": True}
+        else:
+            snapshot = {"techLevels": list(self.tech_levels)}
+        if self.component_ids:
+            snapshot["componentIds"] = list(self.component_ids)
+        return snapshot
+
+
+@dataclass(frozen=True)
+class InferenceCatalogFilters:
+    hulls: ComponentFilter
+    engines: ComponentFilter
+    beams: ComponentFilter
+    launchers: ComponentFilter
+
+    def to_snapshot(self) -> dict[str, object]:
+        return {
+            "hulls": self.hulls.to_snapshot(),
+            "engines": self.engines.to_snapshot(),
+            "beams": self.beams.to_snapshot(),
+            "launchers": self.launchers.to_snapshot(),
+        }
+
+    def axis_filter(self, axis: FilterAxis) -> ComponentFilter:
+        return getattr(self, axis)
+
+
+@dataclass(frozen=True)
+class ComponentFilterOverlay:
+    """Per-axis overlay fragment merged at resolve time (#78)."""
+
+    append_tech_levels: tuple[int, ...] = ()
+    append_component_ids: tuple[int, ...] = ()
+    force_all: bool = False
+
+
+@dataclass(frozen=True)
+class TierPolicyOverlay:
+    """Runtime overlay merged into the static policy at resolve time (#78).
+
+    #78 implements deterministic merge into ``InferenceCatalogFilters`` per step.
+    When ``overlay`` is not ``None``, #77 passes the base YAML steps through unchanged.
+    """
+
+    hulls: ComponentFilterOverlay | None = None
+    engines: ComponentFilterOverlay | None = None
+    beams: ComponentFilterOverlay | None = None
+    launchers: ComponentFilterOverlay | None = None
+    aggregate_cap_bumps: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class InferenceTierPolicyStep:
+    id: str
+    filters: InferenceCatalogFilters
+    beam_slot_counts: SlotCountMode
+    launcher_slot_counts: SlotCountMode
+    aggregate_allowlist: dict[str, int]
+    alpha: int
+    max_seeds: int = DEFAULT_MAX_SEEDS
+
+    def constraint_snapshot(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "filters": self.filters.to_snapshot(),
+            "beamSlotCounts": self.beam_slot_counts,
+            "launcherSlotCounts": self.launcher_slot_counts,
+            "aggregateAllowlist": dict(self.aggregate_allowlist),
+            "alpha": self.alpha,
+            "maxSeeds": self.max_seeds,
+        }
+
+
+def default_tier_policy_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[5]
+        / "assets"
+        / "analytics"
+        / "military_score_build_inference"
+        / "tier_policy.yaml"
+    )
+
+
+def load_tier_policy_document(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        document = yaml.safe_load(handle)
+    if not isinstance(document, dict):
+        raise ValueError(f"tier policy root must be a mapping: {path}")
+    return document
+
+
+def _parse_component_ids(raw: object, *, axis: str, step_id: str) -> tuple[int, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, list):
+        raise ValueError(f"step {step_id}: filters.{axis}.componentIds must be a list")
+    ids: list[int] = []
+    for value in raw:
+        if not isinstance(value, int):
+            raise ValueError(f"step {step_id}: filters.{axis}.componentIds entries must be ints")
+        ids.append(value)
+    return tuple(sorted(set(ids)))
+
+
+def _parse_tech_levels_list(raw: object, *, axis: str, step_id: str) -> tuple[int, ...]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(
+            f"step {step_id}: filters.{axis}.techLevels must be a non-empty list when all is false"
+        )
+    levels: list[int] = []
+    for value in raw:
+        if not isinstance(value, int):
+            raise ValueError(f"step {step_id}: filters.{axis}.techLevels entries must be integers")
+        levels.append(value)
+    return tuple(sorted(set(levels)))
+
+
+def _parse_component_filter(raw: object, *, axis: str, step_id: str) -> ComponentFilter:
+    if not isinstance(raw, dict):
+        raise ValueError(f"step {step_id}: filters.{axis} must be a mapping")
+    use_all = bool(raw.get("all", False))
+    component_ids = _parse_component_ids(raw.get("componentIds"), axis=axis, step_id=step_id)
+    if use_all:
+        if "techLevels" in raw:
+            raise ValueError(f"step {step_id}: filters.{axis} cannot set both all and techLevels")
+        return ComponentFilter(all=True, component_ids=component_ids)
+    tech_levels = _parse_tech_levels_list(raw.get("techLevels"), axis=axis, step_id=step_id)
+    return ComponentFilter(all=False, tech_levels=tech_levels, component_ids=component_ids)
+
+
+def _parse_catalog_filters(raw: object, *, step_id: str) -> InferenceCatalogFilters:
+    if not isinstance(raw, dict):
+        raise ValueError(f"step {step_id}: filters must be a mapping")
+    parsed: dict[str, ComponentFilter] = {}
+    for axis in FILTER_AXES:
+        if axis not in raw:
+            raise ValueError(f"step {step_id}: filters must include {axis}")
+        parsed[axis] = _parse_component_filter(raw[axis], axis=axis, step_id=step_id)
+    return InferenceCatalogFilters(
+        hulls=parsed["hulls"],
+        engines=parsed["engines"],
+        beams=parsed["beams"],
+        launchers=parsed["launchers"],
+    )
+
+
+def _parse_slot_mode(raw: object, *, field_name: str, step_id: str) -> SlotCountMode:
+    if raw not in ("none", "partial"):
+        raise ValueError(f"step {step_id}: {field_name} must be 'none' or 'partial'")
+    return raw
+
+
+def _parse_aggregate_allowlist(raw: object, *, step_id: str) -> dict[str, int]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"step {step_id}: aggregateAllowlist must be a mapping")
+    allowlist: dict[str, int] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            raise ValueError(f"step {step_id}: aggregateAllowlist keys must be strings")
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"step {step_id}: aggregateAllowlist values must be non-negative ints")
+        allowlist[key] = value
+    return allowlist
+
+
+def _parse_policy_step(raw: dict[str, Any], *, index: int) -> InferenceTierPolicyStep:
+    step_id = raw.get("id")
+    if not isinstance(step_id, str) or not step_id:
+        raise ValueError(f"step {index}: id must be a non-empty string")
+
+    alpha = raw.get("alpha")
+    if not isinstance(alpha, int) or alpha < 0:
+        raise ValueError(f"step {step_id}: alpha must be a non-negative integer")
+
+    max_seeds = raw.get("maxSeeds", DEFAULT_MAX_SEEDS)
+    if not isinstance(max_seeds, int) or max_seeds < 0:
+        raise ValueError(f"step {step_id}: maxSeeds must be a non-negative integer")
+
+    return InferenceTierPolicyStep(
+        id=step_id,
+        filters=_parse_catalog_filters(raw.get("filters"), step_id=step_id),
+        beam_slot_counts=_parse_slot_mode(
+            raw.get("beamSlotCounts", "none"),
+            field_name="beamSlotCounts",
+            step_id=step_id,
+        ),
+        launcher_slot_counts=_parse_slot_mode(
+            raw.get("launcherSlotCounts", "none"),
+            field_name="launcherSlotCounts",
+            step_id=step_id,
+        ),
+        aggregate_allowlist=_parse_aggregate_allowlist(
+            raw.get("aggregateAllowlist"),
+            step_id=step_id,
+        ),
+        alpha=alpha,
+        max_seeds=max_seeds,
+    )
+
+
+def _component_filter_is_widening(
+    prior: ComponentFilter,
+    current: ComponentFilter,
+    *,
+    axis: str,
+    prior_step_id: str,
+    current_step_id: str,
+) -> None:
+    if prior.all and not current.all:
+        raise ValueError(
+            f"step {current_step_id}: filters.{axis} cannot narrow from all to techLevels "
+            f"after step {prior_step_id} widened the axis"
+        )
+    if current.all:
+        return
+    if prior.all:
+        return
+    prior_set = set(prior.tech_levels)
+    current_set = set(current.tech_levels)
+    if not prior_set.issubset(current_set):
+        raise ValueError(
+            f"step {current_step_id}: filters.{axis}.techLevels must be a superset "
+            f"of step {prior_step_id}"
+        )
+
+
+def _slot_mode_is_widening(
+    prior: SlotCountMode,
+    current: SlotCountMode,
+    *,
+    step_id: str,
+    field_name: str,
+) -> None:
+    if prior == "partial" and current == "none":
+        raise ValueError(f"step {step_id}: {field_name} cannot narrow from partial to none")
+
+
+def validate_tier_policy_steps(steps: tuple[InferenceTierPolicyStep, ...]) -> None:
+    if not steps:
+        raise ValueError("tier policy must contain at least one step")
+    if steps[-1].alpha != 0:
+        raise ValueError("final policy step must have alpha: 0")
+
+    for index in range(1, len(steps)):
+        prior = steps[index - 1]
+        current = steps[index]
+        for axis in FILTER_AXES:
+            _component_filter_is_widening(
+                prior.filters.axis_filter(axis),
+                current.filters.axis_filter(axis),
+                axis=axis,
+                prior_step_id=prior.id,
+                current_step_id=current.id,
+            )
+        _slot_mode_is_widening(
+            prior.beam_slot_counts,
+            current.beam_slot_counts,
+            step_id=current.id,
+            field_name="beamSlotCounts",
+        )
+        _slot_mode_is_widening(
+            prior.launcher_slot_counts,
+            current.launcher_slot_counts,
+            step_id=current.id,
+            field_name="launcherSlotCounts",
+        )
+
+        prior_allowlist = prior.aggregate_allowlist
+        current_allowlist = current.aggregate_allowlist
+        for action_id, prior_cap in prior_allowlist.items():
+            if action_id not in current_allowlist:
+                raise ValueError(
+                    f"step {current.id}: aggregateAllowlist must retain {action_id} "
+                    f"from step {prior.id}"
+                )
+            if current_allowlist[action_id] < prior_cap:
+                raise ValueError(
+                    f"step {current.id}: aggregateAllowlist cap for {action_id} "
+                    f"must be >= {prior_cap} from step {prior.id}"
+                )
+        for action_id, current_cap in current_allowlist.items():
+            if action_id in prior_allowlist and current_cap < prior_allowlist[action_id]:
+                raise ValueError(
+                    f"step {current.id}: aggregateAllowlist cap for {action_id} "
+                    f"must be >= {prior_allowlist[action_id]} from step {prior.id}"
+                )
+
+
+def parse_tier_policy_steps(document: dict[str, Any]) -> tuple[InferenceTierPolicyStep, ...]:
+    raw_steps = document.get("steps")
+    if not isinstance(raw_steps, list) or not raw_steps:
+        raise ValueError("tier policy must contain a non-empty steps list")
+    steps = tuple(
+        _parse_policy_step(raw_step, index=index) for index, raw_step in enumerate(raw_steps)
+    )
+    validate_tier_policy_steps(steps)
+    return steps
+
+
+def resolve_tier_policies(
+    base_path: Path | None = None,
+    overlay: TierPolicyOverlay | None = None,
+) -> tuple[InferenceTierPolicyStep, ...]:
+    """Load and validate the static tier policy ladder.
+
+    When ``overlay`` is ``None``, returns YAML steps only. Overlay merge semantics are
+    implemented in #78; non-``None`` overlays are accepted but not applied yet.
+    """
+    policy_path = default_tier_policy_path() if base_path is None else base_path
+    steps = parse_tier_policy_steps(load_tier_policy_document(policy_path))
+    if overlay is not None:
+        return steps
+    return steps
+
+
+def is_fine_grained_slack_action(action_id: str) -> bool:
+    if action_id in FINE_GRAINED_SLACK_ACTION_IDS:
+        return True
+    return action_id.startswith("ship_torps_loaded_")
+
+
+def resolved_aggregate_cap(action_id: str, allowlist: dict[str, int]) -> int | None:
+    if action_id in allowlist:
+        return allowlist[action_id]
+    if action_id.startswith("ship_torps_loaded_"):
+        return allowlist.get(SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY)
+    if action_id in {"fighters_starbase_to_ship", "fighters_ship_to_starbase"}:
+        return allowlist.get(FIGHTER_TRANSFERS_PER_DIRECTION_ALLOWLIST_KEY)
+    return None

--- a/packages/api/api/analytics/scores.py
+++ b/packages/api/api/analytics/scores.py
@@ -1,6 +1,11 @@
 """Core scoreboard analytic."""
 
-from api.analytics.military_score_inference.analytic import infer_military_score_build
+from collections.abc import Callable
+
+from api.analytics.military_score_inference.analytic import (
+    infer_military_score_build,
+    run_inference_with_artifacts,
+)
 from api.analytics.options import TurnAnalyticsOptions
 from api.models.game import TurnInfo
 
@@ -55,7 +60,12 @@ def get_scores_table(
     return {"analyticId": ANALYTIC_ID, "rows": rows}
 
 
-def get_scores_row_inference(turn: TurnInfo, player_id: int) -> dict[str, object]:
+def get_scores_row_inference(
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
+) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
     if score is None:
@@ -68,5 +78,12 @@ def get_scores_row_inference(turn: TurnInfo, player_id: int) -> dict[str, object
             "solutions": [],
             "diagnostics": {"playerId": player_id, "turn": turn.settings.turn},
         }
-    inference = infer_military_score_build(score, turn)
+    if load_scoreboard_turn is None:
+        inference = infer_military_score_build(score, turn)
+    else:
+        inference, _, _ = run_inference_with_artifacts(
+            score,
+            turn,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )
     return {"playerId": player_id, **inference}

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -2,6 +2,7 @@
 
 from api.analytics import TurnAnalyticsOptions, get_turn_analytic
 from api.diagnostics import NOOP_DIAGNOSTICS, Diagnostics
+from api.errors import NotFoundError
 from api.services.turn_load_service import TurnLoadService
 from api.transport.connections_options import FlareConnectionMode
 
@@ -50,4 +51,19 @@ class TurnAnalyticService:
         from api.analytics.scores import get_scores_row_inference
 
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
-        return get_scores_row_inference(turn, player_id)
+
+        def load_scoreboard_turn(stored_turn_number: int):
+            try:
+                return self._turns.get_turn_info(
+                    game_id,
+                    perspective,
+                    stored_turn_number,
+                )
+            except OSError, ValueError, KeyError, NotFoundError:
+                return None
+
+        return get_scores_row_inference(
+            turn,
+            player_id,
+            load_scoreboard_turn=load_scoreboard_turn,
+        )

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "dacite>=1.8.0",
     "httpx>=0.27.0",
     "ortools>=9.15.6755",
+    "pyyaml>=6.0.2",
 ]
 
 [project.optional-dependencies]

--- a/packages/api/tests/fixtures/military_score_inference.py
+++ b/packages/api/tests/fixtures/military_score_inference.py
@@ -17,6 +17,7 @@ def _observation(
     warship_delta: int = 1,
     freighter_delta: int = 0,
     starbases_owned: int = 3,
+    military_partition_slack_2x: int = 0,
 ) -> InferenceObservation:
     return InferenceObservation(
         player_id=8,
@@ -27,6 +28,7 @@ def _observation(
         priority_point_delta=0,
         starbases_owned=starbases_owned,
         is_after_ship_limit=False,
+        military_partition_slack_2x=military_partition_slack_2x,
     )
 
 

--- a/packages/api/tests/inference_corpus/catalog_coverage.py
+++ b/packages/api/tests/inference_corpus/catalog_coverage.py
@@ -11,10 +11,7 @@ from api.analytics.military_score_inference.models import (
     InferenceObservation,
     ShipBuildCombo,
 )
-from api.analytics.military_score_inference.ship_build_combos import (
-    MAX_SHIP_BUILD_TIER,
-    START_SHIP_BUILD_TIER,
-)
+from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.models.game import TurnInfo
 
 from tests.inference_corpus.ground_truth import GroundTruth, GroundTruthExtraction
@@ -110,16 +107,17 @@ def evaluate_ground_truth_catalog_coverage(
     observation: InferenceObservation,
     score_turn: TurnInfo,
 ) -> CatalogCoverageResult:
-    """Check GT against escalating ship-build tiers, matching solver tier progression."""
+    """Check GT against escalating policy steps, matching solver ladder progression."""
     last_result = CatalogCoverageResult(
         in_search_space=False,
         coverage_reason=COVERAGE_REASON_COMBO_NOT_IN_CATALOG,
     )
-    for tier in range(START_SHIP_BUILD_TIER, MAX_SHIP_BUILD_TIER + 1):
+    for step_index, policy_step in enumerate(resolve_tier_policies()):
         catalog = build_action_catalog_from_turn(
             observation,
             score_turn,
-            ship_build_tier=tier,
+            policy_step=policy_step,
+            policy_step_index=step_index,
         )
         result = evaluate_catalog_coverage(ground_truth, catalog)
         if result.in_search_space:

--- a/packages/api/tests/inference_corpus/discovery.py
+++ b/packages/api/tests/inference_corpus/discovery.py
@@ -17,29 +17,34 @@ def discover_cases_for_game(
     min_host_turn: int | None = None,
     max_host_turn: int | None = None,
 ) -> list[DiscoveredCase]:
-    """Emit one case per consecutive stored turn pair (N, N+1) for each perspective."""
-    cases: list[DiscoveredCase] = []
-    try:
-        game_shallow = store.read_shallow(f"games/{game_id}")
-    except NotFoundError:
+    """Emit one case per consecutive stored turn pair (N, N+1) for each perspective.
+
+    Cases are ordered by host turn first, then perspective, so progressive-turn probes
+    surface simpler failures before later turns and secondary perspectives.
+    """
+    perspectives = _list_game_perspectives(store, game_id)
+    if not perspectives:
         return []
 
-    for perspective_segment in game_shallow["children"]:
-        if not perspective_segment.isdigit():
-            continue
-        perspective = int(perspective_segment)
-        if perspective < 1:
-            continue
-        cases.extend(
-            _discover_cases_for_perspective(
-                store,
-                game_id=game_id,
-                perspective=perspective,
-                min_host_turn=min_host_turn,
-                max_host_turn=max_host_turn,
-            )
-        )
-    return sorted(cases, key=lambda case: (case.perspective, case.host_turn))
+    cases_by_host_turn_and_perspective: dict[tuple[int, int], DiscoveredCase] = {}
+    for perspective in perspectives:
+        for case in _discover_cases_for_perspective(
+            store,
+            game_id=game_id,
+            perspective=perspective,
+            min_host_turn=min_host_turn,
+            max_host_turn=max_host_turn,
+        ):
+            cases_by_host_turn_and_perspective[(case.host_turn, case.perspective)] = case
+
+    host_turns = sorted({host_turn for host_turn, _ in cases_by_host_turn_and_perspective})
+    cases: list[DiscoveredCase] = []
+    for host_turn in host_turns:
+        for perspective in perspectives:
+            case = cases_by_host_turn_and_perspective.get((host_turn, perspective))
+            if case is not None:
+                cases.append(case)
+    return cases
 
 
 def discover_cases(
@@ -77,7 +82,23 @@ def discover_cases(
                 max_host_turn=max_host_turn,
             )
         )
-    return sorted(cases, key=lambda case: (case.game_id, case.perspective, case.host_turn))
+    return sorted(cases, key=lambda case: (case.game_id, case.host_turn, case.perspective))
+
+
+def _list_game_perspectives(store: StoreService, game_id: int) -> list[int]:
+    try:
+        game_shallow = store.read_shallow(f"games/{game_id}")
+    except NotFoundError:
+        return []
+
+    perspectives: list[int] = []
+    for perspective_segment in game_shallow["children"]:
+        if not perspective_segment.isdigit():
+            continue
+        perspective = int(perspective_segment)
+        if perspective >= 1:
+            perspectives.append(perspective)
+    return sorted(perspectives)
 
 
 def list_perspectives_with_turn_pair(

--- a/packages/api/tests/inference_corpus/ground_truth.py
+++ b/packages/api/tests/inference_corpus/ground_truth.py
@@ -3,16 +3,7 @@
 from collections import Counter
 from dataclasses import dataclass
 
-from api.analytics.military_score_inference.scoring import (
-    LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
-    loaded_ship_torpedo_score_delta_2x,
-    planet_defense_post_score_delta_2x,
-    starbase_defense_post_score_delta_2x,
-    starbase_fighter_score_delta_2x,
-)
 from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_label
-from api.analytics.military_score_inference.ship_build_scoring import ship_build_score_delta_2x
-from api.models.components import Torpedo
 from api.models.game import TurnInfo
 from api.models.player import Score
 
@@ -55,7 +46,13 @@ def extract_ground_truth_v1(
     score: Score,
     complexity: ComplexityLevel,
 ) -> GroundTruthExtraction:
-    """Build a normalized action multiset when v1 rules apply."""
+    """Build a normalized action multiset from inventory deltas when v1 rules apply.
+
+    Ground truth is inventory-only. Scoreboard rows (including ``militarychange``) are
+    not used for extraction or validation -- during accelerated start those fields are
+    unreliable while ship/planet/starbase inventory diffs remain authoritative.
+    """
+    del score
     if complexity == "adjunct" or COMPLEXITY_ORDINAL[complexity] > COMPLEXITY_ORDINAL["heavy"]:
         return GroundTruthExtraction(
             available=False,
@@ -76,35 +73,14 @@ def extract_ground_truth_v1(
     for action_id in ship_build_ids:
         multiset[action_id] += 1
     multiset.update(new_ship_load_action_counts(new_ships, score_turn))
-
-    explained_2x = sum(
-        _catalog_score_delta_2x_for_action_id(action_id, score_turn) * multiset[action_id]
-        for action_id in multiset
-    )
-    residual_2x = _ground_truth_military_delta_2x(score) - explained_2x
-    if residual_2x < 0:
-        return GroundTruthExtraction(
-            available=False,
-            unavailable_reason="residual_unexplained",
+    multiset.update(
+        _inventory_aggregate_actions(
+            prior_turn,
+            score_turn,
+            player_id,
+            exclude_ship_ids=new_ship_ids,
         )
-
-    aggregate_result = _allocate_aggregate_residual(
-        prior_turn,
-        score_turn,
-        player_id,
-        residual_2x=residual_2x,
-        torpedos_by_id={torp.id: torp for torp in score_turn.torpedos},
-        exclude_ship_ids=new_ship_ids,
     )
-    if aggregate_result is None:
-        if residual_2x == 0:
-            return GroundTruthExtraction(available=True, ground_truth=_sorted_multiset(multiset))
-        return GroundTruthExtraction(
-            available=False,
-            unavailable_reason="residual_unexplained",
-        )
-
-    multiset.update(aggregate_result)
     return GroundTruthExtraction(available=True, ground_truth=_sorted_multiset(multiset))
 
 
@@ -222,19 +198,59 @@ def format_unavailable_ground_truth(
     return f"{activity} (strict ground truth unavailable: {reason})"
 
 
-def _ground_truth_military_delta_2x(score: Score) -> int:
-    """Turn-pair military delta for residual checks against inventory-derived GT.
-
-    Ground truth is built from inventory deltas between ``prior_turn`` and
-    ``score_turn`` files. That scope matches ``score.militarychange`` on the
-    score row (including accelerated-start games on the first reliable row,
-    where inference uses cumulative totals since homeworld baseline instead).
-    """
-    return 2 * score.militarychange
-
-
 def _sorted_multiset(counter: Counter[str]) -> GroundTruth:
     return tuple(sorted((action_id, count) for action_id, count in counter.items() if count > 0))
+
+
+def _inventory_aggregate_actions(
+    prior_turn: TurnInfo,
+    score_turn: TurnInfo,
+    player_id: int,
+    *,
+    exclude_ship_ids: frozenset[int],
+) -> Counter[str]:
+    """Map non-ship-build inventory deltas to aggregate catalog action ids."""
+    allocated: Counter[str] = Counter()
+
+    ship_fighter_delta = fighter_load_delta(
+        prior_turn,
+        score_turn,
+        player_id,
+        exclude_ship_ids=exclude_ship_ids,
+    )
+    if ship_fighter_delta > 0:
+        allocated["ship_fighters_added_total"] += ship_fighter_delta
+
+    for torp_id, torp_delta in sorted(
+        torpedo_load_delta_by_type(
+            prior_turn,
+            score_turn,
+            player_id,
+            exclude_ship_ids=exclude_ship_ids,
+        ).items()
+    ):
+        if torp_delta > 0:
+            allocated[f"ship_torps_loaded_{torp_id}"] += torp_delta
+
+    starbase_fighter_delta = starbase_fighter_inventory_delta(prior_turn, score_turn, player_id)
+    if starbase_fighter_delta > 0:
+        allocated["starbase_fighters_added_total"] += starbase_fighter_delta
+
+    starbase_defense_delta = starbase_defense_inventory_delta(prior_turn, score_turn, player_id)
+    if starbase_defense_delta > 0:
+        allocated["starbase_defense_posts_added_total"] += starbase_defense_delta
+
+    planet_defense_delta = planet_defense_inventory_delta(prior_turn, score_turn, player_id)
+    if planet_defense_delta > 0:
+        allocated["planet_defense_posts_added_total"] += planet_defense_delta
+
+    transfer = _fighter_transfer_counts(prior_turn, score_turn, player_id)
+    if transfer is not None:
+        direction, count = transfer
+        if count > 0:
+            allocated[direction] += count
+
+    return allocated
 
 
 def _extract_ship_build_combo_ids(
@@ -287,122 +303,6 @@ def _combo_ground_truth_label(combo_id: str, turn: TurnInfo) -> str:
         beam_count=beam_count,
         launcher_count=launcher_count,
     )
-
-
-def _combo_score_delta_2x(combo_id: str, turn: TurnInfo) -> int:
-    parsed = _parse_combo_id(combo_id)
-    if parsed is None:
-        return 0
-    hull_id, engine_id, beam_id, torp_id, beam_count, launcher_count = parsed
-    hull = hulls_by_id(turn).get(hull_id)
-    engine = engines_by_id(turn).get(engine_id)
-    if hull is None or engine is None:
-        return 0
-    beam = beams_by_id(turn).get(beam_id) if beam_id is not None else None
-    torpedo = torpedos_by_id_from_turn(turn).get(torp_id) if torp_id is not None else None
-    return ship_build_score_delta_2x(
-        hull,
-        engine,
-        beam,
-        torpedo,
-        beam_count=beam_count,
-        launcher_count=launcher_count,
-    )
-
-
-def _catalog_score_delta_2x_for_action_id(action_id: str, turn: TurnInfo) -> int:
-    if action_id.startswith("combo_"):
-        return _combo_score_delta_2x(action_id, turn)
-    if action_id == "ship_fighters_added_total":
-        return LOADED_SHIP_FIGHTER_SCORE_DELTA_2X
-    if action_id.startswith("ship_torps_loaded_"):
-        torp_id = int(action_id.removeprefix("ship_torps_loaded_"))
-        torp = next((candidate for candidate in turn.torpedos if candidate.id == torp_id), None)
-        if torp is None:
-            return 0
-        return loaded_ship_torpedo_score_delta_2x(torp.torpedocost)
-    if action_id == "starbase_fighters_added_total":
-        return starbase_fighter_score_delta_2x()
-    if action_id == "starbase_defense_posts_added_total":
-        return starbase_defense_post_score_delta_2x()
-    if action_id == "planet_defense_posts_added_total":
-        return planet_defense_post_score_delta_2x()
-    if action_id in {"fighters_starbase_to_ship", "fighters_ship_to_starbase"}:
-        return starbase_fighter_score_delta_2x()
-    return 0
-
-
-def _allocate_aggregate_residual(
-    prior_turn: TurnInfo,
-    score_turn: TurnInfo,
-    player_id: int,
-    *,
-    residual_2x: int,
-    torpedos_by_id: dict[int, Torpedo],
-    exclude_ship_ids: frozenset[int] = frozenset(),
-) -> Counter[str] | None:
-    if residual_2x == 0:
-        return Counter()
-
-    remaining = residual_2x
-    allocated: Counter[str] = Counter()
-
-    ship_fighter_delta = fighter_load_delta(
-        prior_turn, score_turn, player_id, exclude_ship_ids=exclude_ship_ids
-    )
-    if ship_fighter_delta > 0 and remaining >= LOADED_SHIP_FIGHTER_SCORE_DELTA_2X:
-        count = min(ship_fighter_delta, remaining // LOADED_SHIP_FIGHTER_SCORE_DELTA_2X)
-        if count > 0:
-            allocated["ship_fighters_added_total"] += count
-            remaining -= count * LOADED_SHIP_FIGHTER_SCORE_DELTA_2X
-
-    for torp_id in sorted(torpedos_by_id):
-        torp = torpedos_by_id[torp_id]
-        unit = loaded_ship_torpedo_score_delta_2x(torp.torpedocost)
-        if unit <= 0:
-            continue
-        torp_delta = torpedo_load_delta_by_type(
-            prior_turn, score_turn, player_id, exclude_ship_ids=exclude_ship_ids
-        ).get(torp_id, 0)
-        if torp_delta <= 0 or remaining < unit:
-            continue
-        count = min(torp_delta, remaining // unit)
-        if count > 0:
-            allocated[f"ship_torps_loaded_{torp_id}"] += count
-            remaining -= count * unit
-
-    starbase_fighter_delta = starbase_fighter_inventory_delta(prior_turn, score_turn, player_id)
-    if starbase_fighter_delta > 0 and remaining >= starbase_fighter_score_delta_2x():
-        count = min(starbase_fighter_delta, remaining // starbase_fighter_score_delta_2x())
-        if count > 0:
-            allocated["starbase_fighters_added_total"] += count
-            remaining -= count * starbase_fighter_score_delta_2x()
-
-    starbase_defense_delta = starbase_defense_inventory_delta(prior_turn, score_turn, player_id)
-    if starbase_defense_delta > 0 and remaining >= starbase_defense_post_score_delta_2x():
-        count = min(starbase_defense_delta, remaining // starbase_defense_post_score_delta_2x())
-        if count > 0:
-            allocated["starbase_defense_posts_added_total"] += count
-            remaining -= count * starbase_defense_post_score_delta_2x()
-
-    planet_defense_delta = planet_defense_inventory_delta(prior_turn, score_turn, player_id)
-    if planet_defense_delta > 0 and remaining >= planet_defense_post_score_delta_2x():
-        count = min(planet_defense_delta, remaining // planet_defense_post_score_delta_2x())
-        if count > 0:
-            allocated["planet_defense_posts_added_total"] += count
-            remaining -= count * planet_defense_post_score_delta_2x()
-
-    transfer = _fighter_transfer_counts(prior_turn, score_turn, player_id)
-    if transfer is not None:
-        direction, count = transfer
-        unit = starbase_fighter_score_delta_2x()
-        if count > 0 and remaining >= count * unit:
-            allocated[direction] += count
-            remaining -= count * unit
-
-    if remaining != 0:
-        return None
-    return allocated
 
 
 def _fighter_transfer_counts(

--- a/packages/api/tests/inference_corpus/models.py
+++ b/packages/api/tests/inference_corpus/models.py
@@ -14,6 +14,15 @@ class CaseOutcome(StrEnum):
     RANKING_MISS = "ranking_miss"
 
 
+INFERENCE_FAILURE_OUTCOMES = frozenset(
+    {
+        CaseOutcome.FAILED,
+        CaseOutcome.OUT_OF_SEARCH_SPACE,
+        CaseOutcome.RANKING_MISS,
+    }
+)
+
+
 ComplexityLevel = Literal["minimal", "routine", "heavy", "adjunct"]
 COMPLEXITY_ORDINAL: dict[ComplexityLevel, int] = {
     "minimal": 0,
@@ -67,6 +76,8 @@ class CorpusCaseResult:
 @dataclass
 class CorpusReport:
     results: list[CorpusCaseResult] = field(default_factory=list)
+    stopped_early: bool = False
+    stop_reason: str | None = None
 
     @property
     def passed_count(self) -> int:
@@ -75,6 +86,10 @@ class CorpusReport:
     @property
     def failed_count(self) -> int:
         return sum(1 for result in self.results if result.outcome == CaseOutcome.FAILED)
+
+    @property
+    def inference_failure_count(self) -> int:
+        return sum(1 for result in self.results if result.outcome in INFERENCE_FAILURE_OUTCOMES)
 
     @property
     def skipped_complexity_count(self) -> int:
@@ -106,4 +121,6 @@ class CorpusReport:
         ]
         for result in self.hard_failures:
             lines.append(f"  FAIL {result.case_id}: {result.failure_message}")
+        if self.stopped_early and self.stop_reason is not None:
+            lines.append(f"  stopped_early={self.stop_reason}")
         return lines

--- a/packages/api/tests/inference_corpus/report.py
+++ b/packages/api/tests/inference_corpus/report.py
@@ -1,6 +1,9 @@
 """Aggregate inference corpus case results into a structured report."""
 
 import json
+import os
+import time
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 from api.services.game_service import GameService
@@ -10,11 +13,14 @@ from api.services.turn_load_service import TurnLoadService
 from tests.inference_corpus.discovery import discover_cases
 from tests.inference_corpus.manifest import DEFAULT_MANIFEST_PATH, load_manifest
 from tests.inference_corpus.models import (
+    INFERENCE_FAILURE_OUTCOMES,
     ComplexityLevel,
     CorpusCaseResult,
     CorpusReport,
+    DiscoveredCase,
 )
 from tests.inference_corpus.run import run_discovered_case, run_manifest_case
+from tests.inference_corpus.worker import DiscoveredCaseJob, run_discovered_case_job
 
 
 def run_fixed_corpus(
@@ -37,6 +43,14 @@ def run_fixed_corpus(
     return report
 
 
+def per_process_search_workers(workers: int) -> int | None:
+    """Cap CP-SAT threads per worker so parallel probe runs do not oversubscribe CPU."""
+    if workers <= 1:
+        return None
+    cpu_count = os.process_cpu_count() or workers
+    return max(1, min(8, cpu_count // workers))
+
+
 def run_local_corpus(
     *,
     store: StoreService,
@@ -47,15 +61,114 @@ def run_local_corpus(
     max_host_turn: int | None = None,
     max_complexity: ComplexityLevel = "heavy",
     include_adjunct: bool = False,
+    stop_after_failures: int | None = None,
+    probe_time_limit_seconds: float | None = None,
+    workers: int = 1,
+    storage_root: Path | None = None,
 ) -> CorpusReport:
     """Discover and run inference corpus cases from the file storage backend."""
+    if workers < 1:
+        raise ValueError("workers must be at least 1")
+    if workers > 1 and storage_root is None:
+        raise ValueError("storage_root is required when workers > 1")
+
+    cases = list(
+        discover_cases(
+            store,
+            game_id=game_id,
+            min_host_turn=min_host_turn,
+            max_host_turn=max_host_turn,
+        )
+    )
     report = CorpusReport()
-    for case in discover_cases(
-        store,
-        game_id=game_id,
-        min_host_turn=min_host_turn,
-        max_host_turn=max_host_turn,
-    ):
+    started_at = time.monotonic()
+
+    if workers == 1:
+        _run_cases_sequential(
+            cases,
+            report=report,
+            started_at=started_at,
+            turn_load=turn_load,
+            game_service=game_service,
+            store=store,
+            max_complexity=max_complexity,
+            include_adjunct=include_adjunct,
+            stop_after_failures=stop_after_failures,
+            probe_time_limit_seconds=probe_time_limit_seconds,
+        )
+        return report
+
+    resolved_storage_root = str(storage_root.resolve())
+    search_workers = per_process_search_workers(workers)
+    with ProcessPoolExecutor(max_workers=workers) as pool:
+        _run_cases_in_process_pool(
+            cases,
+            report=report,
+            started_at=started_at,
+            pool=pool,
+            storage_root=resolved_storage_root,
+            max_complexity=max_complexity,
+            include_adjunct=include_adjunct,
+            stop_after_failures=stop_after_failures,
+            probe_time_limit_seconds=probe_time_limit_seconds,
+            workers=workers,
+            num_search_workers=search_workers,
+        )
+    return report
+
+
+def _probe_time_limit_reached(
+    started_at: float,
+    probe_time_limit_seconds: float | None,
+) -> bool:
+    if probe_time_limit_seconds is None:
+        return False
+    return time.monotonic() - started_at >= probe_time_limit_seconds
+
+
+def _mark_probe_time_limit_reached(
+    report: CorpusReport,
+    probe_time_limit_seconds: float,
+) -> None:
+    report.stopped_early = True
+    report.stop_reason = f"probe_time_limit_reached:{probe_time_limit_seconds:g}"
+
+
+def _mark_inference_failure_budget_reached(
+    report: CorpusReport,
+    stop_after_failures: int,
+) -> None:
+    report.stopped_early = True
+    report.stop_reason = f"inference_failure_budget_reached:{stop_after_failures}"
+
+
+def _should_stop_after_failures(
+    results: list[CorpusCaseResult],
+    stop_after_failures: int | None,
+) -> bool:
+    return stop_after_failures is not None and _inference_failure_count(results) >= (
+        stop_after_failures
+    )
+
+
+def _run_cases_sequential(
+    cases: list[DiscoveredCase],
+    *,
+    report: CorpusReport,
+    started_at: float,
+    turn_load: TurnLoadService,
+    game_service: GameService,
+    store: StoreService,
+    max_complexity: ComplexityLevel,
+    include_adjunct: bool,
+    stop_after_failures: int | None,
+    probe_time_limit_seconds: float | None,
+) -> None:
+    for case in cases:
+        if _probe_time_limit_reached(started_at, probe_time_limit_seconds):
+            _mark_probe_time_limit_reached(report, probe_time_limit_seconds)
+            break
+
         report.results.append(
             run_discovered_case(
                 case,
@@ -66,7 +179,52 @@ def run_local_corpus(
                 include_adjunct=include_adjunct,
             )
         )
-    return report
+        if _should_stop_after_failures(report.results, stop_after_failures):
+            _mark_inference_failure_budget_reached(report, stop_after_failures)
+            break
+
+
+def _run_cases_in_process_pool(
+    cases: list[DiscoveredCase],
+    *,
+    report: CorpusReport,
+    started_at: float,
+    pool: ProcessPoolExecutor,
+    storage_root: str,
+    max_complexity: ComplexityLevel,
+    include_adjunct: bool,
+    stop_after_failures: int | None,
+    probe_time_limit_seconds: float | None,
+    workers: int,
+    num_search_workers: int | None,
+) -> None:
+    index = 0
+    while index < len(cases):
+        if _probe_time_limit_reached(started_at, probe_time_limit_seconds):
+            _mark_probe_time_limit_reached(report, probe_time_limit_seconds)
+            break
+
+        batch = cases[index : index + workers]
+        jobs = [
+            DiscoveredCaseJob(
+                case=case,
+                storage_root=storage_root,
+                max_complexity=max_complexity,
+                include_adjunct=include_adjunct,
+                num_search_workers=num_search_workers,
+            )
+            for case in batch
+        ]
+        report.results.extend(pool.map(run_discovered_case_job, jobs))
+        index += len(batch)
+
+        if _should_stop_after_failures(report.results, stop_after_failures):
+            _mark_inference_failure_budget_reached(report, stop_after_failures)
+            break
+
+
+def _inference_failure_count(results: list[CorpusCaseResult]) -> int:
+    return sum(1 for result in results if result.outcome in INFERENCE_FAILURE_OUTCOMES)
 
 
 def case_result_to_dict(result: CorpusCaseResult) -> dict[str, object]:

--- a/packages/api/tests/inference_corpus/run.py
+++ b/packages/api/tests/inference_corpus/run.py
@@ -3,12 +3,14 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from api.analytics.military_score_inference.accelerated_start import needs_accelerated_backfill
 from api.analytics.military_score_inference.actions import (
     ActionCatalog,
     build_action_catalog_from_turn,
 )
 from api.analytics.military_score_inference.analytic import (
     build_inference_observation,
+    resolve_inference_target_for_host_turn,
     run_inference_with_artifacts,
 )
 from api.analytics.military_score_inference.models import InferenceObservation
@@ -223,6 +225,12 @@ def run_discovered_case(
             skip_reason=skip_reason,
         )
 
+    def load_scoreboard_turn(turn_number: int) -> TurnInfo | None:
+        try:
+            return turn_load.get_turn_info(case.game_id, case.perspective, turn_number)
+        except OSError, ValueError, KeyError:
+            return None
+
     return run_loaded_case(
         LoadedCorpusCase(
             case_id=case.id,
@@ -234,11 +242,16 @@ def run_discovered_case(
             complexity_reasons=complexity_reasons,
             expected_status=expected_status,
             expect_coverage=expect_coverage,
-        )
+        ),
+        load_scoreboard_turn=load_scoreboard_turn,
     )
 
 
-def run_loaded_case(loaded: LoadedCorpusCase) -> CorpusCaseResult:
+def run_loaded_case(
+    loaded: LoadedCorpusCase,
+    *,
+    load_scoreboard_turn=None,
+) -> CorpusCaseResult:
     """Ground truth, coverage, and Tier 1 on one observation and catalog build."""
     extraction = extract_ground_truth_v1(
         prior_turn=loaded.prior_turn,
@@ -247,15 +260,37 @@ def run_loaded_case(loaded: LoadedCorpusCase) -> CorpusCaseResult:
         score=loaded.score,
         complexity=loaded.complexity,
     )
-    observation = build_inference_observation(loaded.score, loaded.score_turn)
-    catalog = build_action_catalog_from_turn(observation, loaded.score_turn)
-    coverage_block = resolve_coverage_for_case(
-        extraction=extraction,
-        ground_truth=extraction.ground_truth,
-        catalog=catalog,
-        complexity_reasons=loaded.complexity_reasons,
-        observation=observation,
-        score_turn=loaded.score_turn,
+    host_turn = loaded.score_turn.settings.turn - 1
+    resolved = resolve_inference_target_for_host_turn(
+        loaded.score,
+        loaded.score_turn,
+        host_turn=host_turn,
+        load_scoreboard_turn=load_scoreboard_turn,
+    )
+    if resolved is not None:
+        observation = resolved.observation
+        catalog_turn = resolved.turn_info
+    else:
+        observation = build_inference_observation(loaded.score, loaded.score_turn)
+        catalog_turn = loaded.score_turn
+
+    catalog = build_action_catalog_from_turn(observation, catalog_turn)
+    skip_coverage = (
+        extraction.available
+        and resolved is None
+        and needs_accelerated_backfill(loaded.score_turn.settings.turn, loaded.score_turn.settings)
+    )
+    coverage_block = (
+        None
+        if skip_coverage
+        else resolve_coverage_for_case(
+            extraction=extraction,
+            ground_truth=extraction.ground_truth,
+            catalog=catalog,
+            complexity_reasons=loaded.complexity_reasons,
+            observation=observation,
+            score_turn=catalog_turn,
+        )
     )
 
     if loaded.expect_coverage:
@@ -306,6 +341,7 @@ def run_loaded_case(loaded: LoadedCorpusCase) -> CorpusCaseResult:
         ground_truth_available=extraction.available,
         observation=observation,
         catalog=catalog,
+        load_scoreboard_turn=load_scoreboard_turn,
     )
 
 
@@ -320,12 +356,12 @@ def _run_tier1_for_loaded_case(
     ground_truth_available: bool | None = None,
     observation: InferenceObservation,
     catalog: ActionCatalog,
+    load_scoreboard_turn=None,
 ) -> CorpusCaseResult:
-    inference, _, _ = run_inference_with_artifacts(
+    inference, inference_observation, solve_catalog = run_inference_with_artifacts(
         score,
         score_turn,
-        observation=observation,
-        catalog=catalog,
+        load_scoreboard_turn=load_scoreboard_turn,
     )
     status = inference.get("status")
     if not isinstance(status, str):
@@ -361,8 +397,8 @@ def _run_tier1_for_loaded_case(
 
     if status in {STATUS_EXACT, STATUS_TIME_LIMITED} and solution_count >= 1:
         verify_failure = verify_top_solution_hard_equalities(
-            observation=observation,
-            catalog=catalog,
+            observation=inference_observation,
+            catalog=solve_catalog if solve_catalog is not None else catalog,
             inference_payload=inference,
         )
         if verify_failure is not None:

--- a/packages/api/tests/inference_corpus/run.py
+++ b/packages/api/tests/inference_corpus/run.py
@@ -10,8 +10,10 @@ from api.analytics.military_score_inference.actions import (
 )
 from api.analytics.military_score_inference.analytic import (
     build_inference_observation,
-    resolve_inference_target_for_host_turn,
     run_inference_with_artifacts,
+)
+from api.analytics.military_score_inference.inference_target import (
+    resolve_inference_target_for_host_turn,
 )
 from api.analytics.military_score_inference.models import InferenceObservation
 from api.analytics.military_score_inference.solver import STATUS_EXACT, STATUS_TIME_LIMITED

--- a/packages/api/tests/inference_corpus/verify.py
+++ b/packages/api/tests/inference_corpus/verify.py
@@ -61,10 +61,11 @@ def verify_top_solution_hard_equalities(
         warship_sum += catalog_combo.warship_delta * count
         freighter_sum += catalog_combo.freighter_delta * count
 
-    if military_sum != observation.military_delta_2x:
+    if abs(military_sum - observation.military_delta_2x) > observation.military_partition_slack_2x:
         return (
             f"military delta mismatch: explained 2x={military_sum} "
-            f"observed 2x={observation.military_delta_2x}"
+            f"observed 2x={observation.military_delta_2x} "
+            f"(slack 2x={observation.military_partition_slack_2x})"
         )
     if warship_sum != observation.warship_delta:
         return (

--- a/packages/api/tests/inference_corpus/worker.py
+++ b/packages/api/tests/inference_corpus/worker.py
@@ -1,0 +1,48 @@
+"""Process-pool worker entry points for local inference corpus runs."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from api.services.store_service import StoreService
+
+from tests.inference_corpus.models import ComplexityLevel, CorpusCaseResult, DiscoveredCase
+from tests.inference_corpus.run import run_discovered_case
+from tests.inference_corpus.storage_loader import (
+    configure_file_storage,
+    make_game_service,
+    make_turn_load_service,
+)
+
+
+@dataclass(frozen=True)
+class DiscoveredCaseJob:
+    case: DiscoveredCase
+    storage_root: str
+    max_complexity: ComplexityLevel
+    include_adjunct: bool
+    num_search_workers: int | None = None
+
+
+def run_discovered_case_job(job: DiscoveredCaseJob) -> CorpusCaseResult:
+    """Run one discovered case in an isolated worker process."""
+    if job.num_search_workers is not None:
+        os.environ["MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS"] = str(job.num_search_workers)
+    else:
+        os.environ.pop("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS", None)
+
+    storage_root = Path(job.storage_root)
+    storage = configure_file_storage(storage_root=storage_root)
+    turn_load = make_turn_load_service(storage)
+    game_service = make_game_service(storage)
+    store = StoreService(storage)
+    return run_discovered_case(
+        job.case,
+        turn_load=turn_load,
+        game_service=game_service,
+        store=store,
+        max_complexity=job.max_complexity,
+        include_adjunct=job.include_adjunct,
+    )

--- a/packages/api/tests/test_accelerated_start_scoreboard.py
+++ b/packages/api/tests/test_accelerated_start_scoreboard.py
@@ -204,9 +204,7 @@ def test_unreliable_turn2_backfills_host_turn1_when_turn3_stored():
     assert with_loader["diagnostics"]["accelerated_backfill_source_turn"] == 3
     assert observation.military_delta_2x == 110
     action_labels = [
-        action["label"]
-        for solution in with_loader["solutions"]
-        for action in solution["actions"]
+        action["label"] for solution in with_loader["solutions"] for action in solution["actions"]
     ]
     assert any("Planet defense" in label for label in action_labels)
 

--- a/packages/api/tests/test_accelerated_start_scoreboard.py
+++ b/packages/api/tests/test_accelerated_start_scoreboard.py
@@ -6,18 +6,27 @@ from pathlib import Path
 import pytest
 from api.analytics.military_score_inference.accelerated_start import (
     HOMEBASE_STARTING_FREIGHTERS,
+    SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+    accelerated_inference_segments,
+    accelerated_window_military_change,
+    accelerated_window_military_delta_2x,
+    cumulative_military_delta_2x,
     effective_prior_score_row,
+    homeworld_baseline_military_2x,
     infer_accelerated_window_ship_builds,
     is_first_reliable_scoreboard_turn,
     is_unreliable_accelerated_scoreboard_turn,
     observation_deltas_from_score,
+    reported_host_military_delta_2x,
     starting_scoreboard_snapshot,
     synthetic_scoreboard_before_reported_deltas,
 )
 from api.analytics.military_score_inference.analytic import (
+    STATUS_NO_PRIOR_TURN,
     build_inference_observation,
     infer_military_score_build,
     prior_turn_score_data_available,
+    run_inference_with_artifacts,
 )
 from api.serialization.game import game_info_from_json
 from api.serialization.turn import turn_info_from_json
@@ -67,9 +76,14 @@ def test_starting_baseline_uses_twenty_fighters_and_one_freighter():
     settings = _game_settings_from_sample()
     baseline = starting_scoreboard_snapshot(settings)
     assert baseline.militaryscore == 2110
+    assert homeworld_baseline_military_2x(settings) == 4220
     assert baseline.freighters == 1
     assert baseline.capitalships == 0
     assert baseline.starbases == 1
+
+
+def test_scoreboard_partition_slack_constant():
+    assert SCOREBOARD_MILITARY_PARTITION_SLACK_2X == 1
 
 
 @pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")
@@ -104,20 +118,41 @@ def test_synthetic_prior_from_turn3_matches_subtracted_totals():
 
 
 @pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")
-def test_first_reliable_turn_observation_uses_starting_baseline():
+def test_first_reliable_turn_observation_uses_reported_host_turn_deltas():
     turn = _load_store_turn(3)
     score = next(s for s in turn.scores if s.ownerid == 1)
     assert is_first_reliable_scoreboard_turn(3, turn.settings)
     military_delta_2x, warship_delta, freighter_delta, _priority = observation_deltas_from_score(
         score, turn
     )
-    baseline = starting_scoreboard_snapshot(turn.settings)
-    assert military_delta_2x == 2 * (score.militaryscore - baseline.militaryscore)
-    assert warship_delta == 1
+    assert military_delta_2x == 2 * score.militarychange
+    assert warship_delta == score.shipchange
     assert freighter_delta == score.freighterchange
     observation = build_inference_observation(score, turn)
     assert observation.military_delta_2x == military_delta_2x
     assert observation.freighter_delta == freighter_delta
+
+
+@pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")
+def test_accelerated_window_residual_matches_cumulative_minus_reported_delta():
+    turn = _load_store_turn(3)
+    score = next(s for s in turn.scores if s.ownerid == 1)
+    baseline = starting_scoreboard_snapshot(turn.settings)
+    cumulative_2x = cumulative_military_delta_2x(score, turn.settings)
+    reported_2x = reported_host_military_delta_2x(score)
+    assert cumulative_2x == 2 * (score.militaryscore - baseline.militaryscore)
+    assert accelerated_window_military_delta_2x(score, turn) == cumulative_2x - reported_2x
+    assert accelerated_window_military_change(score, turn) == (
+        score.militaryscore - baseline.militaryscore - score.militarychange
+    )
+    segments = accelerated_inference_segments(score, turn)
+    assert segments is not None
+    assert segments[-1].segment_id == "reported_host_turn"
+    assert segments[-1].military_delta_2x == reported_2x
+    assert segments[0].segment_id == "accel_window"
+    assert segments[0].military_delta_2x == cumulative_2x - reported_2x
+    assert segments[0].military_delta_2x == 110
+    assert segments[0].freighter_delta == 1
 
 
 @pytest.mark.skipif(not DATA_ROOT.joinpath("4.json").is_file(), reason="local store only")
@@ -132,16 +167,56 @@ def test_turn4_uses_scoreboard_delta_fields():
     assert freighter_delta == score.freighterchange
 
 
-def test_fixture_turn3_observation_uses_accelerated_baseline():
+def test_fixture_turn3_observation_uses_reported_host_turn_delta():
     _, cases = load_manifest()
     turn = load_turn_fixture(cases[0].score_turn_path)
     player_id = resolve_player_id(cases[0])
     score = next(s for s in turn.scores if s.ownerid == player_id)
     assert turn.settings.acceleratedturns == 3
     observation = build_inference_observation(score, turn)
-    baseline = starting_scoreboard_snapshot(turn.settings)
-    assert observation.military_delta_2x == 2 * (score.militaryscore - baseline.militaryscore)
+    assert observation.military_delta_2x == 2 * score.militarychange
+    assert observation.warship_delta == score.shipchange
     assert observation.freighter_delta == score.freighterchange
+
+
+@pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")
+def test_unreliable_turn2_backfills_host_turn1_when_turn3_stored():
+    turn_two = _load_store_turn(2)
+    score = next(s for s in turn_two.scores if s.ownerid == 1)
+
+    without_loader, _, _ = run_inference_with_artifacts(score, turn_two)
+    assert without_loader["status"] == STATUS_NO_PRIOR_TURN
+
+    def load_scoreboard_turn(turn_number: int):
+        if turn_number != 3:
+            return None
+        return _load_store_turn(3)
+
+    with_loader, observation, _ = run_inference_with_artifacts(
+        score,
+        turn_two,
+        load_scoreboard_turn=load_scoreboard_turn,
+    )
+    assert with_loader["status"] == "exact"
+    assert with_loader["solutionCount"] >= 1
+    assert with_loader["diagnostics"]["accelerated_backfill"] is True
+    assert with_loader["diagnostics"]["accelerated_backfill_host_turn"] == 1
+    assert with_loader["diagnostics"]["accelerated_backfill_source_turn"] == 3
+    assert observation.military_delta_2x == 110
+    assert "Planet defense" in with_loader["summary"]
+
+
+@pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")
+def test_unreliable_turn2_fails_when_turn3_not_stored():
+    turn_two = _load_store_turn(2)
+    score = next(s for s in turn_two.scores if s.ownerid == 1)
+    payload, _, _ = run_inference_with_artifacts(
+        score,
+        turn_two,
+        load_scoreboard_turn=lambda _turn_number: None,
+    )
+    assert payload["status"] == STATUS_NO_PRIOR_TURN
+    assert payload["diagnostics"]["reason"] == "accelerated_backfill_unavailable"
 
 
 def test_corpus_case_still_infers_exact_with_accelerated_adjustment():
@@ -153,3 +228,39 @@ def test_corpus_case_still_infers_exact_with_accelerated_adjustment():
     result = infer_military_score_build(score, turn)
     assert result["status"] == "exact"
     assert result["solutionCount"] >= 1
+
+
+def test_p2_turn3_accel_segment_includes_freighter_only_window():
+    turn = load_turn_fixture("628580/1/turns/3.json")
+    score = next(s for s in turn.scores if s.ownerid == 2)
+    segments = accelerated_inference_segments(score, turn)
+    assert segments is not None
+    assert segments[0].segment_id == "accel_window"
+    assert segments[0].military_delta_2x == 0
+    assert segments[0].freighter_delta == 1
+    assert segments[-1].freighter_delta == 1
+
+
+def test_p2_unreliable_turn2_backfills_host_turn1_freighter_only():
+    turn_two = load_turn_fixture("628580/1/turns/2.json")
+    score = next(s for s in turn_two.scores if s.ownerid == 2)
+
+    without_loader, _, _ = run_inference_with_artifacts(score, turn_two)
+    assert without_loader["status"] == STATUS_NO_PRIOR_TURN
+
+    def load_scoreboard_turn(turn_number: int):
+        if turn_number != 3:
+            return None
+        return load_turn_fixture("628580/1/turns/3.json")
+
+    with_loader, observation, _ = run_inference_with_artifacts(
+        score,
+        turn_two,
+        load_scoreboard_turn=load_scoreboard_turn,
+    )
+    assert with_loader["status"] == "exact"
+    assert with_loader["solutionCount"] >= 1
+    assert observation.military_delta_2x == 0
+    assert observation.freighter_delta == 1
+    assert with_loader["diagnostics"]["accelerated_backfill"] is True
+    assert with_loader["diagnostics"]["accelerated_backfill_host_turn"] == 1

--- a/packages/api/tests/test_accelerated_start_scoreboard.py
+++ b/packages/api/tests/test_accelerated_start_scoreboard.py
@@ -203,7 +203,12 @@ def test_unreliable_turn2_backfills_host_turn1_when_turn3_stored():
     assert with_loader["diagnostics"]["accelerated_backfill_host_turn"] == 1
     assert with_loader["diagnostics"]["accelerated_backfill_source_turn"] == 3
     assert observation.military_delta_2x == 110
-    assert "Planet defense" in with_loader["summary"]
+    action_labels = [
+        action["label"]
+        for solution in with_loader["solutions"]
+        for action in solution["actions"]
+    ]
+    assert any("Planet defense" in label for label in action_labels)
 
 
 @pytest.mark.skipif(not DATA_ROOT.joinpath("3.json").is_file(), reason="local store only")

--- a/packages/api/tests/test_inference_corpus_coverage.py
+++ b/packages/api/tests/test_inference_corpus_coverage.py
@@ -2,11 +2,15 @@
 
 from unittest.mock import patch
 
+import pytest
 from api.analytics.military_score_inference.actions import (
     ActionCatalog,
     build_action_catalog_from_turn,
 )
-from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.analytic import (
+    build_inference_observation,
+    resolve_inference_target_for_host_turn,
+)
 from api.analytics.military_score_inference.models import CandidateAction
 
 from tests.inference_corpus.case_helpers import score_for_player
@@ -27,7 +31,7 @@ from tests.inference_corpus.ground_truth import (
 )
 from tests.inference_corpus.manifest import FIXTURES_ROOT, load_manifest, resolve_player_id
 from tests.inference_corpus.models import CaseOutcome
-from tests.inference_corpus.run import run_manifest_case
+from tests.inference_corpus.run import run_discovered_case, run_manifest_case
 from tests.inference_corpus.ship_inventory import new_owned_ships, ship_to_build_combo_id
 
 
@@ -171,15 +175,20 @@ def test_host2_ground_truth_passes_catalog_coverage_with_tier_escalation():
         score=score,
         complexity="minimal",
     )
-    observation = build_inference_observation(score, score_turn)
-    tier0_catalog = build_action_catalog_from_turn(observation, score_turn)
+    resolved = resolve_inference_target_for_host_turn(
+        score,
+        score_turn,
+        host_turn=host2.host_turn,
+    )
+    assert resolved is not None
+    tier0_catalog = build_action_catalog_from_turn(resolved.observation, resolved.turn_info)
     tier0_coverage = evaluate_catalog_coverage(extraction.ground_truth, tier0_catalog)
     assert tier0_coverage.in_search_space is False
     assert (
         evaluate_ground_truth_catalog_coverage(
             ground_truth=extraction.ground_truth,
-            observation=observation,
-            score_turn=score_turn,
+            observation=resolved.observation,
+            score_turn=resolved.turn_info,
         ).in_search_space
         is True
     )
@@ -236,17 +245,23 @@ def test_available_ground_truth_action_not_in_catalog_out_of_search_without_expe
     assert result.coverage_reason == COVERAGE_REASON_ACTION_NOT_IN_CATALOG
 
 
-def test_host2_ground_truth_residual_uses_turn_pair_not_cumulative_observation():
+def test_host2_reported_host_turn_observation_matches_turn_pair_ground_truth():
+    from api.analytics.military_score_inference.accelerated_start import (
+        accelerated_inference_segments,
+    )
+
     _, cases = load_manifest()
     host2 = next(case for case in cases if case.id == "628580-p1-host2")
     score_turn = load_turn_fixture(host2.score_turn_path, fixtures_root=FIXTURES_ROOT)
     player_id = resolve_player_id(host2, fixtures_root=FIXTURES_ROOT)
     score = score_for_player(score_turn.scores, player_id, host2.id)
     observation = build_inference_observation(score, score_turn)
+    segments = accelerated_inference_segments(score, score_turn)
     assert score.militarychange == 4275
-    assert observation.military_delta_2x == 8660
-    assert 2 * score.militarychange == 8550
-    assert observation.military_delta_2x != 2 * score.militarychange
+    assert observation.military_delta_2x == 2 * score.militarychange == 8550
+    assert segments is not None
+    assert segments[-1].military_delta_2x == observation.military_delta_2x
+    assert segments[0].military_delta_2x == 110
 
 
 def test_host51_fixture_ground_truth_in_catalog():
@@ -269,3 +284,133 @@ def test_host51_fixture_ground_truth_in_catalog():
     assert extraction.available is True
     assert extraction.ground_truth == ()
     assert coverage.in_search_space is True
+
+
+CATS_PAW_COMBO_ID = "combo_81_9_6_10_4_2"
+REPO_ROOT = FIXTURES_ROOT.parents[4]
+P9_TURN1_PATH = REPO_ROOT / ".data" / "games" / "628580" / "9" / "turns" / "1.json"
+P8_TURN1_PATH = REPO_ROOT / ".data" / "games" / "628580" / "8" / "turns" / "1.json"
+P5_TURN1_PATH = REPO_ROOT / ".data" / "games" / "628580" / "5" / "turns" / "1.json"
+
+
+@pytest.mark.skipif(not P9_TURN1_PATH.is_file(), reason="local store only")
+def test_p9_cats_paw_ground_truth_from_inventory_on_accel_host_turns():
+    """Inventory GT ignores unreliable scoreboard militarychange on accel rows."""
+    from tests.inference_corpus.storage_loader import (
+        configure_file_storage,
+        make_game_service,
+        make_turn_load_service,
+        resolve_player_id_for_case,
+    )
+
+    storage = configure_file_storage(storage_root=REPO_ROOT / ".data")
+    turn_load = make_turn_load_service(storage)
+    game_service = make_game_service(storage)
+    player_id = resolve_player_id_for_case(game_service, 628580, 9)
+
+    for host_turn in (1, 2):
+        prior = turn_load.get_turn_info(628580, 9, host_turn)
+        score_turn = turn_load.get_turn_info(628580, 9, host_turn + 1)
+        score = score_for_player(score_turn.scores, player_id, f"628580-p9-host{host_turn}")
+        if host_turn == 1:
+            assert score.militarychange == 0
+        extraction = extract_ground_truth_v1(
+            prior_turn=prior,
+            score_turn=score_turn,
+            player_id=player_id,
+            score=score,
+            complexity="minimal",
+        )
+        assert extraction.available is True
+        assert extraction.ground_truth == ((CATS_PAW_COMBO_ID, 1),)
+        summary = format_ground_truth_summary(extraction.ground_truth, score_turn=score_turn)
+        assert "Cat's Paw" in summary
+        assert "Transwarp" in summary
+        assert "Disruptor" in summary
+        assert "Mark 8 Photon" in summary
+
+
+@pytest.mark.skipif(not P9_TURN1_PATH.is_file(), reason="local store only")
+def test_p9_host1_discovered_case_passes_coverage_gate():
+    from api.services.store_service import StoreService
+
+    from tests.inference_corpus.discovery import discover_cases_for_game
+    from tests.inference_corpus.models import CaseOutcome
+    from tests.inference_corpus.storage_loader import (
+        configure_file_storage,
+        make_game_service,
+        make_turn_load_service,
+    )
+
+    storage = configure_file_storage(storage_root=REPO_ROOT / ".data")
+    turn_load = make_turn_load_service(storage)
+    game_service = make_game_service(storage)
+    store = StoreService(storage)
+    case = next(c for c in discover_cases_for_game(store, 628580) if c.id == "628580-p9-host1")
+    result = run_discovered_case(
+        case,
+        turn_load=turn_load,
+        game_service=game_service,
+        store=store,
+    )
+    assert result.outcome != CaseOutcome.OUT_OF_SEARCH_SPACE
+    assert result.ground_truth_available is True
+    assert result.coverage_reason is None
+
+
+@pytest.mark.skipif(not P8_TURN1_PATH.is_file(), reason="local store only")
+def test_p8_host1_discovered_case_passes_coverage_gate():
+    """Five starbase fighters (625 in 2x) fit partition slack when accel window shows 624."""
+    from api.services.store_service import StoreService
+
+    from tests.inference_corpus.discovery import discover_cases_for_game
+    from tests.inference_corpus.models import CaseOutcome
+    from tests.inference_corpus.storage_loader import (
+        configure_file_storage,
+        make_game_service,
+        make_turn_load_service,
+    )
+
+    storage = configure_file_storage(storage_root=REPO_ROOT / ".data")
+    turn_load = make_turn_load_service(storage)
+    game_service = make_game_service(storage)
+    store = StoreService(storage)
+    case = next(c for c in discover_cases_for_game(store, 628580) if c.id == "628580-p8-host1")
+    result = run_discovered_case(
+        case,
+        turn_load=turn_load,
+        game_service=game_service,
+        store=store,
+    )
+    assert result.outcome != CaseOutcome.OUT_OF_SEARCH_SPACE
+    assert result.ground_truth_available is True
+    assert result.coverage_reason is None
+
+
+@pytest.mark.skipif(not P5_TURN1_PATH.is_file(), reason="local store only")
+def test_p5_host5_discovered_case_passes_coverage_gate():
+    """Br5 Kaye build combo is in catalog when buildable hulls use turn.racehulls."""
+    from api.services.store_service import StoreService
+
+    from tests.inference_corpus.discovery import discover_cases_for_game
+    from tests.inference_corpus.models import CaseOutcome
+    from tests.inference_corpus.storage_loader import (
+        configure_file_storage,
+        make_game_service,
+        make_turn_load_service,
+    )
+
+    storage = configure_file_storage(storage_root=REPO_ROOT / ".data")
+    turn_load = make_turn_load_service(storage)
+    game_service = make_game_service(storage)
+    store = StoreService(storage)
+    case = next(c for c in discover_cases_for_game(store, 628580) if c.id == "628580-p5-host5")
+    result = run_discovered_case(
+        case,
+        turn_load=turn_load,
+        game_service=game_service,
+        store=store,
+    )
+    assert result.outcome != CaseOutcome.OUT_OF_SEARCH_SPACE
+    assert result.ground_truth_available is True
+    assert result.coverage_reason is None

--- a/packages/api/tests/test_inference_corpus_coverage.py
+++ b/packages/api/tests/test_inference_corpus_coverage.py
@@ -7,8 +7,8 @@ from api.analytics.military_score_inference.actions import (
     ActionCatalog,
     build_action_catalog_from_turn,
 )
-from api.analytics.military_score_inference.analytic import (
-    build_inference_observation,
+from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.inference_target import (
     resolve_inference_target_for_host_turn,
 )
 from api.analytics.military_score_inference.models import CandidateAction

--- a/packages/api/tests/test_inference_corpus_discovery.py
+++ b/packages/api/tests/test_inference_corpus_discovery.py
@@ -68,3 +68,24 @@ def test_discover_cases_ignores_non_numeric_perspective_segments(discovery_stora
     """Non-numeric game child segments are ignored; only perspective 1 has turn pairs."""
     cases = discover_cases_for_game(discovery_storage, 628580)
     assert all(case.perspective == 1 for case in cases)
+
+
+def test_discover_cases_orders_host_turn_before_perspective(tmp_path):
+    backend = FileStorageBackend(tmp_path / "data")
+    backend.put("games/42/info", {"settings": {}, "players": [{"id": 1}, {"id": 2}]})
+    for perspective in (1, 2):
+        for turn_number in (1, 2, 3):
+            backend.put(
+                f"games/42/{perspective}/turns/{turn_number}",
+                {"settings": {"turn": turn_number}, "scores": []},
+            )
+    store = StoreService(backend)
+
+    cases = discover_cases_for_game(store, 42)
+
+    assert [case.id for case in cases] == [
+        "42-p1-host1",
+        "42-p2-host1",
+        "42-p1-host2",
+        "42-p2-host2",
+    ]

--- a/packages/api/tests/test_inference_corpus_probe.py
+++ b/packages/api/tests/test_inference_corpus_probe.py
@@ -1,0 +1,144 @@
+"""Tests for sequential local corpus runs with inference-failure early stop."""
+
+import time
+from unittest.mock import MagicMock
+
+from tests.inference_corpus.models import CaseOutcome, CorpusCaseResult, DiscoveredCase
+from tests.inference_corpus.report import run_local_corpus
+from tests.inference_corpus.worker import DiscoveredCaseJob
+
+
+def _discovered_case(host_turn: int) -> DiscoveredCase:
+    return DiscoveredCase(
+        id=f"628580-p1-host{host_turn}",
+        game_id=628580,
+        perspective=1,
+        host_turn=host_turn,
+    )
+
+
+def _result(case_id: str, outcome: CaseOutcome) -> CorpusCaseResult:
+    return CorpusCaseResult(case_id=case_id, outcome=outcome)
+
+
+def test_run_local_corpus_stops_after_inference_failure_budget(monkeypatch):
+    cases = [_discovered_case(host_turn) for host_turn in (2, 3, 4, 5, 6)]
+    outcomes = [
+        CaseOutcome.PASSED,
+        CaseOutcome.FAILED,
+        CaseOutcome.SKIPPED_COMPLEXITY,
+        CaseOutcome.OUT_OF_SEARCH_SPACE,
+        CaseOutcome.PASSED,
+    ]
+
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.discover_cases",
+        lambda *args, **kwargs: cases,
+    )
+
+    def fake_run_discovered_case(case, **kwargs):
+        index = cases.index(case)
+        return _result(case.id, outcomes[index])
+
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.run_discovered_case",
+        fake_run_discovered_case,
+    )
+
+    report = run_local_corpus(
+        store=MagicMock(),
+        turn_load=MagicMock(),
+        game_service=MagicMock(),
+        game_id=628580,
+        stop_after_failures=2,
+    )
+
+    assert [result.case_id for result in report.results] == [
+        "628580-p1-host2",
+        "628580-p1-host3",
+        "628580-p1-host4",
+        "628580-p1-host5",
+    ]
+    assert report.inference_failure_count == 2
+    assert report.stopped_early is True
+    assert report.stop_reason == "inference_failure_budget_reached:2"
+
+
+def test_run_local_corpus_stops_after_probe_time_limit(monkeypatch):
+    cases = [_discovered_case(host_turn) for host_turn in (2, 3, 4, 5)]
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.discover_cases",
+        lambda *args, **kwargs: cases,
+    )
+
+    def fake_run_discovered_case(case, **kwargs):
+        time.sleep(0.05)
+        return _result(case.id, CaseOutcome.PASSED)
+
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.run_discovered_case",
+        fake_run_discovered_case,
+    )
+
+    report = run_local_corpus(
+        store=MagicMock(),
+        turn_load=MagicMock(),
+        game_service=MagicMock(),
+        game_id=628580,
+        probe_time_limit_seconds=0.08,
+    )
+
+    assert len(report.results) < len(cases)
+    assert report.stopped_early is True
+    assert report.stop_reason == "probe_time_limit_reached:0.08"
+
+
+def test_run_local_corpus_uses_process_pool_when_workers_gt_one(monkeypatch, tmp_path):
+    cases = [_discovered_case(host_turn) for host_turn in (2, 3, 4, 5)]
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.discover_cases",
+        lambda *args, **kwargs: cases,
+    )
+
+    mapped_jobs: list[DiscoveredCaseJob] = []
+
+    class FakePool:
+        def __init__(self, max_workers: int) -> None:
+            assert max_workers == 2
+
+        def __enter__(self) -> FakePool:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def map(self, worker_fn, jobs: list[DiscoveredCaseJob]) -> list[CorpusCaseResult]:
+            mapped_jobs.extend(jobs)
+            return [_result(job.case.id, CaseOutcome.PASSED) for job in jobs]
+
+    monkeypatch.setattr("tests.inference_corpus.report.ProcessPoolExecutor", FakePool)
+    monkeypatch.setattr(
+        "tests.inference_corpus.report.per_process_search_workers",
+        lambda workers: 2,
+    )
+
+    report = run_local_corpus(
+        store=MagicMock(),
+        turn_load=MagicMock(),
+        game_service=MagicMock(),
+        game_id=628580,
+        workers=2,
+        storage_root=tmp_path,
+    )
+
+    assert len(mapped_jobs) == len(cases)
+    assert all(job.storage_root == str(tmp_path.resolve()) for job in mapped_jobs)
+    assert all(job.num_search_workers == 2 for job in mapped_jobs)
+    assert report.passed_count == len(cases)
+
+
+def test_per_process_search_workers_scales_down_with_parallelism():
+    from tests.inference_corpus.report import per_process_search_workers
+
+    assert per_process_search_workers(1) is None
+    assert per_process_search_workers(4) >= 1

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -25,7 +25,6 @@ from api.serialization.game import game_info_from_json
 from api.serialization.turn import turn_info_from_json
 
 from tests.fixtures.military_score_inference import _observation
-from tests.inference_corpus.fixtures import load_turn_fixture
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 EE_TURN_PATH = REPO_ROOT / ".data" / "games" / "628580" / "8" / "turns" / "3.json"

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -19,14 +19,17 @@ from api.analytics.military_score_inference.scoring import (
     STARBASE_FIGHTER_SCORE_DELTA_2X,
     ship_construction_score_delta_2x,
 )
+from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.concepts.races import evil_empire_free_starbase_fighters_per_host_turn
 from api.serialization.game import game_info_from_json
 from api.serialization.turn import turn_info_from_json
 
 from tests.fixtures.military_score_inference import _observation
+from tests.inference_corpus.fixtures import load_turn_fixture
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 EE_TURN_PATH = REPO_ROOT / ".data" / "games" / "628580" / "8" / "turns" / "3.json"
+P5_TURN6_PATH = REPO_ROOT / ".data" / "games" / "628580" / "5" / "turns" / "6.json"
 GAME_INFO_PATH = REPO_ROOT / ".data" / "games" / "628580" / "info.json"
 
 
@@ -98,8 +101,29 @@ def test_residual_count_bound_uses_abs_residual_regardless_of_sign(
     assert _residual_count_bound(observation, score_delta_2x, configured_cap) == expected
 
 
+def test_residual_count_bound_applies_scoreboard_partition_slack():
+    from api.analytics.military_score_inference.accelerated_start import (
+        SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+    )
+    from api.analytics.military_score_inference.scoring import STARBASE_FIGHTER_SCORE_DELTA_2X
+
+    observation = _observation(
+        military_delta_2x=624,
+        military_partition_slack_2x=SCOREBOARD_MILITARY_PARTITION_SLACK_2X,
+    )
+    assert (
+        _residual_count_bound(
+            observation,
+            STARBASE_FIGHTER_SCORE_DELTA_2X,
+            100,
+        )
+        == 5
+    )
+
+
 def test_negative_fighter_transfer_cannot_create_unbounded_cancellation_loops():
     config = ActionCatalogConfig(max_fighter_transfers=7)
+    full_step = resolve_tier_policies()[-1]
     catalog = build_action_catalog(
         _observation(military_delta_2x=500),
         hulls_by_id={},
@@ -111,6 +135,7 @@ def test_negative_fighter_transfer_cannot_create_unbounded_cancellation_loops():
         eligible_beam_ids=frozenset(),
         eligible_torp_ids=frozenset(),
         config=config,
+        policy_step=full_step,
     )
 
     negative_transfer = next(
@@ -201,6 +226,18 @@ def test_no_flat_build_preset_actions_remain(synthetic_catalog_context):
     assert not any(action.id.startswith("build_") for action in catalog.aggregate_actions)
 
 
+@pytest.mark.skipif(not P5_TURN6_PATH.is_file(), reason="local store only")
+def test_buildable_hull_ids_from_turn_racehulls_not_activehulls():
+    """Br5 Kaye (45) is in turn.racehulls but not player.activehulls for Privateer."""
+    with open(GAME_INFO_PATH) as handle:
+        settings_defaults = json.load(handle)["settings"]
+    with open(P5_TURN6_PATH) as handle:
+        turn = turn_info_from_json(json.load(handle), settings_defaults=settings_defaults)
+    buildable_hulls = buildable_hull_ids_for_player(turn, 5)
+    assert 45 in buildable_hulls
+    assert "45" not in turn.player.activehulls
+
+
 def test_build_action_catalog_from_turn_sample(sample_turn):
     observation = _observation(
         military_delta_2x=110,
@@ -209,7 +246,8 @@ def test_build_action_catalog_from_turn_sample(sample_turn):
         starbases_owned=10,
     )
     buildable_hulls = buildable_hull_ids_for_player(sample_turn, observation.player_id)
-    catalog = build_action_catalog_from_turn(observation, sample_turn)
+    full_step = resolve_tier_policies()[-1]
+    catalog = build_action_catalog_from_turn(observation, sample_turn, policy_step=full_step)
 
     assert catalog.catalog_size > 0
     assert "planet_defense_posts_added_total" in {action.id for action in catalog.aggregate_actions}

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -126,7 +126,7 @@ def test_solver_failure_is_isolated_per_player(sample_turn):
         return solve_inference_problem(problem)
 
     with patch(
-        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         side_effect=_solve_side_effect,
     ):
         failing_inference = get_scores_row_inference(sample_turn, failing_player_id)

--- a/packages/api/tests/test_military_score_inference_analytic.py
+++ b/packages/api/tests/test_military_score_inference_analytic.py
@@ -148,7 +148,8 @@ def _minimal_inference_problem(
         observation=observation,
         aggregate_actions=catalog.aggregate_actions,
         ship_build_combos=catalog.ship_build_combos,
-        ship_build_tier=catalog.ship_build_tier,
+        policy_step_id=catalog.policy_step_id,
+        policy_step_index=catalog.policy_step_index,
         probability_buckets_by_action_id=catalog.probability_buckets_by_action_id,
     )
 
@@ -331,15 +332,17 @@ def test_row_inference_includes_structured_solver_diagnostics(sample_turn):
     assert "shipBuildCombos" in diagnostics["actionCatalog"]
 
 
-def test_inference_diagnostics_include_tier_retry_fields(sample_turn):
+def test_inference_diagnostics_include_policy_ladder_fields(sample_turn):
     score = sample_turn.scores[0]
     inference = infer_military_score_build(score, sample_turn)
     diagnostics = inference["diagnostics"]
-    assert "ship_build_tier" in diagnostics
+    assert "policy_step_id" in diagnostics
+    assert "policy_step_index" in diagnostics
     assert "ship_build_combo_count" in diagnostics
-    assert "tiers_attempted" in diagnostics
-    assert isinstance(diagnostics["tiers_attempted"], list)
-    assert diagnostics["tiers_attempted"]
+    assert "policy_steps_attempted" in diagnostics
+    assert isinstance(diagnostics["policy_steps_attempted"], list)
+    assert diagnostics["policy_steps_attempted"]
+    assert "policy_step_attempts" in diagnostics
 
 
 def test_registry_still_exposes_only_scores_analytic(sample_turn):

--- a/packages/api/tests/test_military_score_inference_constraints.py
+++ b/packages/api/tests/test_military_score_inference_constraints.py
@@ -1,6 +1,7 @@
 """Parity tests: CP-SAT hard constraints and diagnostic appliedEqualities stay aligned."""
 
 from api.analytics.military_score_inference.constraints import (
+    FIGHTER_TRANSFER_DIRECTIONS_EXCLUSIVE_DIAGNOSTIC,
     PRIORITY_POINT_DIAGNOSTIC_NOTE,
     InferenceHardConstraints,
     observation_to_constraints_payload,
@@ -10,11 +11,37 @@ from api.analytics.military_score_inference.models import (
     InferenceObservation,
     InferenceProblem,
 )
+from api.analytics.military_score_inference.scoring import STARBASE_FIGHTER_SCORE_DELTA_2X
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_NO_EXACT_SOLUTION,
     solve_inference_problem,
 )
+
+
+def _fighter_transfer_actions(*, upper_bound: int = 4) -> tuple[CandidateAction, CandidateAction]:
+    starbase_to_ship = CandidateAction(
+        id="fighters_starbase_to_ship",
+        label="Fighters SB to ship",
+        score_delta_2x=STARBASE_FIGHTER_SCORE_DELTA_2X,
+        upper_bound=upper_bound,
+        probability_weight=10,
+    )
+    ship_to_starbase = CandidateAction(
+        id="fighters_ship_to_starbase",
+        label="Fighters ship to SB",
+        score_delta_2x=-STARBASE_FIGHTER_SCORE_DELTA_2X,
+        upper_bound=upper_bound,
+        probability_weight=10,
+    )
+    return starbase_to_ship, ship_to_starbase
+
+
+def _action_count(solution, action_id: str) -> int:
+    return next(
+        (action.count for action in solution.actions if action.action_id == action_id),
+        0,
+    )
 
 
 def _observation(
@@ -24,6 +51,7 @@ def _observation(
     freighter_delta: int = 0,
     priority_point_delta: int = 0,
     starbases_owned: int = 3,
+    military_partition_slack_2x: int = 0,
 ) -> InferenceObservation:
     return InferenceObservation(
         player_id=1,
@@ -34,6 +62,7 @@ def _observation(
         priority_point_delta=priority_point_delta,
         starbases_owned=starbases_owned,
         is_after_ship_limit=False,
+        military_partition_slack_2x=military_partition_slack_2x,
     )
 
 
@@ -131,3 +160,134 @@ def test_enforced_priority_point_equality_satisfiable_when_catalog_matches():
 
     assert result.status == STATUS_EXACT
     assert any("priorityPointDelta" in line for line in payload["appliedEqualities"])
+
+
+def test_military_score_band_constraint_allows_lower_explained_score():
+    build_action = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    observation = _observation(military_delta_2x=450, warship_delta=1)
+    exact_problem = InferenceProblem(
+        observation=observation,
+        aggregate_actions=(build_action,),
+        probability_buckets_by_action_id={},
+    )
+    band_problem = InferenceProblem(
+        observation=observation,
+        aggregate_actions=(build_action,),
+        probability_buckets_by_action_id={},
+        military_score_alpha=50,
+    )
+
+    assert solve_inference_problem(exact_problem).status == STATUS_NO_EXACT_SOLUTION
+    assert solve_inference_problem(band_problem).status == STATUS_EXACT
+
+    band_payload = observation_to_constraints_payload(
+        observation,
+        hard_constraints=InferenceHardConstraints.from_problem(band_problem),
+    )
+    assert band_payload["militaryScoreAlpha"] == 50
+    assert any(">= 400" in line for line in band_payload["appliedEqualities"])
+
+
+def test_scoreboard_partition_slack_allows_half_point_military_rounding():
+    fighters = CandidateAction(
+        id="starbase_fighters_added_total",
+        label="Starbase fighters",
+        score_delta_2x=STARBASE_FIGHTER_SCORE_DELTA_2X,
+        upper_bound=5,
+        probability_weight=10,
+    )
+    observation = _observation(
+        military_delta_2x=624,
+        warship_delta=0,
+        freighter_delta=0,
+        military_partition_slack_2x=1,
+    )
+    problem = InferenceProblem(
+        observation=observation,
+        aggregate_actions=(fighters,),
+        probability_buckets_by_action_id={},
+    )
+
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_EXACT
+    assert result.solutions[0].actions[0].count == 5
+
+    payload = observation_to_constraints_payload(
+        observation,
+        hard_constraints=InferenceHardConstraints.from_problem(problem),
+    )
+    assert payload["militaryPartitionSlack2x"] == 1
+    applied = payload["appliedEqualities"]
+    assert any("623 <= sum(scoreDelta2x * count) <= 625" in line for line in applied)
+
+
+def test_applied_equalities_include_fighter_transfer_exclusivity_when_both_actions_present():
+    observation = _observation(military_delta_2x=0, warship_delta=0)
+    starbase_to_ship, ship_to_starbase = _fighter_transfer_actions()
+    problem = InferenceProblem(
+        observation=observation,
+        aggregate_actions=(starbase_to_ship, ship_to_starbase),
+        probability_buckets_by_action_id={},
+    )
+    hard_constraints = InferenceHardConstraints.from_problem(problem)
+    aggregate_action_ids = frozenset(action.id for action in problem.aggregate_actions)
+
+    payload = observation_to_constraints_payload(
+        observation,
+        hard_constraints=hard_constraints,
+        aggregate_action_ids=aggregate_action_ids,
+    )
+
+    assert FIGHTER_TRANSFER_DIRECTIONS_EXCLUSIVE_DIAGNOSTIC in payload["appliedEqualities"]
+
+
+def test_fighter_transfer_directions_are_mutually_exclusive():
+    """Cancellation loops (SB->ship plus ship->SB) must not appear in any solution."""
+    observation = _observation(military_delta_2x=0, warship_delta=0, freighter_delta=0)
+    starbase_to_ship, ship_to_starbase = _fighter_transfer_actions(upper_bound=4)
+    problem = InferenceProblem(
+        observation=observation,
+        aggregate_actions=(starbase_to_ship, ship_to_starbase),
+        probability_buckets_by_action_id={},
+        max_solutions=50,
+    )
+
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_EXACT
+    for solution in result.solutions:
+        sb_to_ship = _action_count(solution, "fighters_starbase_to_ship")
+        ship_to_sb = _action_count(solution, "fighters_ship_to_starbase")
+        assert sb_to_ship == 0 or ship_to_sb == 0
+
+
+def test_single_direction_fighter_transfer_still_satisfies_observation():
+    starbase_to_ship, ship_to_starbase = _fighter_transfer_actions(upper_bound=4)
+    for action, military_delta_2x in (
+        (starbase_to_ship, 2 * STARBASE_FIGHTER_SCORE_DELTA_2X),
+        (ship_to_starbase, -2 * STARBASE_FIGHTER_SCORE_DELTA_2X),
+    ):
+        observation = _observation(military_delta_2x=military_delta_2x, warship_delta=0)
+        problem = InferenceProblem(
+            observation=observation,
+            aggregate_actions=(starbase_to_ship, ship_to_starbase),
+            probability_buckets_by_action_id={},
+        )
+        result = solve_inference_problem(problem)
+        assert result.status == STATUS_EXACT
+        solution = result.solutions[0]
+        assert _action_count(solution, action.id) == 2
+        other_id = (
+            "fighters_ship_to_starbase"
+            if action.id == "fighters_starbase_to_ship"
+            else "fighters_starbase_to_ship"
+        )
+        assert _action_count(solution, other_id) == 0

--- a/packages/api/tests/test_military_score_inference_ship_build_combos.py
+++ b/packages/api/tests/test_military_score_inference_ship_build_combos.py
@@ -14,10 +14,12 @@ from api.analytics.military_score_inference.analytic import (
     build_inference_observation,
     run_inference_with_artifacts,
 )
+from api.analytics.military_score_inference.component_eligibility import (
+    turn_catalog_context_for_policy_step,
+)
 from api.analytics.military_score_inference.models import InferenceObservation
 from api.analytics.military_score_inference.scoring import ship_construction_score_delta_2x
 from api.analytics.military_score_inference.ship_build_combos import (
-    MAX_SHIP_BUILD_TIER,
     generate_ship_build_combos,
     ship_build_combo_id,
 )
@@ -27,6 +29,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_TIME_LIMITED,
     solve_inference_problem,
 )
+from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.serialization.turn import turn_info_from_json
 
 from tests.fixtures.military_score_inference import _observation
@@ -88,6 +91,22 @@ def test_minimal_beam_only_and_fully_armed_scores(synthetic_catalog_context):
     )
 
 
+def test_freighter_combo_has_zero_military_score(synthetic_catalog_context):
+    combos = generate_ship_build_combos(
+        _observation(military_delta_2x=0, warship_delta=0, freighter_delta=1),
+        **synthetic_catalog_context,
+    )
+    freighter_combos = [combo for combo in combos if combo.freighter_delta == 1]
+    assert freighter_combos
+    assert all(combo.score_delta_2x == 0 for combo in freighter_combos)
+
+    warship_combos = generate_ship_build_combos(
+        _observation(warship_delta=1),
+        **synthetic_catalog_context,
+    )
+    assert all(combo.score_delta_2x > 0 for combo in warship_combos if combo.warship_delta == 1)
+
+
 def test_beams_and_launchers_may_be_omitted_independently(synthetic_catalog_context):
     torp_hull = replace(
         synthetic_catalog_context["hulls_by_id"][24],
@@ -134,7 +153,8 @@ def test_empty_active_lists_jump_to_turn_catalog_for_components():
         turn = turn_info_from_json(json.load(handle), settings_defaults=settings)
     score = next(s for s in turn.scores if s.ownerid == 1)
     observation = build_inference_observation(score, turn)
-    catalog = build_action_catalog_from_turn(observation, turn, ship_build_tier=3)
+    full_step = next(step for step in resolve_tier_policies() if step.id == "full_catalog_exact")
+    catalog = build_action_catalog_from_turn(observation, turn, policy_step=full_step)
     combos = catalog.ship_build_combos
     missouri = next(
         (
@@ -161,7 +181,8 @@ def test_early_tier_limits_beam_counts_to_zero_or_max(synthetic_catalog_context)
     }
     combos = generate_ship_build_combos(
         _observation(warship_delta=1),
-        ship_build_tier=0,
+        beam_slot_counts="none",
+        launcher_slot_counts="none",
         **context,
     )
     beam_counts = {combo.beam_count for combo in combos if combo.hull_id == hull.id}
@@ -181,7 +202,8 @@ def test_max_tier_includes_partial_beam_and_launcher_counts(synthetic_catalog_co
     }
     combos = generate_ship_build_combos(
         _observation(warship_delta=1),
-        ship_build_tier=MAX_SHIP_BUILD_TIER,
+        beam_slot_counts="partial",
+        launcher_slot_counts="partial",
         **context,
     )
     hull_combos = [combo for combo in combos if combo.hull_id == hull.id]
@@ -366,7 +388,8 @@ def test_missouri_host_turn_2_regression_becomes_feasible():
         turn = turn_info_from_json(json.load(handle), settings_defaults=settings)
     score = next(s for s in turn.scores if s.ownerid == 1)
     observation = build_inference_observation(score, turn)
-    catalog = build_action_catalog_from_turn(observation, turn, ship_build_tier=3)
+    full_step = next(step for step in resolve_tier_policies() if step.id == "full_catalog_exact")
+    catalog = build_action_catalog_from_turn(observation, turn, policy_step=full_step)
     missouri_combos = [
         combo
         for combo in catalog.ship_build_combos
@@ -392,98 +415,36 @@ def test_missouri_host_turn_2_regression_becomes_feasible():
             aggregate_actions=catalog.aggregate_actions,
             ship_build_combos=tuple(missouri_combos),
             probability_buckets_by_action_id=catalog.probability_buckets_by_action_id,
-            ship_build_tier=catalog.ship_build_tier,
+            policy_step_id=catalog.policy_step_id,
+            policy_step_index=catalog.policy_step_index,
         ),
     )
     assert solve_inference_problem(missouri_only).status == STATUS_EXACT
 
 
-def test_tier_zero_catalog_uses_single_default_engine_beam_and_torp(sample_turn):
+def test_early_policy_step_catalog_uses_early_game_band_filters(sample_turn):
     observation = _observation(warship_delta=1, freighter_delta=1, starbases_owned=5)
-    catalog = build_action_catalog_from_turn(observation, sample_turn, ship_build_tier=0)
+    early_step = resolve_tier_policies()[0]
+    context = turn_catalog_context_for_policy_step(sample_turn, observation.player_id, early_step)
+    catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=early_step,
+        policy_step_index=0,
+    )
     combos = catalog.ship_build_combos
     if not combos:
         pytest.skip("sample turn has no buildable hull combos for observation")
-    default_engine_id = min(engine.id for engine in sample_turn.engines)
-    default_beam_id = min(beam.id for beam in sample_turn.beams)
-    assert {combo.engine_id for combo in combos} == {default_engine_id}
-    assert {combo.beam_id for combo in combos if combo.beam_id is not None} <= {default_beam_id}
+    assert early_step.filters.engines.all
+    assert {combo.hull_id for combo in combos} <= context.buildable_hull_ids
+    assert {combo.engine_id for combo in combos} <= context.eligible_engine_ids
+    combo_beam_ids = {combo.beam_id for combo in combos if combo.beam_id is not None}
+    combo_torp_ids = {combo.torp_id for combo in combos if combo.torp_id is not None}
+    assert combo_beam_ids <= context.eligible_beam_ids
+    assert combo_torp_ids <= context.eligible_torp_ids
 
 
-def test_solve_with_tier_retry_accumulates_until_no_new_solutions(sample_turn):
-    from unittest.mock import patch
-
-    from api.analytics.military_score_inference.analytic import _solve_with_tier_retry
-    from api.analytics.military_score_inference.models import (
-        InferenceResult,
-        InferenceSolution,
-        InferenceSolutionShipBuild,
-    )
-    from api.analytics.military_score_inference.solver import STATUS_EXACT, STATUS_NO_EXACT_SOLUTION
-
-    score = sample_turn.scores[0]
-    observation = build_inference_observation(score, sample_turn)
-    solution_a = InferenceSolution(
-        objective_value=100,
-        actions=(),
-        ship_builds=(),
-    )
-    solution_b = InferenceSolution(
-        objective_value=50,
-        actions=(),
-        ship_builds=(
-            InferenceSolutionShipBuild(
-                combo_id="combo_a",
-                label="Build A",
-                count=1,
-                hull_id=1,
-                engine_id=1,
-                beam_id=None,
-                torp_id=None,
-                beam_count=0,
-                launcher_count=0,
-            ),
-        ),
-    )
-
-    call_tiers: list[int] = []
-
-    def _solve_side_effect(problem):
-        call_tiers.append(problem.ship_build_tier)
-        if problem.ship_build_tier == 0:
-            return InferenceResult(status=STATUS_NO_EXACT_SOLUTION, solutions=(), diagnostics={})
-        if problem.ship_build_tier == 1:
-            return InferenceResult(
-                status=STATUS_EXACT,
-                solutions=(solution_a,),
-                diagnostics={"ship_build_tier": 1},
-            )
-        if problem.ship_build_tier == 2:
-            return InferenceResult(
-                status=STATUS_EXACT,
-                solutions=(solution_a, solution_b),
-                diagnostics={"ship_build_tier": 2},
-            )
-        return InferenceResult(
-            status=STATUS_EXACT,
-            solutions=(solution_a,),
-            diagnostics={"ship_build_tier": 3},
-        )
-
-    with patch(
-        "api.analytics.military_score_inference.analytic.solve_inference_problem",
-        side_effect=_solve_side_effect,
-    ):
-        result, catalog, problem, tiers_attempted = _solve_with_tier_retry(observation, sample_turn)
-
-    assert tiers_attempted == [0, 1, 2, 3]
-    assert call_tiers == [0, 1, 2, 3]
-    assert [solution.objective_value for solution in result.solutions] == [100, 50]
-    assert catalog.ship_build_tier == 3
-    assert problem.ship_build_tier == 3
-
-
-def test_missouri_host_turn_2_regression_reports_tier_retry_diagnostics():
+def test_missouri_host_turn_2_regression_reports_policy_ladder_diagnostics():
     settings = json.loads((FIXTURES_ROOT / "628580/info.json").read_text())["settings"]
     with open(FIXTURES_ROOT / "628580/1/turns/3.json") as handle:
         turn = turn_info_from_json(json.load(handle), settings_defaults=settings)
@@ -491,8 +452,12 @@ def test_missouri_host_turn_2_regression_reports_tier_retry_diagnostics():
     payload, _, catalog = run_inference_with_artifacts(score, turn)
     assert payload["status"] in (STATUS_EXACT, STATUS_TIME_LIMITED)
     assert payload["solutionCount"] > 0
-    assert payload["diagnostics"]["tiers_attempted"]
-    tiers_attempted = payload["diagnostics"]["tiers_attempted"]
-    assert payload["diagnostics"]["ship_build_tier"] == tiers_attempted[-1]
+    assert payload["diagnostics"]["policy_steps_attempted"]
+    policy_steps_attempted = payload["diagnostics"]["policy_steps_attempted"]
+    assert payload["diagnostics"]["policy_step_id"] == policy_steps_attempted[-1]
     assert catalog is not None
     assert payload["diagnostics"]["ship_build_combo_count"] > 0
+    missouri_combo_id = "combo_13_9_3_6_8_6"
+    top_ship_builds = payload["solutions"][0]["shipBuilds"]
+    assert any(build["comboId"] == missouri_combo_id for build in top_ship_builds)
+    assert "accelerated_segments" in payload["diagnostics"]

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -133,6 +133,32 @@ def test_solve_solution_with_negative_action_contribution():
     assert counts["transfer_to_starbase"] == 1
 
 
+def test_solve_enforced_priority_point_constraint_requires_catalog_pp_deltas():
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    problem = InferenceProblem(
+        observation=_observation(
+            military_delta_2x=400,
+            warship_delta=1,
+            priority_point_delta=54,
+        ),
+        aggregate_actions=(build_warship,),
+        probability_buckets_by_action_id={},
+        enforce_priority_point_constraint=True,
+    )
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_NO_EXACT_SOLUTION
+    assert result.solutions == ()
+
+
 def test_solve_non_zero_priority_points_with_zero_pp_catalog_actions():
     """Regression: PP delta is diagnostic-only until queue semantics model per-build PP."""
     build_warship = CandidateAction(
@@ -155,23 +181,20 @@ def test_solve_non_zero_priority_points_with_zero_pp_catalog_actions():
     assert result.solutions[0].actions[0].action_id == "build_rush"
 
 
-def test_solve_enforced_priority_point_constraint_requires_catalog_pp_deltas():
-    build_warship = CandidateAction(
-        id="build_rush",
-        label="Build Rush",
-        score_delta_2x=400,
-        warship_delta=1,
-        build_slot_usage=1,
-        upper_bound=1,
-        probability_weight=100,
-    )
+def test_solve_pp_only_idle_turn_with_empty_catalog_returns_exact_empty_solution():
+    """Regression: scoreboard PP-only rows must not fail when PP is not a hard constraint."""
+    result = solve_inference_problem(_problem(_observation(priority_point_delta=2)))
+
+    assert result.status == STATUS_EXACT
+    assert len(result.solutions) == 1
+    assert result.solutions[0].actions == ()
+    assert result.diagnostics["solver_status"] == "NO_ACTIONS"
+
+
+def test_solve_pp_only_idle_turn_still_infeasible_when_pp_constraint_enforced():
     problem = InferenceProblem(
-        observation=_observation(
-            military_delta_2x=400,
-            warship_delta=1,
-            priority_point_delta=54,
-        ),
-        aggregate_actions=(build_warship,),
+        observation=_observation(priority_point_delta=2),
+        aggregate_actions=(),
         probability_buckets_by_action_id={},
         enforce_priority_point_constraint=True,
     )

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -7,7 +7,7 @@ from api.analytics.military_score_inference.actions import (
     build_action_catalog,
     build_action_catalog_from_turn,
 )
-from api.analytics.military_score_inference.analytic import _solve_with_policy_ladder
+from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.component_eligibility import (
     eligible_component_ids_for_filter,
     turn_catalog_context_for_policy_step,
@@ -370,10 +370,10 @@ def test_solve_with_policy_ladder_stops_when_no_new_exact_signatures(sample_turn
         )
 
     monkeypatch.setattr(
-        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         _solve_side_effect,
     )
-    result, catalog, problem, attempted, step_diagnostics = _solve_with_policy_ladder(
+    result, catalog, problem, attempted, step_diagnostics = solve_with_policy_ladder(
         observation,
         sample_turn,
     )
@@ -477,10 +477,10 @@ def test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added(
         )
 
     monkeypatch.setattr(
-        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         _solve_side_effect,
     )
-    result, catalog, _, attempted, _ = _solve_with_policy_ladder(
+    result, catalog, _, attempted, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
     )
@@ -529,10 +529,10 @@ def test_solve_with_policy_ladder_reports_exact_when_top_solution_satisfies_hard
         )
 
     monkeypatch.setattr(
-        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         _solve_side_effect,
     )
-    result, _, _, _, _ = _solve_with_policy_ladder(
+    result, _, _, _, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
         time_limit_seconds=60.0,

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -480,6 +480,14 @@ def test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added(
         "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         _solve_side_effect,
     )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder._solution_fully_explained_by_ship_builds_only",
+        lambda solution, observation, catalog: False,
+    )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder._solution_satisfies_exact_hard_equalities",
+        lambda solution, observation, catalog: True,
+    )
     result, catalog, _, attempted, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
@@ -532,6 +540,10 @@ def test_solve_with_policy_ladder_reports_exact_when_top_solution_satisfies_hard
         "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
         _solve_side_effect,
     )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder._solution_satisfies_exact_hard_equalities",
+        lambda solution, observation, catalog: True,
+    )
     result, _, _, _, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
@@ -539,3 +551,102 @@ def test_solve_with_policy_ladder_reports_exact_when_top_solution_satisfies_hard
     )
 
     assert result.status == STATUS_EXACT
+
+
+def _ship_build_solution(*, combo_id: str, objective_value: int, label: str | None = None):
+    return InferenceSolution(
+        objective_value=objective_value,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id=combo_id,
+                label=label or combo_id,
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+
+
+def test_solve_with_policy_ladder_retains_exact_across_combo_widen(sample_turn, monkeypatch):
+    observation = _observation(warship_delta=1)
+    policy_steps = resolve_tier_policies()
+    early_solution = _ship_build_solution(combo_id="combo_early", objective_value=100)
+
+    def _solve_side_effect(problem):
+        if problem.policy_step_id == policy_steps[0].id:
+            return InferenceResult(status=STATUS_NO_EXACT_SOLUTION, solutions=(), diagnostics={})
+        if problem.policy_step_id == policy_steps[1].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(early_solution,),
+                diagnostics={"policy_step_id": policy_steps[1].id},
+            )
+        return InferenceResult(
+            status=STATUS_NO_EXACT_SOLUTION,
+            solutions=(),
+            diagnostics={"policy_step_id": problem.policy_step_id},
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
+        _solve_side_effect,
+    )
+    result, _, _, attempted, _ = solve_with_policy_ladder(
+        observation,
+        sample_turn,
+    )
+
+    assert policy_steps[1].id in attempted
+    assert policy_steps[2].id in attempted
+    assert any(solution.ship_builds[0].combo_id == "combo_early" for solution in result.solutions)
+
+
+def test_solve_with_policy_ladder_evicts_worst_when_k_best_full(sample_turn, monkeypatch):
+    observation = _observation(warship_delta=1)
+    policy_steps = resolve_tier_policies()
+    low_solution = _ship_build_solution(combo_id="combo_low", objective_value=40)
+    mid_solution = _ship_build_solution(combo_id="combo_mid", objective_value=50)
+    high_solution = _ship_build_solution(combo_id="combo_high", objective_value=100)
+
+    def _solve_side_effect(problem):
+        if problem.policy_step_id == policy_steps[0].id:
+            return InferenceResult(status=STATUS_NO_EXACT_SOLUTION, solutions=(), diagnostics={})
+        if problem.policy_step_id == policy_steps[1].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(mid_solution, low_solution),
+                diagnostics={"policy_step_id": policy_steps[1].id},
+            )
+        if problem.policy_step_id == policy_steps[2].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(high_solution,),
+                diagnostics={"policy_step_id": policy_steps[2].id},
+            )
+        return InferenceResult(
+            status=STATUS_NO_EXACT_SOLUTION,
+            solutions=(),
+            diagnostics={"policy_step_id": problem.policy_step_id},
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder.solve_inference_problem",
+        _solve_side_effect,
+    )
+    result, _, _, _, _ = solve_with_policy_ladder(
+        observation,
+        sample_turn,
+        max_solutions=2,
+    )
+
+    assert [solution.objective_value for solution in result.solutions] == [100, 50]
+    assert {solution.ship_builds[0].combo_id for solution in result.solutions} == {
+        "combo_high",
+        "combo_mid",
+    }

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -7,7 +7,6 @@ from api.analytics.military_score_inference.actions import (
     build_action_catalog,
     build_action_catalog_from_turn,
 )
-from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.component_eligibility import (
     eligible_component_ids_for_filter,
     turn_catalog_context_for_policy_step,
@@ -17,6 +16,7 @@ from api.analytics.military_score_inference.models import (
     InferenceSolution,
     InferenceSolutionShipBuild,
 )
+from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.solver import STATUS_EXACT, STATUS_NO_EXACT_SOLUTION
 from api.analytics.military_score_inference.tier_policy import (
     ComponentFilter,

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -1,0 +1,541 @@
+"""Tests for YAML inference search tier policy loading and catalog behavior."""
+
+from pathlib import Path
+
+import pytest
+from api.analytics.military_score_inference.actions import (
+    build_action_catalog,
+    build_action_catalog_from_turn,
+)
+from api.analytics.military_score_inference.analytic import _solve_with_policy_ladder
+from api.analytics.military_score_inference.component_eligibility import (
+    eligible_component_ids_for_filter,
+    turn_catalog_context_for_policy_step,
+)
+from api.analytics.military_score_inference.models import (
+    InferenceResult,
+    InferenceSolution,
+    InferenceSolutionShipBuild,
+)
+from api.analytics.military_score_inference.solver import STATUS_EXACT, STATUS_NO_EXACT_SOLUTION
+from api.analytics.military_score_inference.tier_policy import (
+    ComponentFilter,
+    TierPolicyOverlay,
+    default_tier_policy_path,
+    parse_tier_policy_steps,
+    resolve_tier_policies,
+)
+from api.models.components import Engine
+
+from tests.fixtures.military_score_inference import _observation
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_default_policy_path_exists():
+    path = default_tier_policy_path()
+    assert path.is_file()
+    assert path == REPO_ROOT / "assets/analytics/military_score_build_inference/tier_policy.yaml"
+
+
+def test_policy_loader_validates_final_alpha_zero():
+    steps = resolve_tier_policies()
+    assert steps[-1].alpha == 0
+    assert steps[0].id == "early_game_bands"
+
+
+def test_policy_loader_rejects_non_superset_tech_levels():
+    document = {
+        "steps": [
+            {
+                "id": "narrow",
+                "filters": {
+                    "hulls": {"techLevels": [1, 2]},
+                    "engines": {"techLevels": [1]},
+                    "beams": {"techLevels": [1]},
+                    "launchers": {"techLevels": [1]},
+                },
+                "alpha": 0,
+            },
+            {
+                "id": "too_narrow",
+                "filters": {
+                    "hulls": {"techLevels": [1]},
+                    "engines": {"techLevels": [1]},
+                    "beams": {"techLevels": [1]},
+                    "launchers": {"techLevels": [1]},
+                },
+                "alpha": 0,
+            },
+        ]
+    }
+    with pytest.raises(ValueError, match="superset"):
+        parse_tier_policy_steps(document)
+
+
+def test_policy_loader_rejects_all_and_tech_levels_together():
+    document = {
+        "steps": [
+            {
+                "id": "invalid",
+                "filters": {
+                    "hulls": {"all": True, "techLevels": [1]},
+                    "engines": {"all": True},
+                    "beams": {"all": True},
+                    "launchers": {"all": True},
+                },
+                "alpha": 0,
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="cannot set both all and techLevels"):
+        parse_tier_policy_steps(document)
+
+
+def test_policy_loader_rejects_missing_tech_levels_when_all_false():
+    document = {
+        "steps": [
+            {
+                "id": "invalid",
+                "filters": {
+                    "hulls": {"techLevels": [1]},
+                    "engines": {},
+                    "beams": {"all": True},
+                    "launchers": {"all": True},
+                },
+                "alpha": 0,
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="filters.engines.techLevels"):
+        parse_tier_policy_steps(document)
+
+
+def test_policy_loader_rejects_missing_final_alpha_zero():
+    document = {
+        "steps": [
+            {
+                "id": "banded",
+                "filters": {
+                    "hulls": {"techLevels": [1]},
+                    "engines": {"techLevels": [1]},
+                    "beams": {"techLevels": [1]},
+                    "launchers": {"techLevels": [1]},
+                },
+                "alpha": 10,
+            }
+        ]
+    }
+    with pytest.raises(ValueError, match="alpha: 0"):
+        parse_tier_policy_steps(document)
+
+
+def test_overlay_hook_accepts_none_and_returns_yaml_steps():
+    steps = resolve_tier_policies(overlay=None)
+    assert len(steps) == 8
+
+
+def test_overlay_parameter_is_accepted_without_merge():
+    steps = resolve_tier_policies(overlay=TierPolicyOverlay())
+    assert len(steps) == 8
+
+
+def test_early_step_uses_tech_level_bands_not_lowest_component_id(sample_turn):
+    observation = _observation(warship_delta=1, freighter_delta=1, starbases_owned=5)
+    early_step = resolve_tier_policies()[0]
+    context = turn_catalog_context_for_policy_step(sample_turn, observation.player_id, early_step)
+    hulls_at_allowed_tech = {
+        hull.id
+        for hull in sample_turn.hulls
+        if hull.techlevel in early_step.filters.hulls.tech_levels
+    }
+    beams_at_allowed_tech = {
+        beam.id
+        for beam in sample_turn.beams
+        if beam.techlevel in early_step.filters.beams.tech_levels
+    }
+    launchers_at_allowed_tech = {
+        torp.id
+        for torp in sample_turn.torpedos
+        if torp.techlevel in early_step.filters.launchers.tech_levels
+    }
+    assert early_step.filters.engines.all
+    assert context.buildable_hull_ids <= hulls_at_allowed_tech
+    assert context.eligible_beam_ids <= beams_at_allowed_tech
+    assert context.eligible_torp_ids <= launchers_at_allowed_tech
+    assert len(context.buildable_hull_ids) >= 1
+
+
+def test_hulls_all_filter_uses_buildable_set_without_tech_band(sample_turn):
+    observation = _observation(warship_delta=1, freighter_delta=1, starbases_owned=5)
+    full_step = resolve_tier_policies()[-1]
+    early_step = resolve_tier_policies()[0]
+    full_context = turn_catalog_context_for_policy_step(
+        sample_turn,
+        observation.player_id,
+        full_step,
+    )
+    early_context = turn_catalog_context_for_policy_step(
+        sample_turn,
+        observation.player_id,
+        early_step,
+    )
+    assert full_step.filters.hulls.all
+    assert len(full_context.buildable_hull_ids) >= len(early_context.buildable_hull_ids)
+
+
+def test_slack_deferred_on_early_steps(sample_turn):
+    observation = _observation(military_delta_2x=500)
+    early_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=resolve_tier_policies()[0],
+        policy_step_index=0,
+    )
+    action_ids = {action.id for action in early_catalog.aggregate_actions}
+    assert "planet_defense_posts_added_total" not in action_ids
+    assert "starbase_defense_posts_added_total" not in action_ids
+    assert not any(action_id.startswith("ship_torps_loaded_") for action_id in action_ids)
+    assert "fighters_starbase_to_ship" not in action_ids
+    assert "fighters_ship_to_starbase" not in action_ids
+    assert "starbase_fighters_added_total" not in action_ids
+    assert "ship_fighters_added_total" not in action_ids
+
+
+def test_full_components_step_opens_ship_slots_before_aggregates(sample_turn):
+    observation = _observation(warship_delta=1, freighter_delta=1, starbases_owned=5)
+    widen_hulls = next(step for step in resolve_tier_policies() if step.id == "widen_hulls")
+    full_components = next(step for step in resolve_tier_policies() if step.id == "full_components")
+    widen_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=widen_hulls,
+    )
+    full_components_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=full_components,
+    )
+    assert full_components.beam_slot_counts == "partial"
+    assert full_components.launcher_slot_counts == "partial"
+    assert full_components.aggregate_allowlist == {}
+    action_ids = {action.id for action in full_components_catalog.aggregate_actions}
+    assert "planet_defense_posts_added_total" not in action_ids
+    assert "starbase_fighters_added_total" not in action_ids
+    assert "ship_fighters_added_total" not in action_ids
+    assert "fighters_starbase_to_ship" not in action_ids
+    assert "fighters_ship_to_starbase" not in action_ids
+    assert len(full_components_catalog.ship_build_combos) >= len(widen_catalog.ship_build_combos)
+
+
+def test_fighter_builds_admitted_on_full_components_step_with_caps(sample_turn):
+    observation = _observation(military_delta_2x=500)
+    full_components_step = next(
+        step for step in resolve_tier_policies() if step.id == "full_components_planet_defense"
+    )
+    catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=full_components_step,
+    )
+    starbase_fighters = next(
+        action
+        for action in catalog.aggregate_actions
+        if action.id == "starbase_fighters_added_total"
+    )
+    ship_fighters = next(
+        action for action in catalog.aggregate_actions if action.id == "ship_fighters_added_total"
+    )
+    assert starbase_fighters.upper_bound <= 50
+    assert ship_fighters.upper_bound <= 20
+
+
+def test_slack_admitted_on_later_steps_with_caps(sample_turn):
+    observation = _observation(military_delta_2x=500)
+    torp_step = next(step for step in resolve_tier_policies() if step.id == "admit_ship_torpedoes")
+    catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=torp_step,
+    )
+    planet_action = next(
+        action
+        for action in catalog.aggregate_actions
+        if action.id == "planet_defense_posts_added_total"
+    )
+    torp_actions = [
+        action for action in catalog.aggregate_actions if action.id.startswith("ship_torps_loaded_")
+    ]
+    assert planet_action.upper_bound <= 16
+    assert torp_actions
+    assert all(action.upper_bound <= 10 for action in torp_actions)
+
+
+def test_tech_level_filtering_derives_component_sets(synthetic_catalog_context):
+    early_step = resolve_tier_policies()[0]
+    high_tech_engine = Engine(
+        id=99,
+        name="High Tech",
+        cost=99,
+        tritanium=1,
+        duranium=1,
+        molybdenum=1,
+        techlevel=5,
+        warp1=1,
+        warp2=1,
+        warp3=1,
+        warp4=1,
+        warp5=1,
+        warp6=1,
+        warp7=1,
+        warp8=1,
+        warp9=1,
+    )
+    engines_by_id = {
+        **synthetic_catalog_context["engines_by_id"],
+        high_tech_engine.id: high_tech_engine,
+    }
+    beam_filter = early_step.filters.beams
+    eligible_beam_ids = eligible_component_ids_for_filter(
+        beam_filter,
+        active_component_csv="",
+        components_by_id=synthetic_catalog_context["beams_by_id"],
+    )
+    context = {
+        **synthetic_catalog_context,
+        "engines_by_id": engines_by_id,
+        "eligible_beam_ids": eligible_beam_ids,
+    }
+    early_catalog = build_action_catalog(
+        _observation(warship_delta=1),
+        policy_step=early_step,
+        **context,
+    )
+    assert high_tech_engine.id not in {combo.engine_id for combo in early_catalog.ship_build_combos}
+
+
+def test_component_ids_restriction_is_applied_when_present(synthetic_catalog_context):
+    restricted_filter = ComponentFilter(all=False, tech_levels=(1,), component_ids=(1,))
+    eligible_beam_ids = eligible_component_ids_for_filter(
+        restricted_filter,
+        active_component_csv="",
+        components_by_id=synthetic_catalog_context["beams_by_id"],
+    )
+    assert eligible_beam_ids == frozenset({1})
+
+
+def test_solve_with_policy_ladder_stops_when_no_new_exact_signatures(sample_turn, monkeypatch):
+    observation = _observation(warship_delta=1, starbases_owned=3)
+    solution_a = InferenceSolution(objective_value=100, actions=(), ship_builds=())
+    solution_b = InferenceSolution(
+        objective_value=50,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id="combo_a",
+                label="Build A",
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+    policy_steps = resolve_tier_policies()
+    call_step_ids: list[str] = []
+
+    def _solve_side_effect(problem):
+        call_step_ids.append(problem.policy_step_id)
+        if problem.policy_step_id == policy_steps[0].id:
+            return InferenceResult(status=STATUS_NO_EXACT_SOLUTION, solutions=(), diagnostics={})
+        if problem.policy_step_id == policy_steps[1].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(solution_a,),
+                diagnostics={"policy_step_id": policy_steps[1].id},
+            )
+        if problem.policy_step_id == policy_steps[2].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(solution_a, solution_b),
+                diagnostics={"policy_step_id": policy_steps[2].id},
+            )
+        return InferenceResult(
+            status=STATUS_EXACT,
+            solutions=(solution_a,),
+            diagnostics={"policy_step_id": problem.policy_step_id},
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        _solve_side_effect,
+    )
+    result, catalog, problem, attempted, step_diagnostics = _solve_with_policy_ladder(
+        observation,
+        sample_turn,
+    )
+
+    assert attempted[:4] == [
+        policy_steps[0].id,
+        policy_steps[1].id,
+        policy_steps[2].id,
+        policy_steps[3].id,
+    ]
+    assert call_step_ids[0] == policy_steps[0].id
+    assert policy_steps[1].id in call_step_ids
+    assert policy_steps[2].id in call_step_ids
+    assert [solution.objective_value for solution in result.solutions] == [100, 50]
+    assert catalog.policy_step_id == policy_steps[3].id
+    assert problem.policy_step_id == policy_steps[3].id
+    assert step_diagnostics
+    assert step_diagnostics[0]["policyStepId"] == policy_steps[0].id
+    assert "filters" in step_diagnostics[0]["constraintSnapshot"]
+    assert result.diagnostics["stopped_reason"] == "no_new_exact_signatures"
+
+
+def test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added(
+    sample_turn, monkeypatch
+):
+    observation = _observation(warship_delta=1)
+    policy_steps = resolve_tier_policies()
+    solution_a = InferenceSolution(
+        objective_value=100,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id="combo_a",
+                label="Build A",
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+    solution_b = InferenceSolution(
+        objective_value=50,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id="combo_b",
+                label="Build B",
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+    solution_c = InferenceSolution(
+        objective_value=75,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id="combo_c",
+                label="Build C",
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+
+    def _solve_side_effect(problem):
+        if problem.policy_step_id == policy_steps[0].id:
+            return InferenceResult(status=STATUS_NO_EXACT_SOLUTION, solutions=(), diagnostics={})
+        if problem.policy_step_id == policy_steps[1].id:
+            return InferenceResult(status=STATUS_EXACT, solutions=(solution_a,), diagnostics={})
+        if problem.policy_step_id == policy_steps[2].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(solution_a, solution_b),
+                diagnostics={"policy_step_id": problem.policy_step_id},
+            )
+        if problem.policy_step_id == policy_steps[3].id:
+            return InferenceResult(
+                status=STATUS_EXACT,
+                solutions=(solution_c,),
+                diagnostics={"policy_step_id": problem.policy_step_id},
+            )
+        return InferenceResult(
+            status=STATUS_EXACT,
+            solutions=(solution_a,),
+            diagnostics={"policy_step_id": problem.policy_step_id},
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        _solve_side_effect,
+    )
+    result, catalog, _, attempted, _ = _solve_with_policy_ladder(
+        observation,
+        sample_turn,
+    )
+
+    assert policy_steps[4].id in attempted
+    assert policy_steps[-1].id in attempted
+    assert catalog.policy_step_id == policy_steps[-1].id
+    assert result.status == STATUS_EXACT
+
+
+def test_solve_with_policy_ladder_reports_exact_when_top_solution_satisfies_hard_equalities(
+    sample_turn, monkeypatch
+):
+    from api.analytics.military_score_inference.solver import STATUS_TIME_LIMITED
+
+    observation = _observation(military_delta_2x=400, warship_delta=1)
+    exact_solution = InferenceSolution(
+        objective_value=100,
+        actions=(),
+        ship_builds=(
+            InferenceSolutionShipBuild(
+                combo_id="combo_a",
+                label="Build A",
+                count=1,
+                hull_id=1,
+                engine_id=1,
+                beam_id=None,
+                torp_id=None,
+                beam_count=0,
+                launcher_count=0,
+            ),
+        ),
+    )
+
+    def _solve_side_effect(problem):
+        if problem.military_score_alpha > 0:
+            return InferenceResult(
+                status=STATUS_TIME_LIMITED,
+                solutions=(exact_solution,),
+                diagnostics={"policy_step_id": problem.policy_step_id},
+            )
+        return InferenceResult(
+            status=STATUS_EXACT,
+            solutions=(exact_solution,),
+            diagnostics={"policy_step_id": problem.policy_step_id},
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.analytic.solve_inference_problem",
+        _solve_side_effect,
+    )
+    result, _, _, _, _ = _solve_with_policy_ladder(
+        observation,
+        sample_turn,
+        time_limit_seconds=60.0,
+    )
+
+    assert result.status == STATUS_EXACT

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
@@ -119,6 +119,135 @@ describe('InferenceDetailModal', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
+  it('shows accelerated-start segments instead of duplicate top-level solutions', () => {
+    render(
+      <InferenceDetailModal
+        isOpen
+        onClose={vi.fn()}
+        racePlayer="Federation (alice)"
+        detail={detail({
+          summary: 'Best: Missouri',
+          diagnostics: {
+            turn: 3,
+            constraints: {
+              turn: 3,
+              playerId: 1,
+              militaryDelta2x: 220,
+              warshipDelta: 1,
+              freighterDelta: 0,
+            },
+            accelerated_segments: [
+              {
+                segmentId: 'accel_window',
+                hostTurn: 1,
+                status: 'exact',
+                solutionCount: 1,
+                militaryDelta2x: 220,
+                warshipDelta: 0,
+                freighterDelta: 0,
+                solutions: [
+                  {
+                    objectiveValue: 999,
+                    actions: [
+                      {
+                        actionId: 'planet_defense',
+                        label: 'Planet defense post',
+                        count: 10,
+                      },
+                    ],
+                    militaryScoreArithmetic: {
+                      observedMilitaryChange: 110,
+                      observedMilitaryDelta2x: 220,
+                      explainedMilitaryChange: 110,
+                      explainedMilitaryDelta2x: 220,
+                      matchesObserved: true,
+                      lineItems: [
+                        {
+                          actionId: 'planet_defense',
+                          label: 'Planet defense post',
+                          count: 10,
+                          scoreDelta2xPerUnit: 22,
+                          militaryChangePerUnit: 11,
+                          scoreDelta2xSubtotal: 220,
+                          militaryChangeSubtotal: 110,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+              {
+                segmentId: 'reported_host_turn',
+                hostTurn: 2,
+                status: 'exact',
+                solutionCount: 1,
+                militaryDelta2x: 220,
+                warshipDelta: 1,
+                freighterDelta: 0,
+                solutions: [
+                  {
+                    objectiveValue: 100,
+                    actions: [],
+                    militaryScoreArithmetic: {
+                      observedMilitaryChange: 110,
+                      observedMilitaryDelta2x: 220,
+                      explainedMilitaryChange: 110,
+                      explainedMilitaryDelta2x: 220,
+                      matchesObserved: true,
+                      lineItems: [
+                        {
+                          comboId: 'combo_13_9_3_6_8_6',
+                          label: 'Missouri',
+                          count: 1,
+                          scoreDelta2xPerUnit: 220,
+                          militaryChangePerUnit: 110,
+                          scoreDelta2xSubtotal: 220,
+                          militaryChangeSubtotal: 110,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          solutions: [
+            {
+              objectiveValue: 100,
+              actions: [],
+              militaryScoreArithmetic: {
+                observedMilitaryChange: 110,
+                observedMilitaryDelta2x: 220,
+                explainedMilitaryChange: 110,
+                explainedMilitaryDelta2x: 220,
+                matchesObserved: true,
+                lineItems: [
+                  {
+                    comboId: 'combo_13_9_3_6_8_6',
+                    label: 'Missouri',
+                    count: 1,
+                    scoreDelta2xPerUnit: 220,
+                    militaryChangePerUnit: 110,
+                    scoreDelta2xSubtotal: 220,
+                    militaryChangeSubtotal: 110,
+                  },
+                ],
+              },
+            },
+          ],
+        })}
+      />
+    )
+
+    expect(screen.getByText('Accelerated-start game: build inference split by host turn.')).toBeInTheDocument()
+    expect(screen.getByText('Host turn 1 (accelerated window)')).toBeInTheDocument()
+    expect(screen.getByText('Host turn 2 (on scoreboard row turn 3)')).toBeInTheDocument()
+    expect(screen.getByText('Planet defense post')).toBeInTheDocument()
+    expect(screen.getByText('Missouri')).toBeInTheDocument()
+    expect(screen.getByText('Scoreboard row constraints')).toBeInTheDocument()
+    expect(screen.queryAllByText('Solution 1')).toHaveLength(2)
+  })
+
   it('calls onClose from the close button', () => {
     const onClose = vi.fn()
     render(

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -4,6 +4,11 @@ import { useModalKeydownFocusTrap } from '../../lib/modalKeydownFocusTrap'
 import { restoreFocusToElementOrFallback } from '../../lib/restoreFocus'
 import { cn } from '../../lib/utils'
 import {
+  acceleratedSegmentTitle,
+  readAcceleratedInferenceSegments,
+  type AcceleratedInferenceSegment,
+} from './acceleratedInferenceSegments'
+import {
   formatSignedDelta,
   militaryChangeFromDelta2x,
   readInferenceConstraints,
@@ -101,6 +106,50 @@ function MilitaryScoreArithmeticTable({ arithmetic }: { arithmetic: MilitaryScor
   )
 }
 
+function SegmentConstraints({ segment }: { segment: AcceleratedInferenceSegment }) {
+  return (
+    <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-slate-300">
+      <dt className="text-slate-400">Military change</dt>
+      <dd className="tabular-nums">
+        {formatSignedDelta(militaryChangeFromDelta2x(segment.militaryDelta2x))}
+        <span className="ml-1 text-slate-500">
+          (2× scale {formatSignedDelta(segment.militaryDelta2x)})
+        </span>
+      </dd>
+      <dt className="text-slate-400">Warship change</dt>
+      <dd className="tabular-nums">{formatSignedDelta(segment.warshipDelta)}</dd>
+      <dt className="text-slate-400">Freighter change</dt>
+      <dd className="tabular-nums">{formatSignedDelta(segment.freighterDelta)}</dd>
+    </dl>
+  )
+}
+
+function AcceleratedSegmentSection({
+  segment,
+  scoreboardTurn,
+}: {
+  segment: AcceleratedInferenceSegment
+  scoreboardTurn: number | undefined
+}) {
+  return (
+    <section className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3">
+      <h3 className="text-xs font-medium text-slate-200">
+        {acceleratedSegmentTitle(segment, scoreboardTurn)}
+      </h3>
+      <SegmentConstraints segment={segment} />
+      {segment.solutions.length > 0 ? (
+        <div className="mt-3 flex flex-col gap-3">
+          {segment.solutions.map((solution, index) => (
+            <SolutionSection key={`${segment.segmentId}-solution-${index}`} solution={solution} index={index} />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-slate-500">No feasible build explanation found.</p>
+      )}
+    </section>
+  )
+}
+
 function SolutionSection({
   solution,
   index,
@@ -163,6 +212,7 @@ export function InferenceDetailModal({
 
   const diagnostics = isRecord(detail.diagnostics) ? detail.diagnostics : {}
   const constraints = readInferenceConstraints(diagnostics)
+  const acceleratedSegments = readAcceleratedInferenceSegments(diagnostics)
   const solver = readSolverSummary(diagnostics)
   const priorTurn =
     constraints?.turn != null && constraints.turn > 1 ? constraints.turn - 1 : null
@@ -213,7 +263,11 @@ export function InferenceDetailModal({
 
         {constraints != null ? (
           <section className="rounded border border-[#52575d]/70 bg-[#2a2d30] p-3">
-            <h3 className="text-xs font-medium text-slate-200">Observed constraints</h3>
+            <h3 className="text-xs font-medium text-slate-200">
+              {acceleratedSegments != null
+                ? 'Scoreboard row constraints'
+                : 'Observed constraints'}
+            </h3>
             <dl className="mt-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs text-slate-300">
               {constraints.militaryDelta2x != null ? (
                 <>
@@ -276,11 +330,26 @@ export function InferenceDetailModal({
           </p>
         ) : null}
 
-        <div className="flex flex-col gap-3">
-          {detail.solutions.map((solution, index) => (
-            <SolutionSection key={`solution-${index}`} solution={solution} index={index} />
-          ))}
-        </div>
+        {acceleratedSegments != null ? (
+          <div className="flex flex-col gap-3">
+            <p className="text-xs text-slate-400">
+              Accelerated-start game: build inference split by host turn.
+            </p>
+            {acceleratedSegments.map((segment) => (
+              <AcceleratedSegmentSection
+                key={segment.segmentId}
+                segment={segment}
+                scoreboardTurn={constraints?.turn}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {detail.solutions.map((solution, index) => (
+              <SolutionSection key={`solution-${index}`} solution={solution} index={index} />
+            ))}
+          </div>
+        )}
 
         {!detail.isComplete ? (
           <p className="text-xs text-amber-300/90">

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -15,16 +15,13 @@ import {
   readMilitaryScoreArithmetic,
   type MilitaryScoreArithmetic,
 } from './inferenceConstraints'
+import { isRecord } from './scoresWireParsers'
 
 type InferenceDetailModalProps = {
   isOpen: boolean
   onClose: () => void
   racePlayer: string
   detail: ScoresInferenceRowDetail | null
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value)
 }
 
 function readSolverSummary(diagnostics: Record<string, unknown>): {

--- a/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.test.ts
+++ b/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  acceleratedSegmentTitle,
+  readAcceleratedInferenceSegments,
+} from './acceleratedInferenceSegments'
+
+describe('readAcceleratedInferenceSegments', () => {
+  it('returns null when accelerated segments are absent', () => {
+    expect(readAcceleratedInferenceSegments({})).toBeNull()
+    expect(readAcceleratedInferenceSegments({ accelerated_segments: [] })).toBeNull()
+  })
+
+  it('parses segment payloads and sorts by host turn', () => {
+    const segments = readAcceleratedInferenceSegments({
+      accelerated_segments: [
+        {
+          segmentId: 'reported_host_turn',
+          hostTurn: 2,
+          status: 'exact',
+          solutionCount: 1,
+          militaryDelta2x: 220,
+          warshipDelta: 1,
+          freighterDelta: 0,
+          solutions: [
+            {
+              objectiveValue: 100,
+              actions: [],
+              militaryScoreArithmetic: {
+                observedMilitaryChange: 110,
+                observedMilitaryDelta2x: 220,
+                explainedMilitaryChange: 110,
+                explainedMilitaryDelta2x: 220,
+                matchesObserved: true,
+                lineItems: [
+                  {
+                    comboId: 'combo_13_9_3_6_8_6',
+                    label: 'Missouri',
+                    count: 1,
+                    scoreDelta2xPerUnit: 220,
+                    militaryChangePerUnit: 110,
+                    scoreDelta2xSubtotal: 220,
+                    militaryChangeSubtotal: 110,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          segmentId: 'accel_window',
+          hostTurn: 1,
+          status: 'exact',
+          solutionCount: 1,
+          militaryDelta2x: 220,
+          warshipDelta: 0,
+          freighterDelta: 0,
+          solutions: [
+            {
+              objectiveValue: 999,
+              actions: [
+                {
+                  actionId: 'planet_defense',
+                  label: 'Planet defense post',
+                  count: 10,
+                },
+              ],
+              militaryScoreArithmetic: {
+                observedMilitaryChange: 110,
+                observedMilitaryDelta2x: 220,
+                explainedMilitaryChange: 110,
+                explainedMilitaryDelta2x: 220,
+                matchesObserved: true,
+                lineItems: [
+                  {
+                    actionId: 'planet_defense',
+                    label: 'Planet defense post',
+                    count: 10,
+                    scoreDelta2xPerUnit: 22,
+                    militaryChangePerUnit: 11,
+                    scoreDelta2xSubtotal: 220,
+                    militaryChangeSubtotal: 110,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(segments).not.toBeNull()
+    expect(segments).toHaveLength(2)
+    expect(segments?.[0].segmentId).toBe('accel_window')
+    expect(segments?.[1].segmentId).toBe('reported_host_turn')
+    expect(segments?.[1].solutions[0].militaryScoreArithmetic?.lineItems[0].actionId).toBe(
+      'combo_13_9_3_6_8_6'
+    )
+  })
+})
+
+describe('acceleratedSegmentTitle', () => {
+  it('labels accelerated window and reported host turn segments', () => {
+    expect(
+      acceleratedSegmentTitle(
+        {
+          segmentId: 'accel_window',
+          hostTurn: 1,
+          status: 'exact',
+          solutionCount: 1,
+          militaryDelta2x: 220,
+          warshipDelta: 0,
+          freighterDelta: 0,
+          solutions: [],
+        },
+        3
+      )
+    ).toBe('Host turn 1 (accelerated window)')
+
+    expect(
+      acceleratedSegmentTitle(
+        {
+          segmentId: 'reported_host_turn',
+          hostTurn: 2,
+          status: 'exact',
+          solutionCount: 1,
+          militaryDelta2x: 220,
+          warshipDelta: 1,
+          freighterDelta: 0,
+          solutions: [],
+        },
+        3
+      )
+    ).toBe('Host turn 2 (on scoreboard row turn 3)')
+  })
+})

--- a/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.ts
+++ b/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.ts
@@ -1,0 +1,149 @@
+import type { ScoresInferenceSolution } from '../../api/bff'
+import { readMilitaryScoreArithmetic } from './inferenceConstraints'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export type AcceleratedInferenceSegment = {
+  segmentId: string
+  hostTurn: number
+  status: string
+  solutionCount: number
+  militaryDelta2x: number
+  warshipDelta: number
+  freighterDelta: number
+  solutions: ScoresInferenceSolution[]
+}
+
+function readSolutionAction(entry: unknown): ScoresInferenceSolution['actions'][number] | null {
+  if (!isRecord(entry)) {
+    return null
+  }
+  if (
+    typeof entry.actionId !== 'string' ||
+    typeof entry.label !== 'string' ||
+    typeof entry.count !== 'number'
+  ) {
+    return null
+  }
+  return {
+    actionId: entry.actionId,
+    label: entry.label,
+    count: entry.count,
+  }
+}
+
+function readInferenceSolution(entry: unknown): ScoresInferenceSolution | null {
+  if (!isRecord(entry)) {
+    return null
+  }
+  if (typeof entry.objectiveValue !== 'number') {
+    return null
+  }
+  const actionsRaw = entry.actions
+  const actions: ScoresInferenceSolution['actions'] = []
+  if (Array.isArray(actionsRaw)) {
+    for (const action of actionsRaw) {
+      const parsed = readSolutionAction(action)
+      if (parsed != null) {
+        actions.push(parsed)
+      }
+    }
+  }
+  const arithmetic = readMilitaryScoreArithmetic(entry.militaryScoreArithmetic)
+  return {
+    objectiveValue: entry.objectiveValue,
+    actions,
+    ...(arithmetic != null ? { militaryScoreArithmetic: arithmetic } : {}),
+  }
+}
+
+export function readAcceleratedInferenceSegments(
+  diagnostics: Record<string, unknown>
+): AcceleratedInferenceSegment[] | null {
+  const raw = diagnostics.accelerated_segments ?? diagnostics.acceleratedSegments
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return null
+  }
+
+  const segments: AcceleratedInferenceSegment[] = []
+  for (const entry of raw) {
+    if (!isRecord(entry)) {
+      continue
+    }
+    const segmentId =
+      typeof entry.segmentId === 'string'
+        ? entry.segmentId
+        : typeof entry.segment_id === 'string'
+          ? entry.segment_id
+          : null
+    const hostTurn =
+      typeof entry.hostTurn === 'number'
+        ? entry.hostTurn
+        : typeof entry.host_turn === 'number'
+          ? entry.host_turn
+          : null
+    if (segmentId == null || hostTurn == null) {
+      continue
+    }
+    const solutionsRaw = entry.solutions
+    const solutions: ScoresInferenceSolution[] = []
+    if (Array.isArray(solutionsRaw)) {
+      for (const solution of solutionsRaw) {
+        const parsed = readInferenceSolution(solution)
+        if (parsed != null) {
+          solutions.push(parsed)
+        }
+      }
+    }
+    segments.push({
+      segmentId,
+      hostTurn,
+      status: typeof entry.status === 'string' ? entry.status : 'unknown',
+      solutionCount:
+        typeof entry.solutionCount === 'number'
+          ? entry.solutionCount
+          : typeof entry.solution_count === 'number'
+            ? entry.solution_count
+            : solutions.length,
+      militaryDelta2x:
+        typeof entry.militaryDelta2x === 'number'
+          ? entry.militaryDelta2x
+          : typeof entry.military_delta_2x === 'number'
+            ? entry.military_delta_2x
+            : 0,
+      warshipDelta:
+        typeof entry.warshipDelta === 'number'
+          ? entry.warshipDelta
+          : typeof entry.warship_delta === 'number'
+            ? entry.warship_delta
+            : 0,
+      freighterDelta:
+        typeof entry.freighterDelta === 'number'
+          ? entry.freighterDelta
+          : typeof entry.freighter_delta === 'number'
+            ? entry.freighter_delta
+            : 0,
+      solutions,
+    })
+  }
+
+  if (segments.length === 0) {
+    return null
+  }
+  return [...segments].sort((left, right) => left.hostTurn - right.hostTurn)
+}
+
+export function acceleratedSegmentTitle(
+  segment: AcceleratedInferenceSegment,
+  scoreboardTurn: number | undefined
+): string {
+  if (segment.segmentId === 'accel_window') {
+    return `Host turn ${segment.hostTurn} (accelerated window)`
+  }
+  if (segment.segmentId === 'reported_host_turn' && scoreboardTurn != null) {
+    return `Host turn ${segment.hostTurn} (on scoreboard row turn ${scoreboardTurn})`
+  }
+  return `Host turn ${segment.hostTurn}`
+}

--- a/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.ts
+++ b/packages/frontend/src/analytics/scores/acceleratedInferenceSegments.ts
@@ -1,9 +1,5 @@
 import type { ScoresInferenceSolution } from '../../api/bff'
-import { readMilitaryScoreArithmetic } from './inferenceConstraints'
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value)
-}
+import { isRecord, readInferenceSolution } from './scoresWireParsers'
 
 export type AcceleratedInferenceSegment = {
   segmentId: string
@@ -16,53 +12,10 @@ export type AcceleratedInferenceSegment = {
   solutions: ScoresInferenceSolution[]
 }
 
-function readSolutionAction(entry: unknown): ScoresInferenceSolution['actions'][number] | null {
-  if (!isRecord(entry)) {
-    return null
-  }
-  if (
-    typeof entry.actionId !== 'string' ||
-    typeof entry.label !== 'string' ||
-    typeof entry.count !== 'number'
-  ) {
-    return null
-  }
-  return {
-    actionId: entry.actionId,
-    label: entry.label,
-    count: entry.count,
-  }
-}
-
-function readInferenceSolution(entry: unknown): ScoresInferenceSolution | null {
-  if (!isRecord(entry)) {
-    return null
-  }
-  if (typeof entry.objectiveValue !== 'number') {
-    return null
-  }
-  const actionsRaw = entry.actions
-  const actions: ScoresInferenceSolution['actions'] = []
-  if (Array.isArray(actionsRaw)) {
-    for (const action of actionsRaw) {
-      const parsed = readSolutionAction(action)
-      if (parsed != null) {
-        actions.push(parsed)
-      }
-    }
-  }
-  const arithmetic = readMilitaryScoreArithmetic(entry.militaryScoreArithmetic)
-  return {
-    objectiveValue: entry.objectiveValue,
-    actions,
-    ...(arithmetic != null ? { militaryScoreArithmetic: arithmetic } : {}),
-  }
-}
-
 export function readAcceleratedInferenceSegments(
   diagnostics: Record<string, unknown>
 ): AcceleratedInferenceSegment[] | null {
-  const raw = diagnostics.accelerated_segments ?? diagnostics.acceleratedSegments
+  const raw = diagnostics.accelerated_segments
   if (!Array.isArray(raw) || raw.length === 0) {
     return null
   }
@@ -72,19 +25,7 @@ export function readAcceleratedInferenceSegments(
     if (!isRecord(entry)) {
       continue
     }
-    const segmentId =
-      typeof entry.segmentId === 'string'
-        ? entry.segmentId
-        : typeof entry.segment_id === 'string'
-          ? entry.segment_id
-          : null
-    const hostTurn =
-      typeof entry.hostTurn === 'number'
-        ? entry.hostTurn
-        : typeof entry.host_turn === 'number'
-          ? entry.host_turn
-          : null
-    if (segmentId == null || hostTurn == null) {
+    if (typeof entry.segmentId !== 'string' || typeof entry.hostTurn !== 'number') {
       continue
     }
     const solutionsRaw = entry.solutions
@@ -98,33 +39,14 @@ export function readAcceleratedInferenceSegments(
       }
     }
     segments.push({
-      segmentId,
-      hostTurn,
+      segmentId: entry.segmentId,
+      hostTurn: entry.hostTurn,
       status: typeof entry.status === 'string' ? entry.status : 'unknown',
       solutionCount:
-        typeof entry.solutionCount === 'number'
-          ? entry.solutionCount
-          : typeof entry.solution_count === 'number'
-            ? entry.solution_count
-            : solutions.length,
-      militaryDelta2x:
-        typeof entry.militaryDelta2x === 'number'
-          ? entry.militaryDelta2x
-          : typeof entry.military_delta_2x === 'number'
-            ? entry.military_delta_2x
-            : 0,
-      warshipDelta:
-        typeof entry.warshipDelta === 'number'
-          ? entry.warshipDelta
-          : typeof entry.warship_delta === 'number'
-            ? entry.warship_delta
-            : 0,
-      freighterDelta:
-        typeof entry.freighterDelta === 'number'
-          ? entry.freighterDelta
-          : typeof entry.freighter_delta === 'number'
-            ? entry.freighter_delta
-            : 0,
+        typeof entry.solutionCount === 'number' ? entry.solutionCount : solutions.length,
+      militaryDelta2x: typeof entry.militaryDelta2x === 'number' ? entry.militaryDelta2x : 0,
+      warshipDelta: typeof entry.warshipDelta === 'number' ? entry.warshipDelta : 0,
+      freighterDelta: typeof entry.freighterDelta === 'number' ? entry.freighterDelta : 0,
       solutions,
     })
   }

--- a/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
+++ b/packages/frontend/src/analytics/scores/diagnosticsFromTable.ts
@@ -1,10 +1,7 @@
 import type { AnalyticShellScope, ScoresInferenceRowDetail, TableDataResponse } from '../../api/bff'
 import { isScoresInferenceRowDetail } from '../../api/bff'
 import type { ScoresAnalyticDiagnostics } from '../../stores/analyticDiagnostics'
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value)
-}
+import { isRecord } from './scoresWireParsers'
 
 function readTurn(diagnostics: Record<string, unknown>): number | null {
   if (typeof diagnostics.turn === 'number') {

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.test.ts
@@ -50,6 +50,29 @@ describe('readMilitaryScoreArithmetic', () => {
     expect(arithmetic?.matchesObserved).toBe(true)
     expect(arithmetic?.lineItems[0]?.militaryChangeSubtotal).toBe(22)
   })
+
+  it('parses ship-build line items that use comboId', () => {
+    const arithmetic = readMilitaryScoreArithmetic({
+      observedMilitaryChange: 110,
+      observedMilitaryDelta2x: 220,
+      explainedMilitaryChange: 110,
+      explainedMilitaryDelta2x: 220,
+      matchesObserved: true,
+      lineItems: [
+        {
+          comboId: 'combo_13_9_3_6_8_6',
+          label: 'Missouri',
+          count: 1,
+          scoreDelta2xPerUnit: 220,
+          militaryChangePerUnit: 110,
+          scoreDelta2xSubtotal: 220,
+          militaryChangeSubtotal: 110,
+        },
+      ],
+    })
+    expect(arithmetic?.lineItems[0]?.actionId).toBe('combo_13_9_3_6_8_6')
+    expect(arithmetic?.lineItems[0]?.label).toBe('Missouri')
+  })
 })
 
 describe('militaryChangeFromDelta2x', () => {

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.ts
@@ -1,3 +1,5 @@
+import { isRecord } from './scoresWireParsers'
+
 export type InferenceConstraintsSection = {
   turn?: number
   playerId?: number
@@ -26,10 +28,6 @@ export type MilitaryScoreArithmetic = {
   explainedMilitaryDelta2x: number
   matchesObserved: boolean
   lineItems: MilitaryScoreLineItem[]
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value)
 }
 
 export function readInferenceConstraints(

--- a/packages/frontend/src/analytics/scores/inferenceConstraints.ts
+++ b/packages/frontend/src/analytics/scores/inferenceConstraints.ts
@@ -78,8 +78,14 @@ export function readMilitaryScoreArithmetic(value: unknown): MilitaryScoreArithm
     if (!isRecord(item)) {
       continue
     }
+    const lineId =
+      typeof item.actionId === 'string'
+        ? item.actionId
+        : typeof item.comboId === 'string'
+          ? item.comboId
+          : null
     if (
-      typeof item.actionId !== 'string' ||
+      lineId == null ||
       typeof item.label !== 'string' ||
       typeof item.count !== 'number' ||
       typeof item.scoreDelta2xPerUnit !== 'number' ||
@@ -90,7 +96,7 @@ export function readMilitaryScoreArithmetic(value: unknown): MilitaryScoreArithm
       continue
     }
     lineItems.push({
-      actionId: item.actionId,
+      actionId: lineId,
       label: item.label,
       count: item.count,
       scoreDelta2xPerUnit: item.scoreDelta2xPerUnit,

--- a/packages/frontend/src/analytics/scores/scoresWireParsers.ts
+++ b/packages/frontend/src/analytics/scores/scoresWireParsers.ts
@@ -1,0 +1,49 @@
+import type { ScoresInferenceSolution } from '../../api/bff'
+import { readMilitaryScoreArithmetic } from './inferenceConstraints'
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readSolutionAction(entry: unknown): ScoresInferenceSolution['actions'][number] | null {
+  if (!isRecord(entry)) {
+    return null
+  }
+  if (
+    typeof entry.actionId !== 'string' ||
+    typeof entry.label !== 'string' ||
+    typeof entry.count !== 'number'
+  ) {
+    return null
+  }
+  return {
+    actionId: entry.actionId,
+    label: entry.label,
+    count: entry.count,
+  }
+}
+
+export function readInferenceSolution(entry: unknown): ScoresInferenceSolution | null {
+  if (!isRecord(entry)) {
+    return null
+  }
+  if (typeof entry.objectiveValue !== 'number') {
+    return null
+  }
+  const actionsRaw = entry.actions
+  const actions: ScoresInferenceSolution['actions'] = []
+  if (Array.isArray(actionsRaw)) {
+    for (const action of actionsRaw) {
+      const parsed = readSolutionAction(action)
+      if (parsed != null) {
+        actions.push(parsed)
+      }
+    }
+  }
+  const arithmetic = readMilitaryScoreArithmetic(entry.militaryScoreArithmetic)
+  return {
+    objectiveValue: entry.objectiveValue,
+    actions,
+    ...(arithmetic != null ? { militaryScoreArithmetic: arithmetic } : {}),
+  }
+}

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -222,7 +222,8 @@ export type ScoresInferenceSolutionAction = {
 }
 
 export type ScoresInferenceMilitaryScoreLineItem = {
-  actionId: string
+  actionId?: string
+  comboId?: string
   label: string
   count: number
   scoreDelta2xPerUnit: number

--- a/scripts/run_inference_corpus.py
+++ b/scripts/run_inference_corpus.py
@@ -7,8 +7,10 @@ import sys
 from pathlib import Path
 
 _API_ROOT = Path(__file__).resolve().parents[1] / "packages" / "api"
-if str(_API_ROOT) not in sys.path:
-    sys.path.insert(0, str(_API_ROOT))
+_api_root_str = str(_API_ROOT)
+if _api_root_str in sys.path:
+    sys.path.remove(_api_root_str)
+sys.path.insert(0, _api_root_str)
 
 import typer  # noqa: E402
 from api.services.store_service import StoreService  # noqa: E402
@@ -94,6 +96,30 @@ def run_command(
         "--top-k",
         help="Reserved for ground-truth ranking checks (#65); accepted for CLI stability.",
     ),
+    stop_after_failures: int | None = typer.Option(
+        None,
+        "--stop-after-failures",
+        min=1,
+        help=(
+            "Stop after this many inference failures (failed, out_of_search_space, "
+            "ranking_miss). Skipped cases do not count."
+        ),
+    ),
+    probe_time_limit_seconds: float | None = typer.Option(
+        None,
+        "--probe-time-limit-seconds",
+        min=0,
+        help=(
+            "Stop the run once this many wall-clock seconds have elapsed (checked "
+            "between cases). Use 0 for no limit."
+        ),
+    ),
+    workers: int = typer.Option(
+        1,
+        "--workers",
+        min=1,
+        help="Process pool size for running discovered cases in parallel.",
+    ),
     json_output: bool = typer.Option(
         False,
         "--json",
@@ -126,6 +152,12 @@ def run_command(
         max_host_turn=to_turn,
         max_complexity=complexity_cap,
         include_adjunct=include_adjunct,
+        stop_after_failures=stop_after_failures,
+        probe_time_limit_seconds=(
+            None if probe_time_limit_seconds == 0 else probe_time_limit_seconds
+        ),
+        workers=workers,
+        storage_root=storage_root,
     )
 
     if json_output:
@@ -134,6 +166,8 @@ def run_command(
         for line in report.summary_lines():
             typer.echo(line)
 
+    if stop_after_failures is not None or report.stopped_early:
+        raise typer.Exit(code=0)
     raise typer.Exit(code=report.exit_code)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -69,6 +69,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "ortools" },
+    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -83,6 +84,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "ortools", specifier = ">=9.15.6755" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary

- Replace hardcoded ship-build tiers 0-4 with a YAML-driven inference search tier ladder (`tier_policy.yaml`), including filter-based catalog eligibility, cumulative aggregate allowlist slack deferral, band seed carry-forward, and exact-first solve semantics per design section 8.5.
- Add accelerated-start split inference and backfill (per-segment policy ladders, unreliable row resolution via stored first-reliable turn), plus inventory-only corpus ground truth and a parallel local probe harness (`make inference_corpus_probe`).
- Refactor inference into focused modules (`policy_ladder`, `inference_target`, `inference_path`, `inference_api_payload`) and add frontend accelerated segment display with shared wire parsers.

Closes #77. Supersedes #52, #72, #54.

## Test plan

- [x] `make test` (lint + full backend/frontend suite)
- [x] Tier policy loader validation, slack deferral, band seeding, cross-tier merge semantics (`test_military_score_inference_tier_policy.py`)
- [x] Accelerated start backfill/split inference (`test_accelerated_start_scoreboard.py`)
- [x] Inference corpus coverage and probe harness tests
- [x] Frontend accelerated segment and modal tests


Made with [Cursor](https://cursor.com)