### PR TITLE
Add hull catalog mask for military score build inference

### DIFF
--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -10,6 +10,7 @@ from api.analytics.military_score_inference.component_eligibility import (
     player_by_id,
     turn_catalog_context_for_policy_step,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
     CandidateAction,
     InferenceObservation,
@@ -156,6 +157,7 @@ def build_action_catalog_from_turn(
     config: ActionCatalogConfig | None = None,
     policy_step: InferenceTierPolicyStep | None = None,
     policy_step_index: int = 0,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> ActionCatalog:
     resolved_policy_step = policy_step
     if resolved_policy_step is None:
@@ -164,6 +166,7 @@ def build_action_catalog_from_turn(
         turn,
         observation.player_id,
         resolved_policy_step,
+        resolved_mask=resolved_mask,
     )
     return build_action_catalog(
         observation,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -16,6 +16,7 @@ from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
     observation_to_constraints_payload,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_accelerated import (
     run_accelerated_split_inference,
 )
@@ -198,11 +199,13 @@ def _run_accelerated_backfill_inference(
     resolved_observation: InferenceObservation,
     *,
     load_scoreboard_turn: ScoreboardTurnLoader | None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     backfill = _try_accelerated_backfill_inference(
         score,
         turn,
         load_scoreboard_turn=load_scoreboard_turn,
+        resolved_mask=resolved_mask,
     )
     if backfill is not None:
         return backfill
@@ -213,11 +216,14 @@ def _run_accelerated_split_inference_path(
     score: Score,
     turn: TurnInfo,
     segments: tuple[AcceleratedInferenceSegment, ...],
+    *,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     payload, reported_observation, reported_catalog, _ = run_accelerated_split_inference(
         score,
         turn,
         segments,
+        resolved_mask=resolved_mask,
     )
     return payload, reported_observation, reported_catalog
 
@@ -225,6 +231,8 @@ def _run_accelerated_split_inference_path(
 def _run_policy_ladder_inference(
     resolved_observation: InferenceObservation,
     turn: TurnInfo,
+    *,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[
     InferenceResult,
     ActionCatalog | None,
@@ -235,6 +243,7 @@ def _run_policy_ladder_inference(
     return solve_with_policy_ladder(
         resolved_observation,
         turn,
+        resolved_mask=resolved_mask,
     )
 
 
@@ -279,6 +288,7 @@ def _run_solver_inference_path(
     *,
     catalog: ActionCatalog | None,
     accelerated_segments: tuple[AcceleratedInferenceSegment, ...] | None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     if path == InferencePath.ACCELERATED_SPLIT:
         assert accelerated_segments is not None
@@ -286,6 +296,7 @@ def _run_solver_inference_path(
             score,
             turn,
             accelerated_segments,
+            resolved_mask=resolved_mask,
         )
 
     solve_catalog = catalog
@@ -295,6 +306,7 @@ def _run_solver_inference_path(
                 _run_policy_ladder_inference(
                     resolved_observation,
                     turn,
+                    resolved_mask=resolved_mask,
                 )
             )
         else:
@@ -347,6 +359,7 @@ def run_inference_with_artifacts(
     observation: InferenceObservation | None = None,
     catalog: ActionCatalog | None = None,
     load_scoreboard_turn: ScoreboardTurnLoader | None = None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
 
@@ -374,6 +387,7 @@ def run_inference_with_artifacts(
             turn,
             resolved_observation,
             load_scoreboard_turn=load_scoreboard_turn,
+            resolved_mask=resolved_mask,
         )
     return _run_solver_inference_path(
         path,
@@ -382,6 +396,7 @@ def run_inference_with_artifacts(
         resolved_observation,
         catalog=catalog,
         accelerated_segments=accelerated_segments,
+        resolved_mask=resolved_mask,
     )
 
 
@@ -390,6 +405,7 @@ def _try_accelerated_backfill_inference(
     turn: TurnInfo,
     *,
     load_scoreboard_turn: ScoreboardTurnLoader | None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None] | None:
     """Fill unreliable accelerated rows from the first reliable split when that turn is stored."""
     if load_scoreboard_turn is None:
@@ -412,6 +428,7 @@ def _try_accelerated_backfill_inference(
         backfill_source.source_score,
         backfill_source.source_turn,
         backfill_source.segments,
+        resolved_mask=resolved_mask,
     )
     segment_payload = _segment_payload_for_host_turn(
         payload,

--- a/packages/api/api/analytics/military_score_inference/component_eligibility.py
+++ b/packages/api/api/analytics/military_score_inference/component_eligibility.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from api.analytics.military_score_inference.hull_catalog_mask import (
+    ResolvedHullCatalogMask,
     default_enabled_hull_ids_for_player,
 )
 from api.analytics.military_score_inference.inference_turn_lookup import (
@@ -33,8 +34,13 @@ class TurnCatalogContext:
 def buildable_hull_ids_for_player(
     turn: TurnInfo,
     player_id: int,
+    *,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> frozenset[int]:
     """Return hull ids buildable for the inference target player on this turn snapshot."""
+    catalog_hull_ids = frozenset(hull.id for hull in turn.hulls)
+    if resolved_mask is not None:
+        return resolved_mask.effective_enabled_hull_ids & catalog_hull_ids
     return default_enabled_hull_ids_for_player(turn, player_id)
 
 
@@ -76,12 +82,22 @@ def eligible_hull_ids_for_filter(
     turn: TurnInfo,
     player_id: int,
     hull_filter: ComponentFilter,
+    *,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> frozenset[int]:
     """Resolve hull ids from a policy ``filters.hulls`` entry."""
     if hull_filter.all:
-        eligible_ids = buildable_hull_ids_for_player(turn, player_id)
+        eligible_ids = buildable_hull_ids_for_player(
+            turn,
+            player_id,
+            resolved_mask=resolved_mask,
+        )
     else:
-        buildable_hull_ids = buildable_hull_ids_for_player(turn, player_id)
+        buildable_hull_ids = buildable_hull_ids_for_player(
+            turn,
+            player_id,
+            resolved_mask=resolved_mask,
+        )
         hulls_by_id = {hull.id: hull for hull in turn.hulls}
         eligible_ids = frozenset(
             hull_id
@@ -116,6 +132,8 @@ def turn_catalog_context_for_policy_step(
     turn: TurnInfo,
     player_id: int,
     policy_step: InferenceTierPolicyStep,
+    *,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> TurnCatalogContext:
     hulls_by_id = {hull.id: hull for hull in turn.hulls}
     engines_by_id = {engine.id: engine for engine in turn.engines}
@@ -133,6 +151,7 @@ def turn_catalog_context_for_policy_step(
             turn,
             player_id,
             filters.hulls,
+            resolved_mask=resolved_mask,
         ),
         eligible_engine_ids=eligible_component_ids_for_filter(
             filters.engines,

--- a/packages/api/api/analytics/military_score_inference/hull_catalog_mask.py
+++ b/packages/api/api/analytics/military_score_inference/hull_catalog_mask.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from api.analytics.military_score_inference.inference_turn_lookup import (
     parse_component_id_csv,
     player_by_id,
@@ -25,6 +27,18 @@ REPLACEMENT_SETTING_FIELDS: tuple[str, ...] = (
     "cybernautlightreplacescybernaut",
     "ironslavescoutreplacesironslave",
 )
+
+
+@dataclass(frozen=True)
+class ResolvedHullCatalogMask:
+    """Effective hull eligibility for one inference target player."""
+
+    race_id: int
+    race_name: str
+    master_hull_ids: frozenset[int]
+    default_enabled_hull_ids: frozenset[int]
+    effective_enabled_hull_ids: frozenset[int]
+    has_user_override: bool
 
 
 def catalog_hull_ids(turn: TurnInfo) -> frozenset[int]:
@@ -139,3 +153,30 @@ def default_enabled_hull_ids_for_player(turn: TurnInfo, player_id: int) -> froze
         settings=turn.settings,
     )
     return enabled & master
+
+
+def resolve_hull_catalog_mask(
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    user_enabled_hull_ids: frozenset[int] | None,
+) -> ResolvedHullCatalogMask:
+    player = player_by_id(turn, player_id)
+    race = race_by_id_or_none(turn, player.raceid)
+    race_name = race.name if race is not None else "Unknown"
+    master = master_hull_ids_for_race(turn, player.raceid)
+    default_enabled = default_enabled_hull_ids_for_player(turn, player_id)
+    if user_enabled_hull_ids is None:
+        effective = default_enabled
+        has_override = False
+    else:
+        effective = user_enabled_hull_ids & master
+        has_override = True
+    return ResolvedHullCatalogMask(
+        race_id=player.raceid,
+        race_name=race_name,
+        master_hull_ids=master,
+        default_enabled_hull_ids=default_enabled,
+        effective_enabled_hull_ids=effective,
+        has_user_override=has_override,
+    )

--- a/packages/api/api/analytics/military_score_inference/inference_accelerated.py
+++ b/packages/api/api/analytics/military_score_inference/inference_accelerated.py
@@ -16,6 +16,7 @@ from api.analytics.military_score_inference.actions import (
     DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     ActionCatalog,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import (
     STATUS_NO_PRIOR_TURN,
     _serialize_solution_with_arithmetic,
@@ -73,6 +74,7 @@ def run_accelerated_segment_policy_ladder(
     time_limit_seconds: float | None,
     cancel_token: InferenceCancelToken | None = None,
     on_admitted: Callable[[InferenceSolution], None] | None = None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> AcceleratedSegmentResult:
     """Run the policy ladder for one accelerated segment."""
     observation = observation_from_accelerated_segment(score, turn, segment)
@@ -88,6 +90,7 @@ def run_accelerated_segment_policy_ladder(
         time_limit_seconds=resolved_time_limit,
         cancel_token=cancel_token,
         on_admitted=on_admitted,
+        resolved_mask=resolved_mask,
     )
     return AcceleratedSegmentResult(
         segment=segment,
@@ -197,6 +200,7 @@ def run_accelerated_split_inference(
     segments: tuple[AcceleratedInferenceSegment, ...],
     *,
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[
     dict[str, object],
     InferenceObservation,
@@ -224,6 +228,7 @@ def run_accelerated_split_inference(
             segment,
             max_solutions=20,
             time_limit_seconds=per_segment_time,
+            resolved_mask=resolved_mask,
         )
         if segment.is_streaming_target:
             reported_observation = ladder_result.observation

--- a/packages/api/api/analytics/military_score_inference/inference_row_runner.py
+++ b/packages/api/api/analytics/military_score_inference/inference_row_runner.py
@@ -64,7 +64,9 @@ def _outcome_after_ladder_complete(
         if advance.continue_next_segment:
             return TierJobOutcome(
                 enqueue_continuation=True,
-                next_ladder_state=orchestration.new_ladder_state(),
+                next_ladder_state=orchestration.new_ladder_state(
+                    resolved_mask=run.session.resolved_mask,
+                ),
             )
         if advance.row_complete is not None:
             return TierJobOutcome(row_complete=advance.row_complete)

--- a/packages/api/api/analytics/military_score_inference/inference_scheduler.py
+++ b/packages/api/api/analytics/military_score_inference/inference_scheduler.py
@@ -199,10 +199,15 @@ class InferenceRowScheduler:
         run = self._get_or_create_run(session)
         run.orchestration = orchestration
         if orchestration is not None:
-            run.ladder_state = orchestration.new_ladder_state()
+            run.ladder_state = orchestration.new_ladder_state(
+                resolved_mask=session.resolved_mask,
+            )
         else:
             policy_steps = tuple(resolve_tier_policies(None))
-            run.ladder_state = PolicyLadderState(policy_steps=policy_steps)
+            run.ladder_state = PolicyLadderState(
+                policy_steps=policy_steps,
+                resolved_mask=session.resolved_mask,
+            )
         self._enqueue_job(TierJob(session=session))
 
     def _enqueue_job(self, job: TierJob) -> None:

--- a/packages/api/api/analytics/military_score_inference/inference_scheduler.py
+++ b/packages/api/api/analytics/military_score_inference/inference_scheduler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import threading
+import uuid
 from collections import deque
 
 from api.analytics.military_score_inference.inference_row_runner import (
@@ -27,7 +28,7 @@ from api.analytics.military_score_inference.models import InferenceObservation
 from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
 from api.analytics.military_score_inference.row_run import RowRun, TierJob
 from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
-from api.errors import ConflictError, ValidationError
+from api.errors import ValidationError
 
 _DEFAULT_WORKER_COUNT = 4
 _DEQUEUE_WAIT_SECONDS = 0.25
@@ -59,20 +60,28 @@ class InferenceRowScheduler:
         self._shutdown = False
         self._active_scope: InferenceStreamScope | None = None
         self._has_active_table_stream = False
+        self._active_table_stream_token: str | None = None
         self._globally_paused = False
         for _ in range(worker_count):
             thread = threading.Thread(target=self._worker_loop, daemon=True)
             thread.start()
             self._workers.append(thread)
 
-    def begin_scope(self, scope: InferenceStreamScope) -> None:
+    def begin_scope(self, scope: InferenceStreamScope) -> str:
         with self._condition:
             if self._active_scope == scope and self._has_active_table_stream:
-                raise ConflictError("An inference table stream is already active for this scope.")
-            if self._active_scope != scope:
+                self._preempt_table_stream_for_scope_locked()
+            elif self._active_scope != scope:
                 self._invalidate_retained_state_locked()
                 self._active_scope = scope
+            stream_token = str(uuid.uuid4())
             self._has_active_table_stream = True
+            self._active_table_stream_token = stream_token
+            return stream_token
+
+    def owns_table_stream(self, stream_token: str) -> bool:
+        with self._condition:
+            return self._active_table_stream_token == stream_token
 
     def _global_pause_status_locked(self, scope: InferenceStreamScope) -> dict[str, object]:
         scope_matches = self._active_scope == scope
@@ -146,16 +155,20 @@ class InferenceRowScheduler:
         self,
         scope: InferenceStreamScope,
         sessions: tuple[InferenceRowStreamSession, ...],
+        *,
+        stream_token: str,
     ) -> None:
         """Cancel all row runs for a table stream and clear global pause on disconnect."""
         with self._condition:
+            owns_scope = self._active_table_stream_token == stream_token
             for session in sessions:
                 run_id = session.run_id
                 session.cancel_token.cancel()
                 self._purge_queued_jobs_for_run_locked(run_id)
                 self._runs.pop(run_id, None)
-            if self._active_scope == scope:
+            if owns_scope and self._active_scope == scope:
                 self._has_active_table_stream = False
+                self._active_table_stream_token = None
                 self._clear_global_pause_for_active_scope_locked(scope)
             self._condition.notify_all()
 
@@ -195,7 +208,11 @@ class InferenceRowScheduler:
         session: InferenceRowStreamSession,
         *,
         orchestration: InferenceStreamOrchestration | None = None,
+        stream_token: str | None = None,
     ) -> None:
+        with self._condition:
+            if stream_token is not None and self._active_table_stream_token != stream_token:
+                return
         run = self._get_or_create_run(session)
         run.orchestration = orchestration
         if orchestration is not None:
@@ -238,8 +255,19 @@ class InferenceRowScheduler:
             job = self._work_queue.popleft()
             self._get_or_create_run(job.session).hold_job(job)
 
+    def _preempt_table_stream_for_scope_locked(self) -> None:
+        """Cancel in-flight table-stream work so a reconnect can replace the active stream."""
+        self._globally_paused = False
+        for run in list(self._runs.values()):
+            run.session.cancel_token.cancel()
+        self._runs.clear()
+        while self._work_queue:
+            job = self._work_queue.popleft()
+            job.session.cancel_token.cancel()
+
     def _invalidate_retained_state_locked(self) -> None:
         self._has_active_table_stream = False
+        self._active_table_stream_token = None
         self._globally_paused = False
         for run in list(self._runs.values()):
             run.session.cancel_token.cancel()

--- a/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
@@ -9,13 +9,13 @@ from api.analytics.military_score_inference.accelerated_start import (
     scoreboard_host_turn,
 )
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_accelerated import (
     AcceleratedSegmentResult,
     build_accelerated_backfill_stream_row_complete,
     build_accelerated_segment_payload,
     build_accelerated_split_stream_row_complete,
 )
-from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_path import InferencePath
 from api.analytics.military_score_inference.inference_stream_domain_events import RowComplete
 from api.analytics.military_score_inference.inference_target import (

--- a/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
@@ -15,6 +15,7 @@ from api.analytics.military_score_inference.inference_accelerated import (
     build_accelerated_segment_payload,
     build_accelerated_split_stream_row_complete,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_path import InferencePath
 from api.analytics.military_score_inference.inference_stream_domain_events import RowComplete
 from api.analytics.military_score_inference.inference_target import (
@@ -86,8 +87,15 @@ class InferenceStreamOrchestration:
         segment = self.current_segment()
         return segment is not None and segment.is_streaming_target
 
-    def new_ladder_state(self) -> PolicyLadderState:
-        return PolicyLadderState(policy_steps=tuple(resolve_tier_policies(None)))
+    def new_ladder_state(
+        self,
+        *,
+        resolved_mask: ResolvedHullCatalogMask | None = None,
+    ) -> PolicyLadderState:
+        return PolicyLadderState(
+            policy_steps=tuple(resolve_tier_policies(None)),
+            resolved_mask=resolved_mask,
+        )
 
     def record_segment_ladder_complete(
         self,

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 
 from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import (
     STATUS_NO_PRIOR_TURN,
     no_prior_turn_inference_api_payload,
@@ -121,6 +122,7 @@ def schedule_inference_row(
     game_id: int,
     perspective: int,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> ScheduledInferenceRow:
     observation = build_inference_observation(
         score,
@@ -140,6 +142,7 @@ def schedule_inference_row(
         game_id=game_id,
         perspective=perspective,
         turn_number=turn_number,
+        resolved_mask=resolved_mask,
     )
     orchestration = create_inference_stream_orchestration(
         path,
@@ -221,6 +224,7 @@ def iter_scores_table_inference_events(
     game_id: int,
     perspective: int,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
+    resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
 ) -> Iterator[dict[str, object]]:
     """Yield tagged inference events for all scoreboard rows on one NDJSON stream."""
     turn_number = turn.settings.turn
@@ -248,6 +252,9 @@ def iter_scores_table_inference_events(
             continue
 
         score = next(row for row in turn.scores if row.ownerid == player_id)
+        resolved_mask = (
+            resolve_mask_for_player(player_id) if resolve_mask_for_player is not None else None
+        )
         scheduled_rows.append(
             schedule_inference_row(
                 scheduler,
@@ -257,6 +264,7 @@ def iter_scores_table_inference_events(
                 game_id=game_id,
                 perspective=perspective,
                 load_scoreboard_turn=load_scoreboard_turn,
+                resolved_mask=resolved_mask,
             )
         )
         yield from drain_available_multiplex_events(

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -123,7 +123,8 @@ def schedule_inference_row(
     perspective: int,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
-) -> ScheduledInferenceRow:
+    stream_token: str | None = None,
+) -> ScheduledInferenceRow | None:
     observation = build_inference_observation(
         score,
         turn,
@@ -151,7 +152,13 @@ def schedule_inference_row(
         segments=_segments,
         load_scoreboard_turn=load_scoreboard_turn,
     )
-    scheduler.enqueue_tier_ladder(session, orchestration=orchestration)
+    scheduler.enqueue_tier_ladder(
+        session,
+        orchestration=orchestration,
+        stream_token=stream_token,
+    )
+    if stream_token is not None and not scheduler.owns_table_stream(stream_token):
+        return None
     return ScheduledInferenceRow(player_id=player_id, session=session)
 
 
@@ -183,6 +190,7 @@ def iter_multiplexed_inference_events(
     *,
     tag_player_id: bool,
     finished_run_ids: set[str] | None = None,
+    is_stream_active: Callable[[], bool] | None = None,
 ) -> Iterator[dict[str, object]]:
     """Round-robin blocking reads across row event queues until all rows finish."""
     finished = finished_run_ids if finished_run_ids is not None else set()
@@ -190,6 +198,8 @@ def iter_multiplexed_inference_events(
     active_rows = list(sessions)
     cursor = 0
     while pending_run_ids and active_rows:
+        if is_stream_active is not None and not is_stream_active():
+            return
         row = active_rows[cursor % len(active_rows)]
         cursor += 1
         if row.session.run_id not in pending_run_ids:
@@ -211,10 +221,12 @@ def cleanup_inference_stream_sessions(
     scheduler: InferenceRowScheduler,
     scope: InferenceStreamScope,
     sessions: tuple[InferenceRowStreamSession, ...],
+    *,
+    stream_token: str,
 ) -> None:
     """Tear down row runs when the table stream ends; always recalculate on reconnect."""
     if sessions:
-        scheduler.end_inference_stream(scope, sessions)
+        scheduler.end_inference_stream(scope, sessions, stream_token=stream_token)
 
 
 def iter_scores_table_inference_events(
@@ -234,13 +246,16 @@ def iter_scores_table_inference_events(
         turn_number=turn_number,
     )
     scheduler = get_inference_row_scheduler()
-    scheduler.begin_scope(stream_scope)
+    stream_token = scheduler.begin_scope(stream_scope)
     pause_status = scheduler.global_pause_status(stream_scope)
     yield inference_global_pause_event(paused=bool(pause_status.get("paused")))
 
     scheduled_rows: list[ScheduledInferenceRow] = []
     finished_run_ids: set[str] = set()
     for player_id in player_ids:
+        if not scheduler.owns_table_stream(stream_token):
+            return
+
         immediate = immediate_row_inference_events(
             turn,
             player_id,
@@ -255,18 +270,20 @@ def iter_scores_table_inference_events(
         resolved_mask = (
             resolve_mask_for_player(player_id) if resolve_mask_for_player is not None else None
         )
-        scheduled_rows.append(
-            schedule_inference_row(
-                scheduler,
-                score=score,
-                turn=turn,
-                player_id=player_id,
-                game_id=game_id,
-                perspective=perspective,
-                load_scoreboard_turn=load_scoreboard_turn,
-                resolved_mask=resolved_mask,
-            )
+        scheduled_row = schedule_inference_row(
+            scheduler,
+            score=score,
+            turn=turn,
+            player_id=player_id,
+            game_id=game_id,
+            perspective=perspective,
+            load_scoreboard_turn=load_scoreboard_turn,
+            resolved_mask=resolved_mask,
+            stream_token=stream_token,
         )
+        if scheduled_row is None:
+            return
+        scheduled_rows.append(scheduled_row)
         yield from drain_available_multiplex_events(
             tuple(scheduled_rows),
             tag_player_id=True,
@@ -279,10 +296,12 @@ def iter_scores_table_inference_events(
             sessions,
             tag_player_id=True,
             finished_run_ids=finished_run_ids,
+            is_stream_active=lambda: scheduler.owns_table_stream(stream_token),
         )
     finally:
         cleanup_inference_stream_sessions(
             scheduler,
             stream_scope,
             tuple(row.session for row in sessions),
+            stream_token=stream_token,
         )

--- a/packages/api/api/analytics/military_score_inference/inference_stream_session.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_session.py
@@ -6,6 +6,7 @@ import queue
 import uuid
 from dataclasses import dataclass, field
 
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_cancel import InferenceCancelToken
 from api.analytics.military_score_inference.inference_stream_domain_events import (
     InferenceStreamDomainEvent,
@@ -25,6 +26,7 @@ class InferenceRowStreamSession:
     game_id: int
     perspective: int
     turn_number: int
+    resolved_mask: ResolvedHullCatalogMask | None = None
     cancel_token: InferenceCancelToken = field(default_factory=InferenceCancelToken)
     event_queue: queue.Queue[InferenceStreamDomainEvent] = field(default_factory=queue.Queue)
     run_id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/packages/api/api/analytics/military_score_inference/policy_ladder.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder.py
@@ -12,6 +12,7 @@ from api.analytics.military_score_inference.actions import (
 from api.analytics.military_score_inference.constraints import (
     solution_satisfies_exact_hard_equalities,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_cancel import InferenceCancelToken
 from api.analytics.military_score_inference.models import (
     InferenceObservation,
@@ -151,6 +152,7 @@ def solve_with_policy_ladder(
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     cancel_token: InferenceCancelToken | None = None,
     on_admitted: Callable[[InferenceSolution], None] | None = None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> tuple[
     InferenceResult,
     ActionCatalog | None,
@@ -163,6 +165,7 @@ def solve_with_policy_ladder(
     state = PolicyLadderState(
         policy_steps=tuple(resolve_tier_policies(policy_path)),
         resolved_max_solutions=resolved_max_solutions,
+        resolved_mask=resolved_mask,
     )
     while not state.ladder_complete and state.next_step_index < len(state.policy_steps):
         if cancel_token is not None and cancel_token.is_cancelled():

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass, field
 
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
     InferenceProblem,
     InferenceSolution,
@@ -38,3 +39,4 @@ class PolicyLadderState:
     ladder_complete: bool = False
     cancelled: bool = False
     started_at: float = field(default_factory=time.monotonic)
+    resolved_mask: ResolvedHullCatalogMask | None = None

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
@@ -317,6 +317,7 @@ def run_policy_ladder_tier_step(
         turn,
         policy_step=policy_step,
         policy_step_index=step_index,
+        resolved_mask=state.resolved_mask,
     )
     state.catalog = catalog
     current_combo_ids = frozenset(combo.combo_id for combo in catalog.ship_build_combos)

--- a/packages/api/api/analytics/scores.py
+++ b/packages/api/api/analytics/scores.py
@@ -6,6 +6,7 @@ from api.analytics.military_score_inference.analytic import (
     infer_military_score_build,
     run_inference_with_artifacts,
 )
+from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_stream_rows import (
     iter_scores_table_inference_events,
 )
@@ -68,6 +69,7 @@ def get_scores_row_inference(
     player_id: int,
     *,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
+    resolved_mask: ResolvedHullCatalogMask | None = None,
 ) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
@@ -88,6 +90,7 @@ def get_scores_row_inference(
             score,
             turn,
             load_scoreboard_turn=load_scoreboard_turn,
+            resolved_mask=resolved_mask,
         )
     return {"playerId": player_id, **inference}
 
@@ -99,6 +102,7 @@ def iter_scores_table_inference_stream(
     game_id: int,
     perspective: int,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
+    resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
 ) -> Iterator[dict[str, object]]:
     """Yield NDJSON wire events for all scoreboard rows on one stream."""
     yield from iter_scores_table_inference_events(
@@ -107,4 +111,5 @@ def iter_scores_table_inference_stream(
         game_id=game_id,
         perspective=perspective,
         load_scoreboard_turn=load_scoreboard_turn,
+        resolve_mask_for_player=resolve_mask_for_player,
     )

--- a/packages/api/api/routers/games.py
+++ b/packages/api/api/routers/games.py
@@ -156,7 +156,6 @@ def get_scores_table_inference_stream(
     )
 
 
-
 @router.get("/{game_id}/{perspective}/turns/{turn_number}/analytics/scores/inference/hull-catalog")
 def get_inference_hull_catalog_mask(
     game_id: int,

--- a/packages/api/api/routers/games.py
+++ b/packages/api/api/routers/games.py
@@ -29,6 +29,7 @@ from api.transport.connections_options import (
     FlareConnectionMode,
 )
 from api.transport.game_info_update import GameInfoUpdateRequest, RefreshGameInfoParams
+from api.transport.inference_hull_catalog import InferenceHullCatalogMaskUpdateRequest
 from api.transport.inference_stream import stream_inference_ndjson
 from api.transport.load_all_turns import (
     LoadAllTurnsRequest,
@@ -152,6 +153,62 @@ def get_scores_table_inference_stream(
             )
         ),
         media_type="application/x-ndjson",
+    )
+
+
+
+@router.get("/{game_id}/{perspective}/turns/{turn_number}/analytics/scores/inference/hull-catalog")
+def get_inference_hull_catalog_mask(
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_id: int = Query(..., alias="playerId", ge=0),
+    analytics: TurnAnalyticService = Depends(get_turn_analytic_service),
+) -> dict[str, object]:
+    """Return master hull catalog and effective mask for one inference target player."""
+    return analytics.get_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn_number,
+        player_id,
+    )
+
+
+@router.put("/{game_id}/{perspective}/turns/{turn_number}/analytics/scores/inference/hull-catalog")
+def put_inference_hull_catalog_mask(
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    body: InferenceHullCatalogMaskUpdateRequest,
+    player_id: int = Query(..., alias="playerId", ge=0),
+    analytics: TurnAnalyticService = Depends(get_turn_analytic_service),
+) -> dict[str, object]:
+    """Persist a user hull catalog mask override for one inference target player."""
+    return analytics.put_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn_number,
+        player_id,
+        body.enabled_hull_ids,
+    )
+
+
+@router.delete(
+    "/{game_id}/{perspective}/turns/{turn_number}/analytics/scores/inference/hull-catalog"
+)
+def delete_inference_hull_catalog_mask(
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_id: int = Query(..., alias="playerId", ge=0),
+    analytics: TurnAnalyticService = Depends(get_turn_analytic_service),
+) -> dict[str, object]:
+    """Clear a user hull catalog mask override, restoring game-type defaults."""
+    return analytics.reset_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn_number,
+        player_id,
     )
 
 

--- a/packages/api/api/serialization/inference_hull_catalog.py
+++ b/packages/api/api/serialization/inference_hull_catalog.py
@@ -1,0 +1,28 @@
+"""Codecs for persisted inference hull catalog mask overrides."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dacite import from_dict
+
+from api.serialization.codecs import DACITE_CONFIG, dataclass_to_json
+
+
+@dataclass
+class InferenceHullCatalogMaskOverride:
+    enabled_hull_ids: list[int]
+
+
+def inference_hull_catalog_mask_override_from_json(data: dict) -> InferenceHullCatalogMaskOverride:
+    return from_dict(
+        data_class=InferenceHullCatalogMaskOverride,
+        data=data,
+        config=DACITE_CONFIG,
+    )
+
+
+def inference_hull_catalog_mask_override_to_json(
+    override: InferenceHullCatalogMaskOverride,
+) -> dict:
+    return dataclass_to_json(override)

--- a/packages/api/api/services/inference_hull_catalog_service.py
+++ b/packages/api/api/services/inference_hull_catalog_service.py
@@ -1,0 +1,137 @@
+"""Read and write per-player inference hull catalog mask overrides."""
+
+from __future__ import annotations
+
+from api.analytics.military_score_inference.hull_catalog_mask import (
+    hull_names_by_id,
+    resolve_hull_catalog_mask,
+)
+from api.analytics.scores import ANALYTIC_ID as SCORES_ANALYTIC_ID
+from api.errors import NotFoundError, ValidationError
+from api.serialization.inference_hull_catalog import (
+    InferenceHullCatalogMaskOverride,
+    inference_hull_catalog_mask_override_from_json,
+    inference_hull_catalog_mask_override_to_json,
+)
+from api.services.turn_load_service import TurnLoadService
+from api.storage.base import StorageBackend
+
+_INFERENCE_HULL_CATALOG_MASKS_KEY = "inference_hull_catalog_masks"
+
+
+class InferenceHullCatalogService:
+    def __init__(self, storage: StorageBackend, turns: TurnLoadService) -> None:
+        self._storage = storage
+        self._turns = turns
+
+    def _mask_store_key(self, game_id: int, player_id: int) -> str:
+        return (
+            f"games/{game_id}/analytics/{SCORES_ANALYTIC_ID}/"
+            f"{_INFERENCE_HULL_CATALOG_MASKS_KEY}/{player_id}"
+        )
+
+    def _load_user_override(self, game_id: int, player_id: int) -> frozenset[int] | None:
+        try:
+            data = self._storage.get(self._mask_store_key(game_id, player_id))
+        except NotFoundError:
+            return None
+        if data is None:
+            return None
+        if not isinstance(data, dict):
+            raise ValidationError("stored hull catalog mask override must be a JSON object")
+        override = inference_hull_catalog_mask_override_from_json(data)
+        return frozenset(override.enabled_hull_ids)
+
+    def resolve_mask_for_player(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ):
+        turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        return self.resolve_mask_for_player_on_turn(turn, game_id, player_id)
+
+    def resolve_mask_for_player_on_turn(
+        self,
+        turn,
+        game_id: int,
+        player_id: int,
+    ):
+        user_override = self._load_user_override(game_id, player_id)
+        return resolve_hull_catalog_mask(turn, player_id, user_enabled_hull_ids=user_override)
+
+    def hull_catalog_mask_payload(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        user_override = self._load_user_override(game_id, player_id)
+        resolved = resolve_hull_catalog_mask(turn, player_id, user_enabled_hull_ids=user_override)
+        names = hull_names_by_id(turn)
+        master_entries = [
+            {
+                "hullId": hull_id,
+                "name": names.get(hull_id, f"Hull {hull_id}"),
+                "defaultEnabled": hull_id in resolved.default_enabled_hull_ids,
+                "userEnabled": (
+                    hull_id in user_override
+                    if user_override is not None
+                    else hull_id in resolved.default_enabled_hull_ids
+                ),
+                "effectiveEnabled": hull_id in resolved.effective_enabled_hull_ids,
+            }
+            for hull_id in sorted(resolved.master_hull_ids)
+        ]
+        return {
+            "gameId": game_id,
+            "playerId": player_id,
+            "perspective": perspective,
+            "turn": turn_number,
+            "campaignMode": turn.settings.campaignmode,
+            "raceId": resolved.race_id,
+            "raceName": resolved.race_name,
+            "masterCatalog": master_entries,
+            "defaultEnabledHullIds": sorted(resolved.default_enabled_hull_ids),
+            "userEnabledHullIds": (sorted(user_override) if user_override is not None else None),
+            "effectiveEnabledHullIds": sorted(resolved.effective_enabled_hull_ids),
+            "hasUserOverride": resolved.has_user_override,
+        }
+
+    def put_user_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+        enabled_hull_ids: list[int],
+    ) -> dict[str, object]:
+        turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        resolved = resolve_hull_catalog_mask(turn, player_id, user_enabled_hull_ids=None)
+        master = resolved.master_hull_ids
+        invalid = [hull_id for hull_id in enabled_hull_ids if hull_id not in master]
+        if invalid:
+            raise ValidationError(f"hull ids not in race master catalog: {sorted(invalid)}")
+        override = InferenceHullCatalogMaskOverride(enabled_hull_ids=sorted(enabled_hull_ids))
+        self._storage.put(
+            self._mask_store_key(game_id, player_id),
+            inference_hull_catalog_mask_override_to_json(override),
+        )
+        return self.hull_catalog_mask_payload(game_id, perspective, turn_number, player_id)
+
+    def reset_user_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        key = self._mask_store_key(game_id, player_id)
+        try:
+            self._storage.delete(key)
+        except NotFoundError:
+            pass
+        return self.hull_catalog_mask_payload(game_id, perspective, turn_number, player_id)

--- a/packages/api/api/services/stack.py
+++ b/packages/api/api/services/stack.py
@@ -23,7 +23,7 @@ def build_service_stack(
     turns = TurnLoadService(storage, credentials, games)
     load_all = LoadAllTurnsService(credentials, games, turns)
     concepts = TurnConceptService(turns)
-    analytics = TurnAnalyticService(turns)
+    analytics = TurnAnalyticService(turns, storage=storage)
     return games, turns, load_all, concepts, analytics
 
 

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -6,15 +6,31 @@ from api.analytics import TurnAnalyticsOptions, get_turn_analytic
 from api.diagnostics import NOOP_DIAGNOSTICS, Diagnostics
 from api.errors import NotFoundError
 from api.models.game import TurnInfo
+from api.services.inference_hull_catalog_service import InferenceHullCatalogService
 from api.services.turn_load_service import TurnLoadService
+from api.storage.base import StorageBackend
 from api.transport.connections_options import FlareConnectionMode
 
 
 class TurnAnalyticService:
     """Compute registered turn analytics for a game, perspective, and turn."""
 
-    def __init__(self, turns: TurnLoadService) -> None:
+    def __init__(
+        self,
+        turns: TurnLoadService,
+        hull_catalog_masks: InferenceHullCatalogService | None = None,
+        *,
+        storage: StorageBackend | None = None,
+    ) -> None:
         self._turns = turns
+        if hull_catalog_masks is not None:
+            self._hull_catalog_masks = hull_catalog_masks
+        else:
+            if storage is None:
+                from api.storage import get_storage
+
+                storage = get_storage()
+            self._hull_catalog_masks = InferenceHullCatalogService(storage, turns)
 
     def _load_scoreboard_turn(
         self,
@@ -71,10 +87,17 @@ class TurnAnalyticService:
         from api.analytics.scores import get_scores_row_inference
 
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        resolved_mask = self._hull_catalog_masks.resolve_mask_for_player(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+        )
         return get_scores_row_inference(
             turn,
             player_id,
             load_scoreboard_turn=self._load_scoreboard_turn(game_id, perspective),
+            resolved_mask=resolved_mask,
         )
 
     def iter_scores_table_inference_stream(
@@ -87,12 +110,21 @@ class TurnAnalyticService:
         from api.analytics.scores import iter_scores_table_inference_stream
 
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+
+        def resolve_mask_for_player(player_id: int):
+            return self._hull_catalog_masks.resolve_mask_for_player_on_turn(
+                turn,
+                game_id,
+                player_id,
+            )
+
         return iter_scores_table_inference_stream(
             turn,
             player_ids,
             game_id=game_id,
             perspective=perspective,
             load_scoreboard_turn=self._load_scoreboard_turn(game_id, perspective),
+            resolve_mask_for_player=resolve_mask_for_player,
         )
 
     def _inference_scheduler_scope(
@@ -153,3 +185,47 @@ class TurnAnalyticService:
             turn_number,
         )
         return scheduler.resume_globally(scope)
+
+    def get_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        return self._hull_catalog_masks.hull_catalog_mask_payload(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+        )
+
+    def put_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+        enabled_hull_ids: list[int],
+    ) -> dict[str, object]:
+        return self._hull_catalog_masks.put_user_mask(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+            enabled_hull_ids,
+        )
+
+    def reset_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        return self._hull_catalog_masks.reset_user_mask(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+        )

--- a/packages/api/api/transport/inference_hull_catalog.py
+++ b/packages/api/api/transport/inference_hull_catalog.py
@@ -1,0 +1,9 @@
+"""HTTP transport models for inference hull catalog masks."""
+
+from pydantic import BaseModel, Field
+
+
+class InferenceHullCatalogMaskUpdateRequest(BaseModel):
+    enabled_hull_ids: list[int] = Field(alias="enabledHullIds")
+
+    model_config = {"populate_by_name": True}

--- a/packages/api/tests/storage/test_boundaries.py
+++ b/packages/api/tests/storage/test_boundaries.py
@@ -37,9 +37,9 @@ def test_resolve_breakpoint_credentials():
 
 
 def test_resolve_breakpoint_game_global_analytic_persistence():
-    bp, suffix = resolve_breakpoint("games/628580/analytics/scores/settings/5")
+    bp, suffix = resolve_breakpoint("games/628580/analytics/scores/inference_hull_catalog_masks/5")
     assert bp == "games/628580/analytics/scores"
-    assert suffix == "settings/5"
+    assert suffix == "inference_hull_catalog_masks/5"
 
 
 def test_resolve_breakpoint_perspective_analytic_persistence():

--- a/packages/api/tests/test_hull_catalog_mask.py
+++ b/packages/api/tests/test_hull_catalog_mask.py
@@ -1,9 +1,19 @@
-"""Tests for inference hull catalog master catalogs and default hull eligibility."""
+"""Tests for inference hull catalog master catalogs and per-player masks."""
 
+import json
+from pathlib import Path
+
+import pytest
 from api.analytics.military_score_inference.hull_catalog_mask import (
     default_enabled_hull_ids_for_player,
     master_hull_ids_for_race,
+    resolve_hull_catalog_mask,
 )
+from api.services.stack import build_service_stack
+from api.storage.memory_asset import MemoryAssetBackend
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+P5_TURN6_PATH = REPO_ROOT / ".data" / "games" / "628580" / "5" / "turns" / "6.json"
 
 
 def test_master_hull_ids_intersects_turn_catalog(sample_turn):
@@ -28,3 +38,46 @@ def test_loaded_perspective_player_uses_turn_racehulls(sample_turn):
     enabled = default_enabled_hull_ids_for_player(sample_turn, sample_turn.player.id)
     catalog = {hull.id for hull in sample_turn.hulls}
     assert enabled == frozenset(sample_turn.racehulls) & catalog
+
+
+def test_user_override_intersects_master(sample_turn):
+    player_id = sample_turn.players[0].id
+    resolved = resolve_hull_catalog_mask(
+        sample_turn,
+        player_id,
+        user_enabled_hull_ids=frozenset({99999}),
+    )
+    assert 99999 not in resolved.effective_enabled_hull_ids
+    assert resolved.has_user_override is True
+
+
+@pytest.mark.skipif(not P5_TURN6_PATH.is_file(), reason="local store only")
+def test_hull_catalog_service_put_and_reset_round_trip():
+    backend = MemoryAssetBackend(initial={})
+    _, turns, _, _, analytics = build_service_stack(backend)
+    service = analytics._hull_catalog_masks
+
+    game_id = 628580
+    perspective = 5
+    turn_number = 6
+    player_id = 5
+    with open(REPO_ROOT / ".data" / "games" / "628580" / "info.json") as handle:
+        backend.put(f"games/{game_id}/info", json.load(handle))
+    with open(P5_TURN6_PATH) as handle:
+        backend.put(
+            f"games/{game_id}/{perspective}/turns/{turn_number}",
+            json.load(handle),
+        )
+
+    initial = service.hull_catalog_mask_payload(game_id, perspective, turn_number, player_id)
+    master_ids = {entry["hullId"] for entry in initial["masterCatalog"]}
+    assert master_ids
+
+    subset = sorted(master_ids)[:2]
+    updated = service.put_user_mask(game_id, perspective, turn_number, player_id, subset)
+    assert updated["hasUserOverride"] is True
+    assert updated["effectiveEnabledHullIds"] == subset
+
+    reset = service.reset_user_mask(game_id, perspective, turn_number, player_id)
+    assert reset["hasUserOverride"] is False
+    assert reset["effectiveEnabledHullIds"] == initial["defaultEnabledHullIds"]

--- a/packages/api/tests/test_inference_scheduler_global_pause.py
+++ b/packages/api/tests/test_inference_scheduler_global_pause.py
@@ -17,7 +17,7 @@ from api.analytics.military_score_inference.inference_stream_session import (
 from api.analytics.military_score_inference.models import InferenceSolution, InferenceSolutionAction
 from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
 from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
-from api.errors import ConflictError, ValidationError
+from api.errors import ValidationError
 
 
 def _session_for_turn(
@@ -147,7 +147,7 @@ def test_new_scope_invalidates_retained_pause_state(sample_turn):
     assert status["activeScope"]["turn"] == scope_b.turn_number
 
 
-def test_begin_scope_rejects_duplicate_concurrent_stream(sample_turn):
+def test_begin_scope_preempts_reconnect_for_same_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
     scheduler = InferenceRowScheduler(worker_count=0)
     scope = InferenceStreamScope(
@@ -156,15 +156,15 @@ def test_begin_scope_rejects_duplicate_concurrent_stream(sample_turn):
         turn_number=sample_turn.settings.turn,
     )
     session = _session_for_turn(sample_turn)
-    scheduler.begin_scope(scope)
+    first_token = scheduler.begin_scope(scope)
     scheduler.enqueue_tier_ladder(session)
 
-    with pytest.raises(ConflictError, match="already active for this scope"):
-        scheduler.begin_scope(scope)
+    second_token = scheduler.begin_scope(scope)
 
+    assert second_token != first_token
+    assert session.cancel_token.is_cancelled()
     status = scheduler.global_pause_status(scope)
-    assert status["activeSessionCount"] == 1
-    assert not session.cancel_token.is_cancelled()
+    assert status["activeSessionCount"] == 0
 
 
 def test_begin_scope_succeeds_after_end_inference_stream(sample_turn):
@@ -176,9 +176,9 @@ def test_begin_scope_succeeds_after_end_inference_stream(sample_turn):
         turn_number=sample_turn.settings.turn,
     )
     session = _session_for_turn(sample_turn)
-    scheduler.begin_scope(scope)
+    stream_token = scheduler.begin_scope(scope)
     scheduler.enqueue_tier_ladder(session)
-    scheduler.end_inference_stream(scope, (session,))
+    scheduler.end_inference_stream(scope, (session,), stream_token=stream_token)
 
     scheduler.begin_scope(scope)
 
@@ -196,20 +196,49 @@ def test_end_inference_stream_cancels_runs_and_clears_global_pause(sample_turn):
         turn_number=sample_turn.settings.turn,
     )
     session = _session_for_turn(sample_turn)
-    scheduler.begin_scope(scope)
+    stream_token = scheduler.begin_scope(scope)
     scheduler.enqueue_tier_ladder(session)
     scheduler.pause_globally(scope)
 
     assert scheduler.global_pause_status(scope)["paused"] is True
     assert scheduler.global_pause_status(scope)["activeSessionCount"] == 1
 
-    scheduler.end_inference_stream(scope, (session,))
+    scheduler.end_inference_stream(scope, (session,), stream_token=stream_token)
 
     status = scheduler.global_pause_status(scope)
     assert status["paused"] is False
     assert status["activeSessionCount"] == 0
     assert status["heldJobCount"] == 0
     assert session.cancel_token.is_cancelled()
+
+
+def test_stale_end_inference_stream_does_not_clear_replacement_stream(sample_turn):
+    reset_inference_row_scheduler_for_tests()
+    scheduler = InferenceRowScheduler(worker_count=0)
+    scope = InferenceStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    old_session = _session_for_turn(sample_turn)
+    old_token = scheduler.begin_scope(scope)
+    scheduler.enqueue_tier_ladder(old_session)
+
+    new_session = _session_for_turn(sample_turn)
+    new_token = "replacement-stream-token"
+    scheduler._active_table_stream_token = new_token
+    scheduler.enqueue_tier_ladder(new_session)
+
+    scheduler.end_inference_stream(scope, (old_session,), stream_token=old_token)
+
+    status = scheduler.global_pause_status(scope)
+    assert status["activeSessionCount"] == 1
+    assert scheduler._has_active_table_stream is True
+    assert old_session.cancel_token.is_cancelled()
+    assert not new_session.cancel_token.is_cancelled()
+
+    scheduler.end_inference_stream(scope, (new_session,), stream_token=new_token)
+    assert scheduler.global_pause_status(scope)["activeSessionCount"] == 0
 
 
 def test_emit_held_solutions_snapshots_merged_list(sample_turn):

--- a/packages/api/tests/test_inference_table_stream.py
+++ b/packages/api/tests/test_inference_table_stream.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 
-import pytest
 from api.analytics.military_score_inference.analytic import build_inference_observation
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
+    get_inference_row_scheduler,
     reset_inference_row_scheduler_for_tests,
 )
 from api.analytics.military_score_inference.inference_stream_rows import (
@@ -15,15 +15,16 @@ from api.analytics.military_score_inference.inference_stream_rows import (
     drain_available_multiplex_events,
     iter_multiplexed_inference_events,
     iter_scores_table_inference_events,
+    schedule_inference_row,
     tag_inference_stream_event,
 )
+from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
 from api.analytics.military_score_inference.inference_stream_session import (
     InferenceRowStreamSession,
 )
 from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.row_complete_factory import row_complete_with_summary
 from api.analytics.military_score_inference.solver import STATUS_EXACT
-from api.errors import ConflictError
 from api.transport.inference_stream import stream_inference_ndjson
 
 
@@ -62,7 +63,7 @@ def test_table_stream_emits_global_pause_snapshot_on_connect(sample_turn):
     assert events[0] == {"type": "globalPause", "paused": False}
 
 
-def test_table_stream_rejects_duplicate_concurrent_connection(sample_turn):
+def test_table_stream_reconnect_preempts_in_flight_stream(sample_turn):
     reset_inference_row_scheduler_for_tests()
     active_stream = iter_scores_table_inference_events(
         sample_turn,
@@ -72,20 +73,19 @@ def test_table_stream_rejects_duplicate_concurrent_connection(sample_turn):
     )
     assert next(active_stream) == {"type": "globalPause", "paused": False}
 
-    with pytest.raises(ConflictError, match="already active for this scope"):
-        list(
-            iter_scores_table_inference_events(
-                sample_turn,
-                (),
-                game_id=628580,
-                perspective=1,
-            )
-        )
+    replacement = iter_scores_table_inference_events(
+        sample_turn,
+        (),
+        game_id=628580,
+        perspective=1,
+    )
+    assert next(replacement) == {"type": "globalPause", "paused": False}
 
     active_stream.close()
+    replacement.close()
 
 
-def test_table_stream_duplicate_connection_surfaces_error_event(sample_turn):
+def test_table_stream_reconnect_via_ndjson_transport(sample_turn):
     reset_inference_row_scheduler_for_tests()
     active_stream = iter_scores_table_inference_events(
         sample_turn,
@@ -95,7 +95,7 @@ def test_table_stream_duplicate_connection_surfaces_error_event(sample_turn):
     )
     next(active_stream)
 
-    def duplicate_loader():
+    def replacement_loader():
         yield from iter_scores_table_inference_events(
             sample_turn,
             (),
@@ -103,15 +103,79 @@ def test_table_stream_duplicate_connection_surfaces_error_event(sample_turn):
             perspective=1,
         )
 
-    lines = list(stream_inference_ndjson(duplicate_loader))
+    lines = list(stream_inference_ndjson(replacement_loader))
     active_stream.close()
 
     assert len(lines) == 1
-    error = json.loads(lines[0])
-    assert error == {
-        "type": "error",
-        "detail": "An inference table stream is already active for this scope.",
-    }
+    assert json.loads(lines[0]) == {"type": "globalPause", "paused": False}
+
+
+def test_schedule_inference_row_ignores_stale_stream_token_after_preempt(sample_turn):
+    reset_inference_row_scheduler_for_tests()
+    scheduler = get_inference_row_scheduler()
+    scope = InferenceStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    score = sample_turn.scores[0]
+    first_token = scheduler.begin_scope(scope)
+
+    active_row = schedule_inference_row(
+        scheduler,
+        score=score,
+        turn=sample_turn,
+        player_id=score.ownerid,
+        game_id=628580,
+        perspective=1,
+        stream_token=first_token,
+    )
+    assert active_row is not None
+
+    scheduler.begin_scope(scope)
+
+    stale_row = schedule_inference_row(
+        scheduler,
+        score=score,
+        turn=sample_turn,
+        player_id=score.ownerid,
+        game_id=628580,
+        perspective=1,
+        stream_token=first_token,
+    )
+    assert stale_row is None
+    assert active_row.session.cancel_token.is_cancelled()
+
+
+def test_table_stream_reconnect_cancels_in_flight_rows_for_same_scope(sample_turn):
+    reset_inference_row_scheduler_for_tests()
+    scheduler = get_inference_row_scheduler()
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+
+    first_stream = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+    )
+    assert next(first_stream) == {"type": "globalPause", "paused": False}
+
+    in_flight_run_ids = set(scheduler._runs)
+
+    replacement = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+    )
+    assert next(replacement) == {"type": "globalPause", "paused": False}
+
+    for run_id in in_flight_run_ids:
+        run = scheduler._runs.get(run_id)
+        assert run is None or run.session.cancel_token.is_cancelled()
+
+    first_stream.close()
+    replacement.close()
 
 
 def test_tag_inference_stream_event_adds_player_id_except_global_pause():

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -250,7 +250,6 @@ class CoreClient:
             player_ids,
         )
 
-
     def get_inference_hull_catalog_mask(
         self,
         game_id: int,

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -250,6 +250,57 @@ class CoreClient:
             player_ids,
         )
 
+
+    def get_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        return self._invoke(
+            lambda: self._analytics.get_inference_hull_catalog_mask(
+                game_id,
+                perspective,
+                turn_number,
+                player_id,
+            )
+        )
+
+    def put_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+        enabled_hull_ids: list[int],
+    ) -> dict[str, object]:
+        return self._invoke(
+            lambda: self._analytics.put_inference_hull_catalog_mask(
+                game_id,
+                perspective,
+                turn_number,
+                player_id,
+                enabled_hull_ids,
+            )
+        )
+
+    def reset_inference_hull_catalog_mask(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> dict[str, object]:
+        return self._invoke(
+            lambda: self._analytics.reset_inference_hull_catalog_mask(
+                game_id,
+                perspective,
+                turn_number,
+                player_id,
+            )
+        )
+
     def get_inference_global_pause_status(
         self,
         game_id: int,

--- a/packages/bff/bff/routers/scores_inference.py
+++ b/packages/bff/bff/routers/scores_inference.py
@@ -111,7 +111,6 @@ def get_scores_inference_table_stream(
     )
 
 
-
 @router.get("/inference/hull-catalog")
 def get_scores_inference_hull_catalog(
     game_id: int = Query(..., alias="gameId"),

--- a/packages/bff/bff/routers/scores_inference.py
+++ b/packages/bff/bff/routers/scores_inference.py
@@ -5,6 +5,7 @@ Included from the analytics router at prefix ``/scores`` so paths match
 """
 
 from api.diagnostics import NOOP_DIAGNOSTICS, Diagnostics, timed_section
+from api.transport.inference_hull_catalog import InferenceHullCatalogMaskUpdateRequest
 from api.transport.inference_stream import stream_inference_ndjson
 from fastapi import APIRouter, Query
 from fastapi.responses import StreamingResponse
@@ -107,6 +108,57 @@ def get_scores_inference_table_stream(
             )
         ),
         media_type="application/x-ndjson",
+    )
+
+
+
+@router.get("/inference/hull-catalog")
+def get_scores_inference_hull_catalog(
+    game_id: int = Query(..., alias="gameId"),
+    turn: int = Query(..., ge=1),
+    perspective: int = Query(..., ge=0),
+    player_id: int = Query(..., alias="playerId", ge=0),
+):
+    """Master hull catalog and effective mask for one Scores inference row."""
+    return get_core_client().get_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn,
+        player_id,
+    )
+
+
+@router.put("/inference/hull-catalog")
+def put_scores_inference_hull_catalog(
+    body: InferenceHullCatalogMaskUpdateRequest,
+    game_id: int = Query(..., alias="gameId"),
+    turn: int = Query(..., ge=1),
+    perspective: int = Query(..., ge=0),
+    player_id: int = Query(..., alias="playerId", ge=0),
+):
+    """Persist a user hull catalog mask override for one Scores inference row."""
+    return get_core_client().put_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn,
+        player_id,
+        body.enabled_hull_ids,
+    )
+
+
+@router.delete("/inference/hull-catalog")
+def delete_scores_inference_hull_catalog(
+    game_id: int = Query(..., alias="gameId"),
+    turn: int = Query(..., ge=1),
+    perspective: int = Query(..., ge=0),
+    player_id: int = Query(..., alias="playerId", ge=0),
+):
+    """Clear a user hull catalog mask override for one Scores inference row."""
+    return get_core_client().reset_inference_hull_catalog_mask(
+        game_id,
+        perspective,
+        turn,
+        player_id,
     )
 
 

--- a/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
+++ b/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import type { AnalyticShellScope, InferenceHullCatalogMaskResponse } from '../../api/bff'
+import {
+  fetchInferenceHullCatalogMask,
+  putInferenceHullCatalogMask,
+  resetInferenceHullCatalogMask,
+} from '../../api/bff'
+import { useModalKeydownFocusTrap } from '../../lib/modalKeydownFocusTrap'
+import { restoreFocusToElementOrFallback } from '../../lib/restoreFocus'
+import { errorDetailFromUnknown } from '../../lib/queryRetry'
+import { cn } from '../../lib/utils'
+
+type HullCatalogMaskDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+  scope: AnalyticShellScope
+  playerId: number
+  racePlayer: string
+  onSaved: () => void
+}
+
+function enabledHullIdsFromCatalog(
+  catalog: InferenceHullCatalogMaskResponse['masterCatalog']
+): number[] {
+  return catalog.filter((entry) => entry.userEnabled).map((entry) => entry.hullId)
+}
+
+export function HullCatalogMaskDialog({
+  isOpen,
+  onClose,
+  scope,
+  playerId,
+  racePlayer,
+  onSaved,
+}: HullCatalogMaskDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const openerRef = useRef<HTMLElement | null>(null)
+  const [payload, setPayload] = useState<InferenceHullCatalogMaskResponse | null>(null)
+  const [draftEnabled, setDraftEnabled] = useState<Set<number>>(new Set())
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return
+    }
+    openerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null
+  }, [isOpen])
+
+  const handleClose = useCallback(() => {
+    onClose()
+    restoreFocusToElementOrFallback(openerRef.current, '[data-hull-catalog-opener]')
+  }, [onClose])
+
+  useModalKeydownFocusTrap(isOpen, dialogRef, handleClose)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setPayload(null)
+      setDraftEnabled(new Set())
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    void fetchInferenceHullCatalogMask(scope, playerId)
+      .then((response) => {
+        if (cancelled) {
+          return
+        }
+        setPayload(response)
+        setDraftEnabled(new Set(enabledHullIdsFromCatalog(response.masterCatalog)))
+      })
+      .catch((fetchError) => {
+        if (cancelled) {
+          return
+        }
+        setError(errorDetailFromUnknown(fetchError))
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, scope, playerId])
+
+  const toggleHull = (hullId: number) => {
+    setDraftEnabled((previous) => {
+      const next = new Set(previous)
+      if (next.has(hullId)) {
+        next.delete(hullId)
+      } else {
+        next.add(hullId)
+      }
+      return next
+    })
+  }
+
+  const handleReset = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const response = await resetInferenceHullCatalogMask(scope, playerId)
+      setPayload(response)
+      setDraftEnabled(new Set(enabledHullIdsFromCatalog(response.masterCatalog)))
+    } catch (resetError) {
+      setError(errorDetailFromUnknown(resetError))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const response = await putInferenceHullCatalogMask(scope, playerId, [...draftEnabled].sort())
+      setPayload(response)
+      setDraftEnabled(new Set(enabledHullIdsFromCatalog(response.masterCatalog)))
+      onSaved()
+      handleClose()
+    } catch (saveError) {
+      setError(errorDetailFromUnknown(saveError))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!isOpen) {
+    return null
+  }
+
+  const campaignLabel = payload?.campaignMode ? 'Campaign' : 'Standard'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          handleClose()
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="hull-catalog-mask-title"
+        className="flex max-h-[85vh] w-full max-w-lg flex-col rounded border border-[#52575d] bg-[#1e2226] shadow-xl"
+      >
+        <div className="border-b border-[#52575d]/80 px-4 py-3">
+          <h2 id="hull-catalog-mask-title" className="text-sm font-medium text-slate-100">
+            Buildable hull catalog
+          </h2>
+          <p className="mt-1 text-xs text-slate-400">
+            {racePlayer} · {campaignLabel}
+            {payload?.raceName != null ? ` · ${payload.raceName}` : ''}
+          </p>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+          {loading ? (
+            <p className="text-sm text-slate-400">Loading hull catalog…</p>
+          ) : error != null ? (
+            <p className="text-sm text-red-400">{error}</p>
+          ) : payload == null ? (
+            <p className="text-sm text-slate-400">No catalog data.</p>
+          ) : (
+            <ul className="space-y-1">
+              {payload.masterCatalog.map((entry) => {
+                const checked = draftEnabled.has(entry.hullId)
+                const differsFromDefault = entry.defaultEnabled !== checked
+                return (
+                  <li key={entry.hullId}>
+                    <label
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-white/5',
+                        differsFromDefault ? 'text-amber-200' : 'text-slate-300'
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        className="rounded border-[#52575d]"
+                        checked={checked}
+                        onChange={() => toggleHull(entry.hullId)}
+                        disabled={saving}
+                      />
+                      <span className="tabular-nums text-slate-500">{entry.hullId}</span>
+                      <span>{entry.name}</span>
+                      {entry.defaultEnabled ? (
+                        <span className="ml-auto text-xs text-slate-500">default</span>
+                      ) : null}
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-[#52575d]/80 px-4 py-3">
+          <button
+            type="button"
+            className="rounded border border-[#52575d] px-3 py-1.5 text-xs text-slate-300 hover:bg-white/5 disabled:opacity-50"
+            onClick={() => void handleReset()}
+            disabled={loading || saving || payload == null}
+          >
+            Reset to defaults
+          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded border border-[#52575d] px-3 py-1.5 text-xs text-slate-300 hover:bg-white/5"
+              onClick={handleClose}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="rounded border border-emerald-600/70 bg-emerald-900/30 px-3 py-1.5 text-xs text-emerald-300 hover:bg-emerald-900/50 disabled:opacity-50"
+              onClick={() => void handleSave()}
+              disabled={loading || saving || payload == null}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
+++ b/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
@@ -50,7 +50,10 @@ export function HullCatalogMaskDialog({
 
   const handleClose = useCallback(() => {
     onClose()
-    restoreFocusToElementOrFallback(openerRef.current, '[data-hull-catalog-opener]')
+    restoreFocusToElementOrFallback(
+      openerRef.current,
+      () => document.querySelector<HTMLElement>('[data-hull-catalog-opener]'),
+    )
   }, [onClose])
 
   useModalKeydownFocusTrap(isOpen, dialogRef, handleClose)

--- a/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
+++ b/packages/frontend/src/analytics/scores/HullCatalogMaskDialog.tsx
@@ -113,6 +113,8 @@ export function HullCatalogMaskDialog({
       const response = await resetInferenceHullCatalogMask(scope, playerId)
       setPayload(response)
       setDraftEnabled(new Set(enabledHullIdsFromCatalog(response.masterCatalog)))
+      onSaved()
+      handleClose()
     } catch (resetError) {
       setError(errorDetailFromUnknown(resetError))
     } finally {

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { Octagon, X } from 'lucide-react'
+import { ListFilter, Octagon, X } from 'lucide-react'
 import type {
   AnalyticShellScope,
   ScoresInferenceRowDetail,
   ScoresTableWithInferenceData,
 } from '../../api/bff'
 import { GlobalInferencePauseControl } from './GlobalInferencePauseControl'
+import { HullCatalogMaskDialog } from './HullCatalogMaskDialog'
 import { InferenceDetailModal } from './InferenceDetailModal'
 import { InferenceSolutionCountBadge } from './InferenceSolutionCountBadge'
 import {
@@ -24,6 +25,7 @@ import type { UseGlobalInferencePauseResult } from './useGlobalInferencePause'
 type ScoresTableViewProps = {
   data: ScoresTableWithInferenceData
   analyticScope: AnalyticShellScope
+  onHullCatalogSaved?: () => void
   isGloballyPaused?: boolean
   globalInferencePause?: UseGlobalInferencePauseResult
 }
@@ -31,13 +33,31 @@ type ScoresTableViewProps = {
 function InferenceStatusCell({
   detail,
   onOpenDetail,
+  onOpenHullCatalog,
   isGloballyPaused = false,
 }: {
   detail: ScoresInferenceRowDetail
   onOpenDetail: () => void
+  onOpenHullCatalog: () => void
   isGloballyPaused?: boolean
 }) {
   const label = inferenceAccessibleLabel(detail)
+  const playerId = detail.playerId
+  const showHullCatalog = typeof playerId === 'number'
+
+  const hullCatalogButton =
+    showHullCatalog ? (
+      <button
+        type="button"
+        data-hull-catalog-opener
+        title="Adjust buildable hull catalog"
+        aria-label="Adjust buildable hull catalog"
+        onClick={onOpenHullCatalog}
+        className="inline-flex items-center justify-center rounded p-1 text-slate-300 hover:bg-white/10"
+      >
+        <ListFilter className="h-3.5 w-3.5" aria-hidden />
+      </button>
+    ) : null
 
   if (isIncompleteInferenceRow(detail)) {
     const activelySearching = isActivelySearchingInference(detail, isGloballyPaused)
@@ -51,6 +71,7 @@ function InferenceStatusCell({
           disabled={!canOpenInferenceDetail(detail)}
           onClick={canOpenInferenceDetail(detail) ? onOpenDetail : undefined}
         />
+        {hullCatalogButton}
       </div>
     )
   }
@@ -65,6 +86,7 @@ function InferenceStatusCell({
           disabled={!canOpenInferenceDetail(detail)}
           onClick={canOpenInferenceDetail(detail) ? onOpenDetail : undefined}
         />
+        {hullCatalogButton}
       </div>
     )
   }
@@ -79,6 +101,7 @@ function InferenceStatusCell({
         >
           <Octagon className="h-4 w-4" aria-hidden />
         </span>
+        {hullCatalogButton}
       </div>
     )
   }
@@ -92,17 +115,20 @@ function InferenceStatusCell({
       >
         <X className="h-4 w-4" aria-hidden />
       </span>
+      {hullCatalogButton}
     </div>
   )
 }
 
 export function ScoresTableView({
   data,
-  analyticScope: _analyticScope,
+  analyticScope,
+  onHullCatalogSaved,
   isGloballyPaused = false,
   globalInferencePause,
 }: ScoresTableViewProps) {
   const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null)
+  const [hullCatalogRowIndex, setHullCatalogRowIndex] = useState<number | null>(null)
   const inferenceByRow = data.inferenceByRow
   const selectedDetail =
     selectedRowIndex != null && inferenceByRow != null
@@ -110,6 +136,13 @@ export function ScoresTableView({
       : null
   const selectedRacePlayer =
     selectedRowIndex != null ? data.rows[selectedRowIndex]?.[0] ?? '' : ''
+  const hullCatalogDetail =
+    hullCatalogRowIndex != null && inferenceByRow != null
+      ? inferenceByRow[hullCatalogRowIndex]
+      : null
+  const hullCatalogRacePlayer =
+    hullCatalogRowIndex != null ? data.rows[hullCatalogRowIndex]?.[0] ?? '' : ''
+  const hullCatalogPlayerId = hullCatalogDetail?.playerId
 
   const showGlobalPauseControl =
     data.includeBuildInference && globalInferencePause != null
@@ -147,6 +180,7 @@ export function ScoresTableView({
                         <InferenceStatusCell
                           detail={inferenceByRow[rowIndex]}
                           onOpenDetail={() => setSelectedRowIndex(rowIndex)}
+                          onOpenHullCatalog={() => setHullCatalogRowIndex(rowIndex)}
                           isGloballyPaused={isGloballyPaused}
                         />
                       </td>
@@ -169,6 +203,18 @@ export function ScoresTableView({
         racePlayer={selectedRacePlayer}
         detail={selectedDetail}
       />
+      {typeof hullCatalogPlayerId === 'number' ? (
+        <HullCatalogMaskDialog
+          isOpen={hullCatalogRowIndex != null}
+          onClose={() => setHullCatalogRowIndex(null)}
+          scope={analyticScope}
+          playerId={hullCatalogPlayerId}
+          racePlayer={hullCatalogRacePlayer}
+          onSaved={() => {
+            onHullCatalogSaved?.()
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.test.ts
+++ b/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as bff from '../../api/bff'
+import {
+  TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+  connectTableInferenceStream,
+} from './tableInferenceStreamConnect'
+
+const scope = {
+  gameId: '628580',
+  turn: 111,
+  perspective: 1,
+}
+
+describe('connectTableInferenceStream', () => {
+  it('retries when the scope-level stream conflict error is returned', async () => {
+    const fetchSpy = vi
+      .spyOn(bff, 'fetchScoresTableInferenceStream')
+      .mockImplementationOnce(async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'error',
+          detail: TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+        })
+      })
+      .mockImplementationOnce(async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'complete',
+          playerId: 8,
+          status: 'exact',
+          summary: 'ok',
+          solutionCount: 1,
+          isComplete: true,
+        })
+      })
+
+    const events: unknown[] = []
+    const controller = new AbortController()
+    const result = await connectTableInferenceStream(scope, [8], {
+      signal: controller.signal,
+      onEvent: (event) => {
+        events.push(event)
+      },
+    })
+
+    expect(result).toBe('ok')
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(events).toHaveLength(1)
+  })
+})

--- a/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
+++ b/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
@@ -1,0 +1,73 @@
+import type { AnalyticShellScope } from '../../api/bff'
+import { fetchScoresTableInferenceStream } from '../../api/bff'
+import type { InferenceStreamEvent } from '../../api/inferenceStreamEventSchema'
+
+export const TABLE_STREAM_ALREADY_ACTIVE_DETAIL =
+  'An inference table stream is already active for this scope.'
+
+const STREAM_RETRY_INITIAL_MS = 50
+const STREAM_RETRY_MAX_ATTEMPTS = 10
+const STREAM_RETRY_MAX_DELAY_MS = 500
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+function isScopeLevelStreamConflict(event: InferenceStreamEvent): boolean {
+  return (
+    event.type === 'error' &&
+    event.playerId == null &&
+    event.detail === TABLE_STREAM_ALREADY_ACTIVE_DETAIL
+  )
+}
+
+export type TableInferenceStreamConnectResult = 'ok' | 'aborted' | 'conflict_exhausted'
+
+export async function connectTableInferenceStream(
+  scope: AnalyticShellScope,
+  playerIds: number[],
+  handlers: {
+    signal: AbortSignal
+    onEvent: (event: InferenceStreamEvent) => void
+  }
+): Promise<TableInferenceStreamConnectResult> {
+  for (let attempt = 0; attempt < STREAM_RETRY_MAX_ATTEMPTS; attempt += 1) {
+    if (handlers.signal.aborted) {
+      return 'aborted'
+    }
+
+    let scopeConflict = false
+
+    try {
+      await fetchScoresTableInferenceStream(scope, playerIds, {
+        signal: handlers.signal,
+        onEvent: (event) => {
+          if (isScopeLevelStreamConflict(event)) {
+            scopeConflict = true
+            return
+          }
+          handlers.onEvent(event)
+        },
+      })
+    } catch (error) {
+      if (handlers.signal.aborted) {
+        return 'aborted'
+      }
+      throw error
+    }
+
+    if (handlers.signal.aborted) {
+      return 'aborted'
+    }
+    if (!scopeConflict) {
+      return 'ok'
+    }
+
+    const delayMs = Math.min(STREAM_RETRY_INITIAL_MS * 2 ** attempt, STREAM_RETRY_MAX_DELAY_MS)
+    await sleep(delayMs)
+  }
+
+  return 'conflict_exhausted'
+}

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -181,6 +181,25 @@ describe('useScoresInferenceByRow', () => {
     })
   })
 
+  it('applies scope-level stream errors to every row', async () => {
+    vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
+      async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'error',
+          detail: 'Inference table stream failed',
+        })
+      }
+    )
+
+    const { result } = renderHook(() => useScoresInferenceByRow(tableData, scope, true))
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.displayStatus).toBe('failure')
+      expect(result.current.inferenceByRow?.[1]?.displayStatus).toBe('failure')
+    })
+    expect(result.current.inferenceByRow?.[0]?.summary).toBe('Inference table stream failed')
+  })
+
   it('resets global pause when the table stream ends', () => {
     const onGlobalPauseChange = vi.fn()
     vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
@@ -212,5 +231,74 @@ describe('useScoresInferenceByRow', () => {
     rerender({ enabled: false })
 
     expect(onGlobalPauseChange).toHaveBeenCalledWith(false)
+  })
+
+  it('refreshInference restarts the table stream and applies new row results', async () => {
+    let streamCallCount = 0
+    let releaseSecondStream: (() => void) | null = null
+
+    vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
+      async (_scope, _playerIds, { signal, onEvent }) => {
+        streamCallCount += 1
+        if (streamCallCount === 1) {
+          onEvent({
+            type: 'complete',
+            playerId: 8,
+            status: 'exact',
+            summary: 'Player 8 before mask save',
+            solutionCount: 1,
+            isComplete: true,
+          })
+          await new Promise<void>((resolve) => {
+            signal?.addEventListener('abort', () => {
+              resolve()
+            })
+          })
+          return
+        }
+        await new Promise<void>((resolve) => {
+          releaseSecondStream = resolve
+        })
+        onEvent({
+          type: 'complete',
+          playerId: 8,
+          status: 'exact',
+          summary: 'Player 8 after mask save',
+          solutionCount: 1,
+          isComplete: true,
+        })
+        onEvent({
+          type: 'complete',
+          playerId: 9,
+          status: 'exact',
+          summary: 'Player 9 after mask save',
+          solutionCount: 1,
+          isComplete: true,
+        })
+      }
+    )
+
+    const { result } = renderHook(() => useScoresInferenceByRow(tableData, scope, true))
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.summary).toBe('Player 8 before mask save')
+    })
+
+    result.current.refreshInference()
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.displayStatus).toBe('pending')
+      expect(result.current.inferenceByRow?.[1]?.displayStatus).toBe('pending')
+      expect(streamCallCount).toBe(2)
+    })
+
+    releaseSecondStream?.()
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.summary).toBe('Player 8 after mask save')
+      expect(result.current.inferenceByRow?.[1]?.summary).toBe('Player 9 after mask save')
+      expect(result.current.inferenceByRow?.[0]?.displayStatus).toBe('success')
+      expect(result.current.inferenceByRow?.[1]?.displayStatus).toBe('success')
+    })
   })
 })

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -292,7 +292,7 @@ describe('useScoresInferenceByRow', () => {
       expect(streamCallCount).toBe(2)
     })
 
-    releaseSecondStream?.()
+    releaseSecondStream!()
 
     await waitFor(() => {
       expect(result.current.inferenceByRow?.[0]?.summary).toBe('Player 8 after mask save')

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
@@ -19,6 +19,7 @@ export type UseScoresInferenceByRowOptions = {
 
 export type UseScoresInferenceByRowResult = {
   inferenceByRow: ScoresInferenceRowDetail[] | undefined
+  refreshInference: () => void
 }
 
 export function useScoresInferenceByRow(
@@ -34,6 +35,10 @@ export function useScoresInferenceByRow(
     .map((stub) => stub.playerId)
     .filter((id): id is number => typeof id === 'number')
   const playerIdsKey = useMemo(() => stablePlayerIdsKey(playerIds), [playerIds])
+  const [refreshToken, setRefreshToken] = useState(0)
+  const refreshInference = useCallback(() => {
+    setRefreshToken((value) => value + 1)
+  }, [])
 
   const [detailsByPlayerId, setDetailsByPlayerId] = useState<
     Map<number, ScoresInferenceRowDetail>
@@ -137,10 +142,10 @@ export function useScoresInferenceByRow(
       tableAbortControllerRef.current = null
       onGlobalPauseChange?.(false)
     }
-  }, [enabled, scope, playerIdsKey, handleTableStreamEvent, onGlobalPauseChange])
+  }, [enabled, scope, playerIdsKey, refreshToken, handleTableStreamEvent, onGlobalPauseChange])
 
   if (!enabled || tableData?.inferenceByRow == null) {
-    return { inferenceByRow: undefined }
+    return { inferenceByRow: undefined, refreshInference }
   }
 
   const inferenceByRow = stubs.map((stub, rowIndex) => {
@@ -151,5 +156,5 @@ export function useScoresInferenceByRow(
     return detailsByPlayerId.get(playerId) ?? pendingDetail(playerId)
   })
 
-  return { inferenceByRow }
+  return { inferenceByRow, refreshInference }
 }

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { AnalyticShellScope, ScoresInferenceRowDetail, TableDataResponse } from '../../api/bff'
-import { fetchScoresTableInferenceStream } from '../../api/bff'
 import type { InferenceStreamEvent } from '../../api/inferenceStreamEventSchema'
 import { errorDetailFromUnknown } from '../../lib/queryRetry'
 import {
@@ -12,6 +11,7 @@ import {
   stablePlayerIdsKey,
   type RowStreamState,
 } from './inferenceRowStreamState'
+import { connectTableInferenceStream } from './tableInferenceStreamConnect'
 
 export type UseScoresInferenceByRowOptions = {
   onGlobalPauseChange?: (paused: boolean) => void
@@ -84,6 +84,12 @@ export function useScoresInferenceByRow(
         applyGlobalPauseEvent(event)
         return
       }
+      if (event.type === 'error' && event.playerId == null) {
+        for (const playerId of rowStreamStateRef.current.keys()) {
+          applyStreamEvent(playerId, { ...event, playerId })
+        }
+        return
+      }
       const playerId = 'playerId' in event ? event.playerId : undefined
       if (typeof playerId !== 'number') {
         return
@@ -118,10 +124,32 @@ export function useScoresInferenceByRow(
     const controller = new AbortController()
     tableAbortControllerRef.current = controller
 
-    void fetchScoresTableInferenceStream(scope, playerIds, {
+    void connectTableInferenceStream(scope, playerIds, {
       signal: controller.signal,
       onEvent: handleTableStreamEvent,
-    }).catch((error) => {
+    })
+      .then((result) => {
+        if (controller.signal.aborted || result !== 'conflict_exhausted') {
+          return
+        }
+        setDetailsByPlayerId((previous) => {
+          const next = new Map(previous)
+          for (const playerId of playerIds) {
+            if (next.get(playerId)?.isComplete) {
+              continue
+            }
+            next.set(
+              playerId,
+              failureDetail(
+                playerId,
+                'Build inference could not reconnect after updating the hull catalog.'
+              )
+            )
+          }
+          return next
+        })
+      })
+      .catch((error) => {
       if (controller.signal.aborted) {
         return
       }

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -659,6 +659,85 @@ export async function fetchScoresRowInference(
 
 export type { InferenceStreamEvent }
 
+export type InferenceHullCatalogEntry = {
+  hullId: number
+  name: string
+  defaultEnabled: boolean
+  userEnabled: boolean
+  effectiveEnabled: boolean
+}
+
+export type InferenceHullCatalogMaskResponse = {
+  gameId: number
+  playerId: number
+  perspective: number
+  turn: number
+  campaignMode: boolean
+  raceId: number
+  raceName: string
+  masterCatalog: InferenceHullCatalogEntry[]
+  defaultEnabledHullIds: number[]
+  userEnabledHullIds: number[] | null
+  effectiveEnabledHullIds: number[]
+  hasUserOverride: boolean
+}
+
+export async function fetchInferenceHullCatalogMask(
+  scope: AnalyticShellScope,
+  playerId: number
+): Promise<InferenceHullCatalogMaskResponse> {
+  const path = '/bff/analytics/scores/inference/hull-catalog'
+  const params = analyticScopeParams(scope)
+  params.set('playerId', String(playerId))
+  const qs = `?${params.toString()}`
+  const endpointLabel = `GET ${path}`
+  const r = await bffRequest(`${path}${qs}`, undefined, endpointLabel)
+  if (!r.ok) {
+    throw new Error(withEndpointIfGeneric(String(r.status), endpointLabel))
+  }
+  return r.json()
+}
+
+export async function putInferenceHullCatalogMask(
+  scope: AnalyticShellScope,
+  playerId: number,
+  enabledHullIds: number[]
+): Promise<InferenceHullCatalogMaskResponse> {
+  const path = '/bff/analytics/scores/inference/hull-catalog'
+  const params = analyticScopeParams(scope)
+  params.set('playerId', String(playerId))
+  const qs = `?${params.toString()}`
+  const endpointLabel = `PUT ${path}`
+  const r = await bffRequest(
+    `${path}${qs}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabledHullIds }),
+    },
+    endpointLabel
+  )
+  if (!r.ok) {
+    throw new Error(withEndpointIfGeneric(String(r.status), endpointLabel))
+  }
+  return r.json()
+}
+
+export async function resetInferenceHullCatalogMask(
+  scope: AnalyticShellScope,
+  playerId: number
+): Promise<InferenceHullCatalogMaskResponse> {
+  const path = '/bff/analytics/scores/inference/hull-catalog'
+  const params = analyticScopeParams(scope)
+  params.set('playerId', String(playerId))
+  const qs = `?${params.toString()}`
+  const endpointLabel = `DELETE ${path}`
+  const r = await bffRequest(`${path}${qs}`, { method: 'DELETE' }, endpointLabel)
+  if (!r.ok) {
+    throw new Error(withEndpointIfGeneric(String(r.status), endpointLabel))
+  }
+  return r.json()
+}
 
 export type InferenceGlobalPauseStatus = {
   gameId: number

--- a/packages/frontend/src/api/schema-analytics.ts
+++ b/packages/frontend/src/api/schema-analytics.ts
@@ -44,6 +44,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/scores/inference/hull-catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Scores Inference Hull Catalog
+         * @description Master hull catalog and effective mask for one Scores inference row.
+         */
+        get: operations["get_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_get"];
+        /**
+         * Put Scores Inference Hull Catalog
+         * @description Persist a user hull catalog mask override for one Scores inference row.
+         */
+        put: operations["put_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_put"];
+        post?: never;
+        /**
+         * Delete Scores Inference Hull Catalog
+         * @description Clear a user hull catalog mask override for one Scores inference row.
+         */
+        delete: operations["delete_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics/scores/inference/global-pause": {
         parameters: {
             query?: never;
@@ -154,6 +182,11 @@ export interface components {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
         };
+        /** InferenceHullCatalogMaskUpdateRequest */
+        InferenceHullCatalogMaskUpdateRequest: {
+            /** Enabledhullids */
+            enabledHullIds: number[];
+        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -233,6 +266,112 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                     "application/x-ndjson": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_get: {
+        parameters: {
+            query: {
+                gameId: number;
+                turn: number;
+                perspective: number;
+                playerId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_put: {
+        parameters: {
+            query: {
+                gameId: number;
+                turn: number;
+                perspective: number;
+                playerId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["InferenceHullCatalogMaskUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_scores_inference_hull_catalog_analytics_scores_inference_hull_catalog_delete: {
+        parameters: {
+            query: {
+                gameId: number;
+                turn: number;
+                perspective: number;
+                playerId: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Validation Error */

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -132,7 +132,7 @@ function TableTile({
       ),
     enabled: fetchEnabled,
   })
-  const { inferenceByRow } = useScoresInferenceByRow(
+  const { inferenceByRow, refreshInference } = useScoresInferenceByRow(
     data,
     analyticScope,
     inferenceEnabled && fetchEnabled,
@@ -175,6 +175,7 @@ function TableTile({
       <ScoresTableView
         data={scoresTableWithInference}
         analyticScope={analyticScope}
+        onHullCatalogSaved={refreshInference}
         isGloballyPaused={globalInferencePause.isGloballyPaused}
         globalInferencePause={globalInferencePause}
       />

--- a/scripts/analyze_hull_catalog_sources.py
+++ b/scripts/analyze_hull_catalog_sources.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Analyze buildable hull catalog heuristics against per-perspective ground truth."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[1] / "packages" / "api"
+_api_root_str = str(_API_ROOT)
+if _api_root_str in sys.path:
+    sys.path.remove(_api_root_str)
+sys.path.insert(0, _api_root_str)
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent
+_scripts_root_str = str(_SCRIPTS_ROOT)
+if _scripts_root_str not in sys.path:
+    sys.path.insert(0, _scripts_root_str)
+
+import typer  # noqa: E402
+from hull_catalog_analysis import (  # noqa: E402
+    analysis_to_json,
+    analyze_game,
+    format_text_report,
+    hull_names_from_turn,
+    load_game_info,
+    load_turn_file,
+)
+
+app = typer.Typer(
+    add_completion=False,
+    help="Compare hull catalog heuristics to per-perspective turn.racehulls ground truth.",
+)
+
+DEFAULT_GAME_IDS = (628580, 673864)
+
+
+def _default_storage_root() -> Path:
+    return Path(".data")
+
+
+@app.callback(invoke_without_command=True)
+def run_command(
+    ctx: typer.Context,
+    game_id: list[int] = typer.Option(
+        [],
+        "--game-id",
+        help="Game id to analyze (repeatable). Defaults to 628580 and 673864 when omitted.",
+    ),
+    storage_root: Path = typer.Option(
+        _default_storage_root(),
+        "--storage-root",
+        help="File backend root (default: ./.data).",
+    ),
+    turn: int | None = typer.Option(
+        None,
+        "--turn",
+        help="Host turn to analyze. Defaults to each game's current turn from info.json.",
+    ),
+    loaded_perspective: int = typer.Option(
+        1,
+        "--loaded-perspective",
+        help="Perspective slot used as the single loaded turn snapshot.",
+    ),
+    compare_turn: int | None = typer.Option(
+        None,
+        "--compare-turn",
+        help="Optional second turn to check ground-truth stability across turns.",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print JSON report instead of human-readable text.",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        help="Write report to this file (JSON when --json, else plain text).",
+    ),
+) -> None:
+    """Run hull catalog analysis for one or more stored games."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if not storage_root.is_dir():
+        typer.echo(f"storage root not found: {storage_root}", err=True)
+        raise typer.Exit(code=2)
+
+    selected_game_ids = game_id or list(DEFAULT_GAME_IDS)
+    reports: list[dict[str, object]] = []
+    text_blocks: list[str] = []
+
+    for selected_game_id in selected_game_ids:
+        try:
+            game_info, settings_defaults = load_game_info(storage_root, selected_game_id)
+        except FileNotFoundError:
+            typer.echo(f"warning: missing info.json for game {selected_game_id}", err=True)
+            continue
+
+        host_turn = turn if turn is not None else game_info.settings.turn
+        try:
+            analysis = analyze_game(
+                storage_root,
+                selected_game_id,
+                host_turn=host_turn,
+                loaded_perspective=loaded_perspective,
+                settings_defaults=settings_defaults,
+                game_info=game_info,
+                compare_turn=compare_turn,
+            )
+        except FileNotFoundError as exc:
+            typer.echo(f"warning: {exc}", err=True)
+            continue
+
+        loaded_turn = load_turn_file(
+            storage_root,
+            selected_game_id,
+            loaded_perspective,
+            host_turn,
+            settings_defaults=settings_defaults,
+        )
+        if loaded_turn is None:
+            typer.echo(
+                f"warning: could not reload turn for game {selected_game_id}",
+                err=True,
+            )
+            continue
+
+        hull_names = hull_names_from_turn(loaded_turn)
+        hulls_by_id = {hull.id: hull for hull in loaded_turn.hulls}
+        reports.append(analysis_to_json(analysis, hull_names))
+        text_blocks.append(
+            "\n".join(format_text_report(analysis, hull_names, hulls_by_id=hulls_by_id))
+        )
+
+    if not reports:
+        typer.echo("no games analyzed", err=True)
+        raise typer.Exit(code=2)
+
+    if json_output:
+        payload = {"games": reports}
+        rendered = json.dumps(payload, indent=2)
+        if output is not None:
+            output.write_text(rendered + "\n", encoding="utf-8")
+        else:
+            typer.echo(rendered)
+    else:
+        rendered = "\n\n".join(text_blocks)
+        if output is not None:
+            output.write_text(rendered + "\n", encoding="utf-8")
+        else:
+            typer.echo(rendered)
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hull_catalog_analysis.py
+++ b/scripts/hull_catalog_analysis.py
@@ -1,0 +1,736 @@
+"""Compare buildable-hull heuristics against per-perspective ground truth."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from api.analytics.military_score_inference.component_eligibility import (
+    buildable_hull_ids_for_player,
+)
+from api.analytics.military_score_inference.inference_turn_lookup import (
+    parse_component_id_csv,
+    player_by_id,
+    race_by_id_or_none,
+)
+from api.models.components import Hull
+from api.models.game import GameInfo, GameSettings, TurnInfo
+from api.serialization.game import game_info_from_json
+from api.serialization.turn import turn_info_from_json
+
+HEURISTIC_LABELS: dict[str, str] = {
+    "ground_truth": "Ground truth (player perspective turn.racehulls)",
+    "current_code": "Current code (buildable_hull_ids_for_player)",
+    "loaded_racehulls": "Loaded perspective turn.racehulls",
+    "race_basehulls": "race.basehulls ∩ catalog",
+    "race_hulls": "race.hulls ∩ catalog",
+    "race_union": "(race.basehulls | race.hulls) ∩ catalog",
+    "activehulls": "player.activehulls ∩ catalog",
+    "fleet_hulls": "Fleet hull ids ∩ catalog",
+    "standard_settings_adjusted": "Standard: basehulls + settings adjustments",
+    "proposed_cross_player": "Proposed: perspective-aware synthesis",
+    "catalog_all": "Full turn.hulls catalog",
+}
+
+REPLACEMENT_SETTING_FIELDS: tuple[str, ...] = (
+    "repairshipreplacessagefrigate",
+    "migtransportreplacesmigscout",
+    "saurianlightfrigatereplacessaurian",
+    "scorpiuscarrierreplacesscorpiuslight",
+    "sscruiseriireplacessscruiser",
+    "sscarrierplusreplacessscarrier",
+    "skyfireplusreplacesskyfire",
+    "d7creplacesd7a",
+    "quietusplusreplacesquietus",
+    "cybernautlightreplacescybernaut",
+    "ironslavescoutreplacesironslave",
+)
+
+BIRD_ENLIGHTEN_HULL_ID = 106
+
+
+@dataclass(frozen=True)
+class HullSetComparison:
+    heuristic_id: str
+    hull_ids: frozenset[int]
+    covers_ground_truth: bool
+    missing_from_heuristic: frozenset[int]
+    extra_in_heuristic: frozenset[int]
+    overage: int
+
+
+@dataclass(frozen=True)
+class PlayerHullAnalysis:
+    player_id: int
+    username: str
+    race_id: int
+    race_name: str
+    perspective_slot: int | None
+    ground_truth: frozenset[int]
+    fleet_hull_ids: frozenset[int]
+    comparisons: tuple[HullSetComparison, ...]
+
+
+@dataclass(frozen=True)
+class HeuristicSummary:
+    heuristic_id: str
+    players_with_ground_truth: int
+    players_covered: int
+    avg_overage: float
+    min_overage: int
+    max_overage: int
+    failed_player_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class GameHullAnalysis:
+    game_id: int
+    game_name: str
+    campaign_mode: bool
+    host_turn: int
+    loaded_perspective: int
+    loaded_player_id: int
+    loaded_race_name: str
+    players: tuple[PlayerHullAnalysis, ...]
+    heuristic_summaries: tuple[HeuristicSummary, ...]
+    ground_truth_stable_across_turns: bool | None = None
+    stability_note: str | None = None
+
+
+def format_hull_id(hull_id: int, hull_names_by_id: dict[int, str]) -> str:
+    name = hull_names_by_id.get(hull_id)
+    if name:
+        return f"{hull_id} ({name})"
+    return str(hull_id)
+
+
+def format_hull_set(
+    hull_ids: frozenset[int] | set[int],
+    hull_names_by_id: dict[int, str],
+) -> str:
+    if not hull_ids:
+        return "(none)"
+    return ", ".join(format_hull_id(hull_id, hull_names_by_id) for hull_id in sorted(hull_ids))
+
+
+def hull_names_from_turn(turn: TurnInfo) -> dict[int, str]:
+    return {hull.id: hull.name for hull in turn.hulls}
+
+
+def catalog_hull_ids(turn: TurnInfo) -> frozenset[int]:
+    return frozenset(hull.id for hull in turn.hulls)
+
+
+def fleet_hull_ids_for_player(turn: TurnInfo, player_id: int) -> frozenset[int]:
+    catalog = catalog_hull_ids(turn)
+    return frozenset(
+        ship.hullid
+        for ship in (turn.ships or [])
+        if ship.ownerid == player_id and ship.hullid in catalog
+    )
+
+
+def _apply_parent_child_swap(
+    result: set[int],
+    *,
+    parent_id: int,
+    child_id: int,
+    race_hull_ids: frozenset[int],
+) -> None:
+    if child_id not in race_hull_ids or parent_id not in result:
+        return
+    result.discard(parent_id)
+    result.add(child_id)
+
+
+def swaps_for_enabled_settings(
+    *,
+    settings: GameSettings,
+    hulls_by_id: dict[int, Hull],
+    race_hull_ids: frozenset[int],
+    base_hull_ids: frozenset[int],
+) -> list[tuple[int, int]]:
+    swaps: list[tuple[int, int]] = []
+    if settings.repairshipreplacessagefrigate and 90 in base_hull_ids:
+        swaps.append((90, 1090))
+    for field in REPLACEMENT_SETTING_FIELDS:
+        if field == "repairshipreplacessagefrigate":
+            continue
+        if not getattr(settings, field, False):
+            continue
+        for child_id in sorted(race_hull_ids):
+            child = hulls_by_id.get(child_id)
+            if child is None or child.parentid == 0:
+                continue
+            if child.parentid in base_hull_ids:
+                swaps.append((child.parentid, child_id))
+    return swaps
+
+
+def standard_settings_adjusted_basehulls(
+    *,
+    race_id: int,
+    race_basehulls_csv: str,
+    race_hulls_csv: str,
+    catalog_ids: frozenset[int],
+    hulls_by_id: dict[int, Hull],
+    settings: GameSettings,
+) -> frozenset[int]:
+    result = set(parse_component_id_csv(race_basehulls_csv) & catalog_ids)
+    race_hull_ids = frozenset(parse_component_id_csv(race_hulls_csv) & catalog_ids)
+    base_hull_ids = frozenset(result)
+
+    for parent_id, child_id in swaps_for_enabled_settings(
+        settings=settings,
+        hulls_by_id=hulls_by_id,
+        race_hull_ids=race_hull_ids,
+        base_hull_ids=base_hull_ids,
+    ):
+        _apply_parent_child_swap(
+            result,
+            parent_id=parent_id,
+            child_id=child_id,
+            race_hull_ids=race_hull_ids,
+        )
+
+    if settings.birdshaveenlighten and race_id == 3 and BIRD_ENLIGHTEN_HULL_ID in race_hull_ids:
+        result.add(BIRD_ENLIGHTEN_HULL_ID)
+
+    return frozenset(result)
+
+
+def proposed_cross_player_hull_ids(
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    settings: GameSettings,
+) -> frozenset[int]:
+    catalog_ids = catalog_hull_ids(turn)
+    if player_id == turn.player.id and turn.racehulls:
+        return frozenset(turn.racehulls) & catalog_ids
+
+    player = player_by_id(turn, player_id)
+    race = race_by_id_or_none(turn, player.raceid)
+    if race is None:
+        return catalog_ids
+
+    if settings.campaignmode:
+        return frozenset(parse_component_id_csv(race.hulls) & catalog_ids)
+
+    hulls_by_id = {hull.id: hull for hull in turn.hulls}
+    return standard_settings_adjusted_basehulls(
+        race_id=player.raceid,
+        race_basehulls_csv=race.basehulls,
+        race_hulls_csv=race.hulls,
+        catalog_ids=catalog_ids,
+        hulls_by_id=hulls_by_id,
+        settings=settings,
+    )
+
+
+def classify_gt_gap(
+    hull_id: int,
+    *,
+    race_basehulls: frozenset[int],
+    race_hulls: frozenset[int],
+    hulls_by_id: dict[int, Hull],
+) -> str:
+    if hull_id in race_hulls and hull_id not in race_basehulls:
+        hull = hulls_by_id.get(hull_id)
+        if hull is not None and hull.parentid != 0:
+            parent = hulls_by_id.get(hull.parentid)
+            parent_label = f"{hull.parentid} ({parent.name})" if parent else str(hull.parentid)
+            return f"campaign_or_replacement_variant (parent {parent_label})"
+        if hull_id == BIRD_ENLIGHTEN_HULL_ID:
+            return "birdshaveenlighten hull"
+        return "in race.hulls only (not basehulls)"
+    if hull_id not in race_hulls:
+        return "not in race roster"
+    return "in race.basehulls"
+
+
+def compare_hull_set(
+    *,
+    heuristic_id: str,
+    candidate: frozenset[int],
+    ground_truth: frozenset[int],
+) -> HullSetComparison:
+    missing = ground_truth - candidate
+    extra = candidate - ground_truth
+    return HullSetComparison(
+        heuristic_id=heuristic_id,
+        hull_ids=candidate,
+        covers_ground_truth=not missing,
+        missing_from_heuristic=missing,
+        extra_in_heuristic=extra,
+        overage=len(extra),
+    )
+
+
+def build_heuristic_sets(
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    settings: GameSettings,
+) -> dict[str, frozenset[int]]:
+    catalog_ids = catalog_hull_ids(turn)
+    player = player_by_id(turn, player_id)
+    race = race_by_id_or_none(turn, player.raceid)
+    race_base = frozenset()
+    race_hulls_set = frozenset()
+    race_union = frozenset()
+    if race is not None:
+        race_base = frozenset(parse_component_id_csv(race.basehulls) & catalog_ids)
+        race_hulls_set = frozenset(parse_component_id_csv(race.hulls) & catalog_ids)
+        race_union = frozenset(
+            parse_component_id_csv(race.basehulls) | parse_component_id_csv(race.hulls)
+        )
+        race_union &= catalog_ids
+
+    hulls_by_id = {hull.id: hull for hull in turn.hulls}
+    standard_adjusted = frozenset()
+    if race is not None:
+        standard_adjusted = standard_settings_adjusted_basehulls(
+            race_id=player.raceid,
+            race_basehulls_csv=race.basehulls,
+            race_hulls_csv=race.hulls,
+            catalog_ids=catalog_ids,
+            hulls_by_id=hulls_by_id,
+            settings=settings,
+        )
+
+    return {
+        "current_code": buildable_hull_ids_for_player(turn, player_id),
+        "loaded_racehulls": frozenset(turn.racehulls) & catalog_ids,
+        "race_basehulls": race_base,
+        "race_hulls": race_hulls_set,
+        "race_union": race_union,
+        "activehulls": frozenset(parse_component_id_csv(player.activehulls) & catalog_ids),
+        "fleet_hulls": fleet_hull_ids_for_player(turn, player_id),
+        "standard_settings_adjusted": standard_adjusted,
+        "proposed_cross_player": proposed_cross_player_hull_ids(turn, player_id, settings=settings),
+        "catalog_all": catalog_ids,
+    }
+
+
+def perspective_slots_for_game(storage_root: Path, game_id: int) -> list[int]:
+    game_dir = storage_root / "games" / str(game_id)
+    if not game_dir.is_dir():
+        return []
+    return sorted(
+        int(path.name) for path in game_dir.iterdir() if path.is_dir() and path.name.isdigit()
+    )
+
+
+def load_turn_file(
+    storage_root: Path,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    *,
+    settings_defaults: dict[str, Any],
+) -> TurnInfo | None:
+    turn_path = (
+        storage_root / "games" / str(game_id) / str(perspective) / "turns" / f"{turn_number}.json"
+    )
+    if not turn_path.is_file():
+        return None
+    with turn_path.open() as handle:
+        return turn_info_from_json(json.load(handle), settings_defaults=settings_defaults)
+
+
+def ground_truth_by_player(
+    storage_root: Path,
+    game_id: int,
+    turn_number: int,
+    *,
+    settings_defaults: dict[str, Any],
+    perspective_slots: list[int],
+) -> dict[int, tuple[frozenset[int], int]]:
+    """Map player id -> (ground_truth hull ids, perspective slot)."""
+    ground_truth: dict[int, tuple[frozenset[int], int]] = {}
+    for perspective in perspective_slots:
+        turn = load_turn_file(
+            storage_root,
+            game_id,
+            perspective,
+            turn_number,
+            settings_defaults=settings_defaults,
+        )
+        if turn is None:
+            continue
+        catalog = catalog_hull_ids(turn)
+        player_id = turn.player.id
+        gt = frozenset(turn.racehulls) & catalog
+        ground_truth[player_id] = (gt, perspective)
+    return ground_truth
+
+
+def check_ground_truth_stability(
+    storage_root: Path,
+    game_id: int,
+    *,
+    settings_defaults: dict[str, Any],
+    perspective_slots: list[int],
+    reference_turn: int,
+    compare_turn: int,
+) -> tuple[bool, str]:
+    mismatches: list[str] = []
+    for perspective in perspective_slots:
+        ref = load_turn_file(
+            storage_root,
+            game_id,
+            perspective,
+            reference_turn,
+            settings_defaults=settings_defaults,
+        )
+        other = load_turn_file(
+            storage_root,
+            game_id,
+            perspective,
+            compare_turn,
+            settings_defaults=settings_defaults,
+        )
+        if ref is None or other is None:
+            continue
+        ref_gt = frozenset(ref.racehulls)
+        other_gt = frozenset(other.racehulls)
+        if ref_gt != other_gt:
+            mismatches.append(
+                f"perspective {perspective} player {ref.player.id}: "
+                f"turn {reference_turn} vs {compare_turn}"
+            )
+    if not mismatches:
+        return True, f"Identical ground truth on turns {reference_turn} and {compare_turn}"
+    return False, "; ".join(mismatches[:5])
+
+
+def analyze_game(
+    storage_root: Path,
+    game_id: int,
+    *,
+    host_turn: int,
+    loaded_perspective: int,
+    settings_defaults: dict[str, Any],
+    game_info: GameInfo,
+    compare_turn: int | None = None,
+) -> GameHullAnalysis:
+    loaded_turn = load_turn_file(
+        storage_root,
+        game_id,
+        loaded_perspective,
+        host_turn,
+        settings_defaults=settings_defaults,
+    )
+    if loaded_turn is None:
+        raise FileNotFoundError(
+            "missing turn file for game "
+            f"{game_id} perspective {loaded_perspective} turn {host_turn}"
+        )
+
+    perspective_slots = perspective_slots_for_game(storage_root, game_id)
+    gt_by_player = ground_truth_by_player(
+        storage_root,
+        game_id,
+        host_turn,
+        settings_defaults=settings_defaults,
+        perspective_slots=perspective_slots,
+    )
+    settings = loaded_turn.settings
+
+    player_analyses: list[PlayerHullAnalysis] = []
+    for player_id, (ground_truth, perspective_slot) in sorted(gt_by_player.items()):
+        if not ground_truth:
+            continue
+        player = player_by_id(loaded_turn, player_id)
+        race = race_by_id_or_none(loaded_turn, player.raceid)
+        heuristics = build_heuristic_sets(loaded_turn, player_id, settings=settings)
+        comparisons = tuple(
+            compare_hull_set(
+                heuristic_id=heuristic_id,
+                candidate=candidate,
+                ground_truth=ground_truth,
+            )
+            for heuristic_id, candidate in heuristics.items()
+        )
+        player_analyses.append(
+            PlayerHullAnalysis(
+                player_id=player_id,
+                username=player.username,
+                race_id=player.raceid,
+                race_name=race.name if race is not None else "Unknown",
+                perspective_slot=perspective_slot,
+                ground_truth=ground_truth,
+                fleet_hull_ids=fleet_hull_ids_for_player(loaded_turn, player_id),
+                comparisons=comparisons,
+            )
+        )
+
+    heuristic_summaries = summarize_heuristics(player_analyses)
+
+    stable: bool | None = None
+    stability_note: str | None = None
+    if compare_turn is not None and compare_turn != host_turn:
+        stable, stability_note = check_ground_truth_stability(
+            storage_root,
+            game_id,
+            settings_defaults=settings_defaults,
+            perspective_slots=perspective_slots,
+            reference_turn=host_turn,
+            compare_turn=compare_turn,
+        )
+
+    loaded_race = race_by_id_or_none(loaded_turn, loaded_turn.player.raceid)
+    return GameHullAnalysis(
+        game_id=game_id,
+        game_name=game_info.game.name,
+        campaign_mode=settings.campaignmode,
+        host_turn=host_turn,
+        loaded_perspective=loaded_perspective,
+        loaded_player_id=loaded_turn.player.id,
+        loaded_race_name=loaded_race.name if loaded_race is not None else "Unknown",
+        players=tuple(player_analyses),
+        heuristic_summaries=heuristic_summaries,
+        ground_truth_stable_across_turns=stable,
+        stability_note=stability_note,
+    )
+
+
+def summarize_heuristics(players: list[PlayerHullAnalysis]) -> tuple[HeuristicSummary, ...]:
+    heuristic_order = (
+        "current_code",
+        "loaded_racehulls",
+        "race_basehulls",
+        "race_hulls",
+        "standard_settings_adjusted",
+        "proposed_cross_player",
+        "activehulls",
+        "fleet_hulls",
+        "catalog_all",
+    )
+    summaries: list[HeuristicSummary] = []
+    for heuristic_id in heuristic_order:
+        comparisons_by_player: list[tuple[int, HullSetComparison]] = []
+        for player in players:
+            comparison = next(
+                (entry for entry in player.comparisons if entry.heuristic_id == heuristic_id),
+                None,
+            )
+            if comparison is not None:
+                comparisons_by_player.append((player.player_id, comparison))
+        if not comparisons_by_player:
+            continue
+        covered = [
+            comparison for _, comparison in comparisons_by_player if comparison.covers_ground_truth
+        ]
+        overages = [comparison.overage for comparison in covered]
+        summaries.append(
+            HeuristicSummary(
+                heuristic_id=heuristic_id,
+                players_with_ground_truth=len(comparisons_by_player),
+                players_covered=len(covered),
+                avg_overage=sum(overages) / len(overages) if overages else 0.0,
+                min_overage=min(overages) if overages else 0,
+                max_overage=max(overages) if overages else 0,
+                failed_player_ids=tuple(
+                    player_id
+                    for player_id, comparison in comparisons_by_player
+                    if not comparison.covers_ground_truth
+                ),
+            )
+        )
+    return tuple(summaries)
+
+
+def analysis_to_json(analysis: GameHullAnalysis, hull_names: dict[int, str]) -> dict[str, Any]:
+    return {
+        "gameId": analysis.game_id,
+        "gameName": analysis.game_name,
+        "campaignMode": analysis.campaign_mode,
+        "hostTurn": analysis.host_turn,
+        "loadedPerspective": analysis.loaded_perspective,
+        "loadedPlayerId": analysis.loaded_player_id,
+        "loadedRaceName": analysis.loaded_race_name,
+        "groundTruthStableAcrossTurns": analysis.ground_truth_stable_across_turns,
+        "stabilityNote": analysis.stability_note,
+        "heuristicSummaries": [
+            {
+                "heuristicId": summary.heuristic_id,
+                "label": HEURISTIC_LABELS.get(summary.heuristic_id, summary.heuristic_id),
+                "playersWithGroundTruth": summary.players_with_ground_truth,
+                "playersCovered": summary.players_covered,
+                "avgOverage": round(summary.avg_overage, 2),
+                "minOverage": summary.min_overage,
+                "maxOverage": summary.max_overage,
+                "failedPlayerIds": list(summary.failed_player_ids),
+            }
+            for summary in analysis.heuristic_summaries
+        ],
+        "players": [
+            {
+                "playerId": player.player_id,
+                "username": player.username,
+                "raceId": player.race_id,
+                "raceName": player.race_name,
+                "perspectiveSlot": player.perspective_slot,
+                "groundTruth": [
+                    format_hull_id(hull_id, hull_names) for hull_id in sorted(player.ground_truth)
+                ],
+                "fleetHulls": [
+                    format_hull_id(hull_id, hull_names) for hull_id in sorted(player.fleet_hull_ids)
+                ],
+                "heuristics": [
+                    {
+                        "heuristicId": comparison.heuristic_id,
+                        "label": HEURISTIC_LABELS.get(
+                            comparison.heuristic_id,
+                            comparison.heuristic_id,
+                        ),
+                        "coversGroundTruth": comparison.covers_ground_truth,
+                        "overage": comparison.overage,
+                        "missing": [
+                            format_hull_id(hull_id, hull_names)
+                            for hull_id in sorted(comparison.missing_from_heuristic)
+                        ],
+                        "extra": [
+                            format_hull_id(hull_id, hull_names)
+                            for hull_id in sorted(comparison.extra_in_heuristic)
+                        ],
+                    }
+                    for comparison in player.comparisons
+                ],
+            }
+            for player in analysis.players
+        ],
+    }
+
+
+def format_text_report(
+    analysis: GameHullAnalysis,
+    hull_names: dict[int, str],
+    *,
+    hulls_by_id: dict[int, Hull],
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("=" * 72)
+    lines.append(
+        f"Game {analysis.game_id} ({analysis.game_name}) "
+        f"turn {analysis.host_turn} -- loaded perspective {analysis.loaded_perspective}"
+    )
+    lines.append(
+        f"Campaign: {analysis.campaign_mode} | "
+        f"Loaded player: {analysis.loaded_player_id} ({analysis.loaded_race_name})"
+    )
+    if analysis.stability_note:
+        stable_label = "yes" if analysis.ground_truth_stable_across_turns else "no"
+        lines.append(
+            f"Ground truth stable across turns: {stable_label} -- {analysis.stability_note}"
+        )
+    lines.append("")
+    lines.append("Heuristic summary (smallest avg overage with full coverage is best):")
+    for summary in analysis.heuristic_summaries:
+        label = HEURISTIC_LABELS.get(summary.heuristic_id, summary.heuristic_id)
+        lines.append(
+            f"  {summary.heuristic_id}: "
+            f"{summary.players_covered}/{summary.players_with_ground_truth} covered, "
+            f"avg overage {summary.avg_overage:.1f}, "
+            f"max overage {summary.max_overage}"
+        )
+        if summary.failed_player_ids:
+            lines.append(f"    failed players: {list(summary.failed_player_ids)}")
+        lines.append(f"    {label}")
+
+    lines.append("")
+    lines.append("Per-player detail:")
+
+    for player in analysis.players:
+        lines.append("")
+        lines.append(
+            f"Player {player.player_id} ({player.username}) -- "
+            f"{player.race_name} (race {player.race_id}), "
+            f"ground truth from perspective {player.perspective_slot}"
+        )
+        lines.append(
+            f"  Ground truth ({len(player.ground_truth)}): "
+            f"{format_hull_set(player.ground_truth, hull_names)}"
+        )
+        if player.fleet_hull_ids:
+            lines.append(
+                f"  Fleet hulls ({len(player.fleet_hull_ids)}): "
+                f"{format_hull_set(player.fleet_hull_ids, hull_names)}"
+            )
+        else:
+            lines.append("  Fleet hulls: (none in catalog)")
+
+        for comparison in player.comparisons:
+            if comparison.heuristic_id in {"ground_truth", "race_union"}:
+                continue
+            status = "OK" if comparison.covers_ground_truth else "FAIL"
+            label = HEURISTIC_LABELS.get(comparison.heuristic_id, comparison.heuristic_id)
+            lines.append(
+                f"  [{status}] {comparison.heuristic_id} "
+                f"(size {len(comparison.hull_ids)}, overage {comparison.overage}): {label}"
+            )
+            if comparison.missing_from_heuristic:
+                lines.append(
+                    f"      missing ({len(comparison.missing_from_heuristic)}): "
+                    f"{format_hull_set(comparison.missing_from_heuristic, hull_names)}"
+                )
+            if comparison.extra_in_heuristic and comparison.overage <= 12:
+                lines.append(
+                    f"      extra ({len(comparison.extra_in_heuristic)}): "
+                    f"{format_hull_set(comparison.extra_in_heuristic, hull_names)}"
+                )
+            elif comparison.extra_in_heuristic:
+                extra_count = len(comparison.extra_in_heuristic)
+                lines.append(f"      extra: {extra_count} hulls (list omitted)")
+
+        base_set = next(
+            (
+                comparison.hull_ids
+                for comparison in player.comparisons
+                if comparison.heuristic_id == "race_basehulls"
+            ),
+            frozenset(),
+        )
+        race_hulls_set = next(
+            (
+                comparison.hull_ids
+                for comparison in player.comparisons
+                if comparison.heuristic_id == "race_hulls"
+            ),
+            frozenset(),
+        )
+        gaps = player.ground_truth - base_set
+        if gaps:
+            lines.append(f"  GT gaps vs race.basehulls ({len(gaps)}):")
+            for hull_id in sorted(gaps):
+                classification = classify_gt_gap(
+                    hull_id,
+                    race_basehulls=base_set,
+                    race_hulls=race_hulls_set,
+                    hulls_by_id=hulls_by_id,
+                )
+                lines.append(f"      {format_hull_id(hull_id, hull_names)} -- {classification}")
+
+    return lines
+
+
+def discover_game_ids(storage_root: Path) -> list[int]:
+    games_dir = storage_root / "games"
+    if not games_dir.is_dir():
+        return []
+    return sorted(
+        int(path.name)
+        for path in games_dir.iterdir()
+        if path.is_dir() and path.name.isdigit() and (path / "info.json").is_file()
+    )
+
+
+def load_game_info(storage_root: Path, game_id: int) -> tuple[GameInfo, dict[str, Any]]:
+    info_path = storage_root / "games" / str(game_id) / "info.json"
+    with info_path.open() as handle:
+        raw = json.load(handle)
+    return game_info_from_json(raw), raw["settings"]

--- a/scripts/tests/test_analyze_hull_catalog_sources.py
+++ b/scripts/tests/test_analyze_hull_catalog_sources.py
@@ -1,0 +1,141 @@
+"""Tests for hull catalog analysis helpers and script."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from api.serialization.turn import turn_info_from_json
+from hull_catalog_analysis import (
+    compare_hull_set,
+    format_hull_id,
+    format_hull_set,
+    proposed_cross_player_hull_ids,
+    standard_settings_adjusted_basehulls,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_ROOT = REPO_ROOT / "packages" / "api" / "tests" / "fixtures" / "inference_corpus"
+TURN3_PATH = FIXTURES_ROOT / "628580" / "1" / "turns" / "3.json"
+INFO_PATH = FIXTURES_ROOT / "628580" / "info.json"
+DATA_ROOT = REPO_ROOT / ".data"
+
+
+def _load_fixture_turn() -> tuple[object, dict]:
+    import json
+
+    settings_defaults = json.loads(INFO_PATH.read_text())["settings"]
+    turn = turn_info_from_json(
+        json.loads(TURN3_PATH.read_text()),
+        settings_defaults=settings_defaults,
+    )
+    return turn, settings_defaults
+
+
+def test_format_hull_id_includes_name() -> None:
+    names = {90: "Sage Class Frigate", 1090: "Sage Class Repair Ship"}
+    assert format_hull_id(90, names) == "90 (Sage Class Frigate)"
+    assert format_hull_id(999, names) == "999"
+
+
+def test_format_hull_set_sorted_with_names() -> None:
+    names = {2: "Small Deep Space Freighter", 14: "Large Deep Space Freighter"}
+    rendered = format_hull_set(frozenset({14, 2}), names)
+    assert rendered == "2 (Small Deep Space Freighter), 14 (Large Deep Space Freighter)"
+
+
+def test_compare_hull_set_reports_missing_and_extra() -> None:
+    comparison = compare_hull_set(
+        heuristic_id="race_basehulls",
+        candidate=frozenset({1, 2, 3}),
+        ground_truth=frozenset({2, 3, 4}),
+    )
+    assert comparison.covers_ground_truth is False
+    assert comparison.missing_from_heuristic == frozenset({4})
+    assert comparison.extra_in_heuristic == frozenset({1})
+    assert comparison.overage == 1
+
+
+def test_proposed_cross_player_uses_loaded_racehulls_for_loaded_player() -> None:
+    turn, _ = _load_fixture_turn()
+    buildable = proposed_cross_player_hull_ids(turn, turn.player.id, settings=turn.settings)
+    assert buildable == frozenset(turn.racehulls) & {hull.id for hull in turn.hulls}
+
+
+@pytest.mark.skipif(not DATA_ROOT.is_dir(), reason="local .data store only")
+def test_standard_settings_adjusted_covers_rebel_repair_ship_on_game_628580() -> None:
+
+    from hull_catalog_analysis import analyze_game, load_game_info
+
+    game_info, settings_defaults = load_game_info(DATA_ROOT, 628580)
+    analysis = analyze_game(
+        DATA_ROOT,
+        628580,
+        host_turn=6,
+        loaded_perspective=1,
+        settings_defaults=settings_defaults,
+        game_info=game_info,
+    )
+    rebel = next(player for player in analysis.players if player.player_id == 10)
+    proposed = next(
+        comparison
+        for comparison in rebel.comparisons
+        if comparison.heuristic_id == "proposed_cross_player"
+    )
+    assert proposed.covers_ground_truth
+    assert proposed.overage == 0
+
+
+@pytest.mark.skipif(not DATA_ROOT.is_dir(), reason="local .data store only")
+def test_analyze_game_628580_standard_settings_adjusted_full_coverage() -> None:
+
+    from hull_catalog_analysis import analyze_game, load_game_info
+
+    game_info, settings_defaults = load_game_info(DATA_ROOT, 628580)
+    analysis = analyze_game(
+        DATA_ROOT,
+        628580,
+        host_turn=6,
+        loaded_perspective=1,
+        settings_defaults=settings_defaults,
+        game_info=game_info,
+    )
+    summary = next(
+        entry
+        for entry in analysis.heuristic_summaries
+        if entry.heuristic_id == "standard_settings_adjusted"
+    )
+    assert summary.players_covered == summary.players_with_ground_truth
+    assert summary.avg_overage == 0.0
+
+
+def test_standard_settings_adjusted_swaps_sage_frigate_for_repair_ship() -> None:
+    turn, _ = _load_fixture_turn()
+    race = next(race for race in turn.races if race.id == 10)
+    hulls_by_id = {hull.id: hull for hull in turn.hulls}
+    adjusted = standard_settings_adjusted_basehulls(
+        race_id=10,
+        race_basehulls_csv=race.basehulls,
+        race_hulls_csv=race.hulls,
+        catalog_ids=frozenset(hulls_by_id),
+        hulls_by_id=hulls_by_id,
+        settings=turn.settings,
+    )
+    assert 1090 in adjusted
+    assert 90 not in adjusted
+
+
+def test_standard_settings_adjusted_skips_repair_ship_when_race_lacks_sage_frigate() -> None:
+    turn, _ = _load_fixture_turn()
+    race = next(race for race in turn.races if race.id == 9)
+    hulls_by_id = {hull.id: hull for hull in turn.hulls}
+    adjusted = standard_settings_adjusted_basehulls(
+        race_id=9,
+        race_basehulls_csv=race.basehulls,
+        race_hulls_csv=race.hulls,
+        catalog_ids=frozenset(hulls_by_id),
+        hulls_by_id=hulls_by_id,
+        settings=turn.settings,
+    )
+    assert 1090 not in adjusted
+    assert 90 not in adjusted


### PR DESCRIPTION
## Summary
- Add user-configurable hull catalog masks for Scores build inference: persistence, Core REST and BFF routes, and a per-row hull catalog dialog in the Scores table.
- Wire `resolved_mask` through policy-ladder and table-stream inference paths on top of the refactored Issue_71 streaming stack.
- Fix mask-save reconnect during active inference: preempt same-scope table streams, guard stale stream tokens, and retry frontend stream connect so mid-inference mask changes restart progress instead of failing all rows.
- Include hull catalog analysis scripts and regenerate the analytics OpenAPI slice for the new BFF endpoints.

## Test plan
- [x] `make ci` (lint, typecheck, unit tests, OpenAPI slice check)
- [ ] Open Scores table with build inference enabled; use the hull catalog filter button on a row
- [ ] Toggle hulls, save, and confirm inference restarts with the updated mask
- [ ] Save or reset mask **while inference is in progress** and confirm rows reconnect and continue (not stuck at 0 / reconnect failure)
- [ ] Reset mask override and confirm defaults are restored

Made with [Cursor](https://cursor.com)