### PR TITLE
Collapse zero-score ship builds to generic Freighter combo

### DIFF
--- a/packages/api/api/analytics/military_score_inference/ship_build_combos.py
+++ b/packages/api/api/analytics/military_score_inference/ship_build_combos.py
@@ -4,11 +4,18 @@ from dataclasses import dataclass
 
 from api.analytics.military_score_inference.models import InferenceObservation, ShipBuildCombo
 from api.analytics.military_score_inference.ship_build_scoring import (
-    is_military_hull,
+    ship_build_counts_as_warship,
     ship_build_military_score_delta_2x,
 )
 from api.analytics.military_score_inference.tier_policy import SlotCountMode
 from api.models.components import Beam, Engine, Hull, Torpedo
+
+GENERIC_FREIGHTER_COMBO_ID = "combo_freighter"
+GENERIC_ZERO_MILITARY_SCORE_LABEL = "Freighter"
+
+
+def is_generic_zero_military_score_combo_id(combo_id: str) -> bool:
+    return combo_id == GENERIC_FREIGHTER_COMBO_ID
 
 
 @dataclass(frozen=True)
@@ -85,6 +92,27 @@ def ship_build_upper_bound(
     return min(count_delta, observation.starbases_owned)
 
 
+def _generic_freighter_combo(
+    *,
+    upper_bound: int,
+    probability_weight: int,
+) -> ShipBuildCombo:
+    return ShipBuildCombo(
+        combo_id=GENERIC_FREIGHTER_COMBO_ID,
+        hull_id=0,
+        engine_id=0,
+        beam_id=None,
+        torp_id=None,
+        beam_count=0,
+        launcher_count=0,
+        labels=(GENERIC_ZERO_MILITARY_SCORE_LABEL,),
+        score_delta_2x=0,
+        freighter_delta=1,
+        upper_bound=upper_bound,
+        probability_weight=probability_weight,
+    )
+
+
 def generate_ship_build_combos(
     observation: InferenceObservation,
     *,
@@ -102,20 +130,11 @@ def generate_ship_build_combos(
 ) -> tuple[ShipBuildCombo, ...]:
     combo_config = config or ShipBuildComboConfig()
     combos: list[ShipBuildCombo] = []
+    freighter_upper_bound = 0
 
     for hull_id in sorted(buildable_hull_ids):
         hull = hulls_by_id.get(hull_id)
         if hull is None:
-            continue
-
-        is_warship = is_military_hull(hull)
-        is_freighter = not is_warship
-        build_upper_bound = ship_build_upper_bound(
-            observation,
-            is_warship=is_warship,
-            is_freighter=is_freighter,
-        )
-        if build_upper_bound <= 0:
             continue
 
         beam_count_options = beam_count_options_for_slot_mode(hull, beam_slot_counts)
@@ -154,6 +173,20 @@ def generate_ship_build_combos(
 
                     for beam in beam_choices:
                         for torpedo in torp_choices:
+                            counts_as_warship = ship_build_counts_as_warship(
+                                hull,
+                                beam_count=beam_count,
+                                launcher_count=launcher_count,
+                            )
+                            counts_as_freighter = not counts_as_warship
+                            build_upper_bound = ship_build_upper_bound(
+                                observation,
+                                is_warship=counts_as_warship,
+                                is_freighter=counts_as_freighter,
+                            )
+                            if build_upper_bound <= 0:
+                                continue
+
                             score_delta_2x = ship_build_military_score_delta_2x(
                                 hull,
                                 engine,
@@ -162,7 +195,10 @@ def generate_ship_build_combos(
                                 beam_count=beam_count,
                                 launcher_count=launcher_count,
                             )
-                            if score_delta_2x == 0 and not is_warship and not is_freighter:
+                            if score_delta_2x == 0:
+                                freighter_upper_bound = max(
+                                    freighter_upper_bound, build_upper_bound
+                                )
                                 continue
 
                             armed = beam_count > 0 or launcher_count > 0
@@ -198,12 +234,20 @@ def generate_ship_build_combos(
                                         ),
                                     ),
                                     score_delta_2x=score_delta_2x,
-                                    warship_delta=1 if is_warship else 0,
-                                    freighter_delta=1 if is_freighter else 0,
+                                    warship_delta=1 if counts_as_warship else 0,
+                                    freighter_delta=1 if counts_as_freighter else 0,
                                     upper_bound=build_upper_bound,
                                     probability_weight=probability_weight,
                                 )
                             )
+
+    if freighter_upper_bound > 0:
+        combos.append(
+            _generic_freighter_combo(
+                upper_bound=freighter_upper_bound,
+                probability_weight=combo_config.default_probability_weight,
+            )
+        )
 
     pruned = prune_combos_for_observation(
         observation,

--- a/packages/api/api/analytics/military_score_inference/ship_build_scoring.py
+++ b/packages/api/api/analytics/military_score_inference/ship_build_scoring.py
@@ -17,6 +17,22 @@ def is_military_hull(hull: Hull) -> bool:
     return hull.beams > 0 or hull.launchers > 0 or hull.fighterbays > 0
 
 
+def ship_build_counts_as_warship(
+    hull: Hull,
+    *,
+    beam_count: int,
+    launcher_count: int,
+) -> bool:
+    """Whether a build counts toward ``shipchange`` rather than ``freighterchange``.
+
+    Hulls with fighter bays always count as warships. Other military hulls count as
+    freighters on the scoreboard when built without beams or launchers fitted.
+    """
+    if hull.fighterbays > 0:
+        return True
+    return beam_count > 0 or launcher_count > 0
+
+
 def default_build_components(
     *,
     engines_by_id: dict[int, Engine],
@@ -66,6 +82,18 @@ def ship_build_score_delta_2x(
     )
 
 
+def ship_build_has_zero_military_score(
+    hull: Hull,
+    *,
+    beam_count: int,
+    launcher_count: int,
+) -> bool:
+    """True when military score is zero regardless of which engine is fitted."""
+    if not is_military_hull(hull):
+        return True
+    return beam_count == 0 and launcher_count == 0 and hull.fighterbays == 0
+
+
 def ship_build_military_score_delta_2x(
     hull: Hull,
     engine: Engine,
@@ -75,8 +103,17 @@ def ship_build_military_score_delta_2x(
     beam_count: int,
     launcher_count: int,
 ) -> int:
-    """Military-score contribution for a ship build; pure freighters contribute zero."""
-    if not is_military_hull(hull):
+    """Military-score contribution for a ship build.
+
+    Freighters and unarmed military hulls without fighter bays contribute zero.
+    Carriers and other fighter-bay hulls score hull construction even when empty.
+    Loaded fighters are modeled by separate aggregate actions, not ship combos.
+    """
+    if ship_build_has_zero_military_score(
+        hull,
+        beam_count=beam_count,
+        launcher_count=launcher_count,
+    ):
         return 0
     return ship_build_score_delta_2x(
         hull,

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -23,6 +23,9 @@ from api.analytics.military_score_inference.models import (
     ProbabilityBucket,
     ShipBuildCombo,
 )
+from api.analytics.military_score_inference.ship_build_combos import (
+    is_generic_zero_military_score_combo_id,
+)
 
 STATUS_EXACT = "exact"
 STATUS_INVALID_PROBLEM = "invalid_problem"
@@ -117,11 +120,15 @@ def _merge_score_equivalent_combos(
 ) -> _MergedComboCatalog:
     """Merge score-equivalent combos for CP-SAT feasibility; members kept for extraction."""
     groups: dict[tuple[int, int, int], list[ShipBuildCombo]] = defaultdict(list)
-    for combo in combos:
-        groups[(combo.score_delta_2x, combo.warship_delta, combo.freighter_delta)].append(combo)
-
     merged: list[ShipBuildCombo] = []
     members_by_merged_id: dict[str, tuple[ShipBuildCombo, ...]] = {}
+    for combo in combos:
+        if is_generic_zero_military_score_combo_id(combo.combo_id):
+            merged.append(combo)
+            members_by_merged_id[combo.combo_id] = (combo,)
+            continue
+        groups[(combo.score_delta_2x, combo.warship_delta, combo.freighter_delta)].append(combo)
+
     for members in groups.values():
         sorted_members = tuple(sorted(members, key=lambda combo: combo.combo_id))
         if len(sorted_members) == 1:
@@ -310,6 +317,8 @@ def _ship_build_variants_for_merged_count(
     max_expansions: int,
 ) -> tuple[InferenceSolutionShipBuild, ...]:
     members = merged_combo_catalog.members_by_merged_id[merged_combo_id]
+    if is_generic_zero_military_score_combo_id(merged_combo_id):
+        return (_ship_build_from_member(members[0], count),)
     if len(members) == 1:
         return (_ship_build_from_member(members[0], count),)
 

--- a/packages/api/tests/inference_corpus/ground_truth.py
+++ b/packages/api/tests/inference_corpus/ground_truth.py
@@ -3,7 +3,11 @@
 from collections import Counter
 from dataclasses import dataclass
 
-from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_label
+from api.analytics.military_score_inference.ship_build_combos import (
+    GENERIC_FREIGHTER_COMBO_ID,
+    GENERIC_ZERO_MILITARY_SCORE_LABEL,
+    ship_build_combo_label,
+)
 from api.models.game import GameInfo, TurnInfo
 from api.models.player import Score
 from api.services.turn_load_service import TurnLoadService
@@ -330,6 +334,8 @@ def _parse_combo_id(
 
 
 def _combo_ground_truth_label(combo_id: str, turn: TurnInfo) -> str:
+    if combo_id == GENERIC_FREIGHTER_COMBO_ID:
+        return GENERIC_ZERO_MILITARY_SCORE_LABEL
     parsed = _parse_combo_id(combo_id)
     if parsed is None:
         return combo_id

--- a/packages/api/tests/inference_corpus/ship_inventory.py
+++ b/packages/api/tests/inference_corpus/ship_inventory.py
@@ -2,7 +2,13 @@
 
 from collections import Counter
 
-from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_id
+from api.analytics.military_score_inference.ship_build_combos import (
+    GENERIC_FREIGHTER_COMBO_ID,
+    ship_build_combo_id,
+)
+from api.analytics.military_score_inference.ship_build_scoring import (
+    ship_build_has_zero_military_score,
+)
 from api.models.components import Beam, Engine, Hull, Torpedo
 from api.models.game import TurnInfo
 from api.models.ship import Ship
@@ -70,15 +76,23 @@ def ship_to_build_combo_id(ship: Ship, turn: TurnInfo) -> str | None:
     hull = hulls_by_id(turn).get(ship.hullid)
     if hull is None:
         return None
-    beam_id = ship.beamid if ship.beams > 0 else None
-    torp_id = ship.torpedoid if ship.torps > 0 else None
+    beam_count = ship.beams
+    launcher_count = ship.torps
+    if ship_build_has_zero_military_score(
+        hull,
+        beam_count=beam_count,
+        launcher_count=launcher_count,
+    ):
+        return GENERIC_FREIGHTER_COMBO_ID
+    beam_id = ship.beamid if beam_count > 0 else None
+    torp_id = ship.torpedoid if launcher_count > 0 else None
     return ship_build_combo_id(
         hull_id=ship.hullid,
         engine_id=ship.engineid,
         beam_id=beam_id,
         torp_id=torp_id,
-        beam_count=ship.beams,
-        launcher_count=ship.torps,
+        beam_count=beam_count,
+        launcher_count=launcher_count,
     )
 
 

--- a/packages/api/tests/test_ground_truth_player_perspective.py
+++ b/packages/api/tests/test_ground_truth_player_perspective.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from api.analytics.military_score_inference.ship_build_combos import GENERIC_FREIGHTER_COMBO_ID
 from api.services.store_service import StoreService
 
 from tests.inference_corpus.case_helpers import score_for_player
@@ -64,8 +65,9 @@ def test_ground_truth_turn_snapshots_use_player_perspective_not_spectator():
     )
 
     assert wrong.available is True
-    assert wrong.ground_truth == (("combo_2065_0_none_none_0_0", 1),)
+    assert wrong.ground_truth == ((GENERIC_FREIGHTER_COMBO_ID, 1),)
     assert right.available is True
+    assert right.ground_truth != wrong.ground_truth
     summary = format_ground_truth_summary(right.ground_truth, score_turn=owner_score)
     assert "Imperial Topaz Class Gunboats" in summary
     assert "Quantam Drive 7" in summary

--- a/packages/api/tests/test_inference_corpus_ship_inventory.py
+++ b/packages/api/tests/test_inference_corpus_ship_inventory.py
@@ -2,6 +2,7 @@
 
 import json
 
+from api.analytics.military_score_inference.ship_build_combos import GENERIC_FREIGHTER_COMBO_ID
 from api.serialization.turn import turn_info_from_json
 
 from tests.inference_corpus.ground_truth import describe_inventory_activity
@@ -54,6 +55,14 @@ def test_torp_delta_uses_ammo_not_launcher_count():
     assert deltas == {}
     full_deltas = torpedo_load_delta_by_type(prior_turn, score_turn, player_id=1)
     assert full_deltas.get(6) == 40
+
+
+def test_zero_military_score_ship_maps_to_generic_freighter_combo_id():
+    prior_turn, score_turn = _turn_pair()
+    new_ship = new_owned_ships(prior_turn, score_turn, player_id=1)[0]
+    new_ship.beams = 0
+    new_ship.torps = 0
+    assert ship_to_build_combo_id(new_ship, score_turn) == GENERIC_FREIGHTER_COMBO_ID
 
 
 def test_missouri_maps_to_factored_combo_id():

--- a/packages/api/tests/test_military_score_inference_actions.py
+++ b/packages/api/tests/test_military_score_inference_actions.py
@@ -19,6 +19,10 @@ from api.analytics.military_score_inference.scoring import (
     STARBASE_FIGHTER_SCORE_DELTA_2X,
     ship_construction_score_delta_2x,
 )
+from api.analytics.military_score_inference.ship_build_scoring import (
+    ship_build_military_score_delta_2x,
+    ship_build_score_delta_2x,
+)
 from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.concepts.races import evil_empire_free_starbase_fighters_per_host_turn
 from api.serialization.game import game_info_from_json
@@ -167,33 +171,25 @@ def test_ship_build_combos_exclude_build_time_ammo(synthetic_catalog_context):
 
     assert not any("fighters" in combo_id for combo_id in combo_ids)
 
-    carrier_empty = next(
+    carrier_unarmed = next(
         combo
         for combo in catalog.ship_build_combos
         if combo.hull_id == 71 and combo.beam_count == 0 and combo.launcher_count == 0
     )
     hull = synthetic_catalog_context["hulls_by_id"][71]
     engine = synthetic_catalog_context["engines_by_id"][1]
-    expected_score = ship_construction_score_delta_2x(
-        hull.cost + engine.cost * hull.engines,
-        hull.tritanium
-        + hull.duranium
-        + hull.molybdenum
-        + (engine.tritanium + engine.duranium + engine.molybdenum) * hull.engines,
+    assert carrier_unarmed.score_delta_2x == ship_build_military_score_delta_2x(
+        hull,
+        engine,
+        None,
+        None,
+        beam_count=0,
+        launcher_count=0,
     )
-    assert carrier_empty.score_delta_2x == expected_score
+    assert carrier_unarmed.warship_delta == 1
 
 
 def test_ship_build_score_scales_engine_cost_by_hull_engine_slots(synthetic_catalog_context):
-    catalog = build_action_catalog(
-        _observation(warship_delta=1, freighter_delta=1),
-        **synthetic_catalog_context,
-    )
-    carrier_build = next(
-        combo
-        for combo in catalog.ship_build_combos
-        if combo.hull_id == 71 and combo.beam_count == 0 and combo.launcher_count == 0
-    )
     hull = synthetic_catalog_context["hulls_by_id"][71]
     engine = synthetic_catalog_context["engines_by_id"][1]
     engine_minerals = engine.tritanium + engine.duranium + engine.molybdenum
@@ -202,7 +198,17 @@ def test_ship_build_score_scales_engine_cost_by_hull_engine_slots(synthetic_cata
         hull.cost + engine.cost * hull.engines,
         hull_minerals + engine_minerals * hull.engines,
     )
-    assert carrier_build.score_delta_2x == expected
+    assert (
+        ship_build_score_delta_2x(
+            hull,
+            engine,
+            None,
+            None,
+            beam_count=0,
+            launcher_count=0,
+        )
+        == expected
+    )
     assert hull.engines == 2
 
 

--- a/packages/api/tests/test_military_score_inference_ship_build_combos.py
+++ b/packages/api/tests/test_military_score_inference_ship_build_combos.py
@@ -20,10 +20,17 @@ from api.analytics.military_score_inference.component_eligibility import (
 from api.analytics.military_score_inference.models import InferenceObservation
 from api.analytics.military_score_inference.scoring import ship_construction_score_delta_2x
 from api.analytics.military_score_inference.ship_build_combos import (
+    GENERIC_FREIGHTER_COMBO_ID,
+    GENERIC_ZERO_MILITARY_SCORE_LABEL,
     generate_ship_build_combos,
+    is_generic_zero_military_score_combo_id,
     ship_build_combo_id,
 )
-from api.analytics.military_score_inference.ship_build_scoring import ship_build_score_delta_2x
+from api.analytics.military_score_inference.ship_build_scoring import (
+    ship_build_counts_as_warship,
+    ship_build_military_score_delta_2x,
+    ship_build_score_delta_2x,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_TIME_LIMITED,
@@ -97,14 +104,83 @@ def test_freighter_combo_has_zero_military_score(synthetic_catalog_context):
         **synthetic_catalog_context,
     )
     freighter_combos = [combo for combo in combos if combo.freighter_delta == 1]
-    assert freighter_combos
-    assert all(combo.score_delta_2x == 0 for combo in freighter_combos)
+    assert len(freighter_combos) == 1
+    assert freighter_combos[0].combo_id == GENERIC_FREIGHTER_COMBO_ID
+    assert freighter_combos[0].score_delta_2x == 0
+    assert freighter_combos[0].labels == (GENERIC_ZERO_MILITARY_SCORE_LABEL,)
 
     warship_combos = generate_ship_build_combos(
         _observation(warship_delta=1),
         **synthetic_catalog_context,
     )
-    assert all(combo.score_delta_2x > 0 for combo in warship_combos if combo.warship_delta == 1)
+    armed_warship_combos = [
+        combo
+        for combo in warship_combos
+        if combo.warship_delta == 1 and combo.combo_id != GENERIC_FREIGHTER_COMBO_ID
+    ]
+    assert armed_warship_combos
+    assert all(combo.score_delta_2x > 0 for combo in armed_warship_combos)
+    assert not any(combo.combo_id == GENERIC_FREIGHTER_COMBO_ID for combo in warship_combos)
+
+
+def test_unarmed_military_hull_has_zero_military_score(synthetic_catalog_context):
+    hull = synthetic_catalog_context["hulls_by_id"][24]
+    engine = synthetic_catalog_context["engines_by_id"][1]
+    assert (
+        ship_build_military_score_delta_2x(
+            hull,
+            engine,
+            None,
+            None,
+            beam_count=0,
+            launcher_count=0,
+        )
+        == 0
+    )
+    assert (
+        ship_build_score_delta_2x(
+            hull,
+            engine,
+            None,
+            None,
+            beam_count=0,
+            launcher_count=0,
+        )
+        > 0
+    )
+
+
+def test_carrier_with_fighter_bays_scores_military_when_unarmed(synthetic_catalog_context):
+    hull = synthetic_catalog_context["hulls_by_id"][71]
+    engine = synthetic_catalog_context["engines_by_id"][1]
+    assert ship_build_counts_as_warship(hull, beam_count=0, launcher_count=0)
+    assert (
+        ship_build_military_score_delta_2x(
+            hull,
+            engine,
+            None,
+            None,
+            beam_count=0,
+            launcher_count=0,
+        )
+        > 0
+    )
+
+
+def test_unarmed_escort_counts_as_freighter_on_scoreboard(synthetic_catalog_context):
+    hull = synthetic_catalog_context["hulls_by_id"][24]
+    assert not ship_build_counts_as_warship(hull, beam_count=0, launcher_count=0)
+
+    context = {
+        **synthetic_catalog_context,
+        "buildable_hull_ids": frozenset({hull.id}),
+    }
+    combos = generate_ship_build_combos(
+        _observation(military_delta_2x=0, warship_delta=0, freighter_delta=1),
+        **context,
+    )
+    assert len(combos) == 1
+    assert combos[0].combo_id == GENERIC_FREIGHTER_COMBO_ID
 
 
 def test_beams_and_launchers_may_be_omitted_independently(synthetic_catalog_context):
@@ -126,15 +202,10 @@ def test_beams_and_launchers_may_be_omitted_independently(synthetic_catalog_cont
     assert (torp_hull.beams, 0) in beam_launcher_pairs
     assert (0, torp_hull.launchers) in beam_launcher_pairs
     assert (torp_hull.beams, torp_hull.launchers) in beam_launcher_pairs
-    assert (0, 0) in beam_launcher_pairs
+    assert (0, 0) not in beam_launcher_pairs
 
 
 def test_multi_engine_hull_scales_engine_cost(synthetic_catalog_context):
-    combos = generate_ship_build_combos(
-        _observation(warship_delta=1, freighter_delta=1),
-        **synthetic_catalog_context,
-    )
-    carrier_combo = next(combo for combo in combos if combo.hull_id == 71 and combo.beam_count == 0)
     hull = synthetic_catalog_context["hulls_by_id"][71]
     engine = synthetic_catalog_context["engines_by_id"][1]
     engine_minerals = engine.tritanium + engine.duranium + engine.molybdenum
@@ -143,8 +214,31 @@ def test_multi_engine_hull_scales_engine_cost(synthetic_catalog_context):
         hull.cost + engine.cost * hull.engines,
         hull_minerals + engine_minerals * hull.engines,
     )
-    assert carrier_combo.score_delta_2x == expected
+    assert (
+        ship_build_score_delta_2x(
+            hull,
+            engine,
+            None,
+            None,
+            beam_count=0,
+            launcher_count=0,
+        )
+        == expected
+    )
     assert hull.engines == 2
+
+    combos = generate_ship_build_combos(
+        _observation(warship_delta=1, freighter_delta=1),
+        **synthetic_catalog_context,
+    )
+    carrier_combo = next(
+        combo
+        for combo in combos
+        if combo.hull_id == 71 and combo.beam_count == 0 and combo.launcher_count == 0
+    )
+    assert carrier_combo.score_delta_2x == expected
+    assert carrier_combo.warship_delta == 1
+    assert any(combo.combo_id == GENERIC_FREIGHTER_COMBO_ID for combo in combos)
 
 
 def test_empty_active_lists_jump_to_turn_catalog_for_components():
@@ -186,7 +280,7 @@ def test_early_tier_limits_beam_counts_to_zero_or_max(synthetic_catalog_context)
         **context,
     )
     beam_counts = {combo.beam_count for combo in combos if combo.hull_id == hull.id}
-    assert beam_counts <= {0, hull.beams}
+    assert beam_counts <= {hull.beams}
 
 
 def test_max_tier_includes_partial_beam_and_launcher_counts(synthetic_catalog_context):
@@ -209,8 +303,8 @@ def test_max_tier_includes_partial_beam_and_launcher_counts(synthetic_catalog_co
     hull_combos = [combo for combo in combos if combo.hull_id == hull.id]
     beam_counts = {combo.beam_count for combo in hull_combos if combo.launcher_count == 0}
     launcher_counts = {combo.launcher_count for combo in hull_combos if combo.beam_count == 0}
-    assert beam_counts == {0, 1, 2, 3, 4}
-    assert launcher_counts == {0, 1, 2, 3}
+    assert beam_counts == {1, 2, 3, 4}
+    assert launcher_counts == {1, 2, 3}
 
 
 def test_solver_joint_constraints_with_combo_and_aggregate():
@@ -259,6 +353,43 @@ def test_solver_joint_constraints_with_combo_and_aggregate():
     assert result.status == STATUS_EXACT
     assert result.solutions[0].ship_builds[0].combo_id == combo.combo_id
     assert result.solutions[0].actions[0].count == 40
+
+
+def test_solver_generic_freighter_produces_single_solution_without_expansion(
+    synthetic_catalog_context,
+):
+    from api.analytics.military_score_inference.models import (
+        InferenceProblem,
+        InferenceSolutionShipBuild,
+    )
+
+    combos = generate_ship_build_combos(
+        _observation(military_delta_2x=0, warship_delta=0, freighter_delta=1),
+        **synthetic_catalog_context,
+    )
+    problem = InferenceProblem(
+        observation=_observation(military_delta_2x=0, warship_delta=0, freighter_delta=1),
+        aggregate_actions=(),
+        ship_build_combos=combos,
+        max_solutions=20,
+    )
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_EXACT
+    assert len(result.solutions) == 1
+    assert result.solutions[0].ship_builds == (
+        InferenceSolutionShipBuild(
+            combo_id=GENERIC_FREIGHTER_COMBO_ID,
+            label=GENERIC_ZERO_MILITARY_SCORE_LABEL,
+            count=1,
+            hull_id=0,
+            engine_id=0,
+            beam_id=None,
+            torp_id=None,
+            beam_count=0,
+            launcher_count=0,
+        ),
+    )
 
 
 def test_score_equivalent_merge_preserves_distinct_probability_ranked_solutions():
@@ -485,8 +616,11 @@ def test_early_policy_step_catalog_uses_early_game_band_filters(sample_turn):
     if not combos:
         pytest.skip("sample turn has no buildable hull combos for observation")
     assert early_step.filters.engines.all
-    assert {combo.hull_id for combo in combos} <= context.buildable_hull_ids
-    assert {combo.engine_id for combo in combos} <= context.eligible_engine_ids
+    specific_combos = [
+        combo for combo in combos if not is_generic_zero_military_score_combo_id(combo.combo_id)
+    ]
+    assert {combo.hull_id for combo in specific_combos} <= context.buildable_hull_ids
+    assert {combo.engine_id for combo in specific_combos} <= context.eligible_engine_ids
     combo_beam_ids = {combo.beam_id for combo in combos if combo.beam_id is not None}
     combo_torp_ids = {combo.torp_id for combo in combos if combo.torp_id is not None}
     assert combo_beam_ids <= context.eligible_beam_ids


### PR DESCRIPTION
## Summary
- Treat freighters and unarmed non-carrier military hulls as zero military score; carriers with fighter bays still score hull construction when built empty.
- Classify scoreboard warship vs freighter counts from fitted loadout (fighter bays always warship; empty beams/launchers on other military hulls count as freighters).
- Replace per-hull zero-score catalog combos with one canonical `combo_freighter` entry and skip solver post-solve expansion for it.
- Align ground truth extraction with the same engine-independent zero-score rule via `ship_build_has_zero_military_score()`.

## Test plan
- [x] `make lint`
- [x] `make test_api` (military score inference + ground truth perspective tests)
- [ ] Spot-check inference UI for a turn with freighter-only build explanation (single "Freighter" row, no hull-variant expansion)


Made with [Cursor](https://cursor.com)