### PR TITLE
Skip Horwasp from military score inference and show aggregate counts in solution modal

### DIFF
--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -105,6 +105,7 @@ def build_inference_problem(
     observation: InferenceObservation,
     catalog: ActionCatalog,
     *,
+    race_id: int | None = None,
     max_solutions: int | None = None,
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     military_score_alpha: int = 0,
@@ -122,6 +123,7 @@ def build_inference_problem(
     return InferenceProblem(
         observation=observation,
         aggregate_actions=aggregate_actions,
+        race_id=race_id,
         ship_build_combos=ship_build_combos,
         policy_step_id=catalog.policy_step_id,
         policy_step_index=catalog.policy_step_index,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -12,6 +12,7 @@ from api.analytics.military_score_inference.actions import (
 )
 from api.analytics.military_score_inference.component_eligibility import (
     buildable_hull_ids_for_player,
+    player_by_id,
 )
 from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
@@ -272,8 +273,13 @@ def _run_policy_ladder_inference(
 def _run_corpus_prebuilt_inference(
     resolved_observation: InferenceObservation,
     catalog: ActionCatalog,
+    *,
+    turn: TurnInfo | None = None,
 ) -> tuple[InferenceResult, ActionCatalog, InferenceProblem, list[str], list[dict[str, object]]]:
-    problem = build_inference_problem(resolved_observation, catalog)
+    race_id = (
+        player_by_id(turn, resolved_observation.player_id).raceid if turn is not None else None
+    )
+    problem = build_inference_problem(resolved_observation, catalog, race_id=race_id)
     result = solve_inference_problem(problem)
     return result, catalog, problem, [catalog.policy_step_id], []
 
@@ -337,7 +343,7 @@ def _run_solver_inference_path(
             assert path == InferencePath.CORPUS_PREBUILT
             assert solve_catalog is not None
             result, solve_catalog, problem, policy_steps_attempted, step_diagnostics = (
-                _run_corpus_prebuilt_inference(resolved_observation, solve_catalog)
+                _run_corpus_prebuilt_inference(resolved_observation, solve_catalog, turn=turn)
             )
         if solve_catalog is None or problem is None:
             return (

--- a/packages/api/api/analytics/military_score_inference/models.py
+++ b/packages/api/api/analytics/military_score_inference/models.py
@@ -123,6 +123,7 @@ class ShipBuildCombo:
 class InferenceProblem:
     observation: InferenceObservation
     aggregate_actions: tuple[CandidateAction, ...]
+    race_id: int | None = None
     ship_build_combos: tuple[ShipBuildCombo, ...] = ()
     policy_step_id: str = ""
     policy_step_index: int = 0

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
@@ -12,6 +12,7 @@ from api.analytics.military_score_inference.actions import (
     build_inference_problem,
 )
 from api.analytics.military_score_inference.component_eligibility import (
+    player_by_id,
     turn_catalog_context_for_policy_step,
 )
 from api.analytics.military_score_inference.constraints import (
@@ -141,6 +142,7 @@ def _solve_catalog(
     observation: InferenceObservation,
     catalog: ActionCatalog,
     *,
+    race_id: int | None = None,
     max_solutions: int,
     time_limit_seconds: float,
     military_score_alpha: int = 0,
@@ -152,6 +154,7 @@ def _solve_catalog(
     problem = build_inference_problem(
         observation,
         catalog,
+        race_id=race_id,
         max_solutions=max_solutions,
         time_limit_seconds=time_limit_seconds,
         military_score_alpha=military_score_alpha,
@@ -173,6 +176,7 @@ def _solve_seed_progression(
     catalog: ActionCatalog,
     seed: InferenceSolution,
     *,
+    race_id: int | None = None,
     max_solutions: int,
     time_limit_seconds: float,
     cancel_token: InferenceCancelToken | None = None,
@@ -191,6 +195,7 @@ def _solve_seed_progression(
         result, problem = _solve_catalog(
             observation,
             catalog,
+            race_id=race_id,
             max_solutions=remaining_slots,
             time_limit_seconds=time_limit_seconds,
             fixed_combo_counts=fixed_counts,
@@ -209,6 +214,7 @@ def _solve_seed_progression(
     result, problem = _solve_catalog(
         observation,
         catalog,
+        race_id=race_id,
         max_solutions=remaining_slots,
         time_limit_seconds=time_limit_seconds,
         cancel_token=cancel_token,
@@ -334,6 +340,7 @@ def run_policy_ladder_tier_step(
     step_index = state.next_step_index
     policy_step = state.policy_steps[step_index]
     state.policy_steps_attempted.append(policy_step.id)
+    player_race_id = player_by_id(turn, observation.player_id).raceid
     catalog = build_action_catalog_from_turn(
         observation,
         turn,
@@ -374,6 +381,7 @@ def run_policy_ladder_tier_step(
             observation,
             catalog,
             seed,
+            race_id=player_race_id,
             max_solutions=catalog_solve_max,
             time_limit_seconds=run.remaining_seconds(),
             cancel_token=cancel_token,
@@ -402,6 +410,7 @@ def run_policy_ladder_tier_step(
     exact_result, problem = _solve_catalog(
         observation,
         catalog,
+        race_id=player_race_id,
         max_solutions=catalog_solve_max,
         time_limit_seconds=run.remaining_seconds(),
         cancel_token=cancel_token,
@@ -427,6 +436,7 @@ def run_policy_ladder_tier_step(
             band_result, band_problem = _solve_catalog(
                 observation,
                 catalog,
+                race_id=player_race_id,
                 max_solutions=policy_step.max_seeds,
                 time_limit_seconds=run.remaining_seconds(),
                 military_score_alpha=policy_step.alpha,

--- a/packages/api/api/analytics/military_score_inference/prior_mining/extraction_pool.py
+++ b/packages/api/api/analytics/military_score_inference/prior_mining/extraction_pool.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
 
+from api.concepts.races import is_horwasp
 from api.models.game import GameInfo
 from api.services.game_service import GameService
 from api.services.player_elimination import is_eliminated_at_turn, last_meaningful_turn
@@ -36,6 +37,7 @@ class ExtractionRunSummary:
     units_enqueued: int = 0
     units_ok: int = 0
     adjunct_skips: int = 0
+    horwasp_skips: int = 0
     ship_build_validation_drops: int = 0
     extraction_errors: int = 0
 
@@ -84,6 +86,8 @@ def enumerate_extraction_work_units(
 
     for player in game_info.players:
         player_id = player.id
+        if is_horwasp(player.raceid):
+            continue
         perspective = GameService.perspective_for_player_id(game_info, player_id, game_id)
         last_turn = last_meaningful_turn(player, latest_turn)
         if last_turn < 2:
@@ -222,6 +226,8 @@ def _apply_extraction_row_result(
     if result.outcome == "skip":
         if result.skip_reason == ExtractionSkipReason.ADJUNCT:
             summary.adjunct_skips += 1
+        elif result.skip_reason == ExtractionSkipReason.HORWASP:
+            summary.horwasp_skips += 1
         return
 
     if result.outcome == "error":

--- a/packages/api/api/analytics/military_score_inference/prior_mining/extraction_worker.py
+++ b/packages/api/api/analytics/military_score_inference/prior_mining/extraction_worker.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Literal
 
 from api.analytics.military_score_inference.inference_corpus_complexity import classify_complexity
+from api.concepts.races import is_horwasp
 from api.services.turn_load_service import TurnLoadService
 
 from .component_name_catalog import ComponentNameCatalog, ComponentNameCatalogBuilder
@@ -25,6 +26,7 @@ _worker_turn_load: TurnLoadService | None = None
 
 class ExtractionSkipReason(Enum):
     ADJUNCT = "adjunct"
+    HORWASP = "horwasp"
     MISSING_SCORE = "missing_score"
 
 
@@ -83,6 +85,13 @@ def extract_extraction_work_unit(
     turn_cache: MiningTurnCache | None = None,
 ) -> ExtractionRowResult:
     """Extract one (game, player, host_turn) unit from stored turns."""
+    if is_horwasp(unit.race_id):
+        return ExtractionRowResult(
+            unit=unit,
+            outcome="skip",
+            skip_reason=ExtractionSkipReason.HORWASP,
+        )
+
     cache = turn_cache if turn_cache is not None else MiningTurnCache(turn_load)
     name_builder = ComponentNameCatalogBuilder()
     score_turn_number = unit.host_turn + 1

--- a/packages/api/api/analytics/military_score_inference/prior_mining/report.py
+++ b/packages/api/api/analytics/military_score_inference/prior_mining/report.py
@@ -52,6 +52,7 @@ class PriorMiningReport:
     games_skipped_incomplete_loadall: int = 0
     incomplete_loadall_details: list[IncompleteLoadAllDetail] = field(default_factory=list)
     adjunct_skips: int = 0
+    horwasp_skips: int = 0
     ship_build_validation_drops: int = 0
     extraction_errors: list[ExtractionErrorDetail] = field(default_factory=list)
     game_mining_errors: list[GameMiningErrorDetail] = field(default_factory=list)
@@ -85,6 +86,7 @@ class PriorMiningReport:
                 asdict(detail) for detail in self.incomplete_loadall_details
             ],
             "adjunct_skips": self.adjunct_skips,
+            "horwasp_skips": self.horwasp_skips,
             "ship_build_validation_drops": self.ship_build_validation_drops,
             "extraction_errors": [asdict(error) for error in self.extraction_errors],
             "game_mining_errors": [asdict(error) for error in self.game_mining_errors],

--- a/packages/api/api/analytics/military_score_inference/prior_mining/runner.py
+++ b/packages/api/api/analytics/military_score_inference/prior_mining/runner.py
@@ -445,12 +445,14 @@ def _process_prepared_game(
         extraction_pool=extraction_pool,
     )
     report.adjunct_skips += extraction_summary.adjunct_skips
+    report.horwasp_skips += extraction_summary.horwasp_skips
     report.ship_build_validation_drops += extraction_summary.ship_build_validation_drops
     LOGGER.info(
-        "game %s: extraction finished (%s ok, %s adjunct skips, %s errors)",
+        "game %s: extraction finished (%s ok, %s adjunct skips, %s horwasp skips, %s errors)",
         game_id,
         extraction_summary.units_ok,
         extraction_summary.adjunct_skips,
+        extraction_summary.horwasp_skips,
         extraction_summary.extraction_errors,
     )
     return True

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -36,6 +36,7 @@ from api.analytics.military_score_inference.ranking_heuristics import (
 from api.analytics.military_score_inference.ship_build_combos import (
     is_generic_zero_military_score_combo_id,
 )
+from api.concepts.races import is_horwasp
 
 STATUS_EXACT = "exact"
 STATUS_INVALID_PROBLEM = "invalid_problem"
@@ -477,6 +478,13 @@ def solve_inference_problem(
             status=STATUS_INVALID_PROBLEM,
             solutions=(),
             diagnostics={"reason": validation_error},
+        )
+
+    if problem.race_id is not None and is_horwasp(problem.race_id):
+        return InferenceResult(
+            status=STATUS_NO_EXACT_SOLUTION,
+            solutions=(),
+            diagnostics={"reason": "horwasp_unsupported"},
         )
 
     if not _problem_has_catalog_entries(problem):

--- a/packages/api/api/concepts/races.py
+++ b/packages/api/api/concepts/races.py
@@ -7,12 +7,17 @@ analytics or accelerated-start helpers. Game-wide homeworld defaults stay elsewh
 from api.models.game import GameSettings
 
 EVIL_EMPIRE_RACE_ID = 8
+HORWASP_RACE_ID = 12
 
 EVIL_EMPIRE_FREE_STARBASE_FIGHTERS_BASE = 5
 
 
 def is_evil_empire(race_id: int) -> bool:
     return race_id == EVIL_EMPIRE_RACE_ID
+
+
+def is_horwasp(race_id: int) -> bool:
+    return race_id == HORWASP_RACE_ID
 
 
 def evil_empire_free_starbase_fighters_per_host_turn(settings: GameSettings) -> int:

--- a/packages/api/tests/inference_corpus/models.py
+++ b/packages/api/tests/inference_corpus/models.py
@@ -12,6 +12,7 @@ class CaseOutcome(StrEnum):
     SKIPPED_COMPLEXITY = "skipped_complexity"
     SKIPPED_INCOMPLETE_MULTI_VIEW = "skipped_incomplete_multi_view"
     SKIPPED_PENDING_SOLVER = "skipped_pending_solver"
+    SKIPPED_UNSUPPORTED_RACE = "skipped_unsupported_race"
     OUT_OF_SEARCH_SPACE = "out_of_search_space"
     RANKING_MISS = "ranking_miss"
 
@@ -142,6 +143,7 @@ class CorpusReport:
                 f"skipped_incomplete_multi_view="
                 f"{buckets[CaseOutcome.SKIPPED_INCOMPLETE_MULTI_VIEW]} "
                 f"skipped_pending_solver={buckets[CaseOutcome.SKIPPED_PENDING_SOLVER]} "
+                f"skipped_unsupported_race={buckets[CaseOutcome.SKIPPED_UNSUPPORTED_RACE]} "
                 f"out_of_search_space={buckets[CaseOutcome.OUT_OF_SEARCH_SPACE]} "
                 f"ranking_miss={buckets[CaseOutcome.RANKING_MISS]}"
             ),

--- a/packages/api/tests/inference_corpus/run.py
+++ b/packages/api/tests/inference_corpus/run.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 
 from api.analytics.military_score_inference.actions import DEFAULT_INFERENCE_TIME_LIMIT_SECONDS
+from api.analytics.military_score_inference.component_eligibility import player_by_id
 from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.concepts.races import is_horwasp
 from api.models.game import TurnInfo
 from api.services.game_service import GameService
 from api.services.store_service import StoreService
@@ -43,6 +45,27 @@ from tests.inference_corpus.verify import check_ground_truth_in_top_k
 
 DEFAULT_MAX_COMPLEXITY: ComplexityLevel = "heavy"
 DEFAULT_TOP_K = 3
+HORWASP_SKIP_REASON = "horwasp_unsupported"
+
+
+def _unsupported_race_skip_result(
+    *,
+    case_id: str,
+    score_turn: TurnInfo,
+    player_id: int,
+    complexity: ComplexityLevel | None = None,
+    complexity_reasons: tuple[str, ...] = (),
+) -> CorpusCaseResult | None:
+    player = player_by_id(score_turn, player_id)
+    if not is_horwasp(player.raceid):
+        return None
+    return CorpusCaseResult(
+        case_id=case_id,
+        outcome=CaseOutcome.SKIPPED_UNSUPPORTED_RACE,
+        complexity=complexity,
+        complexity_reasons=complexity_reasons,
+        skip_reason=HORWASP_SKIP_REASON,
+    )
 
 
 def _manifest_scoreboard_turn_loader(
@@ -112,6 +135,15 @@ def run_manifest_case(
             outcome=CaseOutcome.FAILED,
             failure_message=str(exc),
         )
+
+    unsupported_race = _unsupported_race_skip_result(
+        case_id=case.id,
+        score_turn=score_turn,
+        player_id=player_id,
+        complexity=case.complexity,
+    )
+    if unsupported_race is not None:
+        return unsupported_race
 
     merged = merge_turn_inventories(
         case_perspective_prior=prior_turn,
@@ -204,6 +236,14 @@ def run_discovered_case(
             outcome=CaseOutcome.FAILED,
             failure_message=str(exc),
         )
+
+    unsupported_race = _unsupported_race_skip_result(
+        case_id=case.id,
+        score_turn=score_turn,
+        player_id=player_id,
+    )
+    if unsupported_race is not None:
+        return unsupported_race
 
     merged = merged_inventory_for_case(
         case,

--- a/packages/api/tests/test_concepts_races.py
+++ b/packages/api/tests/test_concepts_races.py
@@ -1,0 +1,13 @@
+"""Tests for race-specific game concept helpers."""
+
+from api.concepts.races import HORWASP_RACE_ID, is_horwasp
+
+
+def test_horwasp_race_id_is_twelve() -> None:
+    assert HORWASP_RACE_ID == 12
+
+
+def test_is_horwasp_matches_horwasp_race_id_only() -> None:
+    assert is_horwasp(12) is True
+    assert is_horwasp(11) is False
+    assert is_horwasp(1) is False

--- a/packages/api/tests/test_inference_corpus_harness.py
+++ b/packages/api/tests/test_inference_corpus_harness.py
@@ -1,10 +1,20 @@
 """Unit tests for inference corpus harness helpers."""
 
-import pytest
+from dataclasses import replace
+from unittest.mock import MagicMock, patch
 
+import pytest
+from api.concepts.races import HORWASP_RACE_ID
+
+from tests.inference_corpus.fixtures import load_turn_fixture
 from tests.inference_corpus.manifest import load_manifest, resolve_player_id
-from tests.inference_corpus.models import COMPLEXITY_ORDINAL, CaseOutcome
-from tests.inference_corpus.run import run_manifest_case
+from tests.inference_corpus.models import (
+    COMPLEXITY_ORDINAL,
+    INFERENCE_FAILURE_OUTCOMES,
+    CaseOutcome,
+    DiscoveredCase,
+)
+from tests.inference_corpus.run import HORWASP_SKIP_REASON, run_discovered_case, run_manifest_case
 
 
 def test_load_fixed_manifest_has_seed_cases():
@@ -34,6 +44,83 @@ def test_adjunct_case_skipped_by_default():
     result = run_manifest_case(adjunct_case)
     assert result.outcome == CaseOutcome.SKIPPED_COMPLEXITY
     assert result.skip_reason == "adjunct_disabled"
+
+
+def test_horwasp_manifest_case_skipped_without_inference_failure():
+    _, cases = load_manifest()
+    case = cases[0]
+    prior_turn = load_turn_fixture(case.prior_turn_path)
+    score_turn = load_turn_fixture(case.score_turn_path)
+    horwasp_player = replace(prior_turn.player, raceid=HORWASP_RACE_ID)
+    prior_turn = replace(prior_turn, player=horwasp_player)
+    score_turn = replace(score_turn, player=horwasp_player)
+    horwasp_case = case.__class__(**{**case.__dict__, "id": "horwasp-stub"})
+
+    with (
+        patch(
+            "tests.inference_corpus.run.load_turn_fixture",
+            side_effect=[prior_turn, score_turn],
+        ),
+        patch(
+            "tests.inference_corpus.run.load_manifest_ground_truth_turn_snapshots",
+            return_value=(prior_turn, score_turn),
+        ),
+    ):
+        result = run_manifest_case(horwasp_case)
+
+    assert result.outcome == CaseOutcome.SKIPPED_UNSUPPORTED_RACE
+    assert result.skip_reason == HORWASP_SKIP_REASON
+    assert result.outcome not in INFERENCE_FAILURE_OUTCOMES
+
+
+def test_horwasp_discovered_case_skipped_without_inference_failure():
+    case = DiscoveredCase(
+        id="999-p1-host2",
+        game_id=999,
+        perspective=1,
+        host_turn=2,
+    )
+    prior_turn = load_turn_fixture("628580/1/turns/2.json")
+    score_turn = load_turn_fixture("628580/1/turns/3.json")
+    horwasp_player = replace(prior_turn.player, raceid=HORWASP_RACE_ID)
+    prior_turn = replace(prior_turn, player=horwasp_player)
+    score_turn = replace(score_turn, player=horwasp_player)
+
+    turn_load = MagicMock()
+    turn_load.get_turn_info.side_effect = lambda _gid, _perspective, turn_number: (
+        prior_turn if turn_number == 2 else score_turn
+    )
+    game_service = MagicMock()
+    store = MagicMock()
+
+    with (
+        patch(
+            "tests.inference_corpus.run.resolve_player_id_for_case",
+            return_value=prior_turn.player.id,
+        ),
+        patch(
+            "tests.inference_corpus.run.merged_inventory_for_case",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "tests.inference_corpus.run.score_for_player",
+            return_value=score_turn.scores[0],
+        ),
+        patch(
+            "tests.inference_corpus.run.classify_complexity",
+            return_value=("minimal", ()),
+        ),
+    ):
+        result = run_discovered_case(
+            case,
+            turn_load=turn_load,
+            game_service=game_service,
+            store=store,
+        )
+
+    assert result.outcome == CaseOutcome.SKIPPED_UNSUPPORTED_RACE
+    assert result.skip_reason == HORWASP_SKIP_REASON
+    assert result.outcome not in INFERENCE_FAILURE_OUTCOMES
 
 
 def test_complexity_ordinal_ordering():

--- a/packages/api/tests/test_inference_prior_mining_extraction_pool.py
+++ b/packages/api/tests/test_inference_prior_mining_extraction_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -24,6 +25,7 @@ from api.analytics.military_score_inference.prior_mining.extraction_worker impor
     extract_extraction_work_unit,
 )
 from api.analytics.military_score_inference.prior_mining.report import PriorMiningReport
+from api.concepts.races import HORWASP_RACE_ID
 from api.serialization.game import game_info_from_json
 
 from tests.inference_corpus.fixtures import load_turn_fixture
@@ -47,6 +49,40 @@ def _mock_turn_load_for_host_turn_2() -> MagicMock:
     turn_load.list_stored_turn_numbers.return_value = [2, 3]
     turn_load.list_stored_turn_perspectives.return_value = [1]
     return turn_load
+
+
+def test_enumerate_extraction_work_units_skips_horwasp_players() -> None:
+    game_info = _load_game_info()
+    horwasp_player_id = 2
+    game_info = replace(
+        game_info,
+        players=[
+            replace(player, raceid=HORWASP_RACE_ID) if player.id == horwasp_player_id else player
+            for player in game_info.players
+        ],
+    )
+    turn_load = MagicMock()
+    turn_load.list_stored_turn_numbers.return_value = [2, 3]
+
+    units = enumerate_extraction_work_units(game_info, 628580, turn_load)
+
+    assert all(unit.player_id != horwasp_player_id for unit in units)
+
+
+def test_extract_extraction_work_unit_skips_horwasp_race() -> None:
+    unit = ExtractionWorkUnit(
+        game_id=628580,
+        player_id=2,
+        perspective=2,
+        host_turn=2,
+        race_id=HORWASP_RACE_ID,
+    )
+    result = extract_extraction_work_unit(
+        turn_load=_mock_turn_load_for_host_turn_2(),
+        unit=unit,
+    )
+    assert result.outcome == "skip"
+    assert result.skip_reason == ExtractionSkipReason.HORWASP
 
 
 def test_enumerate_extraction_work_units_respects_stored_turn_pairs() -> None:
@@ -79,6 +115,7 @@ def test_extract_extraction_work_unit_returns_row_for_fixture() -> None:
     if result.outcome == "skip":
         assert result.skip_reason in {
             ExtractionSkipReason.ADJUNCT,
+            ExtractionSkipReason.HORWASP,
             ExtractionSkipReason.MISSING_SCORE,
         }
     else:

--- a/packages/api/tests/test_inference_stream_accelerated_admission.py
+++ b/packages/api/tests/test_inference_stream_accelerated_admission.py
@@ -151,6 +151,7 @@ def test_run_inference_tier_job_does_not_emit_on_admission_for_accel_window_segm
         _observation,
         _catalog,
         *,
+        race_id=None,
         max_solutions,
         time_limit_seconds,
         military_score_alpha=0,
@@ -159,7 +160,7 @@ def test_run_inference_tier_job_does_not_emit_on_admission_for_accel_window_segm
         cancel_token=None,
         on_solution=None,
     ):
-        del max_solutions, time_limit_seconds, military_score_alpha
+        del race_id, max_solutions, time_limit_seconds, military_score_alpha
         del fixed_combo_counts, combo_count_neighborhood, cancel_token
         if on_solution is not None:
             on_solution(solution)
@@ -227,6 +228,7 @@ def test_run_inference_tier_job_emits_on_admission_for_reported_host_turn_segmen
         _observation,
         _catalog,
         *,
+        race_id=None,
         max_solutions,
         time_limit_seconds,
         military_score_alpha=0,
@@ -235,7 +237,7 @@ def test_run_inference_tier_job_emits_on_admission_for_reported_host_turn_segmen
         cancel_token=None,
         on_solution=None,
     ):
-        del max_solutions, time_limit_seconds, military_score_alpha
+        del race_id, max_solutions, time_limit_seconds, military_score_alpha
         del fixed_combo_counts, combo_count_neighborhood, cancel_token
         if on_solution is not None:
             on_solution(solution)

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -217,6 +217,27 @@ def test_solve_infeasible_problem_returns_no_exact_solution():
     assert result.solutions == ()
 
 
+def test_solve_horwasp_player_returns_no_exact_solution_without_solving():
+    build_warship = CandidateAction(
+        id="build_rush",
+        label="Build Rush",
+        score_delta_2x=400,
+        warship_delta=1,
+        build_slot_usage=1,
+        upper_bound=1,
+    )
+    problem = InferenceProblem(
+        observation=_observation(military_delta_2x=400, warship_delta=1),
+        aggregate_actions=(build_warship,),
+        race_id=12,
+    )
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_NO_EXACT_SOLUTION
+    assert result.solutions == ()
+    assert result.diagnostics.get("reason") == "horwasp_unsupported"
+
+
 def test_solve_invalid_problem_with_bad_action_bounds():
     invalid_action = CandidateAction(
         id="planet_defense_posts",

--- a/packages/api/tests/test_policy_ladder_incremental_streaming.py
+++ b/packages/api/tests/test_policy_ladder_incremental_streaming.py
@@ -38,6 +38,7 @@ def test_run_policy_ladder_tier_step_calls_on_admitted_for_each_within_tier_solu
         _observation,
         _catalog,
         *,
+        race_id=None,
         max_solutions,
         time_limit_seconds,
         military_score_alpha=0,
@@ -46,7 +47,7 @@ def test_run_policy_ladder_tier_step_calls_on_admitted_for_each_within_tier_solu
         cancel_token=None,
         on_solution=None,
     ):
-        del max_solutions, time_limit_seconds, military_score_alpha
+        del race_id, max_solutions, time_limit_seconds, military_score_alpha
         del fixed_combo_counts, combo_count_neighborhood, cancel_token
         if on_solution is not None:
             on_solution(solution_one)

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.test.tsx
@@ -82,7 +82,7 @@ describe('InferenceDetailModal', () => {
     expect(screen.queryByText(/Priority points are diagnostic only/)).toBeNull()
     expect(screen.queryByText(/Change columns were missing/)).toBeNull()
     expect(screen.getByText('Solution 1 · Plausibility 999')).toBeInTheDocument()
-    expect(screen.getByText('Planet defense post')).toBeInTheDocument()
+    expect(screen.getByText('Planet defense post (2)')).toBeInTheDocument()
     expect(screen.getByText('Explained military change')).toBeInTheDocument()
     expect(screen.getByText('Observed military change')).toBeInTheDocument()
     expect(screen.queryByText('Best: two defense posts')).toBeNull()

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -13,7 +13,10 @@ import {
 import { InferenceSolutionLineIcon } from './inferenceSolutionLineIcon'
 import { readInferenceRunSummary } from './inferenceRunSummary'
 import { isRecord } from './scoresWireParsers'
-import { sortSolutionLineItemsForDisplay } from './solutionLineItemDisplayOrder'
+import {
+  formatSolutionLineItemLabel,
+  sortSolutionLineItemsForDisplay,
+} from './solutionLineItemDisplayOrder'
 
 type InferenceDetailModalProps = {
   isOpen: boolean
@@ -50,7 +53,7 @@ function SolutionActionTable({
               <td className="py-1 pr-2 align-middle">
                 <InferenceSolutionLineIcon line={line} shipBuilds={solution.shipBuilds} />
               </td>
-              <td className="py-1 pr-2">{line.label}</td>
+              <td className="py-1 pr-2">{formatSolutionLineItemLabel(line)}</td>
               <td className="py-1 tabular-nums">
                 {formatSignedDelta(line.militaryChangeSubtotal)}
               </td>

--- a/packages/frontend/src/analytics/scores/inferenceRowStreamState.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceRowStreamState.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   initialRowStreamState,
+  playerIdsFromStableKey,
   reduceRowStreamState,
   rowDetailFromStreamState,
+  stableAnalyticScopeKey,
   stablePlayerIdsKey,
 } from './inferenceRowStreamState'
 
@@ -10,6 +12,21 @@ describe('stablePlayerIdsKey', () => {
   it('sorts ids so order changes do not alter the key', () => {
     expect(stablePlayerIdsKey([9, 8])).toBe('8,9')
     expect(stablePlayerIdsKey([8, 9])).toBe('8,9')
+  })
+})
+
+describe('stableAnalyticScopeKey', () => {
+  it('keys scope by game, turn, and perspective', () => {
+    expect(
+      stableAnalyticScopeKey({ gameId: '628580', turn: 111, perspective: 1 })
+    ).toBe('628580:111:1')
+  })
+})
+
+describe('playerIdsFromStableKey', () => {
+  it('round-trips sorted player ids', () => {
+    expect(playerIdsFromStableKey('8,9')).toEqual([8, 9])
+    expect(playerIdsFromStableKey('')).toEqual([])
   })
 })
 

--- a/packages/frontend/src/analytics/scores/inferenceRowStreamState.ts
+++ b/packages/frontend/src/analytics/scores/inferenceRowStreamState.ts
@@ -191,3 +191,18 @@ export function reduceRowStreamState(
 export function stablePlayerIdsKey(playerIds: readonly number[]): string {
   return [...playerIds].sort((left, right) => left - right).join(',')
 }
+
+export function stableAnalyticScopeKey(scope: {
+  gameId: string
+  turn: number
+  perspective: number
+}): string {
+  return `${scope.gameId}:${scope.turn}:${scope.perspective}`
+}
+
+export function playerIdsFromStableKey(playerIdsKey: string): number[] {
+  if (playerIdsKey.length === 0) {
+    return []
+  }
+  return playerIdsKey.split(',').map((part) => Number(part))
+}

--- a/packages/frontend/src/analytics/scores/solutionLineItemDisplayOrder.test.ts
+++ b/packages/frontend/src/analytics/scores/solutionLineItemDisplayOrder.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { MilitaryScoreLineItem } from './inferenceConstraints'
-import { sortSolutionLineItemsForDisplay } from './solutionLineItemDisplayOrder'
+import {
+  formatSolutionLineItemLabel,
+  sortSolutionLineItemsForDisplay,
+} from './solutionLineItemDisplayOrder'
 
 function line(actionId: string, label = actionId): MilitaryScoreLineItem {
   return {
@@ -13,6 +16,32 @@ function line(actionId: string, label = actionId): MilitaryScoreLineItem {
     militaryChangeSubtotal: 1,
   }
 }
+
+describe('formatSolutionLineItemLabel', () => {
+  it('appends aggregate counts in brackets', () => {
+    expect(
+      formatSolutionLineItemLabel({
+        ...line('planet_defense_posts_added_total', 'Planet defense posts added'),
+        count: 2,
+      })
+    ).toBe('Planet defense posts added (2)')
+    expect(
+      formatSolutionLineItemLabel({
+        ...line('ship_torps_loaded_8', 'Ship torpedoes loaded (Mark 8 Photon)'),
+        count: 23,
+      })
+    ).toBe('Ship torpedoes loaded (Mark 8 Photon) (23)')
+  })
+
+  it('leaves ship build labels unchanged', () => {
+    expect(
+      formatSolutionLineItemLabel({
+        ...line('combo_13_9_3_6_8_6', 'Build Missouri: 2x Transwarp Drive'),
+        count: 1,
+      })
+    ).toBe('Build Missouri: 2x Transwarp Drive')
+  })
+})
 
 describe('sortSolutionLineItemsForDisplay', () => {
   it('orders ships, starbase defense, planet defense, fighters, then torps', () => {

--- a/packages/frontend/src/analytics/scores/solutionLineItemDisplayOrder.ts
+++ b/packages/frontend/src/analytics/scores/solutionLineItemDisplayOrder.ts
@@ -1,9 +1,17 @@
-import { inferenceActionDisplayRank } from './inferenceActionFamily'
+import { inferenceActionDisplayRank, isComboActionId } from './inferenceActionFamily'
 import type { MilitaryScoreLineItem } from './inferenceConstraints'
 
 /** Player-facing row order within a solution action table. */
 export function solutionLineItemDisplayRank(actionId: string): number {
   return inferenceActionDisplayRank(actionId)
+}
+
+/** Player-facing action label; aggregate rows include the built count in brackets. */
+export function formatSolutionLineItemLabel(line: MilitaryScoreLineItem): string {
+  if (isComboActionId(line.actionId)) {
+    return line.label
+  }
+  return `${line.label} (${line.count})`
 }
 
 export function sortSolutionLineItemsForDisplay(

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -233,6 +233,51 @@ describe('useScoresInferenceByRow', () => {
     expect(onGlobalPauseChange).toHaveBeenCalledWith(false)
   })
 
+  it('does not reconnect when scope object identity changes but values stay the same', async () => {
+    let streamCallCount = 0
+    vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
+      async (_scope, _playerIds, { signal, onEvent }) => {
+        streamCallCount += 1
+        onEvent({
+          type: 'solution',
+          playerId: 8,
+          solutions: [
+            {
+              objectiveValue: 10,
+              actions: [{ actionId: 'a1', label: 'Build fighter', count: 1 }],
+            },
+          ],
+        })
+        await new Promise<void>((resolve) => {
+          signal?.addEventListener('abort', () => {
+            resolve()
+          })
+        })
+      }
+    )
+
+    const { result, rerender } = renderHook(
+      ({ activeScope }) => useScoresInferenceByRow(tableData, activeScope, true),
+      {
+        initialProps: {
+          activeScope: { ...scope },
+        },
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.solutionCount).toBe(1)
+    })
+    expect(streamCallCount).toBe(1)
+
+    rerender({ activeScope: { ...scope } })
+
+    await waitFor(() => {
+      expect(result.current.inferenceByRow?.[0]?.solutionCount).toBe(1)
+    })
+    expect(streamCallCount).toBe(1)
+  })
+
   it('refreshInference restarts the table stream and applies new row results', async () => {
     let streamCallCount = 0
     let releaseSecondStream: (() => void) | null = null

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
@@ -6,8 +6,10 @@ import {
   failureDetail,
   initialRowStreamState,
   pendingDetail,
+  playerIdsFromStableKey,
   reduceRowStreamState,
   rowDetailFromStreamState,
+  stableAnalyticScopeKey,
   stablePlayerIdsKey,
   type RowStreamState,
 } from './inferenceRowStreamState'
@@ -29,22 +31,34 @@ export function useScoresInferenceByRow(
   options: UseScoresInferenceByRowOptions = {}
 ): UseScoresInferenceByRowResult {
   const { onGlobalPauseChange } = options
-  const stubs =
-    enabled && tableData?.inferenceByRow != null ? tableData.inferenceByRow : []
-  const playerIds = stubs
-    .map((stub) => stub.playerId)
-    .filter((id): id is number => typeof id === 'number')
-  const playerIdsKey = useMemo(() => stablePlayerIdsKey(playerIds), [playerIds])
+  const inferenceByRowStubs = tableData?.inferenceByRow
   const [refreshToken, setRefreshToken] = useState(0)
   const refreshInference = useCallback(() => {
     setRefreshToken((value) => value + 1)
   }, [])
+  const playerIdsKey = useMemo(() => {
+    if (!enabled || inferenceByRowStubs == null) {
+      return ''
+    }
+    const playerIds = inferenceByRowStubs
+      .map((stub) => stub.playerId)
+      .filter((id): id is number => typeof id === 'number')
+    return stablePlayerIdsKey(playerIds)
+  }, [enabled, inferenceByRowStubs])
+  const scopeKey = scope != null ? stableAnalyticScopeKey(scope) : null
+  const connectionKey =
+    enabled && scopeKey != null && playerIdsKey.length > 0
+      ? `${scopeKey}:${playerIdsKey}:${refreshToken}`
+      : null
 
   const [detailsByPlayerId, setDetailsByPlayerId] = useState<
     Map<number, ScoresInferenceRowDetail>
   >(new Map())
   const tableAbortControllerRef = useRef<AbortController | null>(null)
   const rowStreamStateRef = useRef<Map<number, RowStreamState>>(new Map())
+  const connectionKeyRef = useRef<string | null>(null)
+  const scopeRef = useRef(scope)
+  scopeRef.current = scope
 
   const publishPlayerState = useCallback((playerId: number) => {
     const state = rowStreamStateRef.current.get(playerId)
@@ -98,35 +112,51 @@ export function useScoresInferenceByRow(
     },
     [applyGlobalPauseEvent, applyStreamEvent]
   )
+  const handleTableStreamEventRef = useRef(handleTableStreamEvent)
+  handleTableStreamEventRef.current = handleTableStreamEvent
+  const onGlobalPauseChangeRef = useRef(onGlobalPauseChange)
+  onGlobalPauseChangeRef.current = onGlobalPauseChange
 
   useEffect(() => {
-    if (!enabled || scope == null || playerIds.length === 0) {
+    if (connectionKey == null) {
+      connectionKeyRef.current = null
       setDetailsByPlayerId(new Map())
       rowStreamStateRef.current = new Map()
-      onGlobalPauseChange?.(false)
+      onGlobalPauseChangeRef.current?.(false)
       return
     }
 
+    const activeScope = scopeRef.current
+    if (activeScope == null) {
+      return
+    }
+
+    const isNewConnection = connectionKeyRef.current !== connectionKey
+    connectionKeyRef.current = connectionKey
+    const playerIds = playerIdsFromStableKey(playerIdsKey)
+
     tableAbortControllerRef.current?.abort()
 
-    const initialStates = new Map<number, RowStreamState>()
-    for (const playerId of playerIds) {
-      initialStates.set(playerId, initialRowStreamState())
-    }
-    rowStreamStateRef.current = initialStates
+    if (isNewConnection) {
+      const initialStates = new Map<number, RowStreamState>()
+      for (const playerId of playerIds) {
+        initialStates.set(playerId, initialRowStreamState())
+      }
+      rowStreamStateRef.current = initialStates
 
-    const initialDetails = new Map<number, ScoresInferenceRowDetail>()
-    for (const playerId of playerIds) {
-      initialDetails.set(playerId, pendingDetail(playerId))
+      const initialDetails = new Map<number, ScoresInferenceRowDetail>()
+      for (const playerId of playerIds) {
+        initialDetails.set(playerId, pendingDetail(playerId))
+      }
+      setDetailsByPlayerId(initialDetails)
     }
-    setDetailsByPlayerId(initialDetails)
 
     const controller = new AbortController()
     tableAbortControllerRef.current = controller
 
-    void connectTableInferenceStream(scope, playerIds, {
+    void connectTableInferenceStream(activeScope, playerIds, {
       signal: controller.signal,
-      onEvent: handleTableStreamEvent,
+      onEvent: (event) => handleTableStreamEventRef.current(event),
     })
       .then((result) => {
         if (controller.signal.aborted || result !== 'conflict_exhausted') {
@@ -150,33 +180,33 @@ export function useScoresInferenceByRow(
         })
       })
       .catch((error) => {
-      if (controller.signal.aborted) {
-        return
-      }
-      setDetailsByPlayerId((previous) => {
-        const next = new Map(previous)
-        for (const playerId of playerIds) {
-          if (next.get(playerId)?.isComplete) {
-            continue
-          }
-          next.set(playerId, failureDetail(playerId, errorDetailFromUnknown(error)))
+        if (controller.signal.aborted) {
+          return
         }
-        return next
+        setDetailsByPlayerId((previous) => {
+          const next = new Map(previous)
+          for (const playerId of playerIds) {
+            if (next.get(playerId)?.isComplete) {
+              continue
+            }
+            next.set(playerId, failureDetail(playerId, errorDetailFromUnknown(error)))
+          }
+          return next
+        })
       })
-    })
 
     return () => {
       controller.abort()
       tableAbortControllerRef.current = null
-      onGlobalPauseChange?.(false)
+      onGlobalPauseChangeRef.current?.(false)
     }
-  }, [enabled, scope, playerIdsKey, refreshToken, handleTableStreamEvent, onGlobalPauseChange])
+  }, [connectionKey, playerIdsKey])
 
   if (!enabled || tableData?.inferenceByRow == null) {
     return { inferenceByRow: undefined, refreshInference }
   }
 
-  const inferenceByRow = stubs.map((stub, rowIndex) => {
+  const inferenceByRow = tableData.inferenceByRow.map((stub, rowIndex) => {
     const playerId = stub.playerId
     if (typeof playerId !== 'number') {
       return failureDetail(-(rowIndex + 1), 'Missing player id for build inference')


### PR DESCRIPTION
## Summary
- Exclude Horwasp players from prior mining extraction and short-circuit the military score inference solver with `horwasp_unsupported` until race-specific mechanics are modeled.
- Pass `race_id` through `InferenceProblem` and policy-ladder solves; corpus harness records Horwasp cases as `skipped_unsupported_race`.
- Show built counts in brackets on aggregate solution line items in the inference detail modal.
- Stabilize `useScoresInferenceByRow` so inference streams do not reconnect when the scope object identity changes but values stay the same.

## Test plan
- [x] `make test_api`
- [x] `make test_frontend`
- [x] Open build inference on a non-Horwasp row and confirm aggregate labels show counts like `Planet defense posts added (2)`
- [x] Confirm Horwasp scoreboard rows do not attempt solver inference


Made with [Cursor](https://cursor.com)