### PR TITLE
Fleet F1.1: Domain types (#116)

### DIFF
--- a/packages/api/api/analytics/fleet/__init__.py
+++ b/packages/api/api/analytics/fleet/__init__.py
@@ -1,4 +1,4 @@
-"""Core Fleet turn analytic (registration shell)."""
+"""Core Fleet turn analytic."""
 
 from api.analytics.catalog import catalog_entry
 from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -1,0 +1,577 @@
+"""JSON codecs for fleet analytic domain types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.analytics.fleet.types import (
+    FLEET_BOUNDED_OPERATORS,
+    FLEET_EVIDENCE_EVENT_KINDS,
+    FLEET_SHIP_DISPOSITIONS,
+    FleetAcquisitionLedger,
+    FleetAlibi,
+    FleetBuildOptionSet,
+    FleetCountDiscrepancy,
+    FleetEvidenceEvent,
+    FleetFieldBounded,
+    FleetFieldConstraint,
+    FleetFieldKnown,
+    FleetFieldOptions,
+    FleetFieldRegion,
+    FleetFieldRegionStarbaseCoord,
+    FleetFieldUnknown,
+    FleetLastSeen,
+    FleetPossiblyLost,
+    FleetRowQualifiers,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+)
+from api.errors import ValidationError
+
+
+def _require_object_list(raw: object, *, field_name: str) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise ValidationError(f"{field_name} must be a list")
+    entries: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise ValidationError(f"{field_name}[{index}] must be an object")
+        entries.append(item)
+    return entries
+
+
+def _require_int_field(data: dict[str, Any], key: str, *, field_name: str) -> int:
+    value = data.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValidationError(f"{field_name} {key} must be an int")
+    return value
+
+
+def append_fleet_evidence_event(
+    record: FleetShipRecord,
+    event: FleetEvidenceEvent,
+) -> None:
+    """Append one evidence event to a ship record timeline."""
+    record.events.append(event)
+
+
+def fleet_field_constraint_to_json(constraint: FleetFieldConstraint) -> dict[str, Any]:
+    if isinstance(constraint, FleetFieldKnown):
+        return {"kind": "known", "value": constraint.value}
+    if isinstance(constraint, FleetFieldUnknown):
+        return {"kind": "unknown"}
+    if isinstance(constraint, FleetFieldBounded):
+        return {
+            "kind": "bounded",
+            "operator": constraint.operator,
+            "value": constraint.value,
+        }
+    if isinstance(constraint, FleetFieldOptions):
+        return {"kind": "options", "values": list(constraint.values)}
+    if isinstance(constraint, FleetFieldRegion):
+        payload: dict[str, Any] = {"kind": "region"}
+        if constraint.planet_ids:
+            payload["planetIds"] = list(constraint.planet_ids)
+        if constraint.starbase_coords:
+            payload["starbaseCoords"] = [
+                {"x": coord.x, "y": coord.y} for coord in constraint.starbase_coords
+            ]
+        if constraint.overlay_id is not None:
+            payload["overlayId"] = constraint.overlay_id
+        return payload
+    raise TypeError(f"unsupported fleet field constraint: {type(constraint).__name__}")
+
+
+def fleet_field_constraint_from_json(data: dict[str, Any]) -> FleetFieldConstraint:
+    kind = data.get("kind")
+    if kind == "known":
+        value = data.get("value")
+        if not isinstance(value, (int, str, float, bool)):
+            raise ValidationError("fleet field constraint known value must be scalar")
+        return FleetFieldKnown(value=value)
+    if kind == "unknown":
+        return FleetFieldUnknown()
+    if kind == "bounded":
+        operator = data.get("operator")
+        value = data.get("value")
+        if operator not in FLEET_BOUNDED_OPERATORS:
+            raise ValidationError("fleet field constraint bounded operator is invalid")
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ValidationError("fleet field constraint bounded value must be numeric")
+        return FleetFieldBounded(operator=operator, value=value)
+    if kind == "options":
+        raw_values = data.get("values")
+        if not isinstance(raw_values, list) or not raw_values:
+            raise ValidationError("fleet field constraint options requires non-empty values")
+        values: list[int | str] = []
+        for entry in raw_values:
+            if not isinstance(entry, (int, str)) or isinstance(entry, bool):
+                raise ValidationError("fleet field constraint options values must be int or str")
+            values.append(entry)
+        return FleetFieldOptions(values=tuple(values))
+    if kind == "region":
+        planet_ids_raw = data.get("planetIds", [])
+        if not isinstance(planet_ids_raw, list):
+            raise ValidationError("fleet field constraint region planetIds must be a list")
+        planet_ids: list[int] = []
+        for planet_id in planet_ids_raw:
+            if not isinstance(planet_id, int) or isinstance(planet_id, bool):
+                raise ValidationError("fleet field constraint region planetIds must be integers")
+            planet_ids.append(planet_id)
+
+        starbase_coords_raw = data.get("starbaseCoords", [])
+        if not isinstance(starbase_coords_raw, list):
+            raise ValidationError("fleet field constraint region starbaseCoords must be a list")
+        starbase_coords: list[FleetFieldRegionStarbaseCoord] = []
+        for coord in starbase_coords_raw:
+            if not isinstance(coord, dict):
+                raise ValidationError(
+                    "fleet field constraint region starbaseCoords entries must be objects"
+                )
+            x = coord.get("x")
+            y = coord.get("y")
+            if not isinstance(x, int) or isinstance(x, bool):
+                raise ValidationError("fleet field constraint region starbaseCoords x must be int")
+            if not isinstance(y, int) or isinstance(y, bool):
+                raise ValidationError("fleet field constraint region starbaseCoords y must be int")
+            starbase_coords.append(FleetFieldRegionStarbaseCoord(x=x, y=y))
+
+        overlay_id = data.get("overlayId")
+        if overlay_id is not None and not isinstance(overlay_id, str):
+            raise ValidationError("fleet field constraint region overlayId must be a string")
+
+        if not planet_ids and not starbase_coords and overlay_id is None:
+            raise ValidationError("fleet field constraint region requires at least one locator")
+
+        return FleetFieldRegion(
+            planet_ids=tuple(planet_ids),
+            starbase_coords=tuple(starbase_coords),
+            overlay_id=overlay_id,
+        )
+    raise ValidationError(f"unknown fleet field constraint kind: {kind!r}")
+
+
+def fleet_build_option_set_to_json(option_set: FleetBuildOptionSet) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "label": option_set.label,
+        "solutionRankWeight": option_set.solution_rank_weight,
+        "beamCount": option_set.beam_count,
+        "launcherCount": option_set.launcher_count,
+    }
+    if option_set.combo_id is not None:
+        payload["comboId"] = option_set.combo_id
+    if option_set.hull_id is not None:
+        payload["hullId"] = option_set.hull_id
+    if option_set.engine_id is not None:
+        payload["engineId"] = option_set.engine_id
+    if option_set.beam_id is not None:
+        payload["beamId"] = option_set.beam_id
+    if option_set.torp_id is not None:
+        payload["torpId"] = option_set.torp_id
+    return payload
+
+
+def fleet_build_option_set_from_json(data: dict[str, Any]) -> FleetBuildOptionSet:
+    combo_id = data.get("comboId")
+    if combo_id is not None and not isinstance(combo_id, str):
+        raise ValidationError("fleet build option set comboId must be a string")
+
+    label = data.get("label", "")
+    if not isinstance(label, str):
+        raise ValidationError("fleet build option set label must be a string")
+
+    solution_rank_weight = data.get("solutionRankWeight", 0)
+    if not isinstance(solution_rank_weight, int) or isinstance(solution_rank_weight, bool):
+        raise ValidationError("fleet build option set solutionRankWeight must be an int")
+
+    beam_count = data.get("beamCount", 0)
+    if not isinstance(beam_count, int) or isinstance(beam_count, bool):
+        raise ValidationError("fleet build option set beamCount must be an int")
+
+    launcher_count = data.get("launcherCount", 0)
+    if not isinstance(launcher_count, int) or isinstance(launcher_count, bool):
+        raise ValidationError("fleet build option set launcherCount must be an int")
+
+    hull_id = data.get("hullId")
+    if hull_id is not None and (not isinstance(hull_id, int) or isinstance(hull_id, bool)):
+        raise ValidationError("fleet build option set hullId must be an int")
+
+    engine_id = data.get("engineId")
+    if engine_id is not None and (not isinstance(engine_id, int) or isinstance(engine_id, bool)):
+        raise ValidationError("fleet build option set engineId must be an int")
+
+    beam_id = data.get("beamId")
+    if beam_id is not None and (not isinstance(beam_id, int) or isinstance(beam_id, bool)):
+        raise ValidationError("fleet build option set beamId must be an int")
+
+    torp_id = data.get("torpId")
+    if torp_id is not None and (not isinstance(torp_id, int) or isinstance(torp_id, bool)):
+        raise ValidationError("fleet build option set torpId must be an int")
+
+    return FleetBuildOptionSet(
+        combo_id=combo_id,
+        label=label,
+        solution_rank_weight=solution_rank_weight,
+        hull_id=hull_id,
+        engine_id=engine_id,
+        beam_id=beam_id,
+        torp_id=torp_id,
+        beam_count=beam_count,
+        launcher_count=launcher_count,
+    )
+
+
+def fleet_last_seen_to_json(last_seen: FleetLastSeen) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "turn": last_seen.turn,
+        "x": last_seen.x,
+        "y": last_seen.y,
+    }
+    if last_seen.planet_id is not None:
+        payload["planetId"] = last_seen.planet_id
+    return payload
+
+
+def fleet_last_seen_from_json(data: dict[str, Any]) -> FleetLastSeen:
+    turn = data.get("turn")
+    x = data.get("x")
+    y = data.get("y")
+    if not isinstance(turn, int) or isinstance(turn, bool):
+        raise ValidationError("fleet last seen turn must be an int")
+    if not isinstance(x, int) or isinstance(x, bool):
+        raise ValidationError("fleet last seen x must be an int")
+    if not isinstance(y, int) or isinstance(y, bool):
+        raise ValidationError("fleet last seen y must be an int")
+    planet_id = data.get("planetId")
+    if planet_id is not None and (not isinstance(planet_id, int) or isinstance(planet_id, bool)):
+        raise ValidationError("fleet last seen planetId must be an int")
+    return FleetLastSeen(turn=turn, x=x, y=y, planet_id=planet_id)
+
+
+def fleet_row_qualifiers_to_json(qualifiers: FleetRowQualifiers) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if qualifiers.possibly_lost is not None:
+        payload["possiblyLost"] = {
+            "sinceTurn": qualifiers.possibly_lost.since_turn,
+            "source": qualifiers.possibly_lost.source,
+        }
+    if qualifiers.alibi is not None:
+        payload["alibi"] = {
+            "afterTurn": qualifiers.alibi.after_turn,
+            "sightingTurn": qualifiers.alibi.sighting_turn,
+            "source": qualifiers.alibi.source,
+        }
+    return payload
+
+
+def fleet_row_qualifiers_from_json(data: dict[str, Any]) -> FleetRowQualifiers:
+    possibly_lost_raw = data.get("possiblyLost")
+    possibly_lost: FleetPossiblyLost | None = None
+    if possibly_lost_raw is not None:
+        if not isinstance(possibly_lost_raw, dict):
+            raise ValidationError("fleet qualifiers possiblyLost must be an object")
+        since_turn = possibly_lost_raw.get("sinceTurn")
+        if not isinstance(since_turn, int) or isinstance(since_turn, bool):
+            raise ValidationError("fleet qualifiers possiblyLost sinceTurn must be an int")
+        source = possibly_lost_raw.get("source", "")
+        if not isinstance(source, str):
+            raise ValidationError("fleet qualifiers possiblyLost source must be a string")
+        possibly_lost = FleetPossiblyLost(since_turn=since_turn, source=source)
+
+    alibi_raw = data.get("alibi")
+    alibi: FleetAlibi | None = None
+    if alibi_raw is not None:
+        if not isinstance(alibi_raw, dict):
+            raise ValidationError("fleet qualifiers alibi must be an object")
+        after_turn = alibi_raw.get("afterTurn")
+        sighting_turn = alibi_raw.get("sightingTurn")
+        if not isinstance(after_turn, int) or isinstance(after_turn, bool):
+            raise ValidationError("fleet qualifiers alibi afterTurn must be an int")
+        if not isinstance(sighting_turn, int) or isinstance(sighting_turn, bool):
+            raise ValidationError("fleet qualifiers alibi sightingTurn must be an int")
+        source = alibi_raw.get("source", "")
+        if not isinstance(source, str):
+            raise ValidationError("fleet qualifiers alibi source must be a string")
+        alibi = FleetAlibi(
+            after_turn=after_turn,
+            sighting_turn=sighting_turn,
+            source=source,
+        )
+
+    return FleetRowQualifiers(possibly_lost=possibly_lost, alibi=alibi)
+
+
+def fleet_evidence_event_to_json(event: FleetEvidenceEvent) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "eventId": event.event_id,
+        "kind": event.kind,
+        "turn": event.turn,
+        "source": event.source,
+    }
+    if event.payload:
+        payload["payload"] = event.payload
+    return payload
+
+
+def fleet_evidence_event_from_json(data: dict[str, Any]) -> FleetEvidenceEvent:
+    event_id = data.get("eventId")
+    kind = data.get("kind")
+    turn = data.get("turn")
+    source = data.get("source")
+    if not isinstance(event_id, str):
+        raise ValidationError("fleet evidence event eventId must be a string")
+    if not isinstance(kind, str):
+        raise ValidationError("fleet evidence event kind must be a string")
+    if kind not in FLEET_EVIDENCE_EVENT_KINDS:
+        raise ValidationError("fleet evidence event kind is invalid")
+    if not isinstance(turn, int) or isinstance(turn, bool):
+        raise ValidationError("fleet evidence event turn must be an int")
+    if not isinstance(source, str):
+        raise ValidationError("fleet evidence event source must be a string")
+    payload = data.get("payload", {})
+    if payload is None:
+        payload = {}
+    if not isinstance(payload, dict):
+        raise ValidationError("fleet evidence event payload must be an object")
+    return FleetEvidenceEvent(
+        event_id=event_id,
+        kind=kind,
+        turn=turn,
+        source=source,
+        payload=payload,
+    )
+
+
+def fleet_ship_record_fields_to_json(fields: FleetShipRecordFields) -> dict[str, Any]:
+    return {
+        "shipId": fleet_field_constraint_to_json(fields.ship_id),
+        "hull": fleet_field_constraint_to_json(fields.hull),
+        "engine": fleet_field_constraint_to_json(fields.engine),
+        "beams": fleet_field_constraint_to_json(fields.beams),
+        "launchers": fleet_field_constraint_to_json(fields.launchers),
+        "builtTurn": fleet_field_constraint_to_json(fields.built_turn),
+        "location": fleet_field_constraint_to_json(fields.location),
+    }
+
+
+def fleet_ship_record_fields_from_json(data: dict[str, Any]) -> FleetShipRecordFields:
+    return FleetShipRecordFields(
+        ship_id=_required_field_constraint(data, "shipId"),
+        hull=_required_field_constraint(data, "hull"),
+        engine=_required_field_constraint(data, "engine"),
+        beams=_required_field_constraint(data, "beams"),
+        launchers=_required_field_constraint(data, "launchers"),
+        built_turn=_required_field_constraint(data, "builtTurn"),
+        location=_required_field_constraint(data, "location"),
+    )
+
+
+def _required_field_constraint(data: dict[str, Any], key: str) -> FleetFieldConstraint:
+    raw = data.get(key)
+    if not isinstance(raw, dict):
+        raise ValidationError(f"fleet ship record fields {key} must be an object")
+    return fleet_field_constraint_from_json(raw)
+
+
+def fleet_ship_record_to_json(record: FleetShipRecord) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "recordId": record.record_id,
+        "disposition": record.disposition,
+        "qualifiers": fleet_row_qualifiers_to_json(record.qualifiers),
+        "fields": fleet_ship_record_fields_to_json(record.fields),
+        "buildOptionSets": [
+            fleet_build_option_set_to_json(option_set)
+            for option_set in record.build_option_sets
+        ],
+        "events": [fleet_evidence_event_to_json(event) for event in record.events],
+    }
+    if record.display_default_option_set_index is not None:
+        payload["displayDefaultOptionSetIndex"] = record.display_default_option_set_index
+    if record.last_seen is not None:
+        payload["lastSeen"] = fleet_last_seen_to_json(record.last_seen)
+    return payload
+
+
+def fleet_ship_record_from_json(data: dict[str, Any]) -> FleetShipRecord:
+    record_id = data.get("recordId")
+    disposition = data.get("disposition", "active")
+    if not isinstance(record_id, str):
+        raise ValidationError("fleet ship record recordId must be a string")
+    if disposition not in FLEET_SHIP_DISPOSITIONS:
+        raise ValidationError("fleet ship record disposition is invalid")
+
+    qualifiers_raw = data.get("qualifiers", {})
+    if not isinstance(qualifiers_raw, dict):
+        raise ValidationError("fleet ship record qualifiers must be an object")
+
+    fields_raw = data.get("fields")
+    if not isinstance(fields_raw, dict):
+        raise ValidationError("fleet ship record fields must be an object")
+
+    build_option_sets = [
+        fleet_build_option_set_from_json(option_set)
+        for option_set in _require_object_list(
+            data.get("buildOptionSets", []),
+            field_name="fleet ship record buildOptionSets",
+        )
+    ]
+
+    events = [
+        fleet_evidence_event_from_json(event)
+        for event in _require_object_list(
+            data.get("events", []),
+            field_name="fleet ship record events",
+        )
+    ]
+
+    display_default_option_set_index = data.get("displayDefaultOptionSetIndex")
+    if display_default_option_set_index is not None and (
+        not isinstance(display_default_option_set_index, int)
+        or isinstance(display_default_option_set_index, bool)
+    ):
+        raise ValidationError("fleet ship record displayDefaultOptionSetIndex must be an int")
+    if display_default_option_set_index is not None:
+        if not build_option_sets:
+            raise ValidationError(
+                "fleet ship record displayDefaultOptionSetIndex requires buildOptionSets"
+            )
+        if not 0 <= display_default_option_set_index < len(build_option_sets):
+            raise ValidationError(
+                "fleet ship record displayDefaultOptionSetIndex is out of range"
+            )
+
+    last_seen_raw = data.get("lastSeen")
+    last_seen: FleetLastSeen | None = None
+    if last_seen_raw is not None:
+        if not isinstance(last_seen_raw, dict):
+            raise ValidationError("fleet ship record lastSeen must be an object")
+        last_seen = fleet_last_seen_from_json(last_seen_raw)
+
+    return FleetShipRecord(
+        record_id=record_id,
+        disposition=disposition,
+        qualifiers=fleet_row_qualifiers_from_json(qualifiers_raw),
+        fields=fleet_ship_record_fields_from_json(fields_raw),
+        build_option_sets=build_option_sets,
+        display_default_option_set_index=display_default_option_set_index,
+        last_seen=last_seen,
+        events=events,
+    )
+
+
+def fleet_count_discrepancy_to_json(discrepancy: FleetCountDiscrepancy) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "hostTurn": discrepancy.host_turn,
+        "activeRowCount": discrepancy.active_row_count,
+        "scoreboardImpliedCount": discrepancy.scoreboard_implied_count,
+    }
+    if discrepancy.report_refs:
+        payload["reportRefs"] = list(discrepancy.report_refs)
+    return payload
+
+
+def fleet_count_discrepancy_from_json(data: dict[str, Any]) -> FleetCountDiscrepancy:
+    host_turn = data.get("hostTurn")
+    active_row_count = data.get("activeRowCount")
+    scoreboard_implied_count = data.get("scoreboardImpliedCount")
+    if not isinstance(host_turn, int) or isinstance(host_turn, bool):
+        raise ValidationError("fleet count discrepancy hostTurn must be an int")
+    if not isinstance(active_row_count, int) or isinstance(active_row_count, bool):
+        raise ValidationError("fleet count discrepancy activeRowCount must be an int")
+    if not isinstance(scoreboard_implied_count, int) or isinstance(scoreboard_implied_count, bool):
+        raise ValidationError("fleet count discrepancy scoreboardImpliedCount must be an int")
+
+    report_refs_raw = data.get("reportRefs", [])
+    if not isinstance(report_refs_raw, list):
+        raise ValidationError("fleet count discrepancy reportRefs must be a list")
+    report_refs: list[str] = []
+    for report_ref in report_refs_raw:
+        if not isinstance(report_ref, str):
+            raise ValidationError("fleet count discrepancy reportRefs entries must be strings")
+        report_refs.append(report_ref)
+
+    return FleetCountDiscrepancy(
+        host_turn=host_turn,
+        active_row_count=active_row_count,
+        scoreboard_implied_count=scoreboard_implied_count,
+        report_refs=tuple(report_refs),
+    )
+
+
+def fleet_acquisition_ledger_to_json(ledger: FleetAcquisitionLedger) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "playerId": ledger.player_id,
+        "playerName": ledger.player_name,
+        "records": [fleet_ship_record_to_json(record) for record in ledger.records],
+    }
+    if ledger.discrepancy is not None:
+        payload["discrepancy"] = fleet_count_discrepancy_to_json(ledger.discrepancy)
+    return payload
+
+
+def fleet_acquisition_ledger_from_json(data: dict[str, Any]) -> FleetAcquisitionLedger:
+    player_id = data.get("playerId")
+    if not isinstance(player_id, int) or isinstance(player_id, bool):
+        raise ValidationError("fleet acquisition ledger playerId must be an int")
+
+    player_name = data.get("playerName", "")
+    if not isinstance(player_name, str):
+        raise ValidationError("fleet acquisition ledger playerName must be a string")
+
+    discrepancy_raw = data.get("discrepancy")
+    discrepancy: FleetCountDiscrepancy | None = None
+    if discrepancy_raw is not None:
+        if not isinstance(discrepancy_raw, dict):
+            raise ValidationError("fleet acquisition ledger discrepancy must be an object")
+        discrepancy = fleet_count_discrepancy_from_json(discrepancy_raw)
+
+    return FleetAcquisitionLedger(
+        player_id=player_id,
+        player_name=player_name,
+        records=[
+            fleet_ship_record_from_json(record)
+            for record in _require_object_list(
+                data.get("records", []),
+                field_name="fleet acquisition ledger records",
+            )
+        ],
+        discrepancy=discrepancy,
+    )
+
+
+def fleet_turn_snapshot_to_json(snapshot: FleetTurnSnapshot) -> dict[str, Any]:
+    return {
+        "analyticId": snapshot.analytic_id,
+        "gameId": snapshot.game_id,
+        "perspective": snapshot.perspective,
+        "turn": snapshot.turn,
+        "players": [
+            fleet_acquisition_ledger_to_json(player_ledger)
+            for player_ledger in snapshot.players
+        ],
+    }
+
+
+def fleet_turn_snapshot_from_json(data: dict[str, Any]) -> FleetTurnSnapshot:
+    analytic_id = data.get("analyticId", "fleet")
+    if not isinstance(analytic_id, str):
+        raise ValidationError("fleet turn snapshot analyticId must be a string")
+
+    game_id = _require_int_field(data, "gameId", field_name="fleet turn snapshot")
+    perspective = _require_int_field(data, "perspective", field_name="fleet turn snapshot")
+    turn = _require_int_field(data, "turn", field_name="fleet turn snapshot")
+
+    return FleetTurnSnapshot(
+        analytic_id=analytic_id,
+        game_id=game_id,
+        perspective=perspective,
+        turn=turn,
+        players=[
+            fleet_acquisition_ledger_from_json(player_ledger)
+            for player_ledger in _require_object_list(
+                data.get("players", []),
+                field_name="fleet turn snapshot players",
+            )
+        ],
+    )

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -381,8 +381,7 @@ def fleet_ship_record_to_json(record: FleetShipRecord) -> dict[str, Any]:
         "qualifiers": fleet_row_qualifiers_to_json(record.qualifiers),
         "fields": fleet_ship_record_fields_to_json(record.fields),
         "buildOptionSets": [
-            fleet_build_option_set_to_json(option_set)
-            for option_set in record.build_option_sets
+            fleet_build_option_set_to_json(option_set) for option_set in record.build_option_sets
         ],
         "events": [fleet_evidence_event_to_json(event) for event in record.events],
     }
@@ -437,9 +436,7 @@ def fleet_ship_record_from_json(data: dict[str, Any]) -> FleetShipRecord:
                 "fleet ship record displayDefaultOptionSetIndex requires buildOptionSets"
             )
         if not 0 <= display_default_option_set_index < len(build_option_sets):
-            raise ValidationError(
-                "fleet ship record displayDefaultOptionSetIndex is out of range"
-            )
+            raise ValidationError("fleet ship record displayDefaultOptionSetIndex is out of range")
 
     last_seen_raw = data.get("lastSeen")
     last_seen: FleetLastSeen | None = None
@@ -547,8 +544,7 @@ def fleet_turn_snapshot_to_json(snapshot: FleetTurnSnapshot) -> dict[str, Any]:
         "perspective": snapshot.perspective,
         "turn": snapshot.turn,
         "players": [
-            fleet_acquisition_ledger_to_json(player_ledger)
-            for player_ledger in snapshot.players
+            fleet_acquisition_ledger_to_json(player_ledger) for player_ledger in snapshot.players
         ],
     }
 

--- a/packages/api/api/analytics/fleet/types.py
+++ b/packages/api/api/analytics/fleet/types.py
@@ -1,0 +1,183 @@
+"""Domain types for the fleet turn analytic ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+FleetShipDisposition = Literal["active", "lost", "traded", "unknown"]
+
+FleetBoundedOperator = Literal["lte", "gte", "lt", "gt", "eq"]
+
+FleetEvidenceEventKind = Literal[
+    "scoreboard_delta",
+    "inference_update",
+    "sighting",
+    "position_update",
+    "id_bound_tightened",
+    "option_set_match",
+    "disposition_change",
+    "alibi",
+    "possibly_lost",
+    "reconciliation_correction",
+    "report",
+]
+
+FLEET_SHIP_DISPOSITIONS = frozenset({"active", "lost", "traded", "unknown"})
+
+FLEET_BOUNDED_OPERATORS = frozenset({"lte", "gte", "lt", "gt", "eq"})
+
+FLEET_EVIDENCE_EVENT_KINDS = frozenset(
+    {
+        "scoreboard_delta",
+        "inference_update",
+        "sighting",
+        "position_update",
+        "id_bound_tightened",
+        "option_set_match",
+        "disposition_change",
+        "alibi",
+        "possibly_lost",
+        "reconciliation_correction",
+        "report",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FleetFieldKnown:
+    value: int | str | float | bool
+
+
+@dataclass(frozen=True)
+class FleetFieldUnknown:
+    pass
+
+
+@dataclass(frozen=True)
+class FleetFieldBounded:
+    operator: FleetBoundedOperator
+    value: int | float
+
+
+@dataclass(frozen=True)
+class FleetFieldOptions:
+    values: tuple[int | str, ...]
+
+
+@dataclass(frozen=True)
+class FleetFieldRegionStarbaseCoord:
+    x: int
+    y: int
+
+
+@dataclass(frozen=True)
+class FleetFieldRegion:
+    planet_ids: tuple[int, ...] = ()
+    starbase_coords: tuple[FleetFieldRegionStarbaseCoord, ...] = ()
+    overlay_id: str | None = None
+
+
+FleetFieldConstraint = (
+    FleetFieldKnown
+    | FleetFieldUnknown
+    | FleetFieldBounded
+    | FleetFieldOptions
+    | FleetFieldRegion
+)
+
+@dataclass(frozen=True)
+class FleetBuildOptionSet:
+    combo_id: str | None = None
+    label: str = ""
+    solution_rank_weight: int = 0
+    hull_id: int | None = None
+    engine_id: int | None = None
+    beam_id: int | None = None
+    torp_id: int | None = None
+    beam_count: int = 0
+    launcher_count: int = 0
+
+
+@dataclass(frozen=True)
+class FleetLastSeen:
+    turn: int
+    x: int
+    y: int
+    planet_id: int | None = None
+
+
+@dataclass(frozen=True)
+class FleetPossiblyLost:
+    since_turn: int
+    source: str = ""
+
+
+@dataclass(frozen=True)
+class FleetAlibi:
+    after_turn: int
+    sighting_turn: int
+    source: str = ""
+
+
+@dataclass
+class FleetRowQualifiers:
+    possibly_lost: FleetPossiblyLost | None = None
+    alibi: FleetAlibi | None = None
+
+
+@dataclass(frozen=True)
+class FleetEvidenceEvent:
+    event_id: str
+    kind: FleetEvidenceEventKind
+    turn: int
+    source: str
+    payload: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class FleetShipRecordFields:
+    ship_id: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    hull: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    engine: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    beams: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    launchers: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    built_turn: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+    location: FleetFieldConstraint = field(default_factory=FleetFieldUnknown)
+
+
+@dataclass
+class FleetShipRecord:
+    record_id: str
+    disposition: FleetShipDisposition = "active"
+    qualifiers: FleetRowQualifiers = field(default_factory=FleetRowQualifiers)
+    fields: FleetShipRecordFields = field(default_factory=FleetShipRecordFields)
+    build_option_sets: list[FleetBuildOptionSet] = field(default_factory=list)
+    display_default_option_set_index: int | None = None
+    last_seen: FleetLastSeen | None = None
+    events: list[FleetEvidenceEvent] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FleetCountDiscrepancy:
+    host_turn: int
+    active_row_count: int
+    scoreboard_implied_count: int
+    report_refs: tuple[str, ...] = ()
+
+
+@dataclass
+class FleetAcquisitionLedger:
+    player_id: int
+    player_name: str = ""
+    records: list[FleetShipRecord] = field(default_factory=list)
+    discrepancy: FleetCountDiscrepancy | None = None
+
+
+@dataclass
+class FleetTurnSnapshot:
+    analytic_id: str = "fleet"
+    game_id: int = 0
+    perspective: int = 0
+    turn: int = 0
+    players: list[FleetAcquisitionLedger] = field(default_factory=list)

--- a/packages/api/api/analytics/fleet/types.py
+++ b/packages/api/api/analytics/fleet/types.py
@@ -79,12 +79,9 @@ class FleetFieldRegion:
 
 
 FleetFieldConstraint = (
-    FleetFieldKnown
-    | FleetFieldUnknown
-    | FleetFieldBounded
-    | FleetFieldOptions
-    | FleetFieldRegion
+    FleetFieldKnown | FleetFieldUnknown | FleetFieldBounded | FleetFieldOptions | FleetFieldRegion
 )
+
 
 @dataclass(frozen=True)
 class FleetBuildOptionSet:

--- a/packages/api/tests/test_fleet_domain.py
+++ b/packages/api/tests/test_fleet_domain.py
@@ -1,0 +1,362 @@
+"""Tests for fleet analytic domain types and JSON codecs."""
+
+from __future__ import annotations
+
+import pytest
+from api.analytics.fleet.serialization import (
+    append_fleet_evidence_event,
+    fleet_acquisition_ledger_from_json,
+    fleet_acquisition_ledger_to_json,
+    fleet_build_option_set_from_json,
+    fleet_build_option_set_to_json,
+    fleet_count_discrepancy_from_json,
+    fleet_count_discrepancy_to_json,
+    fleet_evidence_event_to_json,
+    fleet_field_constraint_from_json,
+    fleet_field_constraint_to_json,
+    fleet_ship_record_from_json,
+    fleet_ship_record_to_json,
+    fleet_turn_snapshot_from_json,
+    fleet_turn_snapshot_to_json,
+)
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetAlibi,
+    FleetBuildOptionSet,
+    FleetCountDiscrepancy,
+    FleetEvidenceEvent,
+    FleetFieldBounded,
+    FleetFieldKnown,
+    FleetFieldOptions,
+    FleetFieldRegion,
+    FleetFieldRegionStarbaseCoord,
+    FleetFieldUnknown,
+    FleetLastSeen,
+    FleetPossiblyLost,
+    FleetRowQualifiers,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+)
+from api.errors import ValidationError
+
+
+@pytest.mark.parametrize(
+    ("constraint", "wire"),
+    [
+        (FleetFieldKnown(value=318), {"kind": "known", "value": 318}),
+        (FleetFieldUnknown(), {"kind": "unknown"}),
+        (
+            FleetFieldBounded(operator="lte", value=318),
+            {"kind": "bounded", "operator": "lte", "value": 318},
+        ),
+        (
+            FleetFieldOptions(values=(9, 13)),
+            {"kind": "options", "values": [9, 13]},
+        ),
+        (
+            FleetFieldRegion(
+                planet_ids=(101, 202),
+                starbase_coords=(FleetFieldRegionStarbaseCoord(x=1000, y=2000),),
+                overlay_id="sb-region-1",
+            ),
+            {
+                "kind": "region",
+                "planetIds": [101, 202],
+                "starbaseCoords": [{"x": 1000, "y": 2000}],
+                "overlayId": "sb-region-1",
+            },
+        ),
+    ],
+)
+def test_fleet_field_constraint_round_trip(constraint, wire):
+    assert fleet_field_constraint_to_json(constraint) == wire
+    restored = fleet_field_constraint_from_json(wire)
+    assert restored == constraint
+    assert fleet_field_constraint_to_json(restored) == wire
+
+
+def test_fleet_build_option_set_round_trip():
+    option_set = FleetBuildOptionSet(
+        combo_id="combo_13_9_3_6_8_6",
+        label="Heavy Cruiser / Transwarp",
+        solution_rank_weight=42,
+        hull_id=13,
+        engine_id=9,
+        beam_id=3,
+        torp_id=6,
+        beam_count=8,
+        launcher_count=6,
+    )
+    wire = fleet_build_option_set_to_json(option_set)
+    restored = fleet_build_option_set_from_json(wire)
+    assert restored == option_set
+    assert fleet_build_option_set_to_json(restored) == wire
+
+
+def test_fleet_ship_record_round_trip_with_qualifiers_and_fields():
+    record = FleetShipRecord(
+        record_id="rec-1",
+        disposition="active",
+        qualifiers=FleetRowQualifiers(
+            possibly_lost=FleetPossiblyLost(since_turn=7, source="scoreboard"),
+            alibi=FleetAlibi(after_turn=7, sighting_turn=9, source="turnInfo.ships"),
+        ),
+        fields=FleetShipRecordFields(
+            ship_id=FleetFieldBounded(operator="lte", value=318),
+            hull=FleetFieldKnown(value=13),
+            engine=FleetFieldKnown(value=9),
+            beams=FleetFieldOptions(values=(3, 5)),
+            launchers=FleetFieldUnknown(),
+            built_turn=FleetFieldKnown(value=4),
+            location=FleetFieldRegion(planet_ids=(55,)),
+        ),
+        build_option_sets=[
+            FleetBuildOptionSet(
+                combo_id="combo_a",
+                label="Option A",
+                solution_rank_weight=10,
+                hull_id=13,
+                engine_id=9,
+            ),
+            FleetBuildOptionSet(
+                combo_id="combo_b",
+                label="Option B",
+                solution_rank_weight=5,
+                hull_id=1,
+                engine_id=2,
+            ),
+        ],
+        display_default_option_set_index=0,
+        last_seen=FleetLastSeen(turn=9, x=1200, y=800, planet_id=55),
+        events=[
+            FleetEvidenceEvent(
+                event_id="evt-1",
+                kind="sighting",
+                turn=9,
+                source="turnInfo.ships",
+                payload={"shipId": 301},
+            )
+        ],
+    )
+
+    wire = fleet_ship_record_to_json(record)
+    restored = fleet_ship_record_from_json(wire)
+    assert restored == record
+    assert fleet_ship_record_to_json(restored) == wire
+
+
+def test_append_fleet_evidence_event_appends_and_round_trips():
+    record = FleetShipRecord(record_id="rec-2")
+    first = FleetEvidenceEvent(
+        event_id="evt-1",
+        kind="scoreboard_delta",
+        turn=3,
+        source="scoreboard",
+        payload={"warshipDelta": 1},
+    )
+    second = FleetEvidenceEvent(
+        event_id="evt-2",
+        kind="inference_update",
+        turn=3,
+        source="scores",
+        payload={"solutionRankWeight": 12},
+    )
+
+    append_fleet_evidence_event(record, first)
+    append_fleet_evidence_event(record, second)
+
+    assert record.events == [first, second]
+
+    wire = fleet_ship_record_to_json(record)
+    restored = fleet_ship_record_from_json(wire)
+    assert restored.events == [first, second]
+    assert fleet_evidence_event_to_json(restored.events[1]) == fleet_evidence_event_to_json(second)
+
+
+def test_fleet_count_discrepancy_round_trip():
+    discrepancy = FleetCountDiscrepancy(
+        host_turn=8,
+        active_row_count=5,
+        scoreboard_implied_count=4,
+        report_refs=("report:host:8:player:2",),
+    )
+    wire = fleet_count_discrepancy_to_json(discrepancy)
+    restored = fleet_count_discrepancy_from_json(wire)
+    assert restored == discrepancy
+    assert fleet_count_discrepancy_to_json(restored) == wire
+
+
+def test_fleet_turn_snapshot_round_trip():
+    snapshot = FleetTurnSnapshot(
+        analytic_id="fleet",
+        game_id=628580,
+        perspective=1,
+        turn=111,
+        players=[
+            FleetAcquisitionLedger(
+                player_id=8,
+                player_name="koshling",
+                records=[
+                    FleetShipRecord(
+                        record_id="rec-1",
+                        fields=FleetShipRecordFields(
+                            ship_id=FleetFieldKnown(value=301),
+                            hull=FleetFieldKnown(value=13),
+                        ),
+                    )
+                ],
+                discrepancy=FleetCountDiscrepancy(
+                    host_turn=111,
+                    active_row_count=2,
+                    scoreboard_implied_count=1,
+                ),
+            )
+        ],
+    )
+
+    wire = fleet_turn_snapshot_to_json(snapshot)
+    restored = fleet_turn_snapshot_from_json(wire)
+    assert restored == snapshot
+    assert fleet_turn_snapshot_to_json(restored) == wire
+
+
+def test_fleet_acquisition_ledger_round_trip():
+    ledger = FleetAcquisitionLedger(
+        player_id=3,
+        player_name="player-3",
+        records=[FleetShipRecord(record_id="rec-3")],
+    )
+    wire = fleet_acquisition_ledger_to_json(ledger)
+    restored = fleet_acquisition_ledger_from_json(wire)
+    assert restored == ledger
+    assert fleet_acquisition_ledger_to_json(restored) == wire
+
+
+def test_fleet_field_constraint_region_requires_locator():
+    with pytest.raises(ValidationError, match="requires at least one locator"):
+        fleet_field_constraint_from_json({"kind": "region"})
+
+
+@pytest.mark.parametrize(
+    ("from_json", "wire", "match"),
+    [
+        (
+            fleet_field_constraint_from_json,
+            {"kind": "bounded", "operator": "neq", "value": 1},
+            "bounded operator is invalid",
+        ),
+        (
+            fleet_field_constraint_from_json,
+            {"kind": "options", "values": []},
+            "requires non-empty values",
+        ),
+        (
+            fleet_field_constraint_from_json,
+            {"kind": "bogus"},
+            "unknown fleet field constraint kind",
+        ),
+        (
+            fleet_ship_record_from_json,
+            {
+                "recordId": "rec-1",
+                "disposition": "active",
+                "fields": {
+                    "shipId": {"kind": "unknown"},
+                    "hull": {"kind": "unknown"},
+                    "engine": {"kind": "unknown"},
+                    "beams": {"kind": "unknown"},
+                    "launchers": {"kind": "unknown"},
+                    "builtTurn": {"kind": "unknown"},
+                    "location": {"kind": "unknown"},
+                },
+                "events": ["not-an-object"],
+            },
+            "fleet ship record events\\[0\\] must be an object",
+        ),
+        (
+            fleet_ship_record_from_json,
+            {
+                "recordId": "rec-1",
+                "disposition": "vanished",
+                "fields": {
+                    "shipId": {"kind": "unknown"},
+                    "hull": {"kind": "unknown"},
+                    "engine": {"kind": "unknown"},
+                    "beams": {"kind": "unknown"},
+                    "launchers": {"kind": "unknown"},
+                    "builtTurn": {"kind": "unknown"},
+                    "location": {"kind": "unknown"},
+                },
+            },
+            "disposition is invalid",
+        ),
+        (
+            fleet_ship_record_from_json,
+            {
+                "recordId": "rec-1",
+                "disposition": "active",
+                "fields": {
+                    "shipId": {"kind": "unknown"},
+                    "hull": {"kind": "unknown"},
+                    "engine": {"kind": "unknown"},
+                    "beams": {"kind": "unknown"},
+                    "launchers": {"kind": "unknown"},
+                    "builtTurn": {"kind": "unknown"},
+                    "location": {"kind": "unknown"},
+                },
+                "buildOptionSets": [],
+                "displayDefaultOptionSetIndex": 0,
+            },
+            "displayDefaultOptionSetIndex requires buildOptionSets",
+        ),
+        (
+            fleet_acquisition_ledger_from_json,
+            {"playerId": 1, "records": [42]},
+            "fleet acquisition ledger records\\[0\\] must be an object",
+        ),
+        (
+            fleet_turn_snapshot_from_json,
+            {"analyticId": "fleet", "perspective": 1, "turn": 5, "players": []},
+            "fleet turn snapshot gameId must be an int",
+        ),
+    ],
+)
+def test_fleet_deserialization_rejects_invalid_wire(from_json, wire, match):
+    with pytest.raises(ValidationError, match=match):
+        from_json(wire)
+
+
+def test_fleet_evidence_event_rejects_invalid_kind():
+    with pytest.raises(ValidationError, match="kind is invalid"):
+        fleet_ship_record_from_json(
+            {
+                "recordId": "rec-1",
+                "disposition": "active",
+                "fields": {
+                    "shipId": {"kind": "unknown"},
+                    "hull": {"kind": "unknown"},
+                    "engine": {"kind": "unknown"},
+                    "beams": {"kind": "unknown"},
+                    "launchers": {"kind": "unknown"},
+                    "builtTurn": {"kind": "unknown"},
+                    "location": {"kind": "unknown"},
+                },
+                "events": [
+                    {
+                        "eventId": "evt-1",
+                        "kind": "sightng",
+                        "turn": 1,
+                        "source": "turnInfo.ships",
+                    }
+                ],
+            }
+        )
+
+
+def test_fleet_field_constraint_region_round_trip_overlay_only():
+    constraint = FleetFieldRegion(overlay_id="sb-region-2")
+    wire = fleet_field_constraint_to_json(constraint)
+    assert wire == {"kind": "region", "overlayId": "sb-region-2"}
+    restored = fleet_field_constraint_from_json(wire)
+    assert restored == constraint


### PR DESCRIPTION
## Summary
- Split `api/analytics/fleet.py` into a package with domain types for the fleet ledger (`FleetFieldConstraint`, `FleetBuildOptionSet`, `FleetShipRecord`, qualifiers, discrepancy, snapshot).
- Add strict JSON codecs with validation for constraint shapes, evidence events, and snapshot scope fields.
- Add unit tests covering constraint round-trips, event append immutability, and negative deserialization cases.

Closes #116.

## Test plan
- [x] `uv run pytest packages/api/tests/test_fleet_domain.py packages/api/tests/test_fleet_analytic.py -v`
- [x] `make test_api`
- [x] `uv run ruff check packages/api/api/analytics/fleet/ packages/api/tests/test_fleet_domain.py`


Made with [Cursor](https://cursor.com)