### PR TITLE
Fleet F1.3: Direct observation ingest (#118)

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -65,11 +65,9 @@ def advance_snapshot_to_turn(
 def apply_fleet_turn_delta(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
-    *,
-    prior_turn: TurnInfo | None = None,
 ) -> FleetTurnSnapshot:
     """Apply evidence from shell turn T only."""
-    return ingest_turn_ship_observations(snapshot, turn, prior_turn=prior_turn)
+    return ingest_turn_ship_observations(snapshot, turn)
 
 
 def _find_chain_anchor(
@@ -93,7 +91,6 @@ def _materialize_and_persist_turn(
     materialize_turn: int,
     prior_snapshot: FleetTurnSnapshot,
     turn_info: TurnInfo,
-    load_turn: Callable[[int], TurnInfo | None],
 ) -> FleetTurnSnapshot:
     snapshot = advance_snapshot_to_turn(
         prior_snapshot,
@@ -101,8 +98,7 @@ def _materialize_and_persist_turn(
         game_id=game_id,
         perspective=perspective,
     )
-    prior_turn = load_turn(materialize_turn - 1) if materialize_turn > 1 else None
-    snapshot = apply_fleet_turn_delta(snapshot, turn_info, prior_turn=prior_turn)
+    snapshot = apply_fleet_turn_delta(snapshot, turn_info)
     persistence.put_snapshot(game_id, perspective, materialize_turn, snapshot)
     return snapshot
 
@@ -201,7 +197,6 @@ def get_or_materialize_fleet_snapshot(
             materialize_turn=materialize_turn,
             prior_snapshot=current_snapshot,
             turn_info=turn_info,
-            load_turn=cached_load,
         )
 
     return current_snapshot

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -66,7 +66,12 @@ def apply_fleet_turn_delta(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
 ) -> FleetTurnSnapshot:
-    """Apply evidence from shell turn T only."""
+    """Apply all turn-T fleet evidence deltas for materialization.
+
+    Extension seam for fleet delta ingest. Currently delegates to direct ship
+    observation ingest (#118). Scoreboard and inference ingest (#119+) will extend
+    this hook rather than bypassing it from chain call sites.
+    """
     return ingest_turn_ship_observations(snapshot, turn)
 
 

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -6,6 +6,7 @@ import copy
 from collections.abc import Callable
 
 from api.analytics.fleet.constants import ANALYTIC_ID
+from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
 from api.analytics.turn_roster import iter_turn_players
@@ -61,13 +62,14 @@ def advance_snapshot_to_turn(
     )
 
 
-def apply_fleet_turn_delta(snapshot: FleetTurnSnapshot, turn: TurnInfo) -> FleetTurnSnapshot:
-    """Apply evidence from shell turn T only.
-
-    Direct observation ingest (#118) and scores integration (#119+) extend this hook.
-    """
-    _ = turn
-    return snapshot
+def apply_fleet_turn_delta(
+    snapshot: FleetTurnSnapshot,
+    turn: TurnInfo,
+    *,
+    prior_turn: TurnInfo | None = None,
+) -> FleetTurnSnapshot:
+    """Apply evidence from shell turn T only."""
+    return ingest_turn_ship_observations(snapshot, turn, prior_turn=prior_turn)
 
 
 def _find_chain_anchor(
@@ -91,6 +93,7 @@ def _materialize_and_persist_turn(
     materialize_turn: int,
     prior_snapshot: FleetTurnSnapshot,
     turn_info: TurnInfo,
+    load_turn: Callable[[int], TurnInfo | None],
 ) -> FleetTurnSnapshot:
     snapshot = advance_snapshot_to_turn(
         prior_snapshot,
@@ -98,7 +101,8 @@ def _materialize_and_persist_turn(
         game_id=game_id,
         perspective=perspective,
     )
-    snapshot = apply_fleet_turn_delta(snapshot, turn_info)
+    prior_turn = load_turn(materialize_turn - 1) if materialize_turn > 1 else None
+    snapshot = apply_fleet_turn_delta(snapshot, turn_info, prior_turn=prior_turn)
     persistence.put_snapshot(game_id, perspective, materialize_turn, snapshot)
     return snapshot
 
@@ -197,6 +201,7 @@ def get_or_materialize_fleet_snapshot(
             materialize_turn=materialize_turn,
             prior_snapshot=current_snapshot,
             turn_info=turn_info,
+            load_turn=cached_load,
         )
 
     return current_snapshot

--- a/packages/api/api/analytics/fleet/observation_ingest.py
+++ b/packages/api/api/analytics/fleet/observation_ingest.py
@@ -1,0 +1,324 @@
+"""Ingest direct ship sightings from TurnInfo.ships into fleet ledgers."""
+
+from __future__ import annotations
+
+import uuid
+
+from api.analytics.fleet.serialization import append_fleet_evidence_event
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetAlibi,
+    FleetEvidenceEvent,
+    FleetEvidenceEventKind,
+    FleetFieldBounded,
+    FleetFieldConstraint,
+    FleetFieldKnown,
+    FleetFieldUnknown,
+    FleetLastSeen,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+)
+from api.models.game import TurnInfo
+from api.models.ship import Ship
+
+TURN_SHIPS_SOURCE = "turnInfo.ships"
+
+
+def ingest_turn_ship_observations(
+    snapshot: FleetTurnSnapshot,
+    turn: TurnInfo,
+    *,
+    prior_turn: TurnInfo | None = None,
+) -> FleetTurnSnapshot:
+    """Apply turn-T ship sightings to every player ledger in the snapshot."""
+    turn_number = turn.settings.turn
+    ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
+    max_ship_id_bound = compute_max_ship_id_bound(prior_turn, turn)
+
+    for ship in turn.ships:
+        if ship.turnkilled != 0:
+            continue
+        ledger = ledgers_by_player_id.get(ship.ownerid)
+        if ledger is None:
+            continue
+        _ingest_ship_sighting(ledger, ship, turn, turn_number=turn_number)
+
+    if max_ship_id_bound is not None:
+        for ledger in snapshot.players:
+            _tighten_unknown_ship_id_bounds(ledger, max_ship_id_bound, turn_number)
+
+    return snapshot
+
+
+def compute_max_ship_id_bound(prior_turn: TurnInfo | None, turn: TurnInfo) -> int | None:
+    """Upper-bound unknown ship ids from prior global ship totals plus turn builds."""
+    if prior_turn is None:
+        return None
+    prior_count = global_ship_count_from_scores(prior_turn)
+    if prior_count is None:
+        prior_count = len(prior_turn.ships)
+    builds = global_build_count_from_scores(turn)
+    return prior_count + builds
+
+
+def global_ship_count_from_scores(turn: TurnInfo) -> int | None:
+    """Sum scoreboard ship totals for the turn, when score rows exist."""
+    turn_number = turn.settings.turn
+    total = 0
+    found = False
+    for score in turn.scores:
+        if score.turn != turn_number:
+            continue
+        found = True
+        total += score.capitalships + score.freighters
+    return total if found else None
+
+
+def global_build_count_from_scores(turn: TurnInfo) -> int:
+    """Sum positive warship and freighter builds reported on the turn."""
+    turn_number = turn.settings.turn
+    total = 0
+    for score in turn.scores:
+        if score.turn != turn_number:
+            continue
+        if score.shipchange > 0:
+            total += score.shipchange
+        if score.freighterchange > 0:
+            total += score.freighterchange
+    return total
+
+
+def _ingest_ship_sighting(
+    ledger: FleetAcquisitionLedger,
+    ship: Ship,
+    turn: TurnInfo,
+    *,
+    turn_number: int,
+) -> None:
+    record = _find_active_record_for_ship(ledger, ship.id)
+    last_seen = FleetLastSeen(
+        turn=turn_number,
+        x=ship.x,
+        y=ship.y,
+        planet_id=_planet_id_at_coordinates(turn, ship.x, ship.y),
+    )
+    observed_fields = _observed_fields_from_ship(ship)
+
+    if record is None:
+        record = FleetShipRecord(
+            record_id=str(uuid.uuid4()),
+            fields=observed_fields,
+            last_seen=last_seen,
+        )
+        append_fleet_evidence_event(
+            record,
+            _new_evidence_event(
+                kind="sighting",
+                turn=turn_number,
+                payload=_ship_sighting_payload(ship),
+            ),
+        )
+        ledger.records.append(record)
+        return
+
+    prior_last_seen = record.last_seen
+    position_changed = (
+        prior_last_seen is None or prior_last_seen.x != ship.x or prior_last_seen.y != ship.y
+    )
+    record.fields = _merge_observed_fields(record.fields, observed_fields)
+    record.last_seen = last_seen
+    append_fleet_evidence_event(
+        record,
+        _new_evidence_event(
+            kind="position_update" if position_changed else "sighting",
+            turn=turn_number,
+            payload=_ship_sighting_payload(ship),
+        ),
+    )
+    _apply_alibi_if_needed(record, sighting_turn=turn_number)
+
+
+def _find_active_record_for_ship(
+    ledger: FleetAcquisitionLedger,
+    ship_id: int,
+) -> FleetShipRecord | None:
+    for record in ledger.records:
+        if record.disposition != "active":
+            continue
+        if ship_id_matches_constraint(record.fields.ship_id, ship_id):
+            return record
+    return None
+
+
+def ship_id_matches_constraint(constraint: FleetFieldConstraint, ship_id: int) -> bool:
+    if isinstance(constraint, FleetFieldKnown):
+        return constraint.value == ship_id
+    if isinstance(constraint, FleetFieldBounded):
+        bound = constraint.value
+        if not isinstance(bound, (int, float)):
+            return False
+        if constraint.operator == "lte":
+            return ship_id <= bound
+        if constraint.operator == "lt":
+            return ship_id < bound
+        if constraint.operator == "gte":
+            return ship_id >= bound
+        if constraint.operator == "gt":
+            return ship_id > bound
+        if constraint.operator == "eq":
+            return ship_id == bound
+    return False
+
+
+def _observed_fields_from_ship(ship: Ship) -> FleetShipRecordFields:
+    beams = (
+        FleetFieldKnown(ship.beamid)
+        if ship.beams > 0 and ship.beamid > 0
+        else FleetFieldKnown(0)
+        if ship.beams == 0
+        else FleetFieldUnknown()
+    )
+    if ship.bays > 0 or ship.torps > 0:
+        launchers = FleetFieldKnown(ship.torpedoid) if ship.torpedoid > 0 else FleetFieldUnknown()
+    else:
+        launchers = FleetFieldKnown(0)
+    built_turn = FleetFieldKnown(ship.turn) if ship.turn > 0 else FleetFieldUnknown()
+    return FleetShipRecordFields(
+        ship_id=FleetFieldKnown(ship.id),
+        hull=FleetFieldKnown(ship.hullid),
+        engine=FleetFieldKnown(ship.engineid),
+        beams=beams,
+        launchers=launchers,
+        built_turn=built_turn,
+        location=FleetFieldUnknown(),
+    )
+
+
+def _merge_observed_fields(
+    current: FleetShipRecordFields,
+    observed: FleetShipRecordFields,
+) -> FleetShipRecordFields:
+    return FleetShipRecordFields(
+        ship_id=_merge_field_constraint(current.ship_id, observed.ship_id),
+        hull=_merge_field_constraint(current.hull, observed.hull),
+        engine=_merge_field_constraint(current.engine, observed.engine),
+        beams=_merge_field_constraint(current.beams, observed.beams),
+        launchers=_merge_field_constraint(current.launchers, observed.launchers),
+        built_turn=_merge_field_constraint(current.built_turn, observed.built_turn),
+        location=_merge_field_constraint(current.location, observed.location),
+    )
+
+
+def _merge_field_constraint(
+    current: FleetFieldConstraint,
+    observed: FleetFieldConstraint,
+) -> FleetFieldConstraint:
+    if isinstance(current, FleetFieldKnown):
+        return current
+    if isinstance(observed, FleetFieldKnown):
+        return observed
+    return current
+
+
+def _tighten_unknown_ship_id_bounds(
+    ledger: FleetAcquisitionLedger,
+    max_bound: int,
+    turn_number: int,
+) -> None:
+    for record in ledger.records:
+        if record.disposition != "active":
+            continue
+        if isinstance(record.fields.ship_id, FleetFieldKnown):
+            continue
+        tightened = FleetFieldBounded(operator="lte", value=max_bound)
+        if record.fields.ship_id == tightened:
+            continue
+        if isinstance(record.fields.ship_id, FleetFieldBounded):
+            if record.fields.ship_id.operator == "lte" and record.fields.ship_id.value <= max_bound:
+                continue
+        record.fields.ship_id = tightened
+        append_fleet_evidence_event(
+            record,
+            _new_evidence_event(
+                kind="id_bound_tightened",
+                turn=turn_number,
+                payload={"maxShipId": max_bound},
+            ),
+        )
+
+
+def _apply_alibi_if_needed(record: FleetShipRecord, *, sighting_turn: int) -> None:
+    if record.qualifiers.alibi is not None:
+        return
+    decrease_turn = _recorded_count_decrease_turn(record)
+    if decrease_turn is None or sighting_turn <= decrease_turn:
+        return
+    record.qualifiers.alibi = FleetAlibi(
+        after_turn=decrease_turn,
+        sighting_turn=sighting_turn,
+        source=TURN_SHIPS_SOURCE,
+    )
+    append_fleet_evidence_event(
+        record,
+        _new_evidence_event(
+            kind="alibi",
+            turn=sighting_turn,
+            payload={
+                "afterTurn": decrease_turn,
+                "sightingTurn": sighting_turn,
+            },
+        ),
+    )
+
+
+def _recorded_count_decrease_turn(record: FleetShipRecord) -> int | None:
+    if record.qualifiers.possibly_lost is not None:
+        return record.qualifiers.possibly_lost.since_turn
+    for event in record.events:
+        if event.kind != "scoreboard_delta":
+            continue
+        warship_delta = event.payload.get("warshipDelta", 0)
+        freighter_delta = event.payload.get("freighterDelta", 0)
+        if not isinstance(warship_delta, int) or isinstance(warship_delta, bool):
+            continue
+        if not isinstance(freighter_delta, int) or isinstance(freighter_delta, bool):
+            continue
+        if warship_delta + freighter_delta < 0:
+            return event.turn
+    return None
+
+
+def _planet_id_at_coordinates(turn: TurnInfo, x: int, y: int) -> int | None:
+    for planet in turn.planets:
+        if planet.x == x and planet.y == y:
+            return planet.id
+    return None
+
+
+def _ship_sighting_payload(ship: Ship) -> dict[str, object]:
+    return {
+        "shipId": ship.id,
+        "ownerId": ship.ownerid,
+        "x": ship.x,
+        "y": ship.y,
+        "hullId": ship.hullid,
+        "engineId": ship.engineid,
+        "beamId": ship.beamid,
+        "torpId": ship.torpedoid,
+    }
+
+
+def _new_evidence_event(
+    *,
+    kind: FleetEvidenceEventKind,
+    turn: int,
+    payload: dict[str, object],
+) -> FleetEvidenceEvent:
+    return FleetEvidenceEvent(
+        event_id=str(uuid.uuid4()),
+        kind=kind,
+        turn=turn,
+        source=TURN_SHIPS_SOURCE,
+        payload=payload,
+    )

--- a/packages/api/api/analytics/fleet/observation_ingest.py
+++ b/packages/api/api/analytics/fleet/observation_ingest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 
+from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
 from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -47,54 +48,6 @@ def ingest_turn_ship_observations(
             _tighten_unknown_ship_id_bounds(ledger, max_ship_id_bound, turn_number)
 
     return snapshot
-
-
-def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
-    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas."""
-    total = global_ship_count_from_scores(turn)
-    if total is None:
-        return None
-    net = global_net_delta_from_scores(turn)
-    builds = global_build_count_from_scores(turn)
-    return total - net + builds
-
-
-def global_ship_count_from_scores(turn: TurnInfo) -> int | None:
-    """Sum scoreboard ship totals for the turn, when score rows exist."""
-    turn_number = turn.settings.turn
-    total = 0
-    found = False
-    for score in turn.scores:
-        if score.turn != turn_number:
-            continue
-        found = True
-        total += score.capitalships + score.freighters
-    return total if found else None
-
-
-def global_build_count_from_scores(turn: TurnInfo) -> int:
-    """Sum positive warship and freighter builds reported on the turn."""
-    turn_number = turn.settings.turn
-    total = 0
-    for score in turn.scores:
-        if score.turn != turn_number:
-            continue
-        if score.shipchange > 0:
-            total += score.shipchange
-        if score.freighterchange > 0:
-            total += score.freighterchange
-    return total
-
-
-def global_net_delta_from_scores(turn: TurnInfo) -> int:
-    """Sum signed warship and freighter scoreboard deltas for the turn."""
-    turn_number = turn.settings.turn
-    total = 0
-    for score in turn.scores:
-        if score.turn != turn_number:
-            continue
-        total += score.shipchange + score.freighterchange
-    return total
 
 
 def _ingest_ship_sighting(

--- a/packages/api/api/analytics/fleet/observation_ingest.py
+++ b/packages/api/api/analytics/fleet/observation_ingest.py
@@ -236,6 +236,7 @@ def _apply_alibi_if_needed(record: FleetShipRecord, *, sighting_turn: int) -> No
 def _recorded_count_decrease_turn(record: FleetShipRecord) -> int | None:
     if record.qualifiers.possibly_lost is not None:
         return record.qualifiers.possibly_lost.since_turn
+    latest_decrease_turn: int | None = None
     for event in record.events:
         if event.kind != "scoreboard_delta":
             continue
@@ -246,8 +247,9 @@ def _recorded_count_decrease_turn(record: FleetShipRecord) -> int | None:
         if not isinstance(freighter_delta, int) or isinstance(freighter_delta, bool):
             continue
         if warship_delta + freighter_delta < 0:
-            return event.turn
-    return None
+            if latest_decrease_turn is None or event.turn > latest_decrease_turn:
+                latest_decrease_turn = event.turn
+    return latest_decrease_turn
 
 
 def _planet_id_at_coordinates(turn: TurnInfo, x: int, y: int) -> int | None:

--- a/packages/api/api/analytics/fleet/observation_ingest.py
+++ b/packages/api/api/analytics/fleet/observation_ingest.py
@@ -28,13 +28,11 @@ TURN_SHIPS_SOURCE = "turnInfo.ships"
 def ingest_turn_ship_observations(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
-    *,
-    prior_turn: TurnInfo | None = None,
 ) -> FleetTurnSnapshot:
     """Apply turn-T ship sightings to every player ledger in the snapshot."""
     turn_number = turn.settings.turn
     ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
-    max_ship_id_bound = compute_max_ship_id_bound(prior_turn, turn)
+    max_ship_id_bound = compute_max_ship_id_bound(turn)
 
     for ship in turn.ships:
         if ship.turnkilled != 0:
@@ -51,15 +49,14 @@ def ingest_turn_ship_observations(
     return snapshot
 
 
-def compute_max_ship_id_bound(prior_turn: TurnInfo | None, turn: TurnInfo) -> int | None:
-    """Upper-bound unknown ship ids from prior global ship totals plus turn builds."""
-    if prior_turn is None:
+def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
+    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas."""
+    total = global_ship_count_from_scores(turn)
+    if total is None:
         return None
-    prior_count = global_ship_count_from_scores(prior_turn)
-    if prior_count is None:
-        prior_count = len(prior_turn.ships)
+    net = global_net_delta_from_scores(turn)
     builds = global_build_count_from_scores(turn)
-    return prior_count + builds
+    return total - net + builds
 
 
 def global_ship_count_from_scores(turn: TurnInfo) -> int | None:
@@ -86,6 +83,17 @@ def global_build_count_from_scores(turn: TurnInfo) -> int:
             total += score.shipchange
         if score.freighterchange > 0:
             total += score.freighterchange
+    return total
+
+
+def global_net_delta_from_scores(turn: TurnInfo) -> int:
+    """Sum signed warship and freighter scoreboard deltas for the turn."""
+    turn_number = turn.settings.turn
+    total = 0
+    for score in turn.scores:
+        if score.turn != turn_number:
+            continue
+        total += score.shipchange + score.freighterchange
     return total
 
 

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -36,9 +36,7 @@ def global_build_count_from_scores(turn: TurnInfo) -> int:
 
 def global_net_delta_from_scores(turn: TurnInfo) -> int:
     """Sum signed warship and freighter scoreboard deltas for the turn."""
-    return sum(
-        score.shipchange + score.freighterchange for score in _current_turn_scores(turn)
-    )
+    return sum(score.shipchange + score.freighterchange for score in _current_turn_scores(turn))
 
 
 def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -1,0 +1,51 @@
+"""Scoreboard ship-count aggregation for fleet analytics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+
+def _current_turn_scores(turn: TurnInfo) -> Iterator[Score]:
+    turn_number = turn.settings.turn
+    for score in turn.scores:
+        if score.turn == turn_number:
+            yield score
+
+
+def global_ship_count_from_scores(turn: TurnInfo) -> int | None:
+    """Sum scoreboard ship totals for the turn, when score rows exist."""
+    scores = list(_current_turn_scores(turn))
+    if not scores:
+        return None
+    return sum(score.capitalships + score.freighters for score in scores)
+
+
+def global_build_count_from_scores(turn: TurnInfo) -> int:
+    """Sum positive warship and freighter builds reported on the turn."""
+    total = 0
+    for score in _current_turn_scores(turn):
+        if score.shipchange > 0:
+            total += score.shipchange
+        if score.freighterchange > 0:
+            total += score.freighterchange
+    return total
+
+
+def global_net_delta_from_scores(turn: TurnInfo) -> int:
+    """Sum signed warship and freighter scoreboard deltas for the turn."""
+    return sum(
+        score.shipchange + score.freighterchange for score in _current_turn_scores(turn)
+    )
+
+
+def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
+    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas."""
+    total = global_ship_count_from_scores(turn)
+    if total is None:
+        return None
+    net = global_net_delta_from_scores(turn)
+    builds = global_build_count_from_scores(turn)
+    return total - net + builds

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -42,7 +42,11 @@ def global_net_delta_from_scores(turn: TurnInfo) -> int:
 
 
 def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
-    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas."""
+    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas.
+
+    Returns None when the current turn has no scoreboard rows; callers must skip
+    id-bound tightening rather than inferring from visible ship lists.
+    """
     total = global_ship_count_from_scores(turn)
     if total is None:
         return None

--- a/packages/api/tests/fleet_fixtures.py
+++ b/packages/api/tests/fleet_fixtures.py
@@ -1,0 +1,94 @@
+"""Shared helpers for fleet analytic tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
+from api.models.game import TurnInfo
+from api.serialization.turn import turn_info_from_json
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+def single_ship_turn(
+    *,
+    turn_number: int,
+    ship_id: int,
+    owner_id: int,
+    x: int,
+    y: int,
+    hull_id: int = 13,
+) -> TurnInfo:
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        turn_data = json.load(handle)
+    turn_data["settings"]["turn"] = turn_number
+    turn_data["game"]["turn"] = turn_number
+    turn_data["ships"] = [
+        {
+            "friendlycode": "tst",
+            "name": "Test Ship",
+            "warp": 9,
+            "x": x,
+            "y": y,
+            "beams": 8,
+            "bays": 6,
+            "torps": 6,
+            "mission": 0,
+            "mission1target": 0,
+            "mission2target": 0,
+            "enemy": 0,
+            "damage": 0,
+            "crew": 100,
+            "clans": 0,
+            "neutronium": 0,
+            "tritanium": 0,
+            "duranium": 0,
+            "molybdenum": 0,
+            "supplies": 0,
+            "ammo": 0,
+            "megacredits": 0,
+            "transferclans": 0,
+            "transferneutronium": 0,
+            "transferduranium": 0,
+            "transfertritanium": 0,
+            "transfermolybdenum": 0,
+            "transfersupplies": 0,
+            "transferammo": 0,
+            "transfermegacredits": 0,
+            "transfertargetid": 0,
+            "transfertargettype": 0,
+            "targetx": x,
+            "targety": y,
+            "mass": 100,
+            "heading": 0,
+            "turn": 1,
+            "turnkilled": 0,
+            "beamid": 3,
+            "engineid": 9,
+            "hullid": hull_id,
+            "ownerid": owner_id,
+            "torpedoid": 6,
+            "experience": 0,
+            "infoturn": turn_number,
+            "podhullid": 0,
+            "podcargo": 0,
+            "goal": 0,
+            "goaltarget": 0,
+            "goaltarget2": 0,
+            "waypoints": [],
+            "history": [],
+            "iscloaked": False,
+            "readystatus": 0,
+            "id": ship_id,
+        }
+    ]
+    return turn_info_from_json(turn_data)
+
+
+def ledger_for_player(snapshot: FleetTurnSnapshot, player_id: int) -> FleetAcquisitionLedger:
+    for ledger in snapshot.players:
+        if ledger.player_id == player_id:
+            return ledger
+    raise AssertionError(f"missing player ledger {player_id}")

--- a/packages/api/tests/test_fleet_analytic.py
+++ b/packages/api/tests/test_fleet_analytic.py
@@ -23,18 +23,15 @@ def test_fleet_registered_in_turn_analytics():
     assert "fleet" in TURN_ANALYTICS
 
 
-def test_fleet_compute_returns_scaffold_players_with_empty_records(sample_turn):
+def test_fleet_compute_returns_players_with_observed_records(sample_turn):
     data = get_fleet(sample_turn)
     assert data["analyticId"] == "fleet"
     players = data["players"]
     assert len(players) == 4
-    assert players[0] == {
-        "playerId": 8,
-        "playerName": "koshling",
-        "records": [],
-    }
+    koshling = next(player for player in players if player["playerId"] == 8)
+    assert len(koshling["records"]) == 4
+    assert koshling["records"][0]["events"][0]["kind"] == "sighting"
     for player in players:
-        assert player["records"] == []
         assert isinstance(player["playerId"], int)
         assert isinstance(player["playerName"], str)
 

--- a/packages/api/tests/test_fleet_analytic.py
+++ b/packages/api/tests/test_fleet_analytic.py
@@ -1,22 +1,9 @@
 """Tests for Fleet turn analytic registration shell."""
 
-import json
-from pathlib import Path
-
-import pytest
 from api.analytics import TurnAnalyticsOptions, get_turn_analytic
 from api.analytics.fleet import ANALYTIC_ID, get_fleet
 from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
 from api.analytics.registry import TURN_ANALYTICS
-from api.serialization.turn import turn_info_from_json
-
-ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
-
-
-@pytest.fixture
-def sample_turn():
-    with open(ASSETS_DIR / "turn_sample.json") as f:
-        return turn_info_from_json(json.load(f))
 
 
 def test_fleet_registered_in_turn_analytics():

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -199,6 +199,29 @@ def test_turn_one_sightings_seed_ledger_without_game_start_inventory():
     assert ledger.records[0].fields.ship_id == FleetFieldKnown(value=7)
 
 
+def test_id_bound_skipped_when_scores_missing():
+    current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
+    current_turn = replace(current_turn, scores=[])
+    snapshot = ensure_fleet_baseline(628580, 1, current_turn)
+    snapshot.players[0].records.append(
+        FleetShipRecord(
+            record_id="inferred-placeholder",
+            fields=FleetShipRecordFields(ship_id=FleetFieldUnknown()),
+        )
+    )
+
+    result = ingest_turn_ship_observations(snapshot, current_turn)
+
+    placeholder = next(
+        rec
+        for rec in _ledger_for_player(result, 8).records
+        if rec.record_id == "inferred-placeholder"
+    )
+    assert placeholder.fields.ship_id == FleetFieldUnknown()
+    assert not any(event.kind == "id_bound_tightened" for event in placeholder.events)
+    assert compute_max_ship_id_bound(current_turn) is None
+
+
 def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
     current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
     score = replace(

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -9,10 +9,8 @@ from pathlib import Path
 
 import pytest
 from api.analytics.fleet.chain import apply_fleet_turn_delta, ensure_fleet_baseline
-from api.analytics.fleet.observation_ingest import (
-    compute_max_ship_id_bound,
-    ingest_turn_ship_observations,
-)
+from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
+from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
 from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -153,7 +153,7 @@ def test_repeat_sighting_appends_events_and_updates_position():
         turn_two,
         scores=[replace(score, turn=2) for score in turn_two.scores],
     )
-    result = ingest_turn_ship_observations(snapshot, turn_two, prior_turn=turn_one)
+    result = ingest_turn_ship_observations(snapshot, turn_two)
 
     record = _ledger_for_player(result, 8).records[0]
     assert record.record_id == record_id
@@ -202,10 +202,17 @@ def test_turn_one_sightings_seed_ledger_without_game_start_inventory():
 
 
 def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
-    prior_turn = _single_ship_turn(turn_number=1, ship_id=1, owner_id=8, x=100, y=100)
-    prior_turn = replace(prior_turn, scores=[])
     current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
-    current_turn = replace(current_turn, scores=[])
+    score = replace(
+        current_turn.scores[0],
+        turn=2,
+        ownerid=8,
+        capitalships=1,
+        freighters=0,
+        shipchange=0,
+        freighterchange=0,
+    )
+    current_turn = replace(current_turn, scores=[score])
     snapshot = ensure_fleet_baseline(628580, 1, current_turn)
     snapshot.players[0].records.append(
         FleetShipRecord(
@@ -214,7 +221,7 @@ def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
         )
     )
 
-    result = ingest_turn_ship_observations(snapshot, current_turn, prior_turn=prior_turn)
+    result = ingest_turn_ship_observations(snapshot, current_turn)
 
     placeholder = next(
         rec
@@ -226,17 +233,15 @@ def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
 
 
 def test_compute_max_ship_id_bound_uses_scoreboard_totals(sample_turn):
-    prior_turn = replace(sample_turn, settings=replace(sample_turn.settings, turn=110))
-    prior_turn = replace(prior_turn, game=replace(prior_turn.game, turn=110))
-    prior_scores = [replace(score, turn=110) for score in sample_turn.scores]
-    prior_turn = replace(prior_turn, scores=prior_scores)
-
-    bound = compute_max_ship_id_bound(prior_turn, sample_turn)
-    prior_total = sum(score.capitalships + score.freighters for score in prior_scores)
+    bound = compute_max_ship_id_bound(sample_turn)
+    turn_number = sample_turn.settings.turn
+    current_scores = [score for score in sample_turn.scores if score.turn == turn_number]
+    total = sum(score.capitalships + score.freighters for score in current_scores)
+    net = sum(score.shipchange + score.freighterchange for score in current_scores)
     builds = sum(
-        max(0, score.shipchange) + max(0, score.freighterchange) for score in sample_turn.scores
+        max(0, score.shipchange) + max(0, score.freighterchange) for score in current_scores
     )
-    assert bound == prior_total + builds
+    assert bound == total - net + builds
 
 
 def test_alibi_applies_after_recorded_count_decrease_and_later_sighting():
@@ -248,7 +253,7 @@ def test_alibi_applies_after_recorded_count_decrease_and_later_sighting():
     )
 
     turn_six = _single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
-    result = ingest_turn_ship_observations(snapshot, turn_six, prior_turn=turn_one)
+    result = ingest_turn_ship_observations(snapshot, turn_six)
 
     updated = _ledger_for_player(result, 8).records[0]
     assert updated.qualifiers.alibi is not None

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import copy
-import json
 from dataclasses import replace
-from pathlib import Path
 
-import pytest
 from api.analytics.fleet.chain import apply_fleet_turn_delta, ensure_fleet_baseline
 from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
 from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
 from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
-    FleetAcquisitionLedger,
     FleetEvidenceEvent,
     FleetFieldBounded,
     FleetFieldKnown,
@@ -23,109 +19,18 @@ from api.analytics.fleet.types import (
     FleetRowQualifiers,
     FleetShipRecord,
     FleetShipRecordFields,
-    FleetTurnSnapshot,
 )
-from api.models.game import TurnInfo
-from api.serialization.turn import turn_info_from_json
 
-ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
-
-
-@pytest.fixture
-def sample_turn() -> TurnInfo:
-    with open(ASSETS_DIR / "turn_sample.json") as handle:
-        return turn_info_from_json(json.load(handle))
-
-
-def _single_ship_turn(
-    *,
-    turn_number: int,
-    ship_id: int,
-    owner_id: int,
-    x: int,
-    y: int,
-    hull_id: int = 13,
-) -> TurnInfo:
-    with open(ASSETS_DIR / "turn_sample.json") as handle:
-        turn_data = json.load(handle)
-    turn_data["settings"]["turn"] = turn_number
-    turn_data["game"]["turn"] = turn_number
-    turn_data["ships"] = [
-        {
-            "friendlycode": "tst",
-            "name": "Test Ship",
-            "warp": 9,
-            "x": x,
-            "y": y,
-            "beams": 8,
-            "bays": 6,
-            "torps": 6,
-            "mission": 0,
-            "mission1target": 0,
-            "mission2target": 0,
-            "enemy": 0,
-            "damage": 0,
-            "crew": 100,
-            "clans": 0,
-            "neutronium": 0,
-            "tritanium": 0,
-            "duranium": 0,
-            "molybdenum": 0,
-            "supplies": 0,
-            "ammo": 0,
-            "megacredits": 0,
-            "transferclans": 0,
-            "transferneutronium": 0,
-            "transferduranium": 0,
-            "transfertritanium": 0,
-            "transfermolybdenum": 0,
-            "transfersupplies": 0,
-            "transferammo": 0,
-            "transfermegacredits": 0,
-            "transfertargetid": 0,
-            "transfertargettype": 0,
-            "targetx": x,
-            "targety": y,
-            "mass": 100,
-            "heading": 0,
-            "turn": 1,
-            "turnkilled": 0,
-            "beamid": 3,
-            "engineid": 9,
-            "hullid": hull_id,
-            "ownerid": owner_id,
-            "torpedoid": 6,
-            "experience": 0,
-            "infoturn": turn_number,
-            "podhullid": 0,
-            "podcargo": 0,
-            "goal": 0,
-            "goaltarget": 0,
-            "goaltarget2": 0,
-            "waypoints": [],
-            "history": [],
-            "iscloaked": False,
-            "readystatus": 0,
-            "id": ship_id,
-        }
-    ]
-    return turn_info_from_json(turn_data)
-
-
-def _ledger_for_player(snapshot: FleetTurnSnapshot, player_id: int) -> FleetAcquisitionLedger:
-    for ledger in snapshot.players:
-        if ledger.player_id == player_id:
-            return ledger
-    raise AssertionError(f"missing player ledger {player_id}")
+from tests.fleet_fixtures import ledger_for_player, single_ship_turn
 
 
 def test_new_sighting_creates_observed_ship_row():
-    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn = single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ensure_fleet_baseline(628580, 1, turn)
 
     result = ingest_turn_ship_observations(snapshot, turn)
 
-    ledger = _ledger_for_player(result, 8)
+    ledger = ledger_for_player(result, 8)
     assert len(ledger.records) == 1
     record = ledger.records[0]
     assert record.disposition == "active"
@@ -142,18 +47,18 @@ def test_new_sighting_creates_observed_ship_row():
 
 
 def test_repeat_sighting_appends_events_and_updates_position():
-    turn_one = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn_one = single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn_one), turn_one)
-    record_id = _ledger_for_player(snapshot, 8).records[0].record_id
+    record_id = ledger_for_player(snapshot, 8).records[0].record_id
 
-    turn_two = _single_ship_turn(turn_number=2, ship_id=42, owner_id=8, x=1100, y=2100)
+    turn_two = single_ship_turn(turn_number=2, ship_id=42, owner_id=8, x=1100, y=2100)
     turn_two = replace(
         turn_two,
         scores=[replace(score, turn=2) for score in turn_two.scores],
     )
     result = ingest_turn_ship_observations(snapshot, turn_two)
 
-    record = _ledger_for_player(result, 8).records[0]
+    record = ledger_for_player(result, 8).records[0]
     assert record.record_id == record_id
     assert [event.kind for event in record.events] == ["sighting", "position_update"]
     assert record.last_seen is not None
@@ -162,7 +67,7 @@ def test_repeat_sighting_appends_events_and_updates_position():
 
 
 def test_events_are_append_only():
-    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn = single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ensure_fleet_baseline(628580, 1, turn)
     first_event = FleetEvidenceEvent(
         event_id="evt-prior",
@@ -183,7 +88,7 @@ def test_events_are_append_only():
     result = ingest_turn_ship_observations(snapshot, turn)
 
     record = next(
-        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "seed-rec"
+        rec for rec in ledger_for_player(result, 8).records if rec.record_id == "seed-rec"
     )
     assert record.events[0] == first_event
     assert record.events[-1].kind == "sighting"
@@ -191,16 +96,16 @@ def test_events_are_append_only():
 
 
 def test_turn_one_sightings_seed_ledger_without_game_start_inventory():
-    turn = _single_ship_turn(turn_number=1, ship_id=7, owner_id=8, x=500, y=600)
+    turn = single_ship_turn(turn_number=1, ship_id=7, owner_id=8, x=500, y=600)
     snapshot = apply_fleet_turn_delta(ensure_fleet_baseline(628580, 1, turn), turn)
 
-    ledger = _ledger_for_player(snapshot, 8)
+    ledger = ledger_for_player(snapshot, 8)
     assert len(ledger.records) == 1
     assert ledger.records[0].fields.ship_id == FleetFieldKnown(value=7)
 
 
 def test_id_bound_skipped_when_scores_missing():
-    current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
+    current_turn = single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
     current_turn = replace(current_turn, scores=[])
     snapshot = ensure_fleet_baseline(628580, 1, current_turn)
     snapshot.players[0].records.append(
@@ -214,7 +119,7 @@ def test_id_bound_skipped_when_scores_missing():
 
     placeholder = next(
         rec
-        for rec in _ledger_for_player(result, 8).records
+        for rec in ledger_for_player(result, 8).records
         if rec.record_id == "inferred-placeholder"
     )
     assert placeholder.fields.ship_id == FleetFieldUnknown()
@@ -223,7 +128,7 @@ def test_id_bound_skipped_when_scores_missing():
 
 
 def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
-    current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
+    current_turn = single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
     score = replace(
         current_turn.scores[0],
         turn=2,
@@ -246,7 +151,7 @@ def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
 
     placeholder = next(
         rec
-        for rec in _ledger_for_player(result, 8).records
+        for rec in ledger_for_player(result, 8).records
         if rec.record_id == "inferred-placeholder"
     )
     assert placeholder.fields.ship_id == FleetFieldBounded(operator="lte", value=1)
@@ -254,7 +159,7 @@ def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
 
 
 def test_bounded_placeholder_absorbs_matching_sighting():
-    current_turn = _single_ship_turn(turn_number=2, ship_id=3, owner_id=8, x=200, y=200)
+    current_turn = single_ship_turn(turn_number=2, ship_id=3, owner_id=8, x=200, y=200)
     snapshot = ensure_fleet_baseline(628580, 1, current_turn)
     snapshot.players[0].records.append(
         FleetShipRecord(
@@ -268,7 +173,7 @@ def test_bounded_placeholder_absorbs_matching_sighting():
 
     result = ingest_turn_ship_observations(snapshot, current_turn)
 
-    ledger = _ledger_for_player(result, 8)
+    ledger = ledger_for_player(result, 8)
     assert len(ledger.records) == 1
     record = ledger.records[0]
     assert record.record_id == "bounded-placeholder"
@@ -290,17 +195,17 @@ def test_compute_max_ship_id_bound_uses_scoreboard_totals(sample_turn):
 
 
 def test_alibi_applies_after_recorded_count_decrease_and_later_sighting():
-    turn_one = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn_one = single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn_one), turn_one)
-    record = _ledger_for_player(snapshot, 8).records[0]
+    record = ledger_for_player(snapshot, 8).records[0]
     record.qualifiers = FleetRowQualifiers(
         possibly_lost=FleetPossiblyLost(since_turn=5, source="scoreboard"),
     )
 
-    turn_six = _single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn_six = single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
     result = ingest_turn_ship_observations(snapshot, turn_six)
 
-    updated = _ledger_for_player(result, 8).records[0]
+    updated = ledger_for_player(result, 8).records[0]
     assert updated.qualifiers.alibi is not None
     assert updated.qualifiers.alibi.after_turn == 5
     assert updated.qualifiers.alibi.sighting_turn == 6
@@ -308,18 +213,18 @@ def test_alibi_applies_after_recorded_count_decrease_and_later_sighting():
 
 
 def test_killed_ships_are_ignored():
-    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn = single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
     killed_ship = copy.deepcopy(turn.ships[0])
     killed_ship = replace(killed_ship, turnkilled=1)
     turn = replace(turn, ships=[killed_ship])
 
     result = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn), turn)
 
-    assert _ledger_for_player(result, 8).records == []
+    assert ledger_for_player(result, 8).records == []
 
 
 def test_alibi_from_scoreboard_delta_event_on_record():
-    turn_five = _single_ship_turn(turn_number=5, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn_five = single_ship_turn(turn_number=5, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ensure_fleet_baseline(628580, 1, turn_five)
     record = FleetShipRecord(
         record_id="tracked",
@@ -340,14 +245,14 @@ def test_alibi_from_scoreboard_delta_event_on_record():
     result = ingest_turn_ship_observations(snapshot, turn_five)
 
     updated = next(
-        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "tracked"
+        rec for rec in ledger_for_player(result, 8).records if rec.record_id == "tracked"
     )
     assert updated.qualifiers.alibi is not None
     assert updated.qualifiers.alibi.after_turn == 4
 
 
 def test_alibi_uses_latest_scoreboard_decrease_before_sighting():
-    turn_six = _single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
+    turn_six = single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
     snapshot = ensure_fleet_baseline(628580, 1, turn_six)
     record = FleetShipRecord(
         record_id="tracked",
@@ -369,7 +274,7 @@ def test_alibi_uses_latest_scoreboard_decrease_before_sighting():
     result = ingest_turn_ship_observations(snapshot, turn_six)
 
     updated = next(
-        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "tracked"
+        rec for rec in ledger_for_player(result, 8).records if rec.record_id == "tracked"
     )
     assert updated.qualifiers.alibi is not None
     assert updated.qualifiers.alibi.after_turn == 5

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -253,6 +253,30 @@ def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
     assert placeholder.events[-1].kind == "id_bound_tightened"
 
 
+def test_bounded_placeholder_absorbs_matching_sighting():
+    current_turn = _single_ship_turn(turn_number=2, ship_id=3, owner_id=8, x=200, y=200)
+    snapshot = ensure_fleet_baseline(628580, 1, current_turn)
+    snapshot.players[0].records.append(
+        FleetShipRecord(
+            record_id="bounded-placeholder",
+            fields=FleetShipRecordFields(
+                ship_id=FleetFieldBounded(operator="lte", value=5),
+            ),
+            last_seen=FleetLastSeen(turn=1, x=200, y=200),
+        )
+    )
+
+    result = ingest_turn_ship_observations(snapshot, current_turn)
+
+    ledger = _ledger_for_player(result, 8)
+    assert len(ledger.records) == 1
+    record = ledger.records[0]
+    assert record.record_id == "bounded-placeholder"
+    assert record.fields.ship_id == FleetFieldKnown(value=3)
+    assert record.events[-1].kind == "sighting"
+    assert record.events[-1].payload["shipId"] == 3
+
+
 def test_compute_max_ship_id_bound_uses_scoreboard_totals(sample_turn):
     bound = compute_max_ship_id_bound(sample_turn)
     turn_number = sample_turn.settings.turn

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -344,3 +344,33 @@ def test_alibi_from_scoreboard_delta_event_on_record():
     )
     assert updated.qualifiers.alibi is not None
     assert updated.qualifiers.alibi.after_turn == 4
+
+
+def test_alibi_uses_latest_scoreboard_decrease_before_sighting():
+    turn_six = _single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ensure_fleet_baseline(628580, 1, turn_six)
+    record = FleetShipRecord(
+        record_id="tracked",
+        fields=FleetShipRecordFields(ship_id=FleetFieldKnown(value=42)),
+    )
+    for turn, event_id in ((3, "evt-decrease-3"), (5, "evt-decrease-5")):
+        append_fleet_evidence_event(
+            record,
+            FleetEvidenceEvent(
+                event_id=event_id,
+                kind="scoreboard_delta",
+                turn=turn,
+                source="scoreboard",
+                payload={"warshipDelta": -1, "freighterDelta": 0},
+            ),
+        )
+    snapshot.players[0].records.append(record)
+
+    result = ingest_turn_ship_observations(snapshot, turn_six)
+
+    updated = next(
+        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "tracked"
+    )
+    assert updated.qualifiers.alibi is not None
+    assert updated.qualifiers.alibi.after_turn == 5
+    assert updated.qualifiers.alibi.sighting_turn == 6

--- a/packages/api/tests/test_fleet_observation_ingest.py
+++ b/packages/api/tests/test_fleet_observation_ingest.py
@@ -1,0 +1,296 @@
+"""Tests for fleet direct observation ingest."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from api.analytics.fleet.chain import apply_fleet_turn_delta, ensure_fleet_baseline
+from api.analytics.fleet.observation_ingest import (
+    compute_max_ship_id_bound,
+    ingest_turn_ship_observations,
+)
+from api.analytics.fleet.serialization import append_fleet_evidence_event
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetEvidenceEvent,
+    FleetFieldBounded,
+    FleetFieldKnown,
+    FleetFieldUnknown,
+    FleetLastSeen,
+    FleetPossiblyLost,
+    FleetRowQualifiers,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+)
+from api.models.game import TurnInfo
+from api.serialization.turn import turn_info_from_json
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def sample_turn() -> TurnInfo:
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        return turn_info_from_json(json.load(handle))
+
+
+def _single_ship_turn(
+    *,
+    turn_number: int,
+    ship_id: int,
+    owner_id: int,
+    x: int,
+    y: int,
+    hull_id: int = 13,
+) -> TurnInfo:
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        turn_data = json.load(handle)
+    turn_data["settings"]["turn"] = turn_number
+    turn_data["game"]["turn"] = turn_number
+    turn_data["ships"] = [
+        {
+            "friendlycode": "tst",
+            "name": "Test Ship",
+            "warp": 9,
+            "x": x,
+            "y": y,
+            "beams": 8,
+            "bays": 6,
+            "torps": 6,
+            "mission": 0,
+            "mission1target": 0,
+            "mission2target": 0,
+            "enemy": 0,
+            "damage": 0,
+            "crew": 100,
+            "clans": 0,
+            "neutronium": 0,
+            "tritanium": 0,
+            "duranium": 0,
+            "molybdenum": 0,
+            "supplies": 0,
+            "ammo": 0,
+            "megacredits": 0,
+            "transferclans": 0,
+            "transferneutronium": 0,
+            "transferduranium": 0,
+            "transfertritanium": 0,
+            "transfermolybdenum": 0,
+            "transfersupplies": 0,
+            "transferammo": 0,
+            "transfermegacredits": 0,
+            "transfertargetid": 0,
+            "transfertargettype": 0,
+            "targetx": x,
+            "targety": y,
+            "mass": 100,
+            "heading": 0,
+            "turn": 1,
+            "turnkilled": 0,
+            "beamid": 3,
+            "engineid": 9,
+            "hullid": hull_id,
+            "ownerid": owner_id,
+            "torpedoid": 6,
+            "experience": 0,
+            "infoturn": turn_number,
+            "podhullid": 0,
+            "podcargo": 0,
+            "goal": 0,
+            "goaltarget": 0,
+            "goaltarget2": 0,
+            "waypoints": [],
+            "history": [],
+            "iscloaked": False,
+            "readystatus": 0,
+            "id": ship_id,
+        }
+    ]
+    return turn_info_from_json(turn_data)
+
+
+def _ledger_for_player(snapshot: FleetTurnSnapshot, player_id: int) -> FleetAcquisitionLedger:
+    for ledger in snapshot.players:
+        if ledger.player_id == player_id:
+            return ledger
+    raise AssertionError(f"missing player ledger {player_id}")
+
+
+def test_new_sighting_creates_observed_ship_row():
+    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ensure_fleet_baseline(628580, 1, turn)
+
+    result = ingest_turn_ship_observations(snapshot, turn)
+
+    ledger = _ledger_for_player(result, 8)
+    assert len(ledger.records) == 1
+    record = ledger.records[0]
+    assert record.disposition == "active"
+    assert record.fields.ship_id == FleetFieldKnown(value=42)
+    assert record.fields.hull == FleetFieldKnown(value=13)
+    assert record.last_seen is not None
+    assert record.last_seen.turn == 1
+    assert record.last_seen.x == 1000
+    assert record.last_seen.y == 2000
+    assert len(record.events) == 1
+    assert record.events[0].kind == "sighting"
+    assert record.events[0].source == "turnInfo.ships"
+    assert record.events[0].payload["shipId"] == 42
+
+
+def test_repeat_sighting_appends_events_and_updates_position():
+    turn_one = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn_one), turn_one)
+    record_id = _ledger_for_player(snapshot, 8).records[0].record_id
+
+    turn_two = _single_ship_turn(turn_number=2, ship_id=42, owner_id=8, x=1100, y=2100)
+    turn_two = replace(
+        turn_two,
+        scores=[replace(score, turn=2) for score in turn_two.scores],
+    )
+    result = ingest_turn_ship_observations(snapshot, turn_two, prior_turn=turn_one)
+
+    record = _ledger_for_player(result, 8).records[0]
+    assert record.record_id == record_id
+    assert [event.kind for event in record.events] == ["sighting", "position_update"]
+    assert record.last_seen is not None
+    assert record.last_seen.turn == 2
+    assert record.last_seen.x == 1100
+
+
+def test_events_are_append_only():
+    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ensure_fleet_baseline(628580, 1, turn)
+    first_event = FleetEvidenceEvent(
+        event_id="evt-prior",
+        kind="scoreboard_delta",
+        turn=1,
+        source="scoreboard",
+        payload={"warshipDelta": -1},
+    )
+    snapshot.players[0].records.append(
+        FleetShipRecord(
+            record_id="seed-rec",
+            fields=FleetShipRecordFields(ship_id=FleetFieldKnown(value=42)),
+            last_seen=FleetLastSeen(turn=0, x=1000, y=2000),
+            events=[first_event],
+        )
+    )
+
+    result = ingest_turn_ship_observations(snapshot, turn)
+
+    record = next(
+        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "seed-rec"
+    )
+    assert record.events[0] == first_event
+    assert record.events[-1].kind == "sighting"
+    assert len(record.events) == 2
+
+
+def test_turn_one_sightings_seed_ledger_without_game_start_inventory():
+    turn = _single_ship_turn(turn_number=1, ship_id=7, owner_id=8, x=500, y=600)
+    snapshot = apply_fleet_turn_delta(ensure_fleet_baseline(628580, 1, turn), turn)
+
+    ledger = _ledger_for_player(snapshot, 8)
+    assert len(ledger.records) == 1
+    assert ledger.records[0].fields.ship_id == FleetFieldKnown(value=7)
+
+
+def test_id_bound_tightens_for_unmatched_rows_when_counts_known():
+    prior_turn = _single_ship_turn(turn_number=1, ship_id=1, owner_id=8, x=100, y=100)
+    prior_turn = replace(prior_turn, scores=[])
+    current_turn = _single_ship_turn(turn_number=2, ship_id=2, owner_id=8, x=200, y=200)
+    current_turn = replace(current_turn, scores=[])
+    snapshot = ensure_fleet_baseline(628580, 1, current_turn)
+    snapshot.players[0].records.append(
+        FleetShipRecord(
+            record_id="inferred-placeholder",
+            fields=FleetShipRecordFields(ship_id=FleetFieldUnknown()),
+        )
+    )
+
+    result = ingest_turn_ship_observations(snapshot, current_turn, prior_turn=prior_turn)
+
+    placeholder = next(
+        rec
+        for rec in _ledger_for_player(result, 8).records
+        if rec.record_id == "inferred-placeholder"
+    )
+    assert placeholder.fields.ship_id == FleetFieldBounded(operator="lte", value=1)
+    assert placeholder.events[-1].kind == "id_bound_tightened"
+
+
+def test_compute_max_ship_id_bound_uses_scoreboard_totals(sample_turn):
+    prior_turn = replace(sample_turn, settings=replace(sample_turn.settings, turn=110))
+    prior_turn = replace(prior_turn, game=replace(prior_turn.game, turn=110))
+    prior_scores = [replace(score, turn=110) for score in sample_turn.scores]
+    prior_turn = replace(prior_turn, scores=prior_scores)
+
+    bound = compute_max_ship_id_bound(prior_turn, sample_turn)
+    prior_total = sum(score.capitalships + score.freighters for score in prior_scores)
+    builds = sum(
+        max(0, score.shipchange) + max(0, score.freighterchange) for score in sample_turn.scores
+    )
+    assert bound == prior_total + builds
+
+
+def test_alibi_applies_after_recorded_count_decrease_and_later_sighting():
+    turn_one = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn_one), turn_one)
+    record = _ledger_for_player(snapshot, 8).records[0]
+    record.qualifiers = FleetRowQualifiers(
+        possibly_lost=FleetPossiblyLost(since_turn=5, source="scoreboard"),
+    )
+
+    turn_six = _single_ship_turn(turn_number=6, ship_id=42, owner_id=8, x=1000, y=2000)
+    result = ingest_turn_ship_observations(snapshot, turn_six, prior_turn=turn_one)
+
+    updated = _ledger_for_player(result, 8).records[0]
+    assert updated.qualifiers.alibi is not None
+    assert updated.qualifiers.alibi.after_turn == 5
+    assert updated.qualifiers.alibi.sighting_turn == 6
+    assert any(event.kind == "alibi" for event in updated.events)
+
+
+def test_killed_ships_are_ignored():
+    turn = _single_ship_turn(turn_number=1, ship_id=42, owner_id=8, x=1000, y=2000)
+    killed_ship = copy.deepcopy(turn.ships[0])
+    killed_ship = replace(killed_ship, turnkilled=1)
+    turn = replace(turn, ships=[killed_ship])
+
+    result = ingest_turn_ship_observations(ensure_fleet_baseline(628580, 1, turn), turn)
+
+    assert _ledger_for_player(result, 8).records == []
+
+
+def test_alibi_from_scoreboard_delta_event_on_record():
+    turn_five = _single_ship_turn(turn_number=5, ship_id=42, owner_id=8, x=1000, y=2000)
+    snapshot = ensure_fleet_baseline(628580, 1, turn_five)
+    record = FleetShipRecord(
+        record_id="tracked",
+        fields=FleetShipRecordFields(ship_id=FleetFieldKnown(value=42)),
+    )
+    append_fleet_evidence_event(
+        record,
+        FleetEvidenceEvent(
+            event_id="evt-decrease",
+            kind="scoreboard_delta",
+            turn=4,
+            source="scoreboard",
+            payload={"warshipDelta": -1, "freighterDelta": 0},
+        ),
+    )
+    snapshot.players[0].records.append(record)
+
+    result = ingest_turn_ship_observations(snapshot, turn_five)
+
+    updated = next(
+        rec for rec in _ledger_for_player(result, 8).records if rec.record_id == "tracked"
+    )
+    assert updated.qualifiers.alibi is not None
+    assert updated.qualifiers.alibi.after_turn == 4

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -12,7 +12,12 @@ from api.analytics.fleet.chain import (
     get_or_materialize_fleet_snapshot,
 )
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord, FleetTurnSnapshot
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetFieldKnown,
+    FleetShipRecord,
+    FleetTurnSnapshot,
+)
 from api.errors import NotFoundError, ValidationError
 from api.serialization.turn import turn_info_from_json
 from api.services.stack import build_service_stack
@@ -124,11 +129,15 @@ def test_put_snapshot_rejects_metadata_mismatch(
         persistence.put_snapshot(game_id, perspective, turn_number, snapshot)
 
 
-def test_turn_one_baseline_is_empty_per_player(persistence, load_turn, memory_backend):
+def test_turn_one_baseline_seeds_from_turn_one_sightings(persistence, load_turn, memory_backend):
     turn_one_data = copy.deepcopy(memory_backend.get("games/628580/1/turns/110"))
     assert isinstance(turn_one_data, dict)
     turn_one_data["settings"]["turn"] = 1
     turn_one_data["game"]["turn"] = 1
+    turn_one_data["ships"] = [turn_one_data["ships"][0]]
+    turn_one_data["ships"][0]["id"] = 99
+    turn_one_data["ships"][0]["ownerid"] = 8
+    turn_one_data["ships"][0]["turnkilled"] = 0
     memory_backend.put("games/628580/1/turns/1", turn_one_data)
     turn_one = turn_info_from_json(memory_backend.get("games/628580/1/turns/1"))
 
@@ -141,7 +150,8 @@ def test_turn_one_baseline_is_empty_per_player(persistence, load_turn, memory_ba
     )
     assert snapshot.turn == 1
     assert len(snapshot.players) == 4
-    assert all(player.records == [] for player in snapshot.players)
+    assert len(snapshot.players[0].records) == 1
+    assert snapshot.players[0].records[0].fields.ship_id == FleetFieldKnown(value=99)
     assert persistence.get_snapshot(628580, 1, 1) == snapshot
 
 
@@ -174,12 +184,12 @@ def test_chain_gap_fill_persists_intermediate_turn(persistence, load_turn, memor
     )
 
     assert snapshot.turn == 112
-    assert len(snapshot.players[0].records) == 1
+    assert len(snapshot.players[0].records) == 5
     assert snapshot.players[0].records[0].record_id == "gap-rec"
     intermediate = persistence.get_snapshot(628580, 1, 111)
     assert intermediate is not None
     assert intermediate.turn == 111
-    assert len(intermediate.players[0].records) == 1
+    assert len(intermediate.players[0].records) == 5
     assert persistence.get_snapshot(628580, 1, 112) == snapshot
 
 
@@ -226,7 +236,7 @@ def test_implicit_turn_one_baseline_without_persisting_turn_one(
 
     assert snapshot.turn == 111
     assert len(snapshot.players) == 4
-    assert all(player.records == [] for player in snapshot.players)
+    assert len(snapshot.players[0].records) == 4
     assert persistence.get_snapshot(628580, 1, 1) is None
     assert persistence.get_snapshot(628580, 1, 111) == snapshot
 
@@ -246,7 +256,7 @@ def test_chain_materializes_turn_from_prior_snapshot(persistence, load_turn, sam
         load_turn=load_turn,
     )
     assert snapshot.turn == 111
-    assert len(snapshot.players[0].records) == 1
+    assert len(snapshot.players[0].records) == 5
     assert snapshot.players[0].records[0].record_id == "rec-1"
     assert persistence.get_snapshot(628580, 1, 111) == snapshot
 
@@ -319,5 +329,6 @@ def test_turn_analytic_service_materializes_persisted_fleet(memory_backend, load
     data = analytics.get_turn_analytics(628580, 1, 111, "fleet")
     assert data["analyticId"] == "fleet"
     assert len(data["players"]) == 4
-    assert all(player["records"] == [] for player in data["players"])
+    koshling = next(player for player in data["players"] if player["playerId"] == 8)
+    assert len(koshling["records"]) == 4
     assert persistence.get_snapshot(628580, 1, 111) is not None

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -276,7 +276,7 @@ def test_list_analytics_includes_fleet_table_and_map_analytic():
     }
 
 
-def test_fleet_table_returns_scaffold_players():
+def test_fleet_table_returns_players_with_observed_records():
     response = client.get(f"/analytics/fleet/table?{SCOPE_QS}")
     assert response.status_code == 200
     data = response.json()
@@ -284,7 +284,9 @@ def test_fleet_table_returns_scaffold_players():
     players = data["players"]
     assert len(players) == 4
     assert players[0]["playerName"] == "koshling"
-    assert players[0]["records"] == []
+    koshling = next(player for player in players if player["playerId"] == 8)
+    assert len(koshling["records"]) == 4
+    assert koshling["records"][0]["events"][0]["kind"] == "sighting"
 
 
 def test_fleet_map_returns_scaffold_nodes():


### PR DESCRIPTION
## Summary

- Ingest `TurnInfo.ships` into per-player fleet acquisition ledgers during chain materialization, creating or updating observed ship rows with append-only sighting/position events and last-seen updates.
- Tighten unknown ship-id bounds from current-turn scoreboard totals and deltas (`total - net + builds`), skipping when score rows are absent; apply fleet alibi when a sighting follows a recorded count decrease.
- Extract `scoreboard_counts.py` and shared fleet test fixtures; wire ingest through `apply_fleet_turn_delta` as the turn-T evidence hook for upcoming scoreboard ingest (#119).

Closes #118

## Test plan

- [x] `make test` (full suite)
- [x] `cd packages/api && uv run pytest tests/test_fleet_observation_ingest.py tests/test_fleet_persistence.py tests/test_fleet_analytic.py -q`
- [x] Fleet BFF table endpoint returns observed records from materialized snapshots


Made with [Cursor](https://cursor.com)