### PR TITLE
Fleet F5.1: Sidebar + fleet player visibility (#127)

### DIFF
--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -209,7 +209,7 @@ Types: Zod module under `packages/frontend/src/analytics/fleet/` (not central Op
 
 - Master fleet analytic enable (global localStorage, like other analytics)
 - **Fleet player visibility** checklist: one toggle per **Player** for **both** map and table
-- Default: viewpoint **Player** on; others off
+- Default: all **Players** on until the user toggles an override
 - Persisted globally (not per game), same pattern as **Cartography layer**
 
 ### 8.2 Map (deliverable separate from table)

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import {
   applyShellGameBootstrapResult,
   fetchShellGameBootstrap,
 } from './shell/shellGameBootstrap'
+import { viewpointPlayerIdForName } from './analytics/fleet/fleetPlayerVisibilityPolicy'
 import { useShellContext, useShellGameSelection } from './shell'
 import { TurnKeyboardShortcuts } from './components/shell/TurnKeyboardShortcuts'
 import { shouldRetryTanStackQuery } from './lib/queryRetry'
@@ -254,6 +255,12 @@ function ConsoleShell() {
       ? (stellarCartographyTurnSummary?.ionStormCount ?? null)
       : null
 
+  const fleetPlayers = gameInfoContext?.perspectives ?? []
+  const fleetViewpointPlayerId = viewpointPlayerIdForName(
+    fleetPlayers,
+    shellSelectedViewpointName
+  )
+
   const analytics = analyticsData?.analytics ?? []
   const enabledAnalyticIds = useMemo(
     () => analytics.filter((a) => enabledIds.has(a.id)).map((a) => a.id),
@@ -321,6 +328,8 @@ function ConsoleShell() {
           onScoresTableParamsChange={setScoresTableParams}
           stellarCartographyGates={stellarCartographyGates}
           ionStormCount={ionStormCount}
+          fleetPlayers={fleetPlayers}
+          fleetViewpointPlayerId={fleetViewpointPlayerId}
         />
         {isPending ? (
           <main className="flex flex-1 items-center justify-center bg-black p-8 text-gray-400">

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import {
   applyShellGameBootstrapResult,
   fetchShellGameBootstrap,
 } from './shell/shellGameBootstrap'
-import { viewpointPlayerIdForName } from './analytics/fleet/fleetPlayerVisibilityPolicy'
+import { playerIdForViewpointName } from './lib/gameInfoShell'
 import { useShellContext, useShellGameSelection } from './shell'
 import { TurnKeyboardShortcuts } from './components/shell/TurnKeyboardShortcuts'
 import { shouldRetryTanStackQuery } from './lib/queryRetry'
@@ -256,7 +256,7 @@ function ConsoleShell() {
       : null
 
   const fleetPlayers = gameInfoContext?.perspectives ?? []
-  const fleetViewpointPlayerId = viewpointPlayerIdForName(
+  const fleetViewpointPlayerId = playerIdForViewpointName(
     fleetPlayers,
     shellSelectedViewpointName
   )

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ComponentProps } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FleetAnalyticTile } from './FleetAnalyticTile'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+
+const players = [
+  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
+  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
+] as const
+
+function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>> = {}) {
+  return render(
+    <FleetAnalyticTile
+      name="Fleet"
+      enabled
+      supportsMode
+      depressed
+      onToggle={() => {}}
+      players={[...players]}
+      viewpointPlayerId={8}
+      {...overrides}
+    />
+  )
+}
+
+describe('FleetAnalyticTile', () => {
+  beforeEach(() => {
+    useFleetPlayerVisibilityStore.setState({ overrides: {} })
+  })
+
+  it('hides player checkboxes until expanded', () => {
+    renderTile()
+    expect(screen.queryByLabelText('Alice')).not.toBeInTheDocument()
+  })
+
+  it('shows all players enabled by default', async () => {
+    const user = userEvent.setup()
+    renderTile()
+    await user.click(screen.getByLabelText('Expand Fleet player visibility'))
+    expect(screen.getByLabelText('Alice')).toBeChecked()
+    expect(screen.getByLabelText('Bob')).toBeChecked()
+  })
+
+  it('persists player toggle changes through the visibility store', async () => {
+    const user = userEvent.setup()
+    renderTile()
+    await user.click(screen.getByLabelText('Expand Fleet player visibility'))
+    await user.click(screen.getByLabelText('Bob'))
+    expect(useFleetPlayerVisibilityStore.getState().isFleetPlayerVisible(9, 8)).toBe(false)
+  })
+})

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -43,11 +43,14 @@ describe('FleetAnalyticTile', () => {
     expect(screen.getByLabelText('Bob')).toBeChecked()
   })
 
-  it('persists player toggle changes through the visibility store', async () => {
+  it('persists player toggle changes and updates checkbox state', async () => {
     const user = userEvent.setup()
     renderTile()
     await user.click(screen.getByLabelText('Expand Fleet player visibility'))
-    await user.click(screen.getByLabelText('Bob'))
+    const bob = screen.getByLabelText('Bob')
+    expect(bob).toBeChecked()
+    await user.click(bob)
+    expect(bob).not.toBeChecked()
     expect(useFleetPlayerVisibilityStore.getState().isFleetPlayerVisible(9, 8)).toBe(false)
   })
 })

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { orderFleetSidebarPlayers } from './fleetPlayerVisibilityPolicy'
+import { tileClassName } from '../tileChrome'
+
+type FleetAnalyticTileProps = {
+  name: string
+  enabled: boolean
+  supportsMode: boolean
+  depressed: boolean
+  onToggle: () => void
+  players: PerspectiveRow[]
+  viewpointPlayerId: number | null
+}
+
+export function FleetAnalyticTile({
+  name,
+  enabled,
+  supportsMode,
+  depressed,
+  onToggle,
+  players,
+  viewpointPlayerId,
+}: FleetAnalyticTileProps) {
+  const [expanded, setExpanded] = useState(false)
+  const canExpand = supportsMode && enabled && players.length > 0
+  const isFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.isFleetPlayerVisible)
+  const setFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.setFleetPlayerVisible)
+  const orderedPlayers = orderFleetSidebarPlayers(players, viewpointPlayerId)
+
+  useEffect(() => {
+    if (!canExpand) {
+      setExpanded(false)
+    }
+  }, [canExpand])
+
+  const showExpandedBody = canExpand && expanded
+  const chevronPointsDown = showExpandedBody
+
+  return (
+    <div
+      className={cn(
+        tileClassName({ supportsMode, depressed }),
+        'flex min-w-0 max-w-full flex-col'
+      )}
+    >
+      <div className="flex items-center gap-1 py-1.5 pl-2 pr-0.5">
+        <label
+          className={cn(
+            'flex min-w-0 flex-1 cursor-pointer items-center gap-2 py-0.5',
+            !supportsMode && 'cursor-default'
+          )}
+        >
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={() => supportsMode && onToggle()}
+            disabled={!supportsMode}
+            className="h-4 w-4 shrink-0 rounded border-[#52575d] bg-slate-700 text-slate-200 accent-slate-400 focus:ring-[#52575d] focus:ring-offset-0"
+          />
+          <span className="min-w-0 truncate">{name}</span>
+        </label>
+        <button
+          type="button"
+          aria-expanded={chevronPointsDown}
+          aria-label={
+            chevronPointsDown ? 'Collapse Fleet player visibility' : 'Expand Fleet player visibility'
+          }
+          disabled={!canExpand}
+          onClick={() => canExpand && setExpanded((value) => !value)}
+          className={cn(
+            'flex h-7 w-7 shrink-0 items-center justify-center rounded text-slate-400 transition-colors',
+            canExpand &&
+              'hover:bg-black/15 hover:text-slate-200 focus-visible:outline focus-visible:ring-1 focus-visible:ring-slate-500',
+            !canExpand && 'cursor-default opacity-40'
+          )}
+        >
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 shrink-0 transition-transform duration-150',
+              !chevronPointsDown && '-rotate-90'
+            )}
+            aria-hidden
+          />
+        </button>
+      </div>
+      {showExpandedBody ? (
+        <div
+          className="flex min-w-0 flex-col gap-1 border-t border-[#52575d]/70 px-2 pb-2 pt-1.5 text-xs text-slate-300"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {orderedPlayers.map((player) => (
+            <label key={player.playerId} className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={isFleetPlayerVisible(player.playerId, viewpointPlayerId)}
+                onChange={(event) =>
+                  setFleetPlayerVisible(player.playerId, event.target.checked)
+                }
+                className="h-3.5 w-3.5 shrink-0 rounded border-[#52575d] bg-slate-700 accent-slate-400"
+              />
+              <span className="min-w-0 truncate">{player.name}</span>
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
@@ -3,7 +3,10 @@ import { ChevronDown } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import type { PerspectiveRow } from '../../lib/gameInfoShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
-import { orderFleetSidebarPlayers } from './fleetPlayerVisibilityPolicy'
+import {
+  orderFleetSidebarPlayers,
+  resolveFleetPlayerVisible,
+} from './fleetPlayerVisibilityPolicy'
 import { tileClassName } from '../tileChrome'
 
 type FleetAnalyticTileProps = {
@@ -27,7 +30,7 @@ export function FleetAnalyticTile({
 }: FleetAnalyticTileProps) {
   const [expanded, setExpanded] = useState(false)
   const canExpand = supportsMode && enabled && players.length > 0
-  const isFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.isFleetPlayerVisible)
+  const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
   const setFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.setFleetPlayerVisible)
   const orderedPlayers = orderFleetSidebarPlayers(players, viewpointPlayerId)
 
@@ -96,7 +99,11 @@ export function FleetAnalyticTile({
             <label key={player.playerId} className="flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
-                checked={isFleetPlayerVisible(player.playerId, viewpointPlayerId)}
+                checked={resolveFleetPlayerVisible(
+                  player.playerId,
+                  viewpointPlayerId,
+                  visibilityOverrides
+                )}
                 onChange={(event) =>
                   setFleetPlayerVisible(player.playerId, event.target.checked)
                 }

--- a/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
+import {
+  defaultFleetPlayerVisible,
+  orderFleetSidebarPlayers,
+  resolveFleetPlayerVisible,
+  viewpointPlayerIdForName,
+  visibleFleetPlayerIds,
+} from './fleetPlayerVisibilityPolicy'
+
+const players: PerspectiveRow[] = [
+  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
+  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
+  { ordinal: 3, playerId: 10, name: 'Carol', raceName: null },
+]
+
+describe('fleetPlayerVisibilityPolicy', () => {
+  it('defaults to all players visible', () => {
+    expect(defaultFleetPlayerVisible(8, 8)).toBe(true)
+    expect(defaultFleetPlayerVisible(9, 8)).toBe(true)
+    expect(defaultFleetPlayerVisible(8, null)).toBe(true)
+  })
+
+  it('uses persisted overrides when present', () => {
+    expect(resolveFleetPlayerVisible(9, 8, { '9': false })).toBe(false)
+    expect(resolveFleetPlayerVisible(8, 8, { '8': false })).toBe(false)
+    expect(resolveFleetPlayerVisible(10, 8, {})).toBe(true)
+  })
+
+  it('orders viewpoint player first in the sidebar', () => {
+    expect(orderFleetSidebarPlayers(players, 9).map((player) => player.name)).toEqual([
+      'Bob',
+      'Alice',
+      'Carol',
+    ])
+  })
+
+  it('resolves viewpoint player id from shell viewpoint name', () => {
+    expect(viewpointPlayerIdForName(players, 'Bob')).toBe(9)
+    expect(viewpointPlayerIdForName(players, null)).toBeNull()
+  })
+
+  it('returns visible fleet player ids from defaults and overrides', () => {
+    expect(visibleFleetPlayerIds(players, 8, {})).toEqual([8, 9, 10])
+    expect(visibleFleetPlayerIds(players, 8, { '8': false, '10': false })).toEqual([9])
+  })
+})

--- a/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.test.ts
@@ -4,7 +4,6 @@ import {
   defaultFleetPlayerVisible,
   orderFleetSidebarPlayers,
   resolveFleetPlayerVisible,
-  viewpointPlayerIdForName,
   visibleFleetPlayerIds,
 } from './fleetPlayerVisibilityPolicy'
 
@@ -33,11 +32,6 @@ describe('fleetPlayerVisibilityPolicy', () => {
       'Alice',
       'Carol',
     ])
-  })
-
-  it('resolves viewpoint player id from shell viewpoint name', () => {
-    expect(viewpointPlayerIdForName(players, 'Bob')).toBe(9)
-    expect(viewpointPlayerIdForName(players, null)).toBeNull()
   })
 
   it('returns visible fleet player ids from defaults and overrides', () => {

--- a/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.ts
@@ -1,0 +1,66 @@
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
+
+/** Persisted per-player fleet visibility overrides (playerId string keys). */
+export type FleetPlayerVisibilityOverrides = Record<string, boolean>
+
+export function fleetPlayerVisibilityStorageKey(playerId: number): string {
+  return String(playerId)
+}
+
+/** Default visibility: all players on until the user toggles an override. */
+export function defaultFleetPlayerVisible(
+  _playerId: number,
+  _viewpointPlayerId: number | null
+): boolean {
+  return true
+}
+
+export function resolveFleetPlayerVisible(
+  playerId: number,
+  viewpointPlayerId: number | null,
+  overrides: FleetPlayerVisibilityOverrides
+): boolean {
+  const key = fleetPlayerVisibilityStorageKey(playerId)
+  if (Object.prototype.hasOwnProperty.call(overrides, key)) {
+    return overrides[key]
+  }
+  return defaultFleetPlayerVisible(playerId, viewpointPlayerId)
+}
+
+/** Viewpoint player first, then remaining players in game-info order. */
+export function orderFleetSidebarPlayers(
+  players: readonly PerspectiveRow[],
+  viewpointPlayerId: number | null
+): PerspectiveRow[] {
+  if (viewpointPlayerId == null) {
+    return [...players]
+  }
+  const viewpoint = players.find((player) => player.playerId === viewpointPlayerId)
+  if (!viewpoint) {
+    return [...players]
+  }
+  return [viewpoint, ...players.filter((player) => player.playerId !== viewpointPlayerId)]
+}
+
+export function viewpointPlayerIdForName(
+  players: readonly PerspectiveRow[],
+  viewpointName: string | null
+): number | null {
+  if (viewpointName == null || viewpointName.trim() === '') {
+    return null
+  }
+  const hit = players.find((player) => player.name === viewpointName)
+  return hit?.playerId ?? null
+}
+
+export function visibleFleetPlayerIds(
+  players: readonly PerspectiveRow[],
+  viewpointPlayerId: number | null,
+  overrides: FleetPlayerVisibilityOverrides
+): number[] {
+  return players
+    .filter((player) =>
+      resolveFleetPlayerVisible(player.playerId, viewpointPlayerId, overrides)
+    )
+    .map((player) => player.playerId)
+}

--- a/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerVisibilityPolicy.ts
@@ -42,17 +42,6 @@ export function orderFleetSidebarPlayers(
   return [viewpoint, ...players.filter((player) => player.playerId !== viewpointPlayerId)]
 }
 
-export function viewpointPlayerIdForName(
-  players: readonly PerspectiveRow[],
-  viewpointName: string | null
-): number | null {
-  if (viewpointName == null || viewpointName.trim() === '') {
-    return null
-  }
-  const hit = players.find((player) => player.name === viewpointName)
-  return hit?.playerId ?? null
-}
-
 export function visibleFleetPlayerIds(
   players: readonly PerspectiveRow[],
   viewpointPlayerId: number | null,

--- a/packages/frontend/src/analytics/fleet/mapAnalytic.ts
+++ b/packages/frontend/src/analytics/fleet/mapAnalytic.ts
@@ -1,0 +1,25 @@
+import type { MapAnalyticQueryContext, MapAnalyticRegistration } from '../mapAnalyticRegistry'
+import { FLEET_ANALYTIC_ID } from '../mapAnalyticIds'
+
+/**
+ * Scaffold registration so enabling Fleet in map view does not crash the shell.
+ * Node merge, visibility filter, and fleet map wire parsing land in #128.
+ */
+export const fleetMapAnalytic: MapAnalyticRegistration = {
+  buildQuerySpec(context: MapAnalyticQueryContext) {
+    return {
+      queryKey: [
+        'analytic',
+        FLEET_ANALYTIC_ID,
+        'map',
+        context.analyticScope,
+        'scaffold-v0',
+      ] as const,
+      queryFn: async () => ({ analyticId: FLEET_ANALYTIC_ID, nodes: [], edges: [] }),
+      enabled: false,
+    }
+  },
+  mergeLayer() {
+    // Fleet map layer merge is implemented in #128.
+  },
+}

--- a/packages/frontend/src/analytics/mapAnalyticIds.ts
+++ b/packages/frontend/src/analytics/mapAnalyticIds.ts
@@ -7,5 +7,8 @@ export const CONNECTIONS_ANALYTIC_ID = 'connections'
 /** Canonical id for the Stellar Cartography map overlay analytic. */
 export const STELLAR_CARTOGRAPHY_ANALYTIC_ID = 'stellar-cartography'
 
+/** Canonical id for the Fleet map overlay analytic. */
+export const FLEET_ANALYTIC_ID = 'fleet'
+
 /** Prefix for merged Stellar Cartography node and edge ids on the combined map. */
 export const STELLAR_CARTOGRAPHY_NODE_ID_PREFIX = `${STELLAR_CARTOGRAPHY_ANALYTIC_ID}:`

--- a/packages/frontend/src/analytics/mapAnalyticRegistry.test.ts
+++ b/packages/frontend/src/analytics/mapAnalyticRegistry.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import { connectionsMapAnalytic, connectionsMapQueryKey } from './connections/mapAnalytic'
+import { fleetMapAnalytic } from './fleet/mapAnalytic'
 import { stellarCartographyMapAnalytic } from './stellar-cartography/mapAnalytic'
 import {
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
+  FLEET_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
 } from './mapAnalyticIds'
 import {
@@ -32,6 +34,7 @@ describe('map analytic registry', () => {
       BASE_MAP_ANALYTIC_ID,
       CONNECTIONS_ANALYTIC_ID,
       STELLAR_CARTOGRAPHY_ANALYTIC_ID,
+      FLEET_ANALYTIC_ID,
     ])
     for (const analyticId of REGISTERED_MAP_ANALYTIC_IDS) {
       expect(isRegisteredMapAnalytic(analyticId)).toBe(true)
@@ -41,6 +44,7 @@ describe('map analytic registry', () => {
     expect(mapAnalyticRegistrationFor(STELLAR_CARTOGRAPHY_ANALYTIC_ID)).toBe(
       stellarCartographyMapAnalytic
     )
+    expect(mapAnalyticRegistrationFor(FLEET_ANALYTIC_ID)).toBe(fleetMapAnalytic)
   })
 
   it('throws for unregistered map analytics', () => {
@@ -93,6 +97,23 @@ describe('map analytic registry', () => {
       sampleScope,
       'planet-v2',
     ])
+  })
+
+  it('wires fleet to a disabled scaffold query spec until map layer lands', () => {
+    const registration = mapAnalyticRegistrationFor(FLEET_ANALYTIC_ID)
+    expect(registration).toBe(fleetMapAnalytic)
+    expect(registration.buildQuerySpec).toBeDefined()
+    expect(registration.mergeLayer).not.toBe(defaultMapLayerMerger)
+
+    const spec = mapAnalyticQuerySpecFor(FLEET_ANALYTIC_ID, queryContext)
+    expect(spec.queryKey).toEqual([
+      'analytic',
+      FLEET_ANALYTIC_ID,
+      'map',
+      sampleScope,
+      'scaffold-v0',
+    ])
+    expect(spec.enabled).toBe(false)
   })
 })
 

--- a/packages/frontend/src/analytics/mapAnalyticRegistry.ts
+++ b/packages/frontend/src/analytics/mapAnalyticRegistry.ts
@@ -10,9 +10,11 @@ import { connectionsMapAnalytic } from './connections/mapAnalytic'
 import {
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
+  FLEET_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
 } from './mapAnalyticIds'
 import { stellarCartographyMapAnalytic } from './stellar-cartography/mapAnalytic'
+import { fleetMapAnalytic } from './fleet/mapAnalytic'
 import type { CombineMapDataOptionsBase } from './mapLayers'
 
 export type MapAnalyticQueryContext = {
@@ -102,6 +104,7 @@ const mapAnalyticRegistry: Record<string, MapAnalyticRegistration> = {
   [BASE_MAP_ANALYTIC_ID]: defaultMapAnalyticRegistration,
   [CONNECTIONS_ANALYTIC_ID]: connectionsMapAnalytic,
   [STELLAR_CARTOGRAPHY_ANALYTIC_ID]: stellarCartographyMapAnalytic,
+  [FLEET_ANALYTIC_ID]: fleetMapAnalytic,
 }
 
 /** Canonical map analytic ids with explicit registry entries. */
@@ -109,6 +112,7 @@ export const REGISTERED_MAP_ANALYTIC_IDS = [
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
+  FLEET_ANALYTIC_ID,
 ] as const satisfies readonly string[]
 
 export type RegisteredMapAnalyticId = (typeof REGISTERED_MAP_ANALYTIC_IDS)[number]

--- a/packages/frontend/src/components/AnalyticsBar.tsx
+++ b/packages/frontend/src/components/AnalyticsBar.tsx
@@ -1,8 +1,10 @@
 import { cn } from '../lib/utils'
 import { ConnectionsMapTile } from '../analytics/connections/ConnectionsMapTile'
+import { FleetAnalyticTile } from '../analytics/fleet/FleetAnalyticTile'
 import { ScoresTableTile } from '../analytics/scores/ScoresTableTile'
 import { StellarCartographyMapTile } from '../analytics/stellar-cartography/StellarCartographyMapTile'
 import { tileClassName } from '../analytics/tileChrome'
+import type { PerspectiveRow } from '../lib/gameInfoShell'
 import type { StellarCartographySettingsGates } from '../analytics/stellar-cartography/layers'
 import type { AnalyticItem, ConnectionsMapParams, ScoresTableParams } from '../api/bff'
 
@@ -19,6 +21,8 @@ type AnalyticsBarProps = {
   onScoresTableParamsChange: (next: ScoresTableParams) => void
   stellarCartographyGates: StellarCartographySettingsGates
   ionStormCount: number | null
+  fleetPlayers: PerspectiveRow[]
+  fleetViewpointPlayerId: number | null
 }
 
 function supportsCurrentMode(a: AnalyticItem, viewMode: ViewMode): boolean {
@@ -41,6 +45,8 @@ export function AnalyticsBar({
   onScoresTableParamsChange,
   stellarCartographyGates,
   ionStormCount,
+  fleetPlayers,
+  fleetViewpointPlayerId,
 }: AnalyticsBarProps) {
   const list = selectableAnalytics(analytics)
   return (
@@ -56,6 +62,7 @@ export function AnalyticsBar({
           const isConnectionsMap = a.id === 'connections' && viewMode === 'map'
           const isScoresTable = a.id === 'scores' && viewMode === 'tabular'
           const isStellarCartographyMap = a.id === 'stellar-cartography' && viewMode === 'map'
+          const isFleet = a.id === 'fleet'
 
           if (isScoresTable) {
             return (
@@ -84,6 +91,22 @@ export function AnalyticsBar({
                   onToggle={() => onToggle(a.id)}
                   connectionsMapParams={connectionsMapParams}
                   onConnectionsMapParamsChange={onConnectionsMapParamsChange}
+                />
+              </li>
+            )
+          }
+
+          if (isFleet) {
+            return (
+              <li key={a.id} className="min-w-0">
+                <FleetAnalyticTile
+                  name={a.name}
+                  enabled={enabled}
+                  supportsMode={supportsMode}
+                  depressed={depressed}
+                  onToggle={() => onToggle(a.id)}
+                  players={fleetPlayers}
+                  viewpointPlayerId={fleetViewpointPlayerId}
                 />
               </li>
             )

--- a/packages/frontend/src/lib/gameInfoShell.test.ts
+++ b/packages/frontend/src/lib/gameInfoShell.test.ts
@@ -7,6 +7,7 @@ import {
   isLoginAmongGamePlayers,
   perspectiveOrdinalForName,
   perspectiveNameForOrdinal,
+  playerIdForViewpointName,
   shouldUsePseudoViewpointForLogin,
   selectableTurnMaxForShell,
   SPECTATOR_VIEWPOINT_NAME,
@@ -14,6 +15,7 @@ import {
   viewpointNameForLogin,
 } from './gameInfoShell'
 import type { GameInfoResponse } from '../api/bff'
+import { perspectiveRow } from './perspectiveRowTestFixtures'
 
 const minimalInfo = (overrides: Partial<GameInfoResponse> = {}): GameInfoResponse => ({
   game: { id: 1 },
@@ -142,10 +144,7 @@ describe('getSectorDisplayNameFromGameInfo', () => {
 })
 
 describe('perspectiveOrdinalForName', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('returns null for empty name', () => {
     expect(perspectiveOrdinalForName(p, null)).toBeNull()
@@ -167,10 +166,7 @@ describe('perspectiveOrdinalForName', () => {
 })
 
 describe('viewpointNameForStoredPerspective', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('returns spectator label for pseudo slot 0', () => {
     expect(viewpointNameForStoredPerspective(0, p)).toBe(SPECTATOR_VIEWPOINT_NAME)
@@ -182,10 +178,7 @@ describe('viewpointNameForStoredPerspective', () => {
 })
 
 describe('isLoginAmongGamePlayers', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('is false when login empty', () => {
     expect(isLoginAmongGamePlayers(p, null)).toBe(false)
@@ -202,10 +195,7 @@ describe('isLoginAmongGamePlayers', () => {
 })
 
 describe('shouldUsePseudoViewpointForLogin', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('is true for in-progress game when login is not a player', () => {
     expect(shouldUsePseudoViewpointForLogin(p, 'nobody', false)).toBe(true)
@@ -235,10 +225,7 @@ describe('selectableTurnMaxForShell', () => {
 })
 
 describe('viewpointNameForLogin', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('returns first when no login', () => {
     expect(viewpointNameForLogin(p, null)).toBe('Alpha')
@@ -254,10 +241,7 @@ describe('viewpointNameForLogin', () => {
 })
 
 describe('perspectiveNameForOrdinal', () => {
-  const p = [
-    { ordinal: 1, name: 'Alpha', raceName: null as string | null },
-    { ordinal: 2, name: 'Beta', raceName: null as string | null },
-  ]
+  const p = [perspectiveRow(1, 'Alpha'), perspectiveRow(2, 'Beta')]
 
   it('returns name for known ordinal', () => {
     expect(perspectiveNameForOrdinal(p, 2)).toBe('Beta')
@@ -265,5 +249,26 @@ describe('perspectiveNameForOrdinal', () => {
 
   it('returns null for unknown ordinal', () => {
     expect(perspectiveNameForOrdinal(p, 99)).toBeNull()
+  })
+})
+
+describe('playerIdForViewpointName', () => {
+  const p = [
+    perspectiveRow(1, 'Alpha', { playerId: 8 }),
+    perspectiveRow(2, 'Beta', { playerId: 9 }),
+  ]
+
+  it('returns null for empty name', () => {
+    expect(playerIdForViewpointName(p, null)).toBeNull()
+    expect(playerIdForViewpointName(p, '')).toBeNull()
+    expect(playerIdForViewpointName(p, '   ')).toBeNull()
+  })
+
+  it('returns host player id for exact name match', () => {
+    expect(playerIdForViewpointName(p, 'Beta')).toBe(9)
+  })
+
+  it('returns null when name not in list', () => {
+    expect(playerIdForViewpointName(p, 'Gamma')).toBeNull()
   })
 })

--- a/packages/frontend/src/lib/gameInfoShell.test.ts
+++ b/packages/frontend/src/lib/gameInfoShell.test.ts
@@ -68,8 +68,8 @@ describe('buildPerspectivesFromGameInfo', () => {
       })
     )
     expect(rows).toEqual([
-      { ordinal: 1, name: 'alice', raceName: null },
-      { ordinal: 2, name: 'bob', raceName: null },
+      { ordinal: 1, name: 'alice', playerId: 1, raceName: null },
+      { ordinal: 2, name: 'bob', playerId: 2, raceName: null },
     ])
   })
 
@@ -92,6 +92,7 @@ describe('buildPerspectivesFromGameInfo', () => {
     )
     expect(rows[0]).toEqual({
       ordinal: 1,
+      playerId: 1,
       name: 'alice',
       raceName: 'Override From Turn RST',
     })
@@ -104,6 +105,16 @@ describe('buildPerspectivesFromGameInfo', () => {
       })
     )
     expect(rows[0].raceName).toBe('The Evil Empire')
+  })
+
+  it('uses host player id from game info when present', () => {
+    const rows = buildPerspectivesFromGameInfo(
+      minimalInfo({
+        players: [{ username: 'alice', id: 42 }, { username: 'bob' }],
+      })
+    )
+    expect(rows[0].playerId).toBe(42)
+    expect(rows[1].playerId).toBe(2)
   })
 })
 

--- a/packages/frontend/src/lib/gameInfoShell.ts
+++ b/packages/frontend/src/lib/gameInfoShell.ts
@@ -118,6 +118,18 @@ export function perspectiveOrdinalForName(
   return hit?.ordinal ?? null
 }
 
+/** Host player id for a shell viewpoint name, or null when unknown or empty. */
+export function playerIdForViewpointName(
+  perspectives: PerspectiveRow[],
+  name: string | null
+): number | null {
+  if (name == null || name.trim() === '') {
+    return null
+  }
+  const hit = perspectives.find((p) => p.name === name)
+  return hit?.playerId ?? null
+}
+
 /** Perspective slot used when login is not a game player on an in-progress game. */
 export const PSEUDO_VIEWPOINT_PERSPECTIVE = 0
 

--- a/packages/frontend/src/lib/gameInfoShell.ts
+++ b/packages/frontend/src/lib/gameInfoShell.ts
@@ -6,6 +6,8 @@ import { stellarCartographySettingsGatesFromGameInfo } from './stellarCartograph
 /** 1-based player index in game info `players` order, with display name. */
 export type PerspectiveRow = {
   ordinal: number
+  /** Host player id from game info `players[].id` when present, else ordinal. */
+  playerId: number
   name: string
   /** From turn-style `races` on the payload when present, else static HOST catalog. */
   raceName: string | null
@@ -58,6 +60,7 @@ export function buildPerspectivesFromGameInfo(data: GameInfoResponse): Perspecti
   return raw.map((entry, i) => {
     let username = ''
     let raceId: number | null = null
+    let playerId = i + 1
     if (entry && typeof entry === 'object') {
       const o = entry as Record<string, unknown>
       const u = o.username
@@ -68,12 +71,17 @@ export function buildPerspectivesFromGameInfo(data: GameInfoResponse): Perspecti
       if (typeof rid === 'number' && Number.isFinite(rid)) {
         raceId = rid
       }
+      const hostPlayerId = o.id
+      if (typeof hostPlayerId === 'number' && Number.isFinite(hostPlayerId)) {
+        playerId = hostPlayerId
+      }
     }
     const trimmed = username.trim()
     const name = trimmed || `Player ${i + 1}`
     const raceName = resolveRaceDisplayNameFromGameInfo(raceId, data)
     return {
       ordinal: i + 1,
+      playerId,
       name,
       raceName,
     }

--- a/packages/frontend/src/lib/mapAnalyticQueryPlan.test.ts
+++ b/packages/frontend/src/lib/mapAnalyticQueryPlan.test.ts
@@ -6,6 +6,7 @@ import {
   resolveBaseMapAnalyticId,
 } from './mapAnalyticQueryPlan'
 import { connectionsMapQueryKey } from '../analytics/connections/mapAnalytic'
+import { FLEET_ANALYTIC_ID } from '../analytics/mapAnalyticIds'
 import {
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
@@ -94,6 +95,25 @@ describe('enabledMapAnalyticIds and mapIdsToFetch', () => {
       BASE_MAP_ANALYTIC_ID,
       CONNECTIONS_ANALYTIC_ID,
       STELLAR_CARTOGRAPHY_ANALYTIC_ID,
+    ])
+  })
+
+  it('includes fleet when enabled without throwing', () => {
+    const analyticsWithFleet = [
+      ...sampleAnalytics,
+      {
+        id: FLEET_ANALYTIC_ID,
+        name: 'Fleet',
+        supportsTable: true,
+        supportsMap: true,
+        type: 'selectable' as const,
+      },
+    ]
+    const enabled = enabledMapAnalyticIds([FLEET_ANALYTIC_ID], analyticsWithFleet)
+    expect(enabled).toEqual([FLEET_ANALYTIC_ID])
+    expect(mapIdsToFetch(analyticsWithFleet, enabled)).toEqual([
+      BASE_MAP_ANALYTIC_ID,
+      FLEET_ANALYTIC_ID,
     ])
   })
 

--- a/packages/frontend/src/lib/perspectiveRowTestFixtures.ts
+++ b/packages/frontend/src/lib/perspectiveRowTestFixtures.ts
@@ -1,0 +1,20 @@
+import type { PerspectiveRow } from './gameInfoShell'
+
+type PerspectiveRowFixtureOptions = {
+  playerId?: number
+  raceName?: string | null
+}
+
+/** Build a `PerspectiveRow` for tests; `playerId` defaults to `ordinal`. */
+export function perspectiveRow(
+  ordinal: number,
+  name: string,
+  options: PerspectiveRowFixtureOptions = {}
+): PerspectiveRow {
+  return {
+    ordinal,
+    playerId: options.playerId ?? ordinal,
+    name,
+    raceName: options.raceName ?? null,
+  }
+}

--- a/packages/frontend/src/shell/finalTurnLoadFailuresMessage.test.ts
+++ b/packages/frontend/src/shell/finalTurnLoadFailuresMessage.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { formatFinalTurnLoadFailuresMessage } from './finalTurnLoadFailuresMessage'
-import type { PerspectiveRow } from '../lib/gameInfoShell'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 
-const perspectives: PerspectiveRow[] = [
-  { ordinal: 1, name: 'Alice', raceName: null },
-  { ordinal: 2, name: 'Bob', raceName: null },
-  { ordinal: 3, name: 'Carol', raceName: null },
+const perspectives = [
+  perspectiveRow(1, 'Alice'),
+  perspectiveRow(2, 'Bob'),
+  perspectiveRow(3, 'Carol'),
 ]
 
 describe('formatFinalTurnLoadFailuresMessage', () => {

--- a/packages/frontend/src/shell/shellContext.test.ts
+++ b/packages/frontend/src/shell/shellContext.test.ts
@@ -14,11 +14,12 @@ import {
   shouldClearInProgressPerspectiveOverride,
   type ShellContextInputs,
 } from './shellContext'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 
 const perspectives = [
-  { ordinal: 1, name: 'Alice', raceName: 'Feds' as string | null },
-  { ordinal: 2, name: 'Bob', raceName: 'Lizards' as string | null },
-  { ordinal: 3, name: 'Carol', raceName: null as string | null },
+  perspectiveRow(1, 'Alice', { raceName: 'Feds' }),
+  perspectiveRow(2, 'Bob', { raceName: 'Lizards' }),
+  perspectiveRow(3, 'Carol'),
 ]
 
 function shellContext(overrides: Partial<GameInfoShellContext> = {}): GameInfoShellContext {

--- a/packages/frontend/src/shell/useShellContext.test.tsx
+++ b/packages/frontend/src/shell/useShellContext.test.tsx
@@ -6,6 +6,7 @@ import { useShellContext } from './useShellContext'
 import { useShellStore } from '../stores/shell'
 import { useSessionStore } from '../stores/session'
 import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 
 vi.mock('../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/bff')>()
@@ -61,7 +62,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -97,7 +98,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -126,7 +127,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -158,7 +159,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -197,7 +198,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -235,7 +236,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -258,7 +259,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -289,7 +290,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -322,10 +323,7 @@ describe('useShellContext', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [
-          { ordinal: 1, name: 'Alice', raceName: null },
-          { ordinal: 2, name: 'Bob', raceName: null },
-        ],
+        perspectives: [perspectiveRow(1, 'Alice'), perspectiveRow(2, 'Bob')],
         isGameFinished: false,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },

--- a/packages/frontend/src/shell/useShellGameSelection.test.tsx
+++ b/packages/frontend/src/shell/useShellGameSelection.test.tsx
@@ -6,6 +6,7 @@ import { useShellGameSelection } from './useShellGameSelection'
 import { useShellStore } from '../stores/shell'
 import { useSessionStore } from '../stores/session'
 import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 
 vi.mock('../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/bff')>()
@@ -50,7 +51,7 @@ describe('useShellGameSelection', () => {
       selectedGameId: '99',
       gameInfoContext: {
         turn: 5,
-        perspectives: [{ ordinal: 1, name: 'Alice', raceName: null }],
+        perspectives: [perspectiveRow(1, 'Alice')],
         isGameFinished: false,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
@@ -182,10 +183,7 @@ describe('useShellGameSelection', () => {
     useShellStore.setState({
       gameInfoContext: {
         turn: 5,
-        perspectives: [
-          { ordinal: 1, name: 'Alice', raceName: null },
-          { ordinal: 2, name: 'Bob', raceName: null },
-        ],
+        perspectives: [perspectiveRow(1, 'Alice'), perspectiveRow(2, 'Bob')],
         isGameFinished: true,
         sectorDisplayName: null,
         stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },

--- a/packages/frontend/src/stores/fleetPlayerVisibility.test.ts
+++ b/packages/frontend/src/stores/fleetPlayerVisibility.test.ts
@@ -16,11 +16,13 @@ describe('useFleetPlayerVisibilityStore', () => {
     expect(isFleetPlayerVisible(9, 8)).toBe(true)
   })
 
-  it('persists per-player overrides to localStorage', () => {
-    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, true)
+  it('persists hide override to localStorage', () => {
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
+    const { isFleetPlayerVisible } = useFleetPlayerVisibilityStore.getState()
+    expect(isFleetPlayerVisible(9, 8)).toBe(false)
     const raw = localStorage.getItem(FLEET_PLAYER_VISIBILITY_STORAGE_KEY)
     expect(raw).toBeTruthy()
-    expect(raw).toContain('"9":true')
+    expect(raw).toContain('"9":false')
   })
 
   it('reads persisted overrides after rehydrate-style state', () => {

--- a/packages/frontend/src/stores/fleetPlayerVisibility.test.ts
+++ b/packages/frontend/src/stores/fleetPlayerVisibility.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  FLEET_PLAYER_VISIBILITY_STORAGE_KEY,
+  useFleetPlayerVisibilityStore,
+} from './fleetPlayerVisibility'
+
+describe('useFleetPlayerVisibilityStore', () => {
+  beforeEach(() => {
+    localStorage.removeItem(FLEET_PLAYER_VISIBILITY_STORAGE_KEY)
+    useFleetPlayerVisibilityStore.setState({ overrides: {} })
+  })
+
+  it('defaults to all players visible', () => {
+    const { isFleetPlayerVisible } = useFleetPlayerVisibilityStore.getState()
+    expect(isFleetPlayerVisible(8, 8)).toBe(true)
+    expect(isFleetPlayerVisible(9, 8)).toBe(true)
+  })
+
+  it('persists per-player overrides to localStorage', () => {
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, true)
+    const raw = localStorage.getItem(FLEET_PLAYER_VISIBILITY_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    expect(raw).toContain('"9":true')
+  })
+
+  it('reads persisted overrides after rehydrate-style state', () => {
+    useFleetPlayerVisibilityStore.setState({ overrides: { '9': true, '8': false } })
+    const { isFleetPlayerVisible } = useFleetPlayerVisibilityStore.getState()
+    expect(isFleetPlayerVisible(9, 8)).toBe(true)
+    expect(isFleetPlayerVisible(8, 8)).toBe(false)
+  })
+})

--- a/packages/frontend/src/stores/fleetPlayerVisibility.ts
+++ b/packages/frontend/src/stores/fleetPlayerVisibility.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+import {
+  fleetPlayerVisibilityStorageKey,
+  resolveFleetPlayerVisible,
+  type FleetPlayerVisibilityOverrides,
+} from '../analytics/fleet/fleetPlayerVisibilityPolicy'
+import { createLocalStorageOrMemoryStateStorage } from '../lib/browserPersistStorage'
+
+const fleetPlayerVisibilityPersistStorage = createLocalStorageOrMemoryStateStorage()
+
+export const FLEET_PLAYER_VISIBILITY_STORAGE_KEY = 'planets-console-fleet-player-visibility'
+
+type FleetPlayerVisibilityState = {
+  overrides: FleetPlayerVisibilityOverrides
+  isFleetPlayerVisible: (playerId: number, viewpointPlayerId: number | null) => boolean
+  setFleetPlayerVisible: (playerId: number, enabled: boolean) => void
+}
+
+export const useFleetPlayerVisibilityStore = create<FleetPlayerVisibilityState>()(
+  persist(
+    (set, get) => ({
+      overrides: {},
+      isFleetPlayerVisible: (playerId, viewpointPlayerId) =>
+        resolveFleetPlayerVisible(playerId, viewpointPlayerId, get().overrides),
+      setFleetPlayerVisible: (playerId, enabled) =>
+        set((state) => ({
+          overrides: {
+            ...state.overrides,
+            [fleetPlayerVisibilityStorageKey(playerId)]: enabled,
+          },
+        })),
+    }),
+    {
+      name: FLEET_PLAYER_VISIBILITY_STORAGE_KEY,
+      storage: createJSONStorage(() => fleetPlayerVisibilityPersistStorage),
+      partialize: (state) => ({ overrides: state.overrides }),
+    }
+  )
+)

--- a/packages/frontend/src/stores/shell.test.ts
+++ b/packages/frontend/src/stores/shell.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 import { SHELL_STORAGE_KEY, useShellStore } from '../stores/shell'
 
 describe('useShellStore', () => {
@@ -46,7 +47,7 @@ describe('useShellStore', () => {
       selectedGameId: '628580',
       gameInfoContext: {
         turn: 10,
-        perspectives: [{ ordinal: 1, name: 'A', raceName: 'Federation' }],
+        perspectives: [perspectiveRow(1, 'A', { raceName: 'Federation' })],
         isGameFinished: false,
         sectorDisplayName: 'Test Sector',
         stellarCartographyGates: EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES,


### PR DESCRIPTION
## Summary

- Add an expandable Fleet analytic tile in the sidebar with a per-player visibility checklist persisted globally in localStorage (all players visible by default until toggled).
- Introduce `fleetPlayerVisibilityPolicy`, a Zustand store, and shell wiring via `playerIdForViewpointName` plus shared `perspectiveRow` test fixtures.
- Fix visibility checkbox UI by subscribing to store `overrides` instead of a stable selector function.
- Register a scaffold fleet map analytic so enabling Fleet in map view does not crash before #128 implements the map layer.

## Test plan

- [x] `make test_frontend` (565 tests)
- [ ] Enable Fleet in map mode on http://localhost:5173 -- app should not throw
- [ ] Expand Fleet player visibility -- toggle players; checkboxes should update immediately
- [ ] Refresh browser -- visibility overrides should persist
- [ ] Switch games/viewpoints -- sidebar player order puts viewpoint first

Closes #127


Made with [Cursor](https://cursor.com)