### PR TITLE
Fleet F5.3: Table tiles (#129)

### DIFF
--- a/packages/frontend/package-lock.json
+++ b/packages/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.60.0",
+        "@tanstack/react-table": "^8.21.3",
         "@xyflow/react": "^12.3.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1520,6 +1521,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.60.0",
+    "@tanstack/react-table": "^8.21.3",
     "@xyflow/react": "^12.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -351,8 +351,6 @@ function ConsoleShell() {
             scoresPreferencesHydrated={scoresPreferencesHydrated}
             globalInferencePause={globalInferencePause}
             futureTurnOffset={futureTurnOffset}
-            fleetPlayers={fleetPlayers}
-            fleetViewpointPlayerId={fleetViewpointPlayerId}
             onMapZoomChange={handleMapZoomChange}
             onSetZoomReady={handleSetZoomReady}
           />

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -20,7 +20,6 @@ import {
   applyShellGameBootstrapResult,
   fetchShellGameBootstrap,
 } from './shell/shellGameBootstrap'
-import { playerIdForViewpointName } from './lib/gameInfoShell'
 import { useShellContext, useShellGameSelection } from './shell'
 import { TurnKeyboardShortcuts } from './components/shell/TurnKeyboardShortcuts'
 import { shouldRetryTanStackQuery } from './lib/queryRetry'
@@ -255,12 +254,6 @@ function ConsoleShell() {
       ? (stellarCartographyTurnSummary?.ionStormCount ?? null)
       : null
 
-  const fleetPlayers = gameInfoContext?.perspectives ?? []
-  const fleetViewpointPlayerId = playerIdForViewpointName(
-    fleetPlayers,
-    shellSelectedViewpointName
-  )
-
   const analytics = analyticsData?.analytics ?? []
   const enabledAnalyticIds = useMemo(
     () => analytics.filter((a) => enabledIds.has(a.id)).map((a) => a.id),
@@ -328,8 +321,6 @@ function ConsoleShell() {
           onScoresTableParamsChange={setScoresTableParams}
           stellarCartographyGates={stellarCartographyGates}
           ionStormCount={ionStormCount}
-          fleetPlayers={fleetPlayers}
-          fleetViewpointPlayerId={fleetViewpointPlayerId}
         />
         {isPending ? (
           <main className="flex flex-1 items-center justify-center bg-black p-8 text-gray-400">

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -351,6 +351,8 @@ function ConsoleShell() {
             scoresPreferencesHydrated={scoresPreferencesHydrated}
             globalInferencePause={globalInferencePause}
             futureTurnOffset={futureTurnOffset}
+            fleetPlayers={fleetPlayers}
+            fleetViewpointPlayerId={fleetViewpointPlayerId}
             onMapZoomChange={handleMapZoomChange}
             onSetZoomReady={handleSetZoomReady}
           />

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { AnalyticShellScope } from '../../api/bff'
+import { FleetAnalyticTableTile } from './FleetAnalyticTableTile'
+
+vi.mock('../../api/bff', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/bff')>()
+  return {
+    ...actual,
+    fetchAnalyticTable: vi.fn(),
+  }
+})
+
+import { fetchAnalyticTable } from '../../api/bff'
+
+const sampleScope: AnalyticShellScope = {
+  gameId: '628580',
+  turn: 5,
+  perspective: 1,
+}
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
+describe('FleetAnalyticTableTile', () => {
+  it('shows a parse error when fleet table wire is invalid', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(fetchAnalyticTable).mockResolvedValue({ analyticId: 'fleet' })
+
+    render(
+      <FleetAnalyticTableTile analyticScope={sampleScope} fetchEnabled />,
+      { wrapper: createWrapper(client) }
+    )
+
+    expect(
+      await screen.findByText(/Error loading fleet table\./)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Fleet table payload defaultActiveOnly must be true\./)
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
@@ -1,9 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 import type { AnalyticShellScope } from '../../api/bff'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { useShellStore } from '../../stores/shell'
 import { FleetAnalyticTableTile } from './FleetAnalyticTableTile'
+import { seedShellViewpoint } from './fleetTestShell'
+import {
+  loadFleetTableWireFixture,
+  zodParseableFleetTableWireCases,
+} from './loadFleetTableWireFixture'
 
 vi.mock('../../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/bff')>()
@@ -21,6 +28,10 @@ const sampleScope: AnalyticShellScope = {
   perspective: 1,
 }
 
+const goldenFleetTableWire = zodParseableFleetTableWireCases(
+  loadFleetTableWireFixture().cases
+)[0]!.expectedTableWire
+
 function createWrapper(client: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -28,6 +39,34 @@ function createWrapper(client: QueryClient) {
 }
 
 describe('FleetAnalyticTableTile', () => {
+  beforeEach(() => {
+    useFleetPlayerVisibilityStore.setState({ overrides: {} })
+    useShellStore.setState({
+      selectedGameId: null,
+      gameInfoContext: null,
+      selectedTurn: null,
+      perspectiveOverrideName: null,
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
+    seedShellViewpoint('Alice')
+  })
+
+  it('renders fleet table content when wire is valid', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(fetchAnalyticTable).mockResolvedValue(goldenFleetTableWire)
+
+    render(
+      <FleetAnalyticTableTile analyticScope={sampleScope} fetchEnabled />,
+      { wrapper: createWrapper(client) }
+    )
+
+    expect(
+      await screen.findByRole('heading', { level: 3, name: 'koshling' })
+    ).toBeInTheDocument()
+    expect(screen.getByText('<= 318')).toBeInTheDocument()
+  })
+
   it('shows a parse error when fleet table wire is invalid', async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     vi.mocked(fetchAnalyticTable).mockResolvedValue({ analyticId: 'fleet' })

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
-import type { AnalyticShellScope } from '../../api/bff'
+import type { AnalyticShellScope, TableDataResponse } from '../../api/bff'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
 import { FleetAnalyticTableTile } from './FleetAnalyticTableTile'
@@ -11,6 +11,7 @@ import {
   loadFleetTableWireFixture,
   zodParseableFleetTableWireCases,
 } from './loadFleetTableWireFixture'
+import { parseFleetTableWire } from './fleetTableWireSchema'
 
 vi.mock('../../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/bff')>()
@@ -28,9 +29,9 @@ const sampleScope: AnalyticShellScope = {
   perspective: 1,
 }
 
-const goldenFleetTableWire = zodParseableFleetTableWireCases(
-  loadFleetTableWireFixture().cases
-)[0]!.expectedTableWire
+const goldenFleetTableWire = parseFleetTableWire(
+  zodParseableFleetTableWireCases(loadFleetTableWireFixture().cases)[0]!.expectedTableWire
+)
 
 function createWrapper(client: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -54,7 +55,9 @@ describe('FleetAnalyticTableTile', () => {
 
   it('renders fleet table content when wire is valid', async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    vi.mocked(fetchAnalyticTable).mockResolvedValue(goldenFleetTableWire)
+    vi.mocked(fetchAnalyticTable).mockResolvedValue(
+      goldenFleetTableWire as unknown as TableDataResponse
+    )
 
     render(
       <FleetAnalyticTableTile analyticScope={sampleScope} fetchEnabled />,
@@ -69,7 +72,9 @@ describe('FleetAnalyticTableTile', () => {
 
   it('shows a parse error when fleet table wire is invalid', async () => {
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-    vi.mocked(fetchAnalyticTable).mockResolvedValue({ analyticId: 'fleet' })
+    vi.mocked(fetchAnalyticTable).mockResolvedValue({
+      analyticId: 'fleet',
+    } as unknown as TableDataResponse)
 
     render(
       <FleetAnalyticTableTile analyticScope={sampleScope} fetchEnabled />,

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
@@ -1,13 +1,29 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { fetchAnalyticTable } from '../../api/bff'
 import type { AnalyticShellScope } from '../../api/bff'
 import { errorDetailFromUnknown } from '../../lib/queryRetry'
 import { FleetTableView } from './FleetTableView'
-import { parseFleetTableWire } from './fleetTableWireSchema'
+import { parseFleetTableWire, type FleetTableWire } from './fleetTableWireSchema'
 
 type FleetAnalyticTableTileProps = {
   analyticScope: AnalyticShellScope | null
   fetchEnabled: boolean
+}
+
+type FleetTableParseResult =
+  | { ok: true; data: FleetTableWire }
+  | { ok: false; error: string }
+
+function parseFleetTableWireResult(payload: unknown): FleetTableParseResult {
+  try {
+    return { ok: true, data: parseFleetTableWire(payload) }
+  } catch (parseError) {
+    return {
+      ok: false,
+      error: parseError instanceof Error ? parseError.message : String(parseError),
+    }
+  }
 }
 
 export function FleetAnalyticTableTile({
@@ -19,6 +35,11 @@ export function FleetAnalyticTableTile({
     queryFn: () => fetchAnalyticTable('fleet', analyticScope!),
     enabled: fetchEnabled,
   })
+
+  const parsedFleetTable = useMemo(
+    () => (data != null ? parseFleetTableWireResult(data) : null),
+    [data]
+  )
 
   if (analyticScope == null) {
     return (
@@ -37,15 +58,14 @@ export function FleetAnalyticTableTile({
   }
   if (!data) return null
 
-  try {
-    const fleetTable = parseFleetTableWire(data)
-    return <FleetTableView data={fleetTable} />
-  } catch (parseError) {
+  if (parsedFleetTable == null || !parsedFleetTable.ok) {
     return (
       <div className="max-w-prose p-4 text-sm text-red-400 break-words">
         Error loading fleet table.{' '}
-        {parseError instanceof Error ? parseError.message : String(parseError)}
+        {parsedFleetTable?.ok === false ? parsedFleetTable.error : 'Unknown parse error.'}
       </div>
     )
   }
+
+  return <FleetTableView data={parsedFleetTable.data} />
 }

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchAnalyticTable } from '../../api/bff'
+import type { AnalyticShellScope } from '../../api/bff'
+import { errorDetailFromUnknown } from '../../lib/queryRetry'
+import { FleetTableView } from './FleetTableView'
+import { parseFleetTableWire } from './fleetTableWireSchema'
+
+type FleetAnalyticTableTileProps = {
+  analyticScope: AnalyticShellScope | null
+  fetchEnabled: boolean
+}
+
+export function FleetAnalyticTableTile({
+  analyticScope,
+  fetchEnabled,
+}: FleetAnalyticTableTileProps) {
+  const { data, isPending, error } = useQuery({
+    queryKey: ['analytic', 'fleet', 'table', analyticScope] as const,
+    queryFn: () => fetchAnalyticTable('fleet', analyticScope!),
+    enabled: fetchEnabled,
+  })
+
+  if (analyticScope == null) {
+    return (
+      <div className="p-4 text-sm text-gray-400">
+        Load game info and choose a turn and viewpoint to load this analytic.
+      </div>
+    )
+  }
+  if (isPending) return <div className="p-4 text-sm text-gray-400">Loading…</div>
+  if (error) {
+    return (
+      <div className="max-w-prose p-4 text-sm text-red-400 break-words">
+        Error loading data. {errorDetailFromUnknown(error)}
+      </div>
+    )
+  }
+  if (!data) return null
+
+  try {
+    const fleetTable = parseFleetTableWire(data)
+    return <FleetTableView data={fleetTable} />
+  } catch (parseError) {
+    return (
+      <div className="max-w-prose p-4 text-sm text-red-400 break-words">
+        Error loading fleet table.{' '}
+        {parseError instanceof Error ? parseError.message : String(parseError)}
+      </div>
+    )
+  }
+}

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -3,31 +3,9 @@ import type { ComponentProps } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FleetAnalyticTile } from './FleetAnalyticTile'
+import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
-import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
-
-const players = [
-  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
-  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
-] as const
-
-function seedShellViewpoint(viewpointName: 'Alice' | 'Bob') {
-  useShellStore.setState({
-    selectedGameId: '628580',
-    gameInfoContext: {
-      turn: 10,
-      perspectives: [...players],
-      isGameFinished: true,
-      sectorDisplayName: 'Test Sector',
-      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
-    },
-    selectedTurn: 5,
-    perspectiveOverrideName: viewpointName,
-    storageOnlyLoad: false,
-    storageAvailablePerspectives: null,
-  })
-}
 
 function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>> = {}) {
   return render(

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -4,11 +4,30 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FleetAnalyticTile } from './FleetAnalyticTile'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { useShellStore } from '../../stores/shell'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
 
 const players = [
   { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
   { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
 ] as const
+
+function seedShellViewpoint(viewpointName: 'Alice' | 'Bob') {
+  useShellStore.setState({
+    selectedGameId: '628580',
+    gameInfoContext: {
+      turn: 10,
+      perspectives: [...players],
+      isGameFinished: true,
+      sectorDisplayName: 'Test Sector',
+      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+    },
+    selectedTurn: 5,
+    perspectiveOverrideName: viewpointName,
+    storageOnlyLoad: false,
+    storageAvailablePerspectives: null,
+  })
+}
 
 function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>> = {}) {
   return render(
@@ -18,8 +37,6 @@ function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>>
       supportsMode
       depressed
       onToggle={() => {}}
-      players={[...players]}
-      viewpointPlayerId={8}
       {...overrides}
     />
   )
@@ -28,6 +45,15 @@ function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>>
 describe('FleetAnalyticTile', () => {
   beforeEach(() => {
     useFleetPlayerVisibilityStore.setState({ overrides: {} })
+    useShellStore.setState({
+      selectedGameId: null,
+      gameInfoContext: null,
+      selectedTurn: null,
+      perspectiveOverrideName: null,
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
+    seedShellViewpoint('Alice')
   })
 
   it('hides player checkboxes until expanded', () => {

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '../../lib/utils'
-import type { PerspectiveRow } from '../../lib/gameInfoShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
-import {
-  orderFleetSidebarPlayers,
-  resolveFleetPlayerVisible,
-} from './fleetPlayerVisibilityPolicy'
+import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
 import { tileClassName } from '../tileChrome'
 
 type FleetAnalyticTileProps = {
@@ -15,8 +11,6 @@ type FleetAnalyticTileProps = {
   supportsMode: boolean
   depressed: boolean
   onToggle: () => void
-  players: PerspectiveRow[]
-  viewpointPlayerId: number | null
 }
 
 export function FleetAnalyticTile({
@@ -25,14 +19,11 @@ export function FleetAnalyticTile({
   supportsMode,
   depressed,
   onToggle,
-  players,
-  viewpointPlayerId,
 }: FleetAnalyticTileProps) {
   const [expanded, setExpanded] = useState(false)
-  const canExpand = supportsMode && enabled && players.length > 0
-  const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
+  const { players: orderedPlayers, isPlayerVisible } = useOrderedFleetPlayers()
   const setFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.setFleetPlayerVisible)
-  const orderedPlayers = orderFleetSidebarPlayers(players, viewpointPlayerId)
+  const canExpand = supportsMode && enabled && orderedPlayers.length > 0
 
   useEffect(() => {
     if (!canExpand) {
@@ -99,11 +90,7 @@ export function FleetAnalyticTile({
             <label key={player.playerId} className="flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
-                checked={resolveFleetPlayerVisible(
-                  player.playerId,
-                  viewpointPlayerId,
-                  visibilityOverrides
-                )}
+                checked={isPlayerVisible(player.playerId)}
                 onChange={(event) =>
                   setFleetPlayerVisible(player.playerId, event.target.checked)
                 }

--- a/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
@@ -3,7 +3,9 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
+  getExpandedRowModel,
   useReactTable,
+  type ExpandedState,
 } from '@tanstack/react-table'
 import { AlertTriangle, ChevronDown, ShieldCheck } from 'lucide-react'
 import { cn } from '../../lib/utils'
@@ -62,7 +64,7 @@ export function FleetPlayerTableTile({
   records,
   discrepancy,
 }: FleetPlayerTableTileProps) {
-  const [expandedRecordIds, setExpandedRecordIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [expanded, setExpanded] = useState<ExpandedState>({})
   const activeRecords = useMemo(() => activeFleetRecords(records), [records])
 
   const columns = useMemo(
@@ -71,37 +73,26 @@ export function FleetPlayerTableTile({
         id: 'expander',
         header: '',
         cell: ({ row }) => {
-          const alternates = alternateBuildOptionSets(row.original)
-          if (alternates.length === 0) {
+          if (!row.getCanExpand()) {
             return null
           }
-          const expanded = expandedRecordIds.has(row.original.recordId)
+          const isExpanded = row.getIsExpanded()
           return (
             <button
               type="button"
-              aria-expanded={expanded}
+              aria-expanded={isExpanded}
               aria-label={
-                expanded
+                isExpanded
                   ? `Collapse build options for ${row.original.recordId}`
                   : `Expand build options for ${row.original.recordId}`
               }
-              onClick={() =>
-                setExpandedRecordIds((current) => {
-                  const next = new Set(current)
-                  if (next.has(row.original.recordId)) {
-                    next.delete(row.original.recordId)
-                  } else {
-                    next.add(row.original.recordId)
-                  }
-                  return next
-                })
-              }
+              onClick={row.getToggleExpandedHandler()}
               className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:bg-black/15 hover:text-slate-200"
             >
               <ChevronDown
                 className={cn(
                   'h-4 w-4 transition-transform duration-150',
-                  !expanded && '-rotate-90'
+                  !isExpanded && '-rotate-90'
                 )}
                 aria-hidden
               />
@@ -143,13 +134,17 @@ export function FleetPlayerTableTile({
         cell: ({ row }) => <FleetStatusIcons record={row.original} />,
       }),
     ],
-    [expandedRecordIds]
+    []
   )
 
   const table = useReactTable({
     data: activeRecords,
     columns,
+    state: { expanded },
+    onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getRowCanExpand: (row) => alternateBuildOptionSets(row.original).length > 0,
     getRowId: (record) => record.recordId,
   })
 
@@ -200,37 +195,33 @@ export function FleetPlayerTableTile({
               ))}
             </thead>
             <tbody>
-              {table.getRowModel().rows.map((row) => {
-                const alternates = alternateBuildOptionSets(row.original)
-                const expanded = expandedRecordIds.has(row.original.recordId)
-                return (
-                  <Fragment key={row.id}>
+              {table.getRowModel().rows.map((row) => (
+                <Fragment key={row.id}>
+                  <tr className="border-b border-[#52575d]/50">
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="px-3 py-2 text-gray-400">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                  {row.getIsExpanded() ? (
                     <tr className="border-b border-[#52575d]/50">
-                      {row.getVisibleCells().map((cell) => (
-                        <td key={cell.id} className="px-3 py-2 text-gray-400">
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </td>
-                      ))}
+                      <td
+                        colSpan={columns.length}
+                        className="bg-black/10 px-3 py-2 text-xs text-slate-300"
+                      >
+                        <ul className="space-y-1">
+                          {alternateBuildOptionSets(row.original).map((optionSet) => (
+                            <li key={optionSet.comboId ?? optionSet.label}>
+                              {formatBuildOptionSetSummary(optionSet)}
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
                     </tr>
-                    {expanded && alternates.length > 0 ? (
-                      <tr key={`${row.id}-alternates`} className="border-b border-[#52575d]/50">
-                        <td
-                          colSpan={columns.length}
-                          className="bg-black/10 px-3 py-2 text-xs text-slate-300"
-                        >
-                          <ul className="space-y-1">
-                            {alternates.map((optionSet) => (
-                              <li key={optionSet.comboId ?? optionSet.label}>
-                                {formatBuildOptionSetSummary(optionSet)}
-                              </li>
-                            ))}
-                          </ul>
-                        </td>
-                      </tr>
-                    ) : null}
-                  </Fragment>
-                )
-              })}
+                  ) : null}
+                </Fragment>
+              ))}
             </tbody>
           </table>
         </div>

--- a/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
@@ -1,0 +1,240 @@
+import { Fragment, useMemo, useState } from 'react'
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
+import { AlertTriangle, ChevronDown, ShieldCheck } from 'lucide-react'
+import { cn } from '../../lib/utils'
+import {
+  activeFleetRecords,
+  alternateBuildOptionSets,
+  formatBuildOptionSetSummary,
+  formatFleetCountDiscrepancyBanner,
+  formatFleetLastSeen,
+  formatFleetRecordField,
+} from './fleetRecordDisplay'
+import type { FleetCountDiscrepancy, FleetTableRecord } from './fleetTableWireSchema'
+
+type FleetPlayerTableTileProps = {
+  playerName: string
+  records: readonly FleetTableRecord[]
+  discrepancy?: FleetCountDiscrepancy
+}
+
+const columnHelper = createColumnHelper<FleetTableRecord>()
+
+function FleetStatusIcons({ record }: { record: FleetTableRecord }) {
+  const possiblyLost = record.qualifiers.possiblyLost
+  const alibi = record.qualifiers.alibi
+
+  if (possiblyLost == null && alibi == null) {
+    return <span className="text-slate-500">—</span>
+  }
+
+  return (
+    <div className="inline-flex items-center gap-1">
+      {possiblyLost != null ? (
+        <span
+          title={`Possibly lost since turn ${possiblyLost.sinceTurn} (${possiblyLost.source})`}
+          aria-label={`Possibly lost since turn ${possiblyLost.sinceTurn}`}
+          className="inline-flex text-amber-400"
+        >
+          <AlertTriangle className="h-4 w-4" aria-hidden />
+        </span>
+      ) : null}
+      {alibi != null ? (
+        <span
+          title={`Alibi: sighting turn ${alibi.sightingTurn} after turn ${alibi.afterTurn} (${alibi.source})`}
+          aria-label={`Alibi after turn ${alibi.afterTurn}`}
+          className="inline-flex text-emerald-400"
+        >
+          <ShieldCheck className="h-4 w-4" aria-hidden />
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+export function FleetPlayerTableTile({
+  playerName,
+  records,
+  discrepancy,
+}: FleetPlayerTableTileProps) {
+  const [expandedRecordIds, setExpandedRecordIds] = useState<ReadonlySet<string>>(() => new Set())
+  const activeRecords = useMemo(() => activeFleetRecords(records), [records])
+
+  const columns = useMemo(
+    () => [
+      columnHelper.display({
+        id: 'expander',
+        header: '',
+        cell: ({ row }) => {
+          const alternates = alternateBuildOptionSets(row.original)
+          if (alternates.length === 0) {
+            return null
+          }
+          const expanded = expandedRecordIds.has(row.original.recordId)
+          return (
+            <button
+              type="button"
+              aria-expanded={expanded}
+              aria-label={
+                expanded
+                  ? `Collapse build options for ${row.original.recordId}`
+                  : `Expand build options for ${row.original.recordId}`
+              }
+              onClick={() =>
+                setExpandedRecordIds((current) => {
+                  const next = new Set(current)
+                  if (next.has(row.original.recordId)) {
+                    next.delete(row.original.recordId)
+                  } else {
+                    next.add(row.original.recordId)
+                  }
+                  return next
+                })
+              }
+              className="inline-flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:bg-black/15 hover:text-slate-200"
+            >
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 transition-transform duration-150',
+                  !expanded && '-rotate-90'
+                )}
+                aria-hidden
+              />
+            </button>
+          )
+        },
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'shipId'), {
+        id: 'shipId',
+        header: 'ID',
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'hull'), {
+        id: 'hull',
+        header: 'Hull',
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'engine'), {
+        id: 'engine',
+        header: 'Engine',
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'beams'), {
+        id: 'beams',
+        header: 'Beams',
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'launchers'), {
+        id: 'launchers',
+        header: 'Launchers',
+      }),
+      columnHelper.accessor((record) => formatFleetRecordField(record, 'builtTurn'), {
+        id: 'builtTurn',
+        header: 'Built',
+      }),
+      columnHelper.accessor((record) => formatFleetLastSeen(record.lastSeen), {
+        id: 'lastSeen',
+        header: 'Last seen',
+      }),
+      columnHelper.display({
+        id: 'status',
+        header: 'Status',
+        cell: ({ row }) => <FleetStatusIcons record={row.original} />,
+      }),
+    ],
+    [expandedRecordIds]
+  )
+
+  const table = useReactTable({
+    data: activeRecords,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (record) => record.recordId,
+  })
+
+  return (
+    <section
+      className="rounded-md border border-[#52575d]/80 bg-[#3a3f44]"
+      aria-label={`${playerName} fleet table`}
+    >
+      <header className="border-b border-[#52575d]/70 px-4 py-2">
+        <h3 className="text-sm font-medium text-slate-200">{playerName}</h3>
+        {discrepancy != null ? (
+          <p
+            role="status"
+            className="mt-1 text-xs text-amber-300"
+            aria-label={formatFleetCountDiscrepancyBanner(
+              discrepancy.activeRowCount,
+              discrepancy.scoreboardImpliedCount,
+              discrepancy.hostTurn
+            )}
+          >
+            {formatFleetCountDiscrepancyBanner(
+              discrepancy.activeRowCount,
+              discrepancy.scoreboardImpliedCount,
+              discrepancy.hostTurn
+            )}
+          </p>
+        ) : null}
+      </header>
+      {activeRecords.length === 0 ? (
+        <p className="px-4 py-3 text-sm text-slate-400">No active fleet records.</p>
+      ) : (
+        <div className="overflow-auto">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id} className="border-b border-[#52575d]/70">
+                  {headerGroup.headers.map((header) => (
+                    <th
+                      key={header.id}
+                      className="px-3 py-2 text-left font-medium text-slate-300"
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => {
+                const alternates = alternateBuildOptionSets(row.original)
+                const expanded = expandedRecordIds.has(row.original.recordId)
+                return (
+                  <Fragment key={row.id}>
+                    <tr className="border-b border-[#52575d]/50">
+                      {row.getVisibleCells().map((cell) => (
+                        <td key={cell.id} className="px-3 py-2 text-gray-400">
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      ))}
+                    </tr>
+                    {expanded && alternates.length > 0 ? (
+                      <tr key={`${row.id}-alternates`} className="border-b border-[#52575d]/50">
+                        <td
+                          colSpan={columns.length}
+                          className="bg-black/10 px-3 py-2 text-xs text-slate-300"
+                        >
+                          <ul className="space-y-1">
+                            {alternates.map((optionSet) => (
+                              <li key={optionSet.comboId ?? optionSet.label}>
+                                {formatBuildOptionSetSummary(optionSet)}
+                              </li>
+                            ))}
+                          </ul>
+                        </td>
+                      </tr>
+                    ) : null}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FleetPlayerTableTile } from './FleetPlayerTableTile'
+import { FleetTableView } from './FleetTableView'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import type { FleetTableRecord, FleetTableWire } from './fleetTableWireSchema'
+
+const activeRecord: FleetTableRecord = {
+  recordId: 'rec-active',
+  disposition: 'active',
+  qualifiers: {
+    possiblyLost: { sinceTurn: 7, source: 'scoreboard' },
+    alibi: { afterTurn: 7, sightingTurn: 9, source: 'turnInfo.ships' },
+  },
+  fields: {
+    shipId: { kind: 'bounded', operator: 'lte', value: 318 },
+    hull: { kind: 'known', value: 13 },
+    engine: { kind: 'known', value: 9 },
+    beams: { kind: 'options', values: [3, 5] },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'known', value: 4 },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [
+    {
+      comboId: 'combo_a',
+      label: 'Option A',
+      solutionRankWeight: 10,
+      hullId: 13,
+      engineId: 9,
+      beamCount: 8,
+      launcherCount: 6,
+    },
+    {
+      comboId: 'combo_b',
+      label: 'Option B',
+      solutionRankWeight: 3,
+      hullId: 14,
+      engineId: 10,
+      beamCount: 4,
+      launcherCount: 2,
+    },
+  ],
+  displayDefaultOptionSetIndex: 0,
+  lastSeen: { turn: 9, x: 1200, y: 800, planetId: 55 },
+}
+
+const lostRecord: FleetTableRecord = {
+  recordId: 'rec-lost',
+  disposition: 'lost',
+  qualifiers: {},
+  fields: {
+    shipId: { kind: 'known', value: 42 },
+    hull: { kind: 'unknown' },
+    engine: { kind: 'unknown' },
+    beams: { kind: 'unknown' },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'unknown' },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [],
+}
+
+const players = [
+  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
+  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
+] as const
+
+const fleetWire: FleetTableWire = {
+  analyticId: 'fleet',
+  defaultActiveOnly: true,
+  players: [
+    {
+      playerId: 8,
+      playerName: 'Alice',
+      discrepancy: {
+        hostTurn: 111,
+        activeRowCount: 2,
+        scoreboardImpliedCount: 1,
+      },
+      records: [activeRecord, lostRecord],
+    },
+    {
+      playerId: 9,
+      playerName: 'Bob',
+      records: [],
+    },
+  ],
+}
+
+describe('FleetPlayerTableTile', () => {
+  it('renders only active disposition rows', () => {
+    render(
+      <FleetPlayerTableTile
+        playerName="Alice"
+        records={[activeRecord, lostRecord]}
+      />
+    )
+
+    expect(screen.getByText('<= 318')).toBeInTheDocument()
+    expect(screen.queryByText('42')).not.toBeInTheDocument()
+  })
+
+  it('shows discrepancy banner in the tile header', () => {
+    render(
+      <FleetPlayerTableTile
+        playerName="Alice"
+        records={[activeRecord]}
+        discrepancy={{
+          hostTurn: 111,
+          activeRowCount: 2,
+          scoreboardImpliedCount: 1,
+        }}
+      />
+    )
+
+    expect(
+      screen.getByRole('status', {
+        name: 'Fleet count discrepancy on turn 111: 2 active rows vs 1 implied by scoreboard',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('expands alternate build option sets from the row expander', async () => {
+    const user = userEvent.setup()
+    render(
+      <FleetPlayerTableTile
+        playerName="Alice"
+        records={[activeRecord]}
+      />
+    )
+
+    expect(screen.queryByText(/Option B/)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Expand build options for rec-active' }))
+
+    expect(screen.getByText(/Option B/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Collapse build options for rec-active' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+  })
+
+  it('renders status icons for qualifiers', () => {
+    render(
+      <FleetPlayerTableTile
+        playerName="Alice"
+        records={[activeRecord]}
+      />
+    )
+
+    expect(screen.getByLabelText('Possibly lost since turn 7')).toBeInTheDocument()
+    expect(screen.getByLabelText('Alibi after turn 7')).toBeInTheDocument()
+  })
+})
+
+describe('FleetTableView', () => {
+  beforeEach(() => {
+    useFleetPlayerVisibilityStore.setState({ overrides: {} })
+  })
+
+  it('sorts the viewpoint player tile first', () => {
+    render(
+      <FleetTableView
+        data={fleetWire}
+        players={[...players]}
+        viewpointPlayerId={9}
+      />
+    )
+
+    const tiles = screen.getAllByRole('region', { name: /fleet table$/i })
+    expect(tiles).toHaveLength(2)
+    expect(within(tiles[0]).getByRole('heading', { level: 3 })).toHaveTextContent('Bob')
+    expect(within(tiles[1]).getByRole('heading', { level: 3 })).toHaveTextContent('Alice')
+  })
+
+  it('hides tiles for players turned off in fleet visibility', () => {
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
+
+    render(
+      <FleetTableView
+        data={fleetWire}
+        players={[...players]}
+        viewpointPlayerId={8}
+      />
+    )
+
+    expect(screen.getByRole('region', { name: 'Alice fleet table' })).toBeInTheDocument()
+    expect(screen.queryByRole('region', { name: 'Bob fleet table' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event'
 import { FleetPlayerTableTile } from './FleetPlayerTableTile'
 import { FleetTableView } from './FleetTableView'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { useShellStore } from '../../stores/shell'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
 import type { FleetTableRecord, FleetTableWire } from './fleetTableWireSchema'
 
 const activeRecord: FleetTableRecord = {
@@ -66,6 +68,23 @@ const players = [
   { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
   { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
 ] as const
+
+function seedFleetShellViewpoint(viewpointName: 'Alice' | 'Bob') {
+  useShellStore.setState({
+    selectedGameId: '628580',
+    gameInfoContext: {
+      turn: 10,
+      perspectives: [...players],
+      isGameFinished: true,
+      sectorDisplayName: 'Test Sector',
+      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+    },
+    selectedTurn: 5,
+    perspectiveOverrideName: viewpointName,
+    storageOnlyLoad: false,
+    storageAvailablePerspectives: null,
+  })
+}
 
 const fleetWire: FleetTableWire = {
   analyticId: 'fleet',
@@ -158,16 +177,20 @@ describe('FleetPlayerTableTile', () => {
 describe('FleetTableView', () => {
   beforeEach(() => {
     useFleetPlayerVisibilityStore.setState({ overrides: {} })
+    useShellStore.setState({
+      selectedGameId: null,
+      gameInfoContext: null,
+      selectedTurn: null,
+      perspectiveOverrideName: null,
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
   })
 
   it('sorts the viewpoint player tile first', () => {
-    render(
-      <FleetTableView
-        data={fleetWire}
-        players={[...players]}
-        viewpointPlayerId={9}
-      />
-    )
+    seedFleetShellViewpoint('Bob')
+
+    render(<FleetTableView data={fleetWire} />)
 
     const tiles = screen.getAllByRole('region', { name: /fleet table$/i })
     expect(tiles).toHaveLength(2)
@@ -176,15 +199,10 @@ describe('FleetTableView', () => {
   })
 
   it('hides tiles for players turned off in fleet visibility', () => {
+    seedFleetShellViewpoint('Alice')
     useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
 
-    render(
-      <FleetTableView
-        data={fleetWire}
-        players={[...players]}
-        viewpointPlayerId={8}
-      />
-    )
+    render(<FleetTableView data={fleetWire} />)
 
     expect(screen.getByRole('region', { name: 'Alice fleet table' })).toBeInTheDocument()
     expect(screen.queryByRole('region', { name: 'Bob fleet table' })).not.toBeInTheDocument()

--- a/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
@@ -3,9 +3,9 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FleetPlayerTableTile } from './FleetPlayerTableTile'
 import { FleetTableView } from './FleetTableView'
+import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
-import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
 import type { FleetTableRecord, FleetTableWire } from './fleetTableWireSchema'
 
 const activeRecord: FleetTableRecord = {
@@ -62,28 +62,6 @@ const lostRecord: FleetTableRecord = {
     location: { kind: 'unknown' },
   },
   buildOptionSets: [],
-}
-
-const players = [
-  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
-  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
-] as const
-
-function seedFleetShellViewpoint(viewpointName: 'Alice' | 'Bob') {
-  useShellStore.setState({
-    selectedGameId: '628580',
-    gameInfoContext: {
-      turn: 10,
-      perspectives: [...players],
-      isGameFinished: true,
-      sectorDisplayName: 'Test Sector',
-      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
-    },
-    selectedTurn: 5,
-    perspectiveOverrideName: viewpointName,
-    storageOnlyLoad: false,
-    storageAvailablePerspectives: null,
-  })
 }
 
 const fleetWire: FleetTableWire = {
@@ -188,7 +166,7 @@ describe('FleetTableView', () => {
   })
 
   it('sorts the viewpoint player tile first', () => {
-    seedFleetShellViewpoint('Bob')
+    seedShellViewpoint('Bob')
 
     render(<FleetTableView data={fleetWire} />)
 
@@ -199,7 +177,7 @@ describe('FleetTableView', () => {
   })
 
   it('hides tiles for players turned off in fleet visibility', () => {
-    seedFleetShellViewpoint('Alice')
+    seedShellViewpoint('Alice')
     useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
 
     render(<FleetTableView data={fleetWire} />)

--- a/packages/frontend/src/analytics/fleet/FleetTableView.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.tsx
@@ -1,64 +1,19 @@
 import { useMemo } from 'react'
-import { playerIdForViewpointName } from '../../lib/gameInfoShell'
-import { deriveSelectedViewpointName } from '../../shell/shellContext'
-import { useSessionStore } from '../../stores/session'
-import { useShellStore } from '../../stores/shell'
-import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
-import {
-  orderFleetSidebarPlayers,
-  resolveFleetPlayerVisible,
-} from './fleetPlayerVisibilityPolicy'
 import { FleetPlayerTableTile } from './FleetPlayerTableTile'
 import type { FleetTableWire } from './fleetTableWireSchema'
+import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
 
 type FleetTableViewProps = {
   data: FleetTableWire
 }
 
 export function FleetTableView({ data }: FleetTableViewProps) {
-  const selectedGameId = useShellStore((s) => s.selectedGameId)
-  const gameInfoContext = useShellStore((s) => s.gameInfoContext)
-  const selectedTurn = useShellStore((s) => s.selectedTurn)
-  const perspectiveOverrideName = useShellStore((s) => s.perspectiveOverrideName)
-  const storageOnlyLoad = useShellStore((s) => s.storageOnlyLoad)
-  const storageAvailablePerspectives = useShellStore((s) => s.storageAvailablePerspectives)
-  const loginName = useSessionStore((s) => s.name)
-  const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
-
-  const players = gameInfoContext?.perspectives ?? []
-  const viewpointPlayerId = useMemo(() => {
-    const selectedViewpointName = deriveSelectedViewpointName({
-      selectedGameId,
-      gameInfoContext,
-      selectedTurn,
-      perspectiveOverrideName,
-      loginName,
-      storageOnlyLoad,
-      storageAvailablePerspectives,
-    })
-    return playerIdForViewpointName(players, selectedViewpointName)
-  }, [
-    selectedGameId,
-    gameInfoContext,
-    selectedTurn,
-    perspectiveOverrideName,
-    loginName,
-    storageOnlyLoad,
-    storageAvailablePerspectives,
-    players,
-  ])
+  const { players: visiblePlayers } = useOrderedFleetPlayers({ visibleOnly: true })
 
   const playersById = useMemo(
     () => new Map(data.players.map((player) => [player.playerId, player])),
     [data.players]
   )
-
-  const visiblePlayers = useMemo(() => {
-    const enabled = players.filter((player) =>
-      resolveFleetPlayerVisible(player.playerId, viewpointPlayerId, visibilityOverrides)
-    )
-    return orderFleetSidebarPlayers(enabled, viewpointPlayerId)
-  }, [players, viewpointPlayerId, visibilityOverrides])
 
   if (visiblePlayers.length === 0) {
     return (

--- a/packages/frontend/src/analytics/fleet/FleetTableView.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import {
+  orderFleetSidebarPlayers,
+  resolveFleetPlayerVisible,
+} from './fleetPlayerVisibilityPolicy'
+import { FleetPlayerTableTile } from './FleetPlayerTableTile'
+import type { FleetTableWire } from './fleetTableWireSchema'
+
+type FleetTableViewProps = {
+  data: FleetTableWire
+  players: readonly PerspectiveRow[]
+  viewpointPlayerId: number | null
+}
+
+export function FleetTableView({
+  data,
+  players,
+  viewpointPlayerId,
+}: FleetTableViewProps) {
+  const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
+  const playersById = useMemo(
+    () => new Map(data.players.map((player) => [player.playerId, player])),
+    [data.players]
+  )
+
+  const visiblePlayers = useMemo(() => {
+    const enabled = players.filter((player) =>
+      resolveFleetPlayerVisible(player.playerId, viewpointPlayerId, visibilityOverrides)
+    )
+    return orderFleetSidebarPlayers(enabled, viewpointPlayerId)
+  }, [players, viewpointPlayerId, visibilityOverrides])
+
+  if (visiblePlayers.length === 0) {
+    return (
+      <p className="p-4 text-sm text-slate-400">
+        Enable at least one player in the Fleet sidebar to see fleet tables.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      {visiblePlayers.map((player) => {
+        const wirePlayer = playersById.get(player.playerId)
+        return (
+          <FleetPlayerTableTile
+            key={player.playerId}
+            playerName={wirePlayer?.playerName ?? player.name}
+            records={wirePlayer?.records ?? []}
+            discrepancy={wirePlayer?.discrepancy}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/frontend/src/analytics/fleet/FleetTableView.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from 'react'
-import type { PerspectiveRow } from '../../lib/gameInfoShell'
+import { playerIdForViewpointName } from '../../lib/gameInfoShell'
+import { deriveSelectedViewpointName } from '../../shell/shellContext'
+import { useSessionStore } from '../../stores/session'
+import { useShellStore } from '../../stores/shell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import {
   orderFleetSidebarPlayers,
@@ -10,16 +13,41 @@ import type { FleetTableWire } from './fleetTableWireSchema'
 
 type FleetTableViewProps = {
   data: FleetTableWire
-  players: readonly PerspectiveRow[]
-  viewpointPlayerId: number | null
 }
 
-export function FleetTableView({
-  data,
-  players,
-  viewpointPlayerId,
-}: FleetTableViewProps) {
+export function FleetTableView({ data }: FleetTableViewProps) {
+  const selectedGameId = useShellStore((s) => s.selectedGameId)
+  const gameInfoContext = useShellStore((s) => s.gameInfoContext)
+  const selectedTurn = useShellStore((s) => s.selectedTurn)
+  const perspectiveOverrideName = useShellStore((s) => s.perspectiveOverrideName)
+  const storageOnlyLoad = useShellStore((s) => s.storageOnlyLoad)
+  const storageAvailablePerspectives = useShellStore((s) => s.storageAvailablePerspectives)
+  const loginName = useSessionStore((s) => s.name)
   const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
+
+  const players = gameInfoContext?.perspectives ?? []
+  const viewpointPlayerId = useMemo(() => {
+    const selectedViewpointName = deriveSelectedViewpointName({
+      selectedGameId,
+      gameInfoContext,
+      selectedTurn,
+      perspectiveOverrideName,
+      loginName,
+      storageOnlyLoad,
+      storageAvailablePerspectives,
+    })
+    return playerIdForViewpointName(players, selectedViewpointName)
+  }, [
+    selectedGameId,
+    gameInfoContext,
+    selectedTurn,
+    perspectiveOverrideName,
+    loginName,
+    storageOnlyLoad,
+    storageAvailablePerspectives,
+    players,
+  ])
+
   const playersById = useMemo(
     () => new Map(data.players.map((player) => [player.playerId, player])),
     [data.players]

--- a/packages/frontend/src/analytics/fleet/fleetRecordDisplay.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordDisplay.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  activeFleetRecords,
+  alternateBuildOptionSets,
+  formatFleetCountDiscrepancyBanner,
+  formatFleetRecordField,
+  resolveDefaultBuildOptionSetIndex,
+} from './fleetRecordDisplay'
+import type { FleetTableRecord } from './fleetTableWireSchema'
+
+const activeRecord: FleetTableRecord = {
+  recordId: 'rec-active',
+  disposition: 'active',
+  qualifiers: {},
+  fields: {
+    shipId: { kind: 'bounded', operator: 'lte', value: 318 },
+    hull: { kind: 'known', value: 13 },
+    engine: { kind: 'known', value: 9 },
+    beams: { kind: 'options', values: [3, 5] },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'known', value: 4 },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [
+    {
+      comboId: 'combo_a',
+      label: 'Option A',
+      solutionRankWeight: 10,
+      hullId: 13,
+      engineId: 9,
+      beamCount: 8,
+      launcherCount: 6,
+    },
+    {
+      comboId: 'combo_b',
+      label: 'Option B',
+      solutionRankWeight: 3,
+      hullId: 14,
+      engineId: 10,
+      beamCount: 4,
+      launcherCount: 2,
+    },
+  ],
+  displayDefaultOptionSetIndex: 0,
+}
+
+const lostRecord: FleetTableRecord = {
+  recordId: 'rec-lost',
+  disposition: 'lost',
+  qualifiers: {},
+  fields: {
+    shipId: { kind: 'known', value: 42 },
+    hull: { kind: 'unknown' },
+    engine: { kind: 'unknown' },
+    beams: { kind: 'unknown' },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'unknown' },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [],
+}
+
+describe('fleetRecordDisplay', () => {
+  it('filters to active disposition rows only', () => {
+    expect(activeFleetRecords([activeRecord, lostRecord])).toEqual([activeRecord])
+  })
+
+  it('uses displayDefaultOptionSetIndex when present', () => {
+    expect(resolveDefaultBuildOptionSetIndex(activeRecord)).toBe(0)
+  })
+
+  it('falls back to highest solution rank weight when index is absent', () => {
+    const record: FleetTableRecord = {
+      ...activeRecord,
+      displayDefaultOptionSetIndex: undefined,
+      buildOptionSets: [
+        { label: 'Low', solutionRankWeight: 1, beamCount: 0, launcherCount: 0 },
+        { label: 'High', solutionRankWeight: 99, beamCount: 2, launcherCount: 1 },
+      ],
+    }
+    expect(resolveDefaultBuildOptionSetIndex(record)).toBe(1)
+  })
+
+  it('fills unknown launchers from the default build option set', () => {
+    expect(formatFleetRecordField(activeRecord, 'launchers')).toBe('6')
+  })
+
+  it('lists alternate build option sets excluding the default', () => {
+    expect(alternateBuildOptionSets(activeRecord).map((option) => option.label)).toEqual([
+      'Option B',
+    ])
+  })
+
+  it('formats discrepancy banner copy', () => {
+    expect(formatFleetCountDiscrepancyBanner(2, 1, 111)).toBe(
+      'Fleet count discrepancy on turn 111: 2 active rows vs 1 implied by scoreboard'
+    )
+  })
+})

--- a/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
@@ -1,0 +1,157 @@
+import type {
+  FleetBuildOptionSet,
+  FleetFieldConstraint,
+  FleetLastSeen,
+  FleetTableRecord,
+} from './fleetTableWireSchema'
+
+export type FleetRecordFieldKey =
+  | 'shipId'
+  | 'hull'
+  | 'engine'
+  | 'beams'
+  | 'launchers'
+  | 'builtTurn'
+
+const BOUNDED_OPERATOR_LABEL: Record<FleetFieldConstraint & { kind: 'bounded' }['operator'], string> =
+  {
+    lte: '<=',
+    gte: '>=',
+    lt: '<',
+    gt: '>',
+    eq: '=',
+  }
+
+/** Default consumer filter: active disposition rows only. */
+export function activeFleetRecords(records: readonly FleetTableRecord[]): FleetTableRecord[] {
+  return records.filter((record) => record.disposition === 'active')
+}
+
+export function resolveDefaultBuildOptionSetIndex(record: FleetTableRecord): number {
+  if (record.buildOptionSets.length === 0) {
+    return -1
+  }
+  if (record.displayDefaultOptionSetIndex != null) {
+    return record.displayDefaultOptionSetIndex
+  }
+  let bestIndex = 0
+  for (let index = 1; index < record.buildOptionSets.length; index += 1) {
+    if (
+      record.buildOptionSets[index].solutionRankWeight >
+      record.buildOptionSets[bestIndex].solutionRankWeight
+    ) {
+      bestIndex = index
+    }
+  }
+  return bestIndex
+}
+
+export function defaultBuildOptionSet(record: FleetTableRecord): FleetBuildOptionSet | null {
+  const index = resolveDefaultBuildOptionSetIndex(record)
+  return index >= 0 ? record.buildOptionSets[index] : null
+}
+
+export function alternateBuildOptionSets(record: FleetTableRecord): FleetBuildOptionSet[] {
+  const defaultIndex = resolveDefaultBuildOptionSetIndex(record)
+  return record.buildOptionSets.filter((_, index) => index !== defaultIndex)
+}
+
+function optionSetFieldFallback(
+  optionSet: FleetBuildOptionSet | null,
+  field: FleetRecordFieldKey
+): string | null {
+  if (optionSet == null) {
+    return null
+  }
+  switch (field) {
+    case 'hull':
+      return optionSet.hullId != null ? String(optionSet.hullId) : null
+    case 'engine':
+      return optionSet.engineId != null ? String(optionSet.engineId) : null
+    case 'beams':
+      return String(optionSet.beamCount)
+    case 'launchers':
+      return String(optionSet.launcherCount)
+    default:
+      return null
+  }
+}
+
+export function formatFleetFieldConstraint(
+  constraint: FleetFieldConstraint | undefined,
+  field: FleetRecordFieldKey,
+  optionSet: FleetBuildOptionSet | null = null
+): string {
+  if (constraint == null) {
+    return optionSetFieldFallback(optionSet, field) ?? '?'
+  }
+
+  switch (constraint.kind) {
+    case 'known':
+      return String(constraint.value)
+    case 'unknown':
+      return optionSetFieldFallback(optionSet, field) ?? '?'
+    case 'bounded':
+      return `${BOUNDED_OPERATOR_LABEL[constraint.operator]} ${constraint.value}`
+    case 'options':
+      return constraint.values.map(String).join(' | ')
+    case 'region': {
+      const parts: string[] = []
+      if (constraint.planetIds != null && constraint.planetIds.length > 0) {
+        parts.push(`planet ${constraint.planetIds.join(', ')}`)
+      }
+      if (constraint.starbaseCoords != null && constraint.starbaseCoords.length > 0) {
+        parts.push(
+          constraint.starbaseCoords
+            .map((coord) => `(${coord.x}, ${coord.y})`)
+            .join(', ')
+        )
+      }
+      if (constraint.overlayId != null && constraint.overlayId.length > 0) {
+        parts.push(constraint.overlayId)
+      }
+      return parts.length > 0 ? parts.join('; ') : '?'
+    }
+    default:
+      return '?'
+  }
+}
+
+export function formatFleetRecordField(
+  record: FleetTableRecord,
+  field: FleetRecordFieldKey
+): string {
+  const optionSet = defaultBuildOptionSet(record)
+  const constraint = record.fields?.[field]
+  return formatFleetFieldConstraint(constraint, field, optionSet)
+}
+
+export function formatFleetLastSeen(lastSeen: FleetLastSeen | undefined): string {
+  if (lastSeen == null) {
+    return '—'
+  }
+  const position =
+    lastSeen.planetId != null
+      ? `planet ${lastSeen.planetId}`
+      : `(${lastSeen.x}, ${lastSeen.y})`
+  return `T${lastSeen.turn} ${position}`
+}
+
+export function formatBuildOptionSetSummary(optionSet: FleetBuildOptionSet): string {
+  const parts = [
+    optionSet.label,
+    optionSet.hullId != null ? `hull ${optionSet.hullId}` : null,
+    optionSet.engineId != null ? `engine ${optionSet.engineId}` : null,
+    `beams ${optionSet.beamCount}`,
+    `launchers ${optionSet.launcherCount}`,
+  ].filter((part): part is string => part != null)
+  return parts.join(' · ')
+}
+
+export function formatFleetCountDiscrepancyBanner(
+  activeRowCount: number,
+  scoreboardImpliedCount: number,
+  hostTurn: number
+): string {
+  return `Fleet count discrepancy on turn ${hostTurn}: ${activeRowCount} active rows vs ${scoreboardImpliedCount} implied by scoreboard`
+}

--- a/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
@@ -13,7 +13,9 @@ export type FleetRecordFieldKey =
   | 'launchers'
   | 'builtTurn'
 
-const BOUNDED_OPERATOR_LABEL: Record<FleetFieldConstraint & { kind: 'bounded' }['operator'], string> =
+type FleetBoundedFieldConstraint = Extract<FleetFieldConstraint, { kind: 'bounded' }>
+
+const BOUNDED_OPERATOR_LABEL: Record<FleetBoundedFieldConstraint['operator'], string> =
   {
     lte: '<=',
     gte: '>=',

--- a/packages/frontend/src/analytics/fleet/fleetTableWireSchema.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTableWireSchema.test.ts
@@ -89,4 +89,34 @@ describe('fleetTableWireSchema', () => {
       'Fleet table record disposition is invalid.'
     )
   })
+
+  it('rejects displayDefaultOptionSetIndex out of bounds', () => {
+    expect(primaryGolden).toBeDefined()
+    const invalid = structuredClone(primaryGolden) as {
+      players: Array<{ records: Array<Record<string, unknown>> }>
+    }
+    const record = invalid.players[0]!.records[0]!
+    record.displayDefaultOptionSetIndex = (record.buildOptionSets as unknown[]).length
+
+    const result = fleetTableWireSchema.safeParse(invalid)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'Fleet table record displayDefaultOptionSetIndex must be less than buildOptionSets.length.'
+      )
+    }
+  })
+
+  it('rejects displayDefaultOptionSetIndex when buildOptionSets is empty', () => {
+    expect(primaryGolden).toBeDefined()
+    const invalid = structuredClone(primaryGolden) as {
+      players: Array<{ records: Array<Record<string, unknown>> }>
+    }
+    const record = invalid.players[0]!.records[0]!
+    record.buildOptionSets = []
+    record.displayDefaultOptionSetIndex = 0
+
+    const result = fleetTableWireSchema.safeParse(invalid)
+    expect(result.success).toBe(false)
+  })
 })

--- a/packages/frontend/src/analytics/fleet/fleetTableWireSchema.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTableWireSchema.ts
@@ -48,6 +48,19 @@ export const fleetTableRecordSchema = z
     lastSeen: fleetLastSeenSchema.optional(),
   })
   .strict()
+  .superRefine((record, ctx) => {
+    if (
+      record.displayDefaultOptionSetIndex != null &&
+      record.displayDefaultOptionSetIndex >= record.buildOptionSets.length
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'Fleet table record displayDefaultOptionSetIndex must be less than buildOptionSets.length.',
+        path: ['displayDefaultOptionSetIndex'],
+      })
+    }
+  })
 
 export const fleetCountDiscrepancySchema = z.object({
   hostTurn: z.number().int(),

--- a/packages/frontend/src/analytics/fleet/fleetTestShell.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTestShell.ts
@@ -1,0 +1,26 @@
+import { useShellStore } from '../../stores/shell'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
+
+export const FLEET_TEST_SHELL_PLAYERS = [
+  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
+  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
+] as const
+
+export type FleetTestViewpointName = (typeof FLEET_TEST_SHELL_PLAYERS)[number]['name']
+
+export function seedShellViewpoint(viewpointName: FleetTestViewpointName) {
+  useShellStore.setState({
+    selectedGameId: '628580',
+    gameInfoContext: {
+      turn: 10,
+      perspectives: [...FLEET_TEST_SHELL_PLAYERS],
+      isGameFinished: true,
+      sectorDisplayName: 'Test Sector',
+      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+    },
+    selectedTurn: 5,
+    perspectiveOverrideName: viewpointName,
+    storageOnlyLoad: false,
+    storageAvailablePerspectives: null,
+  })
+}

--- a/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.test.ts
+++ b/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.test.ts
@@ -1,31 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
+import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
-import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
-
-const players = [
-  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
-  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
-] as const
-
-function seedShellViewpoint(viewpointName: 'Alice' | 'Bob') {
-  useShellStore.setState({
-    selectedGameId: '628580',
-    gameInfoContext: {
-      turn: 10,
-      perspectives: [...players],
-      isGameFinished: true,
-      sectorDisplayName: 'Test Sector',
-      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
-    },
-    selectedTurn: 5,
-    perspectiveOverrideName: viewpointName,
-    storageOnlyLoad: false,
-    storageAvailablePerspectives: null,
-  })
-}
 
 describe('useOrderedFleetPlayers', () => {
   beforeEach(() => {

--- a/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.test.ts
+++ b/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { useShellStore } from '../../stores/shell'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
+
+const players = [
+  { ordinal: 1, playerId: 8, name: 'Alice', raceName: null },
+  { ordinal: 2, playerId: 9, name: 'Bob', raceName: null },
+] as const
+
+function seedShellViewpoint(viewpointName: 'Alice' | 'Bob') {
+  useShellStore.setState({
+    selectedGameId: '628580',
+    gameInfoContext: {
+      turn: 10,
+      perspectives: [...players],
+      isGameFinished: true,
+      sectorDisplayName: 'Test Sector',
+      stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+    },
+    selectedTurn: 5,
+    perspectiveOverrideName: viewpointName,
+    storageOnlyLoad: false,
+    storageAvailablePerspectives: null,
+  })
+}
+
+describe('useOrderedFleetPlayers', () => {
+  beforeEach(() => {
+    useFleetPlayerVisibilityStore.setState({ overrides: {} })
+    useShellStore.setState({
+      selectedGameId: null,
+      gameInfoContext: null,
+      selectedTurn: null,
+      perspectiveOverrideName: null,
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
+  })
+
+  it('orders players with the viewpoint first', () => {
+    seedShellViewpoint('Bob')
+
+    const { result } = renderHook(() => useOrderedFleetPlayers())
+
+    expect(result.current.players.map((player) => player.name)).toEqual(['Bob', 'Alice'])
+    expect(result.current.viewpointPlayerId).toBe(9)
+  })
+
+  it('returns all ordered players by default', () => {
+    seedShellViewpoint('Alice')
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
+
+    const { result } = renderHook(() => useOrderedFleetPlayers())
+
+    expect(result.current.players.map((player) => player.playerId)).toEqual([8, 9])
+    expect(result.current.isPlayerVisible(9)).toBe(false)
+  })
+
+  it('filters to visible players when visibleOnly is true', () => {
+    seedShellViewpoint('Alice')
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(9, false)
+
+    const { result } = renderHook(() => useOrderedFleetPlayers({ visibleOnly: true }))
+
+    expect(result.current.players.map((player) => player.name)).toEqual(['Alice'])
+  })
+
+  it('keeps viewpoint ordering when filtering visible players', () => {
+    seedShellViewpoint('Bob')
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(8, false)
+
+    const { result } = renderHook(() => useOrderedFleetPlayers({ visibleOnly: true }))
+
+    expect(result.current.players.map((player) => player.name)).toEqual(['Bob'])
+  })
+})

--- a/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.ts
+++ b/packages/frontend/src/analytics/fleet/useOrderedFleetPlayers.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo } from 'react'
+import { playerIdForViewpointName } from '../../lib/gameInfoShell'
+import { deriveSelectedViewpointName } from '../../shell/shellContext'
+import { useSessionStore } from '../../stores/session'
+import { useShellStore } from '../../stores/shell'
+import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import {
+  orderFleetSidebarPlayers,
+  resolveFleetPlayerVisible,
+} from './fleetPlayerVisibilityPolicy'
+
+type UseOrderedFleetPlayersOptions = {
+  /** When true, only players with fleet visibility enabled are returned. */
+  visibleOnly?: boolean
+}
+
+export function useOrderedFleetPlayers(options: UseOrderedFleetPlayersOptions = {}) {
+  const { visibleOnly = false } = options
+  const selectedGameId = useShellStore((s) => s.selectedGameId)
+  const gameInfoContext = useShellStore((s) => s.gameInfoContext)
+  const selectedTurn = useShellStore((s) => s.selectedTurn)
+  const perspectiveOverrideName = useShellStore((s) => s.perspectiveOverrideName)
+  const storageOnlyLoad = useShellStore((s) => s.storageOnlyLoad)
+  const storageAvailablePerspectives = useShellStore((s) => s.storageAvailablePerspectives)
+  const loginName = useSessionStore((s) => s.name)
+  const visibilityOverrides = useFleetPlayerVisibilityStore((state) => state.overrides)
+
+  const shellPlayers = gameInfoContext?.perspectives ?? []
+  const viewpointPlayerId = useMemo(() => {
+    const selectedViewpointName = deriveSelectedViewpointName({
+      selectedGameId,
+      gameInfoContext,
+      selectedTurn,
+      perspectiveOverrideName,
+      loginName,
+      storageOnlyLoad,
+      storageAvailablePerspectives,
+    })
+    return playerIdForViewpointName(shellPlayers, selectedViewpointName)
+  }, [
+    selectedGameId,
+    gameInfoContext,
+    selectedTurn,
+    perspectiveOverrideName,
+    loginName,
+    storageOnlyLoad,
+    storageAvailablePerspectives,
+    shellPlayers,
+  ])
+
+  const orderedPlayers = useMemo(
+    () => orderFleetSidebarPlayers(shellPlayers, viewpointPlayerId),
+    [shellPlayers, viewpointPlayerId]
+  )
+
+  const players = useMemo(() => {
+    if (!visibleOnly) {
+      return orderedPlayers
+    }
+    return orderedPlayers.filter((player) =>
+      resolveFleetPlayerVisible(player.playerId, viewpointPlayerId, visibilityOverrides)
+    )
+  }, [orderedPlayers, visibleOnly, viewpointPlayerId, visibilityOverrides])
+
+  const isPlayerVisible = useCallback(
+    (playerId: number) =>
+      resolveFleetPlayerVisible(playerId, viewpointPlayerId, visibilityOverrides),
+    [viewpointPlayerId, visibilityOverrides]
+  )
+
+  return {
+    players,
+    viewpointPlayerId,
+    isPlayerVisible,
+  }
+}

--- a/packages/frontend/src/components/AnalyticsBar.tsx
+++ b/packages/frontend/src/components/AnalyticsBar.tsx
@@ -4,7 +4,6 @@ import { FleetAnalyticTile } from '../analytics/fleet/FleetAnalyticTile'
 import { ScoresTableTile } from '../analytics/scores/ScoresTableTile'
 import { StellarCartographyMapTile } from '../analytics/stellar-cartography/StellarCartographyMapTile'
 import { tileClassName } from '../analytics/tileChrome'
-import type { PerspectiveRow } from '../lib/gameInfoShell'
 import type { StellarCartographySettingsGates } from '../analytics/stellar-cartography/layers'
 import type { AnalyticItem, ConnectionsMapParams, ScoresTableParams } from '../api/bff'
 
@@ -21,8 +20,6 @@ type AnalyticsBarProps = {
   onScoresTableParamsChange: (next: ScoresTableParams) => void
   stellarCartographyGates: StellarCartographySettingsGates
   ionStormCount: number | null
-  fleetPlayers: PerspectiveRow[]
-  fleetViewpointPlayerId: number | null
 }
 
 function supportsCurrentMode(a: AnalyticItem, viewMode: ViewMode): boolean {
@@ -45,8 +42,6 @@ export function AnalyticsBar({
   onScoresTableParamsChange,
   stellarCartographyGates,
   ionStormCount,
-  fleetPlayers,
-  fleetViewpointPlayerId,
 }: AnalyticsBarProps) {
   const list = selectableAnalytics(analytics)
   return (
@@ -105,8 +100,6 @@ export function AnalyticsBar({
                   supportsMode={supportsMode}
                   depressed={depressed}
                   onToggle={() => onToggle(a.id)}
-                  players={fleetPlayers}
-                  viewpointPlayerId={fleetViewpointPlayerId}
                 />
               </li>
             )

--- a/packages/frontend/src/components/MainArea.test.tsx
+++ b/packages/frontend/src/components/MainArea.test.tsx
@@ -122,8 +122,6 @@ function defaultMainAreaProps(viewMode: 'tabular' | 'map') {
     scoresPreferencesHydrated: true,
     globalInferencePause: idleGlobalInferencePause,
     futureTurnOffset: 0,
-    fleetPlayers: [],
-    fleetViewpointPlayerId: null,
     onMapZoomChange: vi.fn(),
     onSetZoomReady: vi.fn(),
   }

--- a/packages/frontend/src/components/MainArea.test.tsx
+++ b/packages/frontend/src/components/MainArea.test.tsx
@@ -122,6 +122,8 @@ function defaultMainAreaProps(viewMode: 'tabular' | 'map') {
     scoresPreferencesHydrated: true,
     globalInferencePause: idleGlobalInferencePause,
     futureTurnOffset: 0,
+    fleetPlayers: [],
+    fleetViewpointPlayerId: null,
     onMapZoomChange: vi.fn(),
     onSetZoomReady: vi.fn(),
   }

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -15,9 +15,7 @@ import type {
 import { scoresTableQueryKey } from '../analytics/scores/api'
 import { scoresDiagnosticsFromTable } from '../analytics/scores/diagnosticsFromTable'
 import { ScoresTableView } from '../analytics/scores/ScoresTableView'
-import { FleetTableView } from '../analytics/fleet/FleetTableView'
-import { parseFleetTableWire } from '../analytics/fleet/fleetTableWireSchema'
-import type { PerspectiveRow } from '../lib/gameInfoShell'
+import { FleetAnalyticTableTile } from '../analytics/fleet/FleetAnalyticTableTile'
 import { useScoresInferenceByRow } from '../analytics/scores/useScoresInferenceByRow'
 import type { UseGlobalInferencePauseResult } from '../analytics/scores/useGlobalInferencePause'
 import { useAnalyticDiagnosticsStore } from '../stores/analyticDiagnostics'
@@ -101,8 +99,6 @@ type MainAreaProps = {
   globalInferencePause: UseGlobalInferencePauseResult
   /** Turns beyond latest stored game turn for ion storm prediction. */
   futureTurnOffset: number
-  fleetPlayers: PerspectiveRow[]
-  fleetViewpointPlayerId: number | null
   onMapZoomChange: (zoom: number) => void
   onSetZoomReady: (setZoom: (zoom: number) => void) => void
 }
@@ -113,19 +109,20 @@ function TableTile({
   fetchEnabled,
   scoresTableParams,
   globalInferencePause,
-  fleetPlayers,
-  fleetViewpointPlayerId,
 }: {
   analyticId: string
   analyticScope: AnalyticShellScope | null
   fetchEnabled: boolean
   scoresTableParams: ScoresTableParams
   globalInferencePause: UseGlobalInferencePauseResult
-  fleetPlayers: PerspectiveRow[]
-  fleetViewpointPlayerId: number | null
 }) {
+  if (analyticId === 'fleet') {
+    return (
+      <FleetAnalyticTableTile analyticScope={analyticScope} fetchEnabled={fetchEnabled} />
+    )
+  }
+
   const isScores = analyticId === 'scores'
-  const isFleet = analyticId === 'fleet'
   const inferenceEnabled = isScores && scoresTableParams.includeBuildInference
   const setScoresDiagnostics = useAnalyticDiagnosticsStore((state) => state.setScoresDiagnostics)
   const { data, isPending, error } = useQuery({
@@ -191,25 +188,6 @@ function TableTile({
         globalInferencePause={globalInferencePause}
       />
     )
-  }
-  if (isFleet) {
-    try {
-      const fleetTable = parseFleetTableWire(data)
-      return (
-        <FleetTableView
-          data={fleetTable}
-          players={fleetPlayers}
-          viewpointPlayerId={fleetViewpointPlayerId}
-        />
-      )
-    } catch (parseError) {
-      return (
-        <div className="max-w-prose p-4 text-sm text-red-400 break-words">
-          Error loading fleet table.{' '}
-          {parseError instanceof Error ? parseError.message : String(parseError)}
-        </div>
-      )
-    }
   }
   return (
     <div className="overflow-auto">
@@ -352,8 +330,6 @@ export function MainArea({
   scoresPreferencesHydrated,
   globalInferencePause,
   futureTurnOffset,
-  fleetPlayers,
-  fleetViewpointPlayerId,
   onMapZoomChange,
   onSetZoomReady,
 }: MainAreaProps) {
@@ -408,8 +384,6 @@ export function MainArea({
               }
               scoresTableParams={scoresTableParams}
               globalInferencePause={globalInferencePause}
-              fleetPlayers={fleetPlayers}
-              fleetViewpointPlayerId={fleetViewpointPlayerId}
             />
           </AnalyticTableSection>
         ))}

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -15,6 +15,9 @@ import type {
 import { scoresTableQueryKey } from '../analytics/scores/api'
 import { scoresDiagnosticsFromTable } from '../analytics/scores/diagnosticsFromTable'
 import { ScoresTableView } from '../analytics/scores/ScoresTableView'
+import { FleetTableView } from '../analytics/fleet/FleetTableView'
+import { parseFleetTableWire } from '../analytics/fleet/fleetTableWireSchema'
+import type { PerspectiveRow } from '../lib/gameInfoShell'
 import { useScoresInferenceByRow } from '../analytics/scores/useScoresInferenceByRow'
 import type { UseGlobalInferencePauseResult } from '../analytics/scores/useGlobalInferencePause'
 import { useAnalyticDiagnosticsStore } from '../stores/analyticDiagnostics'
@@ -98,6 +101,8 @@ type MainAreaProps = {
   globalInferencePause: UseGlobalInferencePauseResult
   /** Turns beyond latest stored game turn for ion storm prediction. */
   futureTurnOffset: number
+  fleetPlayers: PerspectiveRow[]
+  fleetViewpointPlayerId: number | null
   onMapZoomChange: (zoom: number) => void
   onSetZoomReady: (setZoom: (zoom: number) => void) => void
 }
@@ -108,14 +113,19 @@ function TableTile({
   fetchEnabled,
   scoresTableParams,
   globalInferencePause,
+  fleetPlayers,
+  fleetViewpointPlayerId,
 }: {
   analyticId: string
   analyticScope: AnalyticShellScope | null
   fetchEnabled: boolean
   scoresTableParams: ScoresTableParams
   globalInferencePause: UseGlobalInferencePauseResult
+  fleetPlayers: PerspectiveRow[]
+  fleetViewpointPlayerId: number | null
 }) {
   const isScores = analyticId === 'scores'
+  const isFleet = analyticId === 'fleet'
   const inferenceEnabled = isScores && scoresTableParams.includeBuildInference
   const setScoresDiagnostics = useAnalyticDiagnosticsStore((state) => state.setScoresDiagnostics)
   const { data, isPending, error } = useQuery({
@@ -181,6 +191,25 @@ function TableTile({
         globalInferencePause={globalInferencePause}
       />
     )
+  }
+  if (isFleet) {
+    try {
+      const fleetTable = parseFleetTableWire(data)
+      return (
+        <FleetTableView
+          data={fleetTable}
+          players={fleetPlayers}
+          viewpointPlayerId={fleetViewpointPlayerId}
+        />
+      )
+    } catch (parseError) {
+      return (
+        <div className="max-w-prose p-4 text-sm text-red-400 break-words">
+          Error loading fleet table.{' '}
+          {parseError instanceof Error ? parseError.message : String(parseError)}
+        </div>
+      )
+    }
   }
   return (
     <div className="overflow-auto">
@@ -323,6 +352,8 @@ export function MainArea({
   scoresPreferencesHydrated,
   globalInferencePause,
   futureTurnOffset,
+  fleetPlayers,
+  fleetViewpointPlayerId,
   onMapZoomChange,
   onSetZoomReady,
 }: MainAreaProps) {
@@ -377,6 +408,8 @@ export function MainArea({
               }
               scoresTableParams={scoresTableParams}
               globalInferencePause={globalInferencePause}
+              fleetPlayers={fleetPlayers}
+              fleetViewpointPlayerId={fleetViewpointPlayerId}
             />
           </AnalyticTableSection>
         ))}

--- a/packages/frontend/src/components/MainArea.tsx
+++ b/packages/frontend/src/components/MainArea.tsx
@@ -116,12 +116,6 @@ function TableTile({
   scoresTableParams: ScoresTableParams
   globalInferencePause: UseGlobalInferencePauseResult
 }) {
-  if (analyticId === 'fleet') {
-    return (
-      <FleetAnalyticTableTile analyticScope={analyticScope} fetchEnabled={fetchEnabled} />
-    )
-  }
-
   const isScores = analyticId === 'scores'
   const inferenceEnabled = isScores && scoresTableParams.includeBuildInference
   const setScoresDiagnostics = useAnalyticDiagnosticsStore((state) => state.setScoresDiagnostics)
@@ -371,22 +365,28 @@ export function MainArea({
 
     return (
       <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto bg-black p-4">
-        {enabledAnalyticIds.map((id) => (
-          <AnalyticTableSection
-            key={id}
-            title={analytics.find((a) => a.id === id)?.name ?? id}
-          >
-            <TableTile
-              analyticId={id}
-              analyticScope={analyticScope}
-              fetchEnabled={
-                analyticFetchEnabled && (id !== 'scores' || scoresPreferencesHydrated)
-              }
-              scoresTableParams={scoresTableParams}
-              globalInferencePause={globalInferencePause}
-            />
-          </AnalyticTableSection>
-        ))}
+        {enabledAnalyticIds.map((id) => {
+          const fetchEnabled =
+            analyticFetchEnabled && (id !== 'scores' || scoresPreferencesHydrated)
+          return (
+            <AnalyticTableSection
+              key={id}
+              title={analytics.find((a) => a.id === id)?.name ?? id}
+            >
+              {id === 'fleet' ? (
+                <FleetAnalyticTableTile analyticScope={analyticScope} fetchEnabled={fetchEnabled} />
+              ) : (
+                <TableTile
+                  analyticId={id}
+                  analyticScope={analyticScope}
+                  fetchEnabled={fetchEnabled}
+                  scoresTableParams={scoresTableParams}
+                  globalInferencePause={globalInferencePause}
+                />
+              )}
+            </AnalyticTableSection>
+          )
+        })}
       </main>
     )
   }


### PR DESCRIPTION
## Summary

- Add per-player fleet table tiles in tabular mode using TanStack Table, with active-row filtering, build-option expanders, discrepancy banners, and status icons
- Wire fleet table fetch/parse/render through `FleetAnalyticTableTile`, sharing player ordering and visibility with the fleet sidebar via `useOrderedFleetPlayers`
- Include review follow-ups: parent-site fleet dispatch (Rules of Hooks), Zod bounds check for `displayDefaultOptionSetIndex`, shared test shell helper, and happy-path component test

Closes #129

## Test plan

- [x] `make test_frontend` (592 tests pass)
- [x] `npm run test -- --run src/analytics/fleet/` (37 fleet tests)
- [ ] Manual: enable Fleet analytic in tabular mode, verify per-player tiles, viewpoint-first ordering, visibility toggles, row expander, discrepancy banner


Made with [Cursor](https://cursor.com)