### PR TITLE
Harden inference streaming and document stream lifecycle gaps

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -93,6 +93,17 @@ def _find_chain_anchor(
     return 0, None
 
 
+def _first_stored_rst_turn(
+    load_turn: Callable[[int], TurnInfo | None],
+    turn_number: int,
+) -> int | None:
+    """Return the lowest stored RST turn in ``1..turn_number``, if any."""
+    for stored_turn_number in range(1, turn_number + 1):
+        if load_turn(stored_turn_number) is not None:
+            return stored_turn_number
+    return None
+
+
 def _materialize_and_persist_turn(
     persistence: FleetSnapshotPersistenceService,
     *,
@@ -163,11 +174,11 @@ def get_or_materialize_fleet_snapshot(
             )
         return turn_info
 
-    def require_prior_rst(materialize_turn: int, *, allow_missing_turn_one_rst: bool) -> None:
+    def require_prior_rst(materialize_turn: int, *, allow_missing_prefix_rst: bool) -> None:
         if materialize_turn <= 1:
             return
         prior_turn_number = materialize_turn - 1
-        if allow_missing_turn_one_rst and prior_turn_number == 1:
+        if allow_missing_prefix_rst:
             return
         if cached_load(prior_turn_number) is None:
             raise NotFoundError(
@@ -181,12 +192,17 @@ def get_or_materialize_fleet_snapshot(
         perspective,
         turn_number,
     )
-    skip_turn_one_rst = anchor_turn == 0 and turn_number > 1 and cached_load(1) is None
+    first_stored_rst = _first_stored_rst_turn(cached_load, turn_number)
+    skip_missing_prefix_rst = (
+        anchor_turn == 0
+        and turn_number > 1
+        and first_stored_rst is not None
+        and first_stored_rst > 1
+    )
     start_turn = anchor_turn + 1
 
-    if skip_turn_one_rst:
-        if start_turn == 1:
-            start_turn = 2
+    if skip_missing_prefix_rst:
+        start_turn = first_stored_rst
         first_rst_turn = require_turn(start_turn)
         implicit_baseline = ensure_fleet_baseline(
             game_id,
@@ -216,7 +232,7 @@ def get_or_materialize_fleet_snapshot(
     for materialize_turn in range(start_turn, turn_number + 1):
         require_prior_rst(
             materialize_turn,
-            allow_missing_turn_one_rst=skip_turn_one_rst and materialize_turn == start_turn,
+            allow_missing_prefix_rst=skip_missing_prefix_rst and materialize_turn == start_turn,
         )
         turn_info = require_turn(materialize_turn)
         current_snapshot = _materialize_and_persist_turn(

--- a/packages/api/api/analytics/military_score_inference/inference_row_runner.py
+++ b/packages/api/api/analytics/military_score_inference/inference_row_runner.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from api.analytics.military_score_inference.actions import DEFAULT_INFERENCE_TIME_LIMIT_SECONDS
-
 from api.analytics.military_score_inference.inference_stream_domain_events import RowComplete
 from api.analytics.military_score_inference.models import InferenceObservation, InferenceSolution
 from api.analytics.military_score_inference.policy_ladder import finalize_policy_ladder_result

--- a/packages/api/api/analytics/military_score_inference/inference_row_runner.py
+++ b/packages/api/api/analytics/military_score_inference/inference_row_runner.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
+
+from api.analytics.military_score_inference.actions import DEFAULT_INFERENCE_TIME_LIMIT_SECONDS
 
 from api.analytics.military_score_inference.inference_stream_domain_events import RowComplete
 from api.analytics.military_score_inference.models import InferenceObservation, InferenceSolution
@@ -18,6 +21,14 @@ from api.analytics.military_score_inference.row_complete_factory import (
 )
 from api.analytics.military_score_inference.row_run import RowRun
 from api.models.game import TurnInfo
+
+
+def stream_tier_time_limit_seconds() -> float:
+    """Per-tier CP-SAT budget for SPA streaming (one policy step per scheduler job)."""
+    raw = os.environ.get("MILITARY_SCORE_INFERENCE_STREAM_TIER_TIME_LIMIT_SECONDS")
+    if raw is not None:
+        return float(raw)
+    return DEFAULT_INFERENCE_TIME_LIMIT_SECONDS
 
 
 @dataclass(frozen=True)
@@ -113,7 +124,7 @@ def run_inference_tier_job(
         state,
         observation,
         turn,
-        time_limit_seconds=None,
+        time_limit_seconds=stream_tier_time_limit_seconds(),
         cancel_token=session.cancel_token,
         on_admitted=on_admitted,
     )

--- a/packages/api/api/analytics/military_score_inference/solver.py
+++ b/packages/api/api/analytics/military_score_inference/solver.py
@@ -184,6 +184,39 @@ def _merge_score_equivalent_combos(
     )
 
 
+def _freighter_only_zero_military_solution(
+    problem: InferenceProblem,
+) -> InferenceSolution | None:
+    """Return a ship-only freighter explanation without CP-SAT when constraints allow."""
+    observation = problem.observation
+    if (
+        observation.military_delta_2x != 0
+        or observation.warship_delta != 0
+        or observation.freighter_delta <= 0
+    ):
+        return None
+    if observation.priority_point_delta != 0 and problem.enforce_priority_point_constraint:
+        return None
+    if any(action.lower_bound > 0 for action in problem.aggregate_actions):
+        return None
+    freighter_combo = next(
+        (
+            combo
+            for combo in problem.ship_build_combos
+            if is_generic_zero_military_score_combo_id(combo.combo_id)
+        ),
+        None,
+    )
+    if freighter_combo is None or freighter_combo.upper_bound < observation.freighter_delta:
+        return None
+    ship_build = _ship_build_from_member(freighter_combo, observation.freighter_delta)
+    return InferenceSolution(
+        objective_value=_objective_value(problem, {}, (ship_build,)),
+        actions=(),
+        ship_builds=(ship_build,),
+    )
+
+
 def _observation_is_solver_idle(problem: InferenceProblem) -> bool:
     """True when the solver has no modeled deltas to explain."""
     observation = problem.observation
@@ -501,6 +534,20 @@ def solve_inference_problem(
             status=STATUS_NO_EXACT_SOLUTION,
             solutions=(),
             diagnostics={"reason": "no candidate actions for non-zero observation deltas"},
+        )
+
+    freighter_only_solution = _freighter_only_zero_military_solution(problem)
+    if freighter_only_solution is not None:
+        if on_solution is not None:
+            on_solution(freighter_only_solution)
+        return InferenceResult(
+            status=STATUS_EXACT,
+            solutions=(freighter_only_solution,),
+            diagnostics={
+                "solver_status": "FREIGHTER_ONLY_FAST_PATH",
+                "solution_count": 1,
+                "stopped_reason": "freighter_only_fast_path",
+            },
         )
 
     merged_combo_catalog = _merge_score_equivalent_combos(problem.ship_build_combos)

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -243,6 +243,30 @@ def test_implicit_turn_one_baseline_without_persisting_turn_one(
     assert persistence.get_snapshot(628580, 1, 111) == snapshot
 
 
+def test_implicit_baseline_when_only_later_turn_rst_stored(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    _put_turn_rst(memory_backend, 3)
+    turn_three = load_turn(3)
+    assert turn_three is not None
+
+    snapshot = get_or_materialize_fleet_snapshot(
+        persistence,
+        628580,
+        1,
+        turn_three,
+        load_turn=load_turn,
+    )
+
+    assert snapshot.turn == 3
+    assert len(snapshot.players) == 4
+    assert persistence.get_snapshot(628580, 1, 1) is None
+    assert persistence.get_snapshot(628580, 1, 2) is None
+    assert persistence.get_snapshot(628580, 1, 3) == snapshot
+
+
 def test_chain_materializes_turn_from_prior_snapshot(persistence, load_turn, sample_turn):
     prior = ensure_fleet_baseline(628580, 1, load_turn(110))
     prior.players[0].records.append(

--- a/packages/api/tests/test_inference_stream_accelerated_admission.py
+++ b/packages/api/tests/test_inference_stream_accelerated_admission.py
@@ -13,6 +13,7 @@ from api.analytics.military_score_inference.inference_path import InferencePath
 from api.analytics.military_score_inference.inference_row_runner import (
     InferenceTierJobCallbacks,
     run_inference_tier_job,
+    stream_tier_time_limit_seconds,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
     HeldSolutionsUpdated,
@@ -326,3 +327,48 @@ def test_emit_held_solutions_includes_reported_host_turn_segment_id(sample_turn)
     wire = wire_events[0]
     assert wire["segmentId"] == REPORTED_HOST_TURN_SEGMENT_ID
     assert "isTargetSegment" not in wire
+
+
+def test_run_inference_tier_job_uses_stream_tier_time_budget(sample_turn, monkeypatch) -> None:
+    orchestration = _accelerated_split_orchestration(sample_turn)
+    score = sample_turn.scores[0]
+    session = InferenceRowStreamSession(
+        player_id=score.ownerid,
+        observation=build_inference_observation(score, sample_turn),
+        turn=sample_turn,
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    run = RowRun(session)
+    run.orchestration = orchestration
+    run.ladder_state = orchestration.new_ladder_state()
+
+    captured: list[float | None] = []
+
+    def fake_tier_step(
+        state,
+        observation,
+        turn,
+        *,
+        time_limit_seconds=None,
+        cancel_token=None,
+        on_admitted=None,
+    ) -> None:
+        del state, observation, turn, cancel_token, on_admitted
+        captured.append(time_limit_seconds)
+        run.ladder_state.ladder_complete = True
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.inference_row_runner.run_policy_ladder_tier_step",
+        fake_tier_step,
+    )
+
+    callbacks = InferenceTierJobCallbacks(
+        emit_tier_started_progress=lambda: None,
+        emit_progress=lambda: None,
+        emit_held_solutions=lambda _observation: None,
+    )
+    run_inference_tier_job(run, callbacks)
+
+    assert captured == [stream_tier_time_limit_seconds()]

--- a/packages/api/tests/test_inference_stream_lifecycle_gaps.py
+++ b/packages/api/tests/test_inference_stream_lifecycle_gaps.py
@@ -13,6 +13,8 @@ import threading
 import time
 from collections.abc import Callable, Iterator
 from pathlib import Path
+
+import pytest
 from api.analytics.military_score_inference.analytic import build_inference_observation
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
@@ -37,8 +39,6 @@ from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.storage.memory_asset import MemoryAssetBackend
-
-import pytest
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
@@ -174,9 +174,7 @@ def test_multiplex_stops_when_scope_deactivates_before_queued_complete_is_yielde
 
     assert remaining == []
     slow_types = [
-        event["type"]
-        for event in remaining
-        if event.get("playerId") == slow_row.player_id
+        event["type"] for event in remaining if event.get("playerId") == slow_row.player_id
     ]
     assert "complete" not in slow_types
 
@@ -248,10 +246,14 @@ def test_stream_preempt_persists_complete_before_first_connection_drains_in_flig
     _wait_until(lambda: len(scheduler._runs) == len(player_ids))
 
     completed_session = next(
-        run.session for run in scheduler._runs.values() if run.session.player_id == completed_player_id
+        run.session
+        for run in scheduler._runs.values()
+        if run.session.player_id == completed_player_id
     )
     in_flight_session = next(
-        run.session for run in scheduler._runs.values() if run.session.player_id == in_flight_player_id
+        run.session
+        for run in scheduler._runs.values()
+        if run.session.player_id == in_flight_player_id
     )
 
     scheduler._emit_row_complete(

--- a/packages/api/tests/test_inference_stream_lifecycle_gaps.py
+++ b/packages/api/tests/test_inference_stream_lifecycle_gaps.py
@@ -1,0 +1,503 @@
+"""Characterization tests for inference stream lifecycle gaps (persist vs deliver).
+
+These tests document edge cases in the stream/multiplex/preempt path where terminal
+row state may be persisted or finalized on the backend while the NDJSON consumer
+never receives a ``complete`` event. They use injected events and failures only --
+no production code changes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.inference_scheduler import (
+    InferenceRowScheduler,
+    reset_inference_row_scheduler_for_tests,
+)
+from api.analytics.military_score_inference.inference_stream_domain_events import (
+    RowComplete,
+    RowCompleteWirePayload,
+    TierProgress,
+)
+from api.analytics.military_score_inference.inference_stream_rows import (
+    ScheduledInferenceRow,
+    iter_multiplexed_inference_events,
+    iter_scores_table_inference_events,
+    schedule_inference_row,
+)
+from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
+from api.analytics.military_score_inference.inference_stream_session import (
+    InferenceRowStreamSession,
+)
+from api.analytics.military_score_inference.models import InferenceResult
+from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+from api.storage.memory_asset import MemoryAssetBackend
+
+import pytest
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+def _diagnostics(*, turn: int, player_id: int) -> dict[str, object]:
+    return {
+        "turn": turn,
+        "constraints": {"playerId": player_id, "turn": turn},
+        "solver": {"status": STATUS_EXACT, "solver_status": "OPTIMAL"},
+    }
+
+
+def _row_complete(
+    *,
+    summary: str,
+    diagnostics: dict[str, object] | None = None,
+) -> RowComplete:
+    wire_diagnostics = diagnostics or {}
+    return RowComplete(
+        result=InferenceResult(status=STATUS_EXACT, solutions=(), diagnostics=wire_diagnostics),
+        wire_payload=RowCompleteWirePayload(
+            status=STATUS_EXACT,
+            summary=summary,
+            solution_count=1,
+            is_complete=True,
+            solutions=[],
+            diagnostics=wire_diagnostics,
+        ),
+    )
+
+
+def _session_for_player(sample_turn, *, player_id: int) -> InferenceRowStreamSession:
+    score = next(row for row in sample_turn.scores if row.ownerid == player_id)
+    return InferenceRowStreamSession(
+        player_id=player_id,
+        observation=build_inference_observation(score, sample_turn),
+        turn=sample_turn,
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+
+
+def _scheduled_row(sample_turn, *, player_id: int) -> ScheduledInferenceRow:
+    return ScheduledInferenceRow(
+        player_id=player_id,
+        session=_session_for_player(sample_turn, player_id=player_id),
+    )
+
+
+def _install_workerless_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    on_row_complete: Callable | None = None,
+) -> InferenceRowScheduler:
+    reset_inference_row_scheduler_for_tests()
+    scheduler = InferenceRowScheduler(
+        worker_count=0,
+        on_row_complete=on_row_complete,
+    )
+
+    def _get_scheduler() -> InferenceRowScheduler:
+        return scheduler
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.inference_scheduler.get_inference_row_scheduler",
+        _get_scheduler,
+    )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.inference_stream_rows.get_inference_row_scheduler",
+        _get_scheduler,
+    )
+    return scheduler
+
+
+def _wait_until(predicate: Callable[[], bool], *, timeout_seconds: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
+def _collect_stream_events(stream: Iterator[dict[str, object]]) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    try:
+        for event in stream:
+            events.append(event)
+    finally:
+        stream.close()
+    return events
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as handle:
+        backend.put("games/628580/info", json.load(handle))
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        backend.put("games/628580/1/turns/111", json.load(handle))
+    return backend
+
+
+def test_multiplex_stops_when_scope_deactivates_before_queued_complete_is_yielded(sample_turn):
+    """Queued terminal events for pending rows are dropped when the stream scope ends."""
+    fast_row = _scheduled_row(sample_turn, player_id=sample_turn.scores[0].ownerid)
+    slow_row = _scheduled_row(sample_turn, player_id=sample_turn.scores[1].ownerid)
+    fast_row.session.event_queue.put(_row_complete(summary="fast complete"))
+    slow_row.session.event_queue.put(
+        _row_complete(
+            summary="slow complete never delivered",
+            diagnostics=_diagnostics(turn=sample_turn.settings.turn, player_id=slow_row.player_id),
+        )
+    )
+
+    scope_active = True
+
+    def is_stream_active() -> bool:
+        return scope_active
+
+    stream = iter_multiplexed_inference_events(
+        (fast_row, slow_row),
+        tag_player_id=True,
+        is_stream_active=is_stream_active,
+    )
+    first = next(stream)
+    assert first["type"] == "complete"
+    assert first["playerId"] == fast_row.player_id
+
+    scope_active = False
+    remaining = list(stream)
+
+    assert remaining == []
+    slow_types = [
+        event["type"]
+        for event in remaining
+        if event.get("playerId") == slow_row.player_id
+    ]
+    assert "complete" not in slow_types
+
+
+def test_multiplex_delivers_all_queued_completes_before_scope_deactivation(sample_turn):
+    """Baseline: both rows receive terminal events when the scope stays active."""
+    rows = tuple(
+        _scheduled_row(sample_turn, player_id=player_id)
+        for player_id in (row.ownerid for row in sample_turn.scores[:2])
+    )
+    for row in rows:
+        row.session.event_queue.put(
+            _row_complete(
+                summary=f"player {row.player_id} complete",
+                diagnostics=_diagnostics(turn=sample_turn.settings.turn, player_id=row.player_id),
+            )
+        )
+
+    events = list(
+        iter_multiplexed_inference_events(
+            rows,
+            tag_player_id=True,
+        )
+    )
+    complete_player_ids = {
+        event["playerId"]
+        for event in events
+        if event.get("type") == "complete" and isinstance(event.get("playerId"), int)
+    }
+    assert complete_player_ids == {row.player_id for row in rows}
+
+
+def test_stream_preempt_persists_complete_before_first_connection_drains_in_flight_row(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+):
+    """Persist can succeed while the preempted stream still shows in-progress for other rows."""
+    persistence = InferenceRowPersistenceService(memory_backend)
+    scheduler = _install_workerless_scheduler(
+        monkeypatch,
+        on_row_complete=persistence.persist_row_complete,
+    )
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    completed_player_id, in_flight_player_id = player_ids
+    turn_number = sample_turn.settings.turn
+
+    first_stream = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    assert next(first_stream) == {"type": "globalPause", "paused": False}
+
+    collected: list[dict[str, object]] = []
+    stream_error: list[BaseException] = []
+
+    def consume_first_stream() -> None:
+        try:
+            collected.extend(_collect_stream_events(first_stream))
+        except BaseException as exc:  # pragma: no cover - surfaced via stream_error
+            stream_error.append(exc)
+
+    thread = threading.Thread(target=consume_first_stream, daemon=True)
+    thread.start()
+    _wait_until(lambda: len(scheduler._runs) == len(player_ids))
+
+    completed_session = next(
+        run.session for run in scheduler._runs.values() if run.session.player_id == completed_player_id
+    )
+    in_flight_session = next(
+        run.session for run in scheduler._runs.values() if run.session.player_id == in_flight_player_id
+    )
+
+    scheduler._emit_row_complete(
+        completed_session,
+        _row_complete(
+            summary="persisted on backend",
+            diagnostics=_diagnostics(turn=turn_number, player_id=completed_player_id),
+        ),
+    )
+    in_flight_session.event_queue.put(
+        TierProgress(policy_step_id="early_game_bands", combo_count=2142, held_count=0)
+    )
+
+    replacement = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    assert next(replacement) == {"type": "globalPause", "paused": False}
+    replacement.close()
+
+    thread.join(timeout=2.0)
+    assert not stream_error
+
+    completed_events = [
+        event
+        for event in collected
+        if event.get("type") == "complete" and event.get("playerId") == completed_player_id
+    ]
+    in_flight_completes = [
+        event
+        for event in collected
+        if event.get("type") == "complete" and event.get("playerId") == in_flight_player_id
+    ]
+    in_flight_progress = [
+        event
+        for event in collected
+        if event.get("type") == "progress" and event.get("playerId") == in_flight_player_id
+    ]
+
+    assert persistence.get_row(628580, 1, turn_number, completed_player_id) is not None
+    assert len(in_flight_completes) == 0
+    assert len(in_flight_progress) >= 0
+
+    replay_stream = iter_scores_table_inference_events(
+        sample_turn,
+        (completed_player_id,),
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    replay_events = [next(replay_stream), next(replay_stream)]
+    replay_stream.close()
+    assert replay_events[1]["type"] == "complete"
+    assert replay_events[1]["summary"] == "persisted on backend"
+    assert len(completed_events) in {0, 1}
+
+
+def test_progress_without_terminal_complete_when_scope_deactivates_mid_row(sample_turn):
+    """A row can emit progress on the stream and still never deliver terminal diagnostics."""
+    row = _scheduled_row(sample_turn, player_id=sample_turn.scores[1].ownerid)
+    row.session.event_queue.put(
+        TierProgress(policy_step_id="early_game_bands", combo_count=2142, held_count=0)
+    )
+    row.session.event_queue.put(
+        _row_complete(
+            summary="terminal queued but not delivered",
+            diagnostics=_diagnostics(
+                turn=sample_turn.settings.turn,
+                player_id=row.player_id,
+            ),
+        )
+    )
+
+    scope_active = True
+    stream = iter_multiplexed_inference_events(
+        (row,),
+        tag_player_id=True,
+        is_stream_active=lambda: scope_active,
+    )
+    progress = next(stream)
+    assert progress["type"] == "progress"
+    assert progress["playerId"] == row.player_id
+    assert progress.get("policyStepId") == "early_game_bands"
+    assert "diagnostics" not in progress
+
+    scope_active = False
+    assert list(stream) == []
+
+
+def test_stream_preempt_leaves_in_flight_row_without_persisted_terminal_state(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+):
+    """Preempt before terminal: in-flight row is cancelled without persistence."""
+    persistence = InferenceRowPersistenceService(memory_backend)
+    scheduler = _install_workerless_scheduler(
+        monkeypatch,
+        on_row_complete=persistence.persist_row_complete,
+    )
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    turn_number = sample_turn.settings.turn
+    target_player_id = player_ids[1]
+
+    first_stream = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    next(first_stream)
+
+    collected: list[dict[str, object]] = []
+
+    def consume_first_stream() -> None:
+        collected.extend(_collect_stream_events(first_stream))
+
+    thread = threading.Thread(target=consume_first_stream, daemon=True)
+    thread.start()
+    _wait_until(lambda: len(scheduler._runs) == len(player_ids))
+
+    replacement = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    next(replacement)
+    replacement.close()
+    thread.join(timeout=2.0)
+
+    assert persistence.get_row(628580, 1, turn_number, target_player_id) is None
+    target_completes = [
+        event
+        for event in collected
+        if event.get("type") == "complete" and event.get("playerId") == target_player_id
+    ]
+    assert target_completes == []
+
+
+def test_open_stream_scope_keeps_multiplex_alive_after_all_rows_terminal(sample_turn):
+    """Documents: an active scope prevents stream exit even after every row has completed."""
+    row = _scheduled_row(sample_turn, player_id=sample_turn.scores[0].ownerid)
+    row.session.event_queue.put(_row_complete(summary="done"))
+
+    stream = iter_multiplexed_inference_events(
+        (row,),
+        tag_player_id=True,
+        is_stream_active=lambda: True,
+    )
+    terminal = next(stream)
+    assert terminal["type"] == "complete"
+
+    blocked = threading.Event()
+
+    def read_next() -> None:
+        try:
+            next(stream)
+        finally:
+            blocked.set()
+
+    reader = threading.Thread(target=read_next, daemon=True)
+    reader.start()
+    reader.join(timeout=0.2)
+    assert not blocked.is_set()
+
+
+def test_late_complete_on_queue_after_scope_deactivation_is_not_yielded(sample_turn):
+    """Terminal events arriving after scope deactivation never reach the consumer."""
+    row = _scheduled_row(sample_turn, player_id=sample_turn.scores[0].ownerid)
+    scope_active = True
+
+    stream = iter_multiplexed_inference_events(
+        (row,),
+        tag_player_id=True,
+        is_stream_active=lambda: scope_active,
+    )
+
+    scope_active = False
+    assert list(stream) == []
+
+    row.session.event_queue.put(
+        _row_complete(
+            summary="too late",
+            diagnostics=_diagnostics(turn=sample_turn.settings.turn, player_id=row.player_id),
+        )
+    )
+
+    assert list(stream) == []
+
+
+def test_persisted_row_replays_on_new_stream_without_scheduler_work(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+):
+    """Reconnect path serves cached terminal state when persistence already holds the row."""
+    persistence = InferenceRowPersistenceService(memory_backend)
+    scheduler = _install_workerless_scheduler(
+        monkeypatch,
+        on_row_complete=persistence.persist_row_complete,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    turn_number = sample_turn.settings.turn
+
+    scope = InferenceStreamScope(game_id=628580, perspective=1, turn_number=turn_number)
+    stream_token = scheduler.begin_scope(scope)
+    scheduled = schedule_inference_row(
+        scheduler,
+        score=sample_turn.scores[0],
+        turn=sample_turn,
+        player_id=player_id,
+        game_id=628580,
+        perspective=1,
+        stream_token=stream_token,
+    )
+    assert scheduled is not None
+    scheduler._emit_row_complete(
+        scheduled.session,
+        _row_complete(
+            summary="terminal before reconnect",
+            diagnostics=_diagnostics(turn=turn_number, player_id=player_id),
+        ),
+    )
+
+    replay = iter_scores_table_inference_events(
+        sample_turn,
+        (player_id,),
+        game_id=628580,
+        perspective=1,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+    events = [next(replay), next(replay)]
+    replay.close()
+
+    assert events[1]["type"] == "complete"
+    assert events[1]["summary"] == "terminal before reconnect"
+    assert isinstance(events[1].get("diagnostics"), dict)
+    assert events[1]["diagnostics"].get("turn") == turn_number

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -6,7 +6,9 @@ from api.analytics.military_score_inference.models import (
     InferenceProblem,
     InferenceSolutionAction,
     ProbabilityBucket,
+    ShipBuildCombo,
 )
+from api.analytics.military_score_inference.ship_build_combos import GENERIC_FREIGHTER_COMBO_ID
 from api.analytics.military_score_inference.scoring import (
     LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
     PLANET_DEFENSE_POST_SCORE_DELTA_2X,
@@ -495,3 +497,49 @@ def test_solver_diagnostics_include_build_time_ranking_metadata():
     diversity_caps = result.diagnostics["diversityCapsApplied"]
     assert isinstance(diversity_caps, list)
     assert any(entry["superclass"] == "torpedo_loads" for entry in diversity_caps)
+
+
+def test_freighter_only_zero_military_score_uses_fast_path():
+    freighter_combo = ShipBuildCombo(
+        combo_id=GENERIC_FREIGHTER_COMBO_ID,
+        hull_id=0,
+        engine_id=0,
+        beam_id=None,
+        torp_id=None,
+        beam_count=0,
+        launcher_count=0,
+        labels=("Freighter",),
+        score_delta_2x=0,
+        freighter_delta=1,
+        upper_bound=1,
+        probability_weight=100,
+    )
+    warship_combo = ShipBuildCombo(
+        combo_id="combo_warship",
+        hull_id=1,
+        engine_id=1,
+        beam_id=None,
+        torp_id=None,
+        beam_count=0,
+        launcher_count=0,
+        labels=("Warship",),
+        score_delta_2x=400,
+        warship_delta=1,
+        upper_bound=1,
+        probability_weight=50,
+    )
+    problem = InferenceProblem(
+        observation=_observation(freighter_delta=1),
+        aggregate_actions=(),
+        ship_build_combos=(warship_combo, freighter_combo),
+        max_solutions=20,
+        time_limit_seconds=0.001,
+    )
+
+    result = solve_inference_problem(problem)
+
+    assert result.status == STATUS_EXACT
+    assert result.diagnostics["solver_status"] == "FREIGHTER_ONLY_FAST_PATH"
+    assert len(result.solutions) == 1
+    assert result.solutions[0].ship_builds[0].combo_id == GENERIC_FREIGHTER_COMBO_ID
+    assert result.solutions[0].ship_builds[0].count == 1

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -8,12 +8,12 @@ from api.analytics.military_score_inference.models import (
     ProbabilityBucket,
     ShipBuildCombo,
 )
-from api.analytics.military_score_inference.ship_build_combos import GENERIC_FREIGHTER_COMBO_ID
 from api.analytics.military_score_inference.scoring import (
     LOADED_SHIP_FIGHTER_SCORE_DELTA_2X,
     PLANET_DEFENSE_POST_SCORE_DELTA_2X,
     STARBASE_FIGHTER_SCORE_DELTA_2X,
 )
+from api.analytics.military_score_inference.ship_build_combos import GENERIC_FREIGHTER_COMBO_ID
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_INVALID_PROBLEM,

--- a/packages/frontend/src/analytics/scores/diagnosticsFromTable.test.ts
+++ b/packages/frontend/src/analytics/scores/diagnosticsFromTable.test.ts
@@ -57,6 +57,50 @@ describe('scoresDiagnosticsFromTable', () => {
     })
   })
 
+  it('omits rows that have not received terminal diagnostics yet', () => {
+    const data: TableDataResponse = {
+      analyticId: 'scores',
+      includeBuildInference: true,
+      columns: ['Race (player)', 'Build inference'],
+      rows: [['cyborg', ''], ['colonies', '']],
+      inferenceByRow: [
+        {
+          playerId: 6,
+          displayStatus: 'pending',
+          status: 'pending',
+          summary: 'Searching (early game bands)',
+          solutionCount: 0,
+          isComplete: false,
+          solutions: [],
+          diagnostics: {},
+        },
+        {
+          playerId: 11,
+          displayStatus: 'success',
+          status: 'pending',
+          summary: 'Searching (early game bands)',
+          solutionCount: 1,
+          isComplete: false,
+          solutions: [
+            {
+              objectiveValue: 10,
+              actions: [{ actionId: 'a1', label: 'Build Cobol', count: 1 }],
+            },
+          ],
+          diagnostics: {},
+        },
+      ],
+    }
+
+    const snapshot = scoresDiagnosticsFromTable(data, {
+      gameId: '628580',
+      turn: 3,
+      perspective: 1,
+    })
+
+    expect(snapshot?.players).toEqual([])
+  })
+
   it('falls back to constraints.playerId when playerId is omitted on the row detail', () => {
     const data: TableDataResponse = {
       analyticId: 'scores',

--- a/packages/frontend/src/analytics/scores/inferenceRowStreamState.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceRowStreamState.test.ts
@@ -111,6 +111,40 @@ describe('reduceRowStreamState', () => {
     expect(rowDetailFromStreamState(8, complete).solutionCount).toBe(1)
   })
 
+  it('leaves diagnostics empty on progress events', () => {
+    const next = reduceRowStreamState(initialRowStreamState(), {
+      type: 'progress',
+      policyStepId: 'early_game_bands',
+      comboCount: 2142,
+      heldCount: 1,
+    })
+
+    expect(next.summary).toBe('Searching (early game bands)')
+    expect(next.isComplete).toBe(false)
+    expect(next.diagnostics).toEqual({})
+    expect(rowDetailFromStreamState(11, next).diagnostics).toEqual({})
+  })
+
+  it('populates diagnostics only on complete events', () => {
+    const complete = reduceRowStreamState(initialRowStreamState(), {
+      type: 'complete',
+      status: 'exact',
+      summary: 'Best: Freighter',
+      solutionCount: 1,
+      isComplete: true,
+      diagnostics: {
+        turn: 3,
+        solver: { status: 'exact', solver_status: 'FREIGHTER_ONLY_FAST_PATH' },
+      },
+    })
+
+    expect(complete.isComplete).toBe(true)
+    expect(complete.diagnostics).toMatchObject({
+      turn: 3,
+      solver: { status: 'exact' },
+    })
+  })
+
   it('preserves held solutions on complete events without solutions payload', () => {
     const withSolution = reduceRowStreamState(initialRowStreamState(), {
       type: 'solution',

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -39,7 +39,8 @@ function longLivedTableStream(
 function emitComplete(
   onEvent: StreamHandlers['onEvent'],
   playerId: number,
-  summary: string
+  summary: string,
+  diagnostics?: Record<string, unknown>
 ): void {
   onEvent({
     type: 'complete',
@@ -48,6 +49,7 @@ function emitComplete(
     summary,
     solutionCount: 1,
     isComplete: true,
+    ...(diagnostics != null ? { diagnostics } : {}),
   })
 }
 
@@ -498,6 +500,99 @@ describe('useScoresInferenceByRow', () => {
         expect(result.current.inferenceByRow?.[1]?.displayStatus).toBe('success')
       })
       expect(streamCallCount).toBe(1)
+    })
+  })
+
+  describe('stream lifecycle gaps (characterization)', () => {
+    const threePlayerTable: TableDataResponse = {
+      analyticId: 'scores',
+      includeBuildInference: true,
+      columns: ['Race (player)', 'Build inference'],
+      rows: [['other', ''], ['cyborg', ''], ['colonies', '']],
+      inferenceByRow: [{ playerId: 8 }, { playerId: 6 }, { playerId: 11 }],
+    }
+
+    it('keeps rows pending with empty diagnostics when the stream resolves without complete', async () => {
+      vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
+        async (_scope, _playerIds, handlers) => {
+          emitComplete(handlers.onEvent, 8, 'Other player complete')
+          emitProgress(handlers.onEvent, 6, 'early_game_bands')
+          emitProgress(handlers.onEvent, 11, 'early_game_bands')
+        }
+      )
+
+      const { result } = renderHook(() =>
+        useScoresInferenceByRow(threePlayerTable, scope, true)
+      )
+
+      await waitFor(() => {
+        expect(result.current.inferenceByRow?.[0]?.isComplete).toBe(true)
+      })
+
+      expect(result.current.inferenceByRow?.[1]).toMatchObject({
+        playerId: 6,
+        displayStatus: 'pending',
+        isComplete: false,
+        diagnostics: {},
+        summary: 'Searching (early game bands)',
+      })
+      expect(result.current.inferenceByRow?.[2]).toMatchObject({
+        playerId: 11,
+        displayStatus: 'pending',
+        isComplete: false,
+        diagnostics: {},
+        summary: 'Searching (early game bands)',
+      })
+    })
+
+    it('remount after stream ends without terminal events can serve cached completes', async () => {
+      let streamGeneration = 0
+
+      vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
+        async (_scope, _playerIds, handlers) => {
+          streamGeneration += 1
+          if (streamGeneration === 1) {
+            emitComplete(handlers.onEvent, 8, 'Other player complete')
+            emitProgress(handlers.onEvent, 6, 'early_game_bands')
+            emitProgress(handlers.onEvent, 11, 'early_game_bands')
+            return
+          }
+          emitComplete(handlers.onEvent, 6, 'Cyborg from cache', {
+            turn: scope.turn,
+            solver: { status: 'exact' },
+          })
+          emitComplete(handlers.onEvent, 11, 'Colonies from cache', {
+            turn: scope.turn,
+            solver: { status: 'exact' },
+          })
+        }
+      )
+
+      const { result, unmount } = renderHook(() =>
+        useScoresInferenceByRow(threePlayerTable, scope, true)
+      )
+
+      await waitFor(() => {
+        expect(result.current.inferenceByRow?.[0]?.isComplete).toBe(true)
+        expect(result.current.inferenceByRow?.[1]?.isComplete).toBe(false)
+      })
+
+      unmount()
+
+      const { result: remounted } = renderHook(() =>
+        useScoresInferenceByRow(threePlayerTable, scope, true)
+      )
+
+      await waitFor(() => {
+        expect(remounted.current.inferenceByRow?.[1]?.summary).toBe('Cyborg from cache')
+        expect(remounted.current.inferenceByRow?.[2]?.summary).toBe('Colonies from cache')
+      })
+      expect(remounted.current.inferenceByRow?.[1]?.isComplete).toBe(true)
+      expect(remounted.current.inferenceByRow?.[2]?.diagnostics).toMatchObject({
+        turn: scope.turn,
+        solver: { status: 'exact' },
+      })
+      expect(streamGeneration).toBe(2)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Apply a per-tier time budget and freighter-only fast path for military score build inference
- Fix fleet chain materialization when early RST turns are missing from storage
- Add characterization tests for persist-vs-deliver stream lifecycle gaps and frontend stale-stream states

Found during manual testing of the fleet analytic; independent of the #129 frontend table tiles work.

## Test plan

- [x] `make test_api` passes
- [x] `make lint` passes
- [ ] Manual: load a game with missing early turns and confirm fleet materializes; run scores inference stream and confirm tier time limits behave as expected


Made with [Cursor](https://cursor.com)