### PR TITLE
Reconnect scoreboard inference stream when rows are incomplete

### DIFF
--- a/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.test.ts
+++ b/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.test.ts
@@ -3,6 +3,7 @@ import * as bff from '../../api/bff'
 import {
   TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
   connectTableInferenceStream,
+  connectTableInferenceStreamUntilComplete,
 } from './tableInferenceStreamConnect'
 
 const scope = {
@@ -44,5 +45,53 @@ describe('connectTableInferenceStream', () => {
     expect(result).toBe('ok')
     expect(fetchSpy).toHaveBeenCalledTimes(2)
     expect(events).toHaveLength(1)
+  })
+
+  it('reconnects when the stream ends before every row is complete', async () => {
+    const fetchSpy = vi
+      .spyOn(bff, 'fetchScoresTableInferenceStream')
+      .mockImplementationOnce(async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'complete',
+          playerId: 8,
+          status: 'exact',
+          summary: 'cached',
+          solutionCount: 1,
+          isComplete: true,
+        })
+      })
+      .mockImplementationOnce(async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'complete',
+          playerId: 8,
+          status: 'exact',
+          summary: 'cached replay',
+          solutionCount: 1,
+          isComplete: true,
+        })
+        handlers.onEvent({
+          type: 'complete',
+          playerId: 6,
+          status: 'exact',
+          summary: 'after reconnect',
+          solutionCount: 1,
+          isComplete: true,
+        })
+      })
+
+    const completedPlayerIds = new Set<number>()
+    const controller = new AbortController()
+    const result = await connectTableInferenceStreamUntilComplete(scope, [8, 6], {
+      signal: controller.signal,
+      onEvent: (event) => {
+        if (event.type === 'complete' && event.playerId != null) {
+          completedPlayerIds.add(event.playerId)
+        }
+      },
+      hasPendingRows: () => [8, 6].some((playerId) => !completedPlayerIds.has(playerId)),
+    })
+
+    expect(result).toBe('ok')
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
+++ b/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
@@ -23,7 +23,15 @@ function isScopeLevelStreamConflict(event: InferenceStreamEvent): boolean {
   )
 }
 
-export type TableInferenceStreamConnectResult = 'ok' | 'aborted' | 'conflict_exhausted'
+export type TableInferenceStreamConnectResult =
+  | 'ok'
+  | 'aborted'
+  | 'conflict_exhausted'
+  | 'incomplete_exhausted'
+
+const STREAM_INCOMPLETE_RETRY_INITIAL_MS = 50
+const STREAM_INCOMPLETE_RETRY_MAX_ATTEMPTS = 10
+const STREAM_INCOMPLETE_RETRY_MAX_DELAY_MS = 500
 
 export async function connectTableInferenceStream(
   scope: AnalyticShellScope,
@@ -70,4 +78,43 @@ export async function connectTableInferenceStream(
   }
 
   return 'conflict_exhausted'
+}
+
+export async function connectTableInferenceStreamUntilComplete(
+  scope: AnalyticShellScope,
+  playerIds: number[],
+  handlers: {
+    signal: AbortSignal
+    onEvent: (event: InferenceStreamEvent) => void
+    hasPendingRows: () => boolean
+  }
+): Promise<TableInferenceStreamConnectResult> {
+  for (let attempt = 0; attempt < STREAM_INCOMPLETE_RETRY_MAX_ATTEMPTS; attempt += 1) {
+    if (handlers.signal.aborted) {
+      return 'aborted'
+    }
+
+    const result = await connectTableInferenceStream(scope, playerIds, {
+      signal: handlers.signal,
+      onEvent: handlers.onEvent,
+    })
+
+    if (handlers.signal.aborted) {
+      return 'aborted'
+    }
+    if (result === 'conflict_exhausted') {
+      return result
+    }
+    if (!handlers.hasPendingRows()) {
+      return 'ok'
+    }
+
+    const delayMs = Math.min(
+      STREAM_INCOMPLETE_RETRY_INITIAL_MS * 2 ** attempt,
+      STREAM_INCOMPLETE_RETRY_MAX_DELAY_MS
+    )
+    await sleep(delayMs)
+  }
+
+  return 'incomplete_exhausted'
 }

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.test.tsx
@@ -512,12 +512,27 @@ describe('useScoresInferenceByRow', () => {
       inferenceByRow: [{ playerId: 8 }, { playerId: 6 }, { playerId: 11 }],
     }
 
-    it('keeps rows pending with empty diagnostics when the stream resolves without complete', async () => {
+    it('reconnects when the stream resolves before every row is complete', async () => {
+      let streamGeneration = 0
+
       vi.spyOn(bff, 'fetchScoresTableInferenceStream').mockImplementation(
         async (_scope, _playerIds, handlers) => {
+          streamGeneration += 1
+          if (streamGeneration === 1) {
+            emitComplete(handlers.onEvent, 8, 'Other player complete')
+            emitProgress(handlers.onEvent, 6, 'early_game_bands')
+            emitProgress(handlers.onEvent, 11, 'early_game_bands')
+            return
+          }
           emitComplete(handlers.onEvent, 8, 'Other player complete')
-          emitProgress(handlers.onEvent, 6, 'early_game_bands')
-          emitProgress(handlers.onEvent, 11, 'early_game_bands')
+          emitComplete(handlers.onEvent, 6, 'Cyborg from cache', {
+            turn: scope.turn,
+            solver: { status: 'exact' },
+          })
+          emitComplete(handlers.onEvent, 11, 'Colonies from cache', {
+            turn: scope.turn,
+            solver: { status: 'exact' },
+          })
         }
       )
 
@@ -526,23 +541,14 @@ describe('useScoresInferenceByRow', () => {
       )
 
       await waitFor(() => {
-        expect(result.current.inferenceByRow?.[0]?.isComplete).toBe(true)
+        expect(result.current.inferenceByRow?.[1]?.summary).toBe('Cyborg from cache')
+        expect(result.current.inferenceByRow?.[2]?.summary).toBe('Colonies from cache')
       })
 
-      expect(result.current.inferenceByRow?.[1]).toMatchObject({
-        playerId: 6,
-        displayStatus: 'pending',
-        isComplete: false,
-        diagnostics: {},
-        summary: 'Searching (early game bands)',
-      })
-      expect(result.current.inferenceByRow?.[2]).toMatchObject({
-        playerId: 11,
-        displayStatus: 'pending',
-        isComplete: false,
-        diagnostics: {},
-        summary: 'Searching (early game bands)',
-      })
+      expect(result.current.inferenceByRow?.[0]?.isComplete).toBe(true)
+      expect(result.current.inferenceByRow?.[1]?.isComplete).toBe(true)
+      expect(result.current.inferenceByRow?.[2]?.isComplete).toBe(true)
+      expect(streamGeneration).toBe(2)
     })
 
     it('remount after stream ends without terminal events can serve cached completes', async () => {

--- a/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
+++ b/packages/frontend/src/analytics/scores/useScoresInferenceByRow.ts
@@ -13,7 +13,7 @@ import {
   stablePlayerIdsKey,
   type RowStreamState,
 } from './inferenceRowStreamState'
-import { connectTableInferenceStream } from './tableInferenceStreamConnect'
+import { connectTableInferenceStreamUntilComplete } from './tableInferenceStreamConnect'
 
 export type UseScoresInferenceByRowOptions = {
   onGlobalPauseChange?: (paused: boolean) => void
@@ -147,30 +147,47 @@ export function useScoresInferenceByRow(
     const controller = new AbortController()
     tableAbortControllerRef.current = controller
 
-    void connectTableInferenceStream(activeScope, playerIds, {
+    const markIncompleteRowsFailed = (summary: string) => {
+      setDetailsByPlayerId((previous) => {
+        const next = new Map(previous)
+        for (const playerId of playerIds) {
+          if (next.get(playerId)?.isComplete) {
+            continue
+          }
+          next.set(playerId, failureDetail(playerId, summary))
+        }
+        return next
+      })
+    }
+
+    void connectTableInferenceStreamUntilComplete(activeScope, playerIds, {
       signal: controller.signal,
       onEvent: (event) => handleTableStreamEventRef.current(event),
+      hasPendingRows: () => {
+        for (const playerId of playerIds) {
+          const state = rowStreamStateRef.current.get(playerId)
+          if (state == null || !state.isComplete) {
+            return true
+          }
+        }
+        return false
+      },
     })
       .then((result) => {
-        if (controller.signal.aborted || result !== 'conflict_exhausted') {
+        if (controller.signal.aborted) {
           return
         }
-        setDetailsByPlayerId((previous) => {
-          const next = new Map(previous)
-          for (const playerId of playerIds) {
-            if (next.get(playerId)?.isComplete) {
-              continue
-            }
-            next.set(
-              playerId,
-              failureDetail(
-                playerId,
-                'Build inference could not reconnect to the table stream.'
-              )
-            )
-          }
-          return next
-        })
+        if (result === 'conflict_exhausted') {
+          markIncompleteRowsFailed(
+            'Build inference could not reconnect to the table stream.'
+          )
+          return
+        }
+        if (result === 'incomplete_exhausted') {
+          markIncompleteRowsFailed(
+            'Build inference stream ended before all scoreboard rows completed.'
+          )
+        }
       })
       .catch((error) => {
         if (controller.signal.aborted) {


### PR DESCRIPTION
## Summary
- Auto-reconnect the scores inference table stream when it closes before every scoreboard row receives a terminal `complete` event.
- Surface a clear failure state if reconnection retries are exhausted, instead of leaving rows stuck at "Build inference in progress".
- Fixes the case where cached rows (e.g. perspective player) show complete while all other players remain pending after a preempted or dropped stream.

## Test plan
- [x] `npm run test -- --run src/analytics/scores/tableInferenceStreamConnect.test.ts src/analytics/scores/useScoresInferenceByRow.test.tsx`
- [x] Open scoreboard with build inference enabled; confirm all rows eventually complete or show failure after refresh
- [x] Verify cached-complete rows still replay instantly on reconnect


Made with [Cursor](https://cursor.com)