### PR TITLE
Fleet gap-fill invalidation safety and richer table component display.

### DIFF
--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -29,6 +29,9 @@ from api.analytics.fleet.types import (
     FleetTurnSnapshot,
 )
 from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
+from api.analytics.military_score_inference.ship_build_combos import (
+    is_generic_zero_military_score_combo_id,
+)
 from api.errors import ValidationError
 
 
@@ -174,20 +177,38 @@ def fleet_build_option_set_to_json(option_set: FleetBuildOptionSet) -> dict[str,
     return payload
 
 
+def _resolved_fleet_component_id(component_id: int) -> int | None:
+    """Map solver sentinel ids (e.g. generic freighter hull 0) to unknown on the wire."""
+    return component_id if component_id > 0 else None
+
+
 def fleet_build_option_set_from_inference_ship_build(
     ship_build: InferenceSolutionShipBuild,
     *,
     solution_rank_weight: int,
 ) -> FleetBuildOptionSet:
     """Map one inference solution ship build into a fleet build option set."""
+    combo_id = ship_build.combo_id or None
+    if combo_id is not None and is_generic_zero_military_score_combo_id(combo_id):
+        return FleetBuildOptionSet(
+            combo_id=combo_id,
+            label=ship_build.label,
+            solution_rank_weight=solution_rank_weight,
+            beam_count=ship_build.beam_count,
+            launcher_count=ship_build.launcher_count,
+        )
     return FleetBuildOptionSet(
-        combo_id=ship_build.combo_id or None,
+        combo_id=combo_id,
         label=ship_build.label,
         solution_rank_weight=solution_rank_weight,
-        hull_id=ship_build.hull_id,
-        engine_id=ship_build.engine_id,
-        beam_id=ship_build.beam_id,
-        torp_id=ship_build.torp_id,
+        hull_id=_resolved_fleet_component_id(ship_build.hull_id),
+        engine_id=_resolved_fleet_component_id(ship_build.engine_id),
+        beam_id=_resolved_fleet_component_id(ship_build.beam_id)
+        if ship_build.beam_id is not None
+        else None,
+        torp_id=_resolved_fleet_component_id(ship_build.torp_id)
+        if ship_build.torp_id is not None
+        else None,
         beam_count=ship_build.beam_count,
         launcher_count=ship_build.launcher_count,
     )

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -29,9 +29,6 @@ from api.analytics.fleet.types import (
     FleetTurnSnapshot,
 )
 from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
-from api.analytics.military_score_inference.ship_build_combos import (
-    is_generic_zero_military_score_combo_id,
-)
 from api.errors import ValidationError
 
 
@@ -189,14 +186,6 @@ def fleet_build_option_set_from_inference_ship_build(
 ) -> FleetBuildOptionSet:
     """Map one inference solution ship build into a fleet build option set."""
     combo_id = ship_build.combo_id or None
-    if combo_id is not None and is_generic_zero_military_score_combo_id(combo_id):
-        return FleetBuildOptionSet(
-            combo_id=combo_id,
-            label=ship_build.label,
-            solution_rank_weight=solution_rank_weight,
-            beam_count=ship_build.beam_count,
-            launcher_count=ship_build.launcher_count,
-        )
     return FleetBuildOptionSet(
         combo_id=combo_id,
         label=ship_build.label,

--- a/packages/api/tests/test_fleet_inference_ingest.py
+++ b/packages/api/tests/test_fleet_inference_ingest.py
@@ -586,3 +586,56 @@ def test_ephemeral_compute_services_refine_from_scheduler(sample_turn):
         if player["playerId"] == player_id
     )
     assert record["buildOptionSets"][0]["hullId"] == 13
+
+
+def test_generic_freighter_option_set_omits_zero_component_ids_on_wire():
+    turn = _turn_with_score_delta(turn_number=3, owner_id=8, freighterchange=1)
+    persistence = InferenceRowPersistenceService(MemoryAssetBackend(initial={}))
+    persistence.put_row(
+        628580,
+        1,
+        3,
+        8,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="one freighter",
+            solution_count=1,
+            is_complete=True,
+            solutions=[
+                {
+                    "objectiveValue": 0,
+                    "actions": [],
+                    "shipBuilds": [
+                        {
+                            "comboId": "combo_freighter",
+                            "label": "Freighter",
+                            "count": 1,
+                            "hullId": 0,
+                            "engineId": 0,
+                            "beamCount": 0,
+                            "launcherCount": 0,
+                        }
+                    ],
+                }
+            ],
+        ),
+    )
+    snapshot = apply_fleet_turn_delta(
+        ensure_fleet_baseline(628580, 1, turn),
+        turn,
+        inference_materialization=_inference_materialization(
+            FleetInferenceSupport(scores_services=ScoresExportContext(persistence=persistence)),
+            turn,
+        ),
+    )
+
+    record = ledger_for_player(snapshot, 8).records[0]
+    assert record.build_option_sets[0].combo_id == "combo_freighter"
+    assert record.build_option_sets[0].hull_id is None
+    assert record.build_option_sets[0].engine_id is None
+
+    wire = fleet_turn_snapshot_to_compute_wire(snapshot)
+    option_set = wire["players"][0]["records"][0]["buildOptionSets"][0]
+    assert option_set["label"] == "Freighter"
+    assert "hullId" not in option_set
+    assert "engineId" not in option_set

--- a/packages/bff/bff/analytics/fleet.py
+++ b/packages/bff/bff/analytics/fleet.py
@@ -2,6 +2,7 @@
 
 from api.analytics.catalog import catalog_entry
 from api.diagnostics import Diagnostics
+from api.models.game import TurnInfo
 
 from bff.analytics.descriptor import AnalyticDescriptor
 from bff.analytics.models import (
@@ -49,9 +50,23 @@ def _shape_table_player(player: dict[str, object]) -> dict[str, object]:
     return shaped
 
 
-def table_from_core(core_data: dict) -> dict:
-    """Shape Core fleet compute output for GET /bff/analytics/fleet/table."""
+def component_catalog_wire(turn: TurnInfo) -> dict[str, dict[str, str]]:
+    """Host component id -> display name tables for fleet table rendering."""
     return {
+        "hulls": {str(hull.id): hull.name for hull in turn.hulls},
+        "engines": {str(engine.id): engine.name for engine in turn.engines},
+        "beams": {str(beam.id): beam.name for beam in turn.beams},
+        "torpedoes": {str(torpedo.id): torpedo.name for torpedo in turn.torpedos},
+    }
+
+
+def table_from_core(
+    core_data: dict,
+    *,
+    component_catalog: dict[str, dict[str, str]] | None = None,
+) -> dict:
+    """Shape Core fleet compute output for GET /bff/analytics/fleet/table."""
+    payload: dict[str, object] = {
         "analyticId": ANALYTIC_ID,
         "defaultActiveOnly": True,
         "players": [
@@ -60,6 +75,9 @@ def table_from_core(core_data: dict) -> dict:
             if isinstance(player, dict)
         ],
     }
+    if component_catalog is not None:
+        payload["componentCatalog"] = component_catalog
+    return payload
 
 
 def map_from_core(core_data: dict) -> dict:
@@ -85,8 +103,11 @@ def get_table(
     load_core: CoreAnalyticsLoader,
     diagnostics: Diagnostics,
 ) -> dict:
+    from bff.core_client import get_core_client
+
     core_data = load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
-    return table_from_core(core_data)
+    turn = get_core_client().get_turn_info(scope.game_id, scope.perspective, scope.turn)
+    return table_from_core(core_data, component_catalog=component_catalog_wire(turn))
 
 
 def get_map(

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -196,6 +196,9 @@ class CoreClient:
             )
         )
 
+    def get_turn_info(self, game_id: int, perspective: int, turn_number: int) -> TurnInfo:
+        return self._invoke(lambda: self._turns.get_turn_info(game_id, perspective, turn_number))
+
     def get_turn_analytics(
         self,
         game_id: int,

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -282,6 +282,7 @@ def test_fleet_table_returns_players_with_observed_records():
     data = response.json()
     assert data["analyticId"] == "fleet"
     assert data["defaultActiveOnly"] is True
+    assert isinstance(data.get("componentCatalog"), dict)
     players = data["players"]
     assert len(players) == 4
     assert players[0]["playerName"] == "koshling"

--- a/packages/bff/tests/test_analytics_registry.py
+++ b/packages/bff/tests/test_analytics_registry.py
@@ -1,8 +1,13 @@
 """Tests for BFF analytics modules and registry dispatch."""
 
+import json
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 from api.analytics.catalog import TURN_ANALYTIC_CATALOG
 from api.diagnostics import NOOP_DIAGNOSTICS
+from api.serialization.turn import turn_info_from_json
 from api.transport.connections_options import derive_include_illustrative_routes
 from bff.analytics import (
     ANALYTICS_LIST,
@@ -15,6 +20,8 @@ from bff.analytics import (
 )
 from bff.analytics.registry import REGISTERED_ANALYTICS
 from bff.errors import BFFValidationError
+
+ASSETS_DIR = Path(__file__).resolve().parents[2] / "api" / "api" / "storage" / "assets"
 
 
 def test_registered_analytics_follow_catalog_order():
@@ -77,18 +84,28 @@ def test_fleet_table_dispatch_forwards_to_core():
             ],
         }
 
-    data = get_table_response("fleet", TurnScope(628580, 1, 111), load_core, NOOP_DIAGNOSTICS)
-    assert data == {
-        "analyticId": "fleet",
-        "defaultActiveOnly": True,
-        "players": [
-            {
-                "playerId": 1,
-                "playerName": "koshling",
-                "records": [],
-            }
-        ],
-    }
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        sample_turn = turn_info_from_json(json.load(handle))
+
+    with patch("bff.core_client.get_core_client") as mock_get_client:
+        mock_get_client.return_value.get_turn_info.return_value = sample_turn
+        data = get_table_response("fleet", TurnScope(628580, 1, 111), load_core, NOOP_DIAGNOSTICS)
+    assert data["analyticId"] == "fleet"
+    assert data["defaultActiveOnly"] is True
+    assert data["players"] == [
+        {
+            "playerId": 1,
+            "playerName": "koshling",
+            "records": [],
+        }
+    ]
+    catalog = data["componentCatalog"]
+    assert isinstance(catalog, dict)
+    assert isinstance(catalog.get("hulls"), dict)
+    assert isinstance(catalog.get("engines"), dict)
+    assert isinstance(catalog.get("beams"), dict)
+    assert isinstance(catalog.get("torpedoes"), dict)
+    assert len(catalog["hulls"]) > 0
     assert calls == [
         (
             628580,

--- a/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
@@ -10,19 +10,31 @@ import {
 import { AlertTriangle, ChevronDown, ShieldCheck } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import {
+  EMPTY_FLEET_COMPONENT_CATALOG,
+  type FleetComponentCatalog,
+} from './fleetTableWireSchema'
+import {
   activeFleetRecords,
   alternateBuildOptionSets,
-  formatBuildOptionSetSummary,
   formatFleetCountDiscrepancyBanner,
   formatFleetLastSeen,
   formatFleetRecordField,
 } from './fleetRecordDisplay'
+import {
+  formatBuildOptionSetComponentSummary,
+  formatFleetBeamsDisplay,
+  formatFleetEngineDisplay,
+  formatFleetHullDisplay,
+  formatFleetLaunchersDisplay,
+} from './fleetRecordComponentDisplay'
+import { FleetRecordHullCell } from './FleetRecordHullCell'
 import type { FleetCountDiscrepancy, FleetTableRecord } from './fleetTableWireSchema'
 
 type FleetPlayerTableTileProps = {
   playerName: string
   records: readonly FleetTableRecord[]
   discrepancy?: FleetCountDiscrepancy
+  componentCatalog?: FleetComponentCatalog
 }
 
 const columnHelper = createColumnHelper<FleetTableRecord>()
@@ -63,6 +75,7 @@ export function FleetPlayerTableTile({
   playerName,
   records,
   discrepancy,
+  componentCatalog = EMPTY_FLEET_COMPONENT_CATALOG,
 }: FleetPlayerTableTileProps) {
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const activeRecords = useMemo(() => activeFleetRecords(records), [records])
@@ -104,22 +117,33 @@ export function FleetPlayerTableTile({
         id: 'shipId',
         header: 'ID',
       }),
-      columnHelper.accessor((record) => formatFleetRecordField(record, 'hull'), {
+      columnHelper.display({
         id: 'hull',
         header: 'Hull',
+        cell: ({ row }) => (
+          <FleetRecordHullCell
+            hull={formatFleetHullDisplay(row.original, componentCatalog)}
+          />
+        ),
       }),
-      columnHelper.accessor((record) => formatFleetRecordField(record, 'engine'), {
-        id: 'engine',
-        header: 'Engine',
-      }),
-      columnHelper.accessor((record) => formatFleetRecordField(record, 'beams'), {
+      columnHelper.accessor(
+        (record) => formatFleetEngineDisplay(record, componentCatalog),
+        {
+          id: 'engine',
+          header: 'Engine',
+        }
+      ),
+      columnHelper.accessor((record) => formatFleetBeamsDisplay(record, componentCatalog), {
         id: 'beams',
         header: 'Beams',
       }),
-      columnHelper.accessor((record) => formatFleetRecordField(record, 'launchers'), {
-        id: 'launchers',
-        header: 'Launchers',
-      }),
+      columnHelper.accessor(
+        (record) => formatFleetLaunchersDisplay(record, componentCatalog),
+        {
+          id: 'launchers',
+          header: 'Launchers',
+        }
+      ),
       columnHelper.accessor((record) => formatFleetRecordField(record, 'builtTurn'), {
         id: 'builtTurn',
         header: 'Built',
@@ -134,7 +158,7 @@ export function FleetPlayerTableTile({
         cell: ({ row }) => <FleetStatusIcons record={row.original} />,
       }),
     ],
-    []
+    [componentCatalog]
   )
 
   const table = useReactTable({
@@ -213,7 +237,7 @@ export function FleetPlayerTableTile({
                         <ul className="space-y-1">
                           {alternateBuildOptionSets(row.original).map((optionSet) => (
                             <li key={optionSet.comboId ?? optionSet.label}>
-                              {formatBuildOptionSetSummary(optionSet)}
+                              {formatBuildOptionSetComponentSummary(optionSet, componentCatalog)}
                             </li>
                           ))}
                         </ul>

--- a/packages/frontend/src/analytics/fleet/FleetRecordHullCell.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetRecordHullCell.tsx
@@ -1,0 +1,22 @@
+import { hullImageUrl } from '../../concepts/hullImageUrl'
+import type { FleetHullDisplay } from './fleetRecordComponentDisplay'
+
+type FleetRecordHullCellProps = {
+  hull: FleetHullDisplay
+}
+
+export function FleetRecordHullCell({ hull }: FleetRecordHullCellProps) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      {hull.hullId != null ? (
+        <img
+          src={hullImageUrl(hull.hullId)}
+          alt=""
+          className="h-7 w-7 shrink-0 object-contain"
+          loading="lazy"
+        />
+      ) : null}
+      <span>{hull.label}</span>
+    </span>
+  )
+}

--- a/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
@@ -6,7 +6,14 @@ import { FleetTableView } from './FleetTableView'
 import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
-import type { FleetTableRecord, FleetTableWire } from './fleetTableWireSchema'
+import type { FleetComponentCatalog, FleetTableRecord, FleetTableWire } from './fleetTableWireSchema'
+
+const testComponentCatalog: FleetComponentCatalog = {
+  hulls: { '13': 'Cruiser A', '14': 'Cruiser B' },
+  engines: { '9': 'Transwarp Drive', '10': 'Heavy Drive' },
+  beams: { '3': 'Plasma Bolt', '5': 'Positron Beam' },
+  torpedoes: { '6': 'Mark 4 Photon' },
+}
 
 const activeRecord: FleetTableRecord = {
   recordId: 'rec-active',
@@ -31,8 +38,10 @@ const activeRecord: FleetTableRecord = {
       solutionRankWeight: 10,
       hullId: 13,
       engineId: 9,
+      beamId: 3,
       beamCount: 8,
       launcherCount: 6,
+      torpId: 6,
     },
     {
       comboId: 'combo_b',
@@ -40,8 +49,10 @@ const activeRecord: FleetTableRecord = {
       solutionRankWeight: 3,
       hullId: 14,
       engineId: 10,
+      beamId: 5,
       beamCount: 4,
       launcherCount: 2,
+      torpId: 6,
     },
   ],
   displayDefaultOptionSetIndex: 0,
@@ -67,6 +78,7 @@ const lostRecord: FleetTableRecord = {
 const fleetWire: FleetTableWire = {
   analyticId: 'fleet',
   defaultActiveOnly: true,
+  componentCatalog: testComponentCatalog,
   players: [
     {
       playerId: 8,
@@ -92,10 +104,11 @@ describe('FleetPlayerTableTile', () => {
       <FleetPlayerTableTile
         playerName="Alice"
         records={[activeRecord, lostRecord]}
+        componentCatalog={testComponentCatalog}
       />
     )
 
-    expect(screen.getByText('<= 318')).toBeInTheDocument()
+    expect(screen.getByText('Cruiser A')).toBeInTheDocument()
     expect(screen.queryByText('42')).not.toBeInTheDocument()
   })
 
@@ -125,14 +138,15 @@ describe('FleetPlayerTableTile', () => {
       <FleetPlayerTableTile
         playerName="Alice"
         records={[activeRecord]}
+        componentCatalog={testComponentCatalog}
       />
     )
 
-    expect(screen.queryByText(/Option B/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Cruiser B/)).not.toBeInTheDocument()
 
     await user.click(screen.getByRole('button', { name: 'Expand build options for rec-active' }))
 
-    expect(screen.getByText(/Option B/)).toBeInTheDocument()
+    expect(screen.getByText(/Cruiser B/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Collapse build options for rec-active' })).toHaveAttribute(
       'aria-expanded',
       'true'

--- a/packages/frontend/src/analytics/fleet/FleetTableView.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.tsx
@@ -33,6 +33,7 @@ export function FleetTableView({ data }: FleetTableViewProps) {
             playerName={wirePlayer?.playerName ?? player.name}
             records={wirePlayer?.records ?? []}
             discrepancy={wirePlayer?.discrepancy}
+            componentCatalog={data.componentCatalog}
           />
         )
       })}

--- a/packages/frontend/src/analytics/fleet/fleetComponentCatalog.ts
+++ b/packages/frontend/src/analytics/fleet/fleetComponentCatalog.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod'
+
+export const fleetComponentCatalogSchema = z.object({
+  hulls: z.record(z.string(), z.string()),
+  engines: z.record(z.string(), z.string()),
+  beams: z.record(z.string(), z.string()),
+  torpedoes: z.record(z.string(), z.string()),
+})
+
+export type FleetComponentCatalog = z.infer<typeof fleetComponentCatalogSchema>
+
+export const EMPTY_FLEET_COMPONENT_CATALOG: FleetComponentCatalog = {
+  hulls: {},
+  engines: {},
+  beams: {},
+  torpedoes: {},
+}
+
+export function parseFleetComponentCatalog(raw: unknown): FleetComponentCatalog | null {
+  const result = fleetComponentCatalogSchema.safeParse(raw)
+  return result.success ? result.data : null
+}
+
+function catalogName(
+  table: Record<string, string>,
+  componentId: number | null | undefined
+): string | null {
+  if (componentId == null || componentId <= 0) {
+    return null
+  }
+  return table[String(componentId)] ?? null
+}
+
+export function fleetHullName(catalog: FleetComponentCatalog, hullId: number): string | null {
+  return catalogName(catalog.hulls, hullId)
+}
+
+export function fleetEngineName(catalog: FleetComponentCatalog, engineId: number): string | null {
+  return catalogName(catalog.engines, engineId)
+}
+
+export function fleetBeamName(catalog: FleetComponentCatalog, beamId: number): string | null {
+  return catalogName(catalog.beams, beamId)
+}
+
+export function fleetTorpedoName(catalog: FleetComponentCatalog, torpId: number): string | null {
+  return catalogName(catalog.torpedoes, torpId)
+}
+
+export function formatComponentQuantityLabel(
+  count: number,
+  componentName: string | null,
+  fallbackId: number | null = null
+): string {
+  if (count <= 0) {
+    return '0'
+  }
+  if (componentName != null && componentName.length > 0) {
+    return `${count} ${componentName}`
+  }
+  if (fallbackId != null && fallbackId > 0) {
+    return `${count} (#${fallbackId})`
+  }
+  return String(count)
+}

--- a/packages/frontend/src/analytics/fleet/fleetRecordComponentDisplay.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordComponentDisplay.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { FleetComponentCatalog } from './fleetComponentCatalog'
+import {
+  formatFleetBeamsDisplay,
+  formatFleetEngineDisplay,
+  formatFleetHullDisplay,
+  formatFleetLaunchersDisplay,
+} from './fleetRecordComponentDisplay'
+import type { FleetTableRecord } from './fleetTableWireSchema'
+
+const catalog: FleetComponentCatalog = {
+  hulls: { '46': 'Meteor Class Blockade Runner', '17': 'Large Deep Space Freighter' },
+  engines: { '9': 'Transwarp Drive' },
+  beams: { '2': 'X-Ray Laser' },
+  torpedoes: { '6': 'Mark 4 Photon' },
+}
+
+const inferredRecord: FleetTableRecord = {
+  recordId: 'rec-inferred',
+  disposition: 'active',
+  qualifiers: {},
+  fields: {
+    shipId: { kind: 'bounded', operator: 'lte', value: 33 },
+    hull: { kind: 'unknown' },
+    engine: { kind: 'unknown' },
+    beams: { kind: 'unknown' },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'known', value: 3 },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [
+    {
+      comboId: 'combo_46_9_2_6_4_4',
+      label: 'Build Meteor Class Blockade Runner: 2x Transwarp Drive, 4x X-Ray Laser',
+      solutionRankWeight: 0,
+      hullId: 46,
+      engineId: 9,
+      beamId: 2,
+      torpId: 6,
+      beamCount: 4,
+      launcherCount: 4,
+    },
+  ],
+  displayDefaultOptionSetIndex: 0,
+}
+
+describe('fleetRecordComponentDisplay', () => {
+  it('resolves hull name and id for inferred builds', () => {
+    expect(formatFleetHullDisplay(inferredRecord, catalog)).toEqual({
+      hullId: 46,
+      label: 'Meteor Class Blockade Runner',
+    })
+  })
+
+  it('formats engine, beams, and launchers with catalog names', () => {
+    expect(formatFleetEngineDisplay(inferredRecord, catalog)).toBe('Transwarp Drive')
+    expect(formatFleetBeamsDisplay(inferredRecord, catalog)).toBe('4 X-Ray Laser')
+    expect(formatFleetLaunchersDisplay(inferredRecord, catalog)).toBe('4 Mark 4 Photon')
+  })
+
+  it('uses observed hull id when field is known', () => {
+    const observed: FleetTableRecord = {
+      ...inferredRecord,
+      fields: {
+        ...inferredRecord.fields,
+        hull: { kind: 'known', value: 17 },
+        engine: { kind: 'known', value: 9 },
+      },
+      buildOptionSets: [],
+      displayDefaultOptionSetIndex: undefined,
+    }
+    expect(formatFleetHullDisplay(observed, catalog).label).toBe('Large Deep Space Freighter')
+    expect(formatFleetEngineDisplay(observed, catalog)).toBe('Transwarp Drive')
+  })
+})

--- a/packages/frontend/src/analytics/fleet/fleetRecordComponentDisplay.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordComponentDisplay.ts
@@ -1,0 +1,171 @@
+import { GENERIC_FREIGHTER_HULL_ID } from '../../concepts/hullImageUrl'
+import type { FleetBuildOptionSet, FleetFieldConstraint, FleetTableRecord } from './fleetTableWireSchema'
+import {
+  type FleetComponentCatalog,
+  fleetBeamName,
+  fleetEngineName,
+  fleetHullName,
+  fleetTorpedoName,
+  formatComponentQuantityLabel,
+} from './fleetComponentCatalog'
+import { defaultBuildOptionSet } from './fleetRecordDisplay'
+
+const GENERIC_FREIGHTER_COMBO_ID = 'combo_freighter'
+
+function knownComponentId(constraint: FleetFieldConstraint | undefined): number | null {
+  if (constraint?.kind !== 'known') {
+    return null
+  }
+  const value = constraint.value
+  if (typeof value !== 'number' || value <= 0) {
+    return null
+  }
+  return value
+}
+
+function resolveHullId(
+  record: FleetTableRecord,
+  optionSet: FleetBuildOptionSet | null
+): number | null {
+  const fromField = knownComponentId(record.fields?.hull)
+  if (fromField != null) {
+    return fromField
+  }
+  if (optionSet?.hullId != null && optionSet.hullId > 0) {
+    return optionSet.hullId
+  }
+  if (optionSet?.comboId === GENERIC_FREIGHTER_COMBO_ID) {
+    return GENERIC_FREIGHTER_HULL_ID
+  }
+  return null
+}
+
+function resolveEngineId(
+  record: FleetTableRecord,
+  optionSet: FleetBuildOptionSet | null
+): number | null {
+  const fromField = knownComponentId(record.fields?.engine)
+  if (fromField != null) {
+    return fromField
+  }
+  if (optionSet?.engineId != null && optionSet.engineId > 0) {
+    return optionSet.engineId
+  }
+  return null
+}
+
+export type FleetHullDisplay = {
+  hullId: number | null
+  label: string
+}
+
+export function formatFleetHullDisplay(
+  record: FleetTableRecord,
+  catalog: FleetComponentCatalog,
+  optionSet: FleetBuildOptionSet | null = defaultBuildOptionSet(record)
+): FleetHullDisplay {
+  const hullId = resolveHullId(record, optionSet)
+  if (hullId != null) {
+    const hullName = fleetHullName(catalog, hullId)
+    if (hullName != null) {
+      return { hullId, label: hullName }
+    }
+    return { hullId, label: String(hullId) }
+  }
+  if (optionSet?.label.length) {
+    return { hullId, label: optionSet.label }
+  }
+  return { hullId, label: '?' }
+}
+
+export function formatFleetEngineDisplay(
+  record: FleetTableRecord,
+  catalog: FleetComponentCatalog,
+  optionSet: FleetBuildOptionSet | null = defaultBuildOptionSet(record)
+): string {
+  const engineId = resolveEngineId(record, optionSet)
+  if (engineId != null) {
+    const engineName = fleetEngineName(catalog, engineId)
+    if (engineName != null) {
+      return engineName
+    }
+    return String(engineId)
+  }
+  return '?'
+}
+
+export function formatFleetBeamsDisplay(
+  record: FleetTableRecord,
+  catalog: FleetComponentCatalog,
+  optionSet: FleetBuildOptionSet | null = defaultBuildOptionSet(record)
+): string {
+  if (optionSet != null) {
+    return formatComponentQuantityLabel(
+      optionSet.beamCount,
+      optionSet.beamId != null ? fleetBeamName(catalog, optionSet.beamId) : null,
+      optionSet.beamId ?? null
+    )
+  }
+  const beamId = knownComponentId(record.fields?.beams)
+  if (beamId != null) {
+    return fleetBeamName(catalog, beamId) ?? String(beamId)
+  }
+  const beams = record.fields?.beams
+  if (beams?.kind === 'known' && beams.value === 0) {
+    return '0'
+  }
+  return '?'
+}
+
+export function formatFleetLaunchersDisplay(
+  record: FleetTableRecord,
+  catalog: FleetComponentCatalog,
+  optionSet: FleetBuildOptionSet | null = defaultBuildOptionSet(record)
+): string {
+  if (optionSet != null) {
+    return formatComponentQuantityLabel(
+      optionSet.launcherCount,
+      optionSet.torpId != null ? fleetTorpedoName(catalog, optionSet.torpId) : null,
+      optionSet.torpId ?? null
+    )
+  }
+  const torpId = knownComponentId(record.fields?.launchers)
+  if (torpId != null) {
+    return fleetTorpedoName(catalog, torpId) ?? String(torpId)
+  }
+  const launchers = record.fields?.launchers
+  if (launchers?.kind === 'known' && launchers.value === 0) {
+    return '0'
+  }
+  return '?'
+}
+
+export function formatBuildOptionSetComponentSummary(
+  optionSet: FleetBuildOptionSet,
+  catalog: FleetComponentCatalog
+): string {
+  const parts: string[] = []
+  if (optionSet.hullId != null && optionSet.hullId > 0) {
+    parts.push(fleetHullName(catalog, optionSet.hullId) ?? `hull ${optionSet.hullId}`)
+  } else if (optionSet.label.length > 0) {
+    parts.push(optionSet.label)
+  }
+  if (optionSet.engineId != null && optionSet.engineId > 0) {
+    parts.push(fleetEngineName(catalog, optionSet.engineId) ?? `engine ${optionSet.engineId}`)
+  }
+  parts.push(
+    formatComponentQuantityLabel(
+      optionSet.beamCount,
+      optionSet.beamId != null ? fleetBeamName(catalog, optionSet.beamId) : null,
+      optionSet.beamId ?? null
+    )
+  )
+  parts.push(
+    formatComponentQuantityLabel(
+      optionSet.launcherCount,
+      optionSet.torpId != null ? fleetTorpedoName(catalog, optionSet.torpId) : null,
+      optionSet.torpId ?? null
+    )
+  )
+  return parts.join(' · ')
+}

--- a/packages/frontend/src/analytics/fleet/fleetRecordDisplay.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordDisplay.test.ts
@@ -96,4 +96,31 @@ describe('fleetRecordDisplay', () => {
       'Fleet count discrepancy on turn 111: 2 active rows vs 1 implied by scoreboard'
     )
   })
+
+  it('shows generic freighter label instead of hull id zero', () => {
+    const record: FleetTableRecord = {
+      ...lostRecord,
+      disposition: 'active',
+      fields: {
+        ...lostRecord.fields,
+        builtTurn: { kind: 'known', value: 3 },
+      },
+      buildOptionSets: [
+        {
+          comboId: 'combo_freighter',
+          label: 'Freighter',
+          solutionRankWeight: 0,
+          hullId: 0,
+          engineId: 0,
+          beamCount: 0,
+          launcherCount: 0,
+        },
+      ],
+      displayDefaultOptionSetIndex: 0,
+    }
+
+    expect(formatFleetRecordField(record, 'hull')).toBe('Freighter')
+    expect(formatFleetRecordField(record, 'engine')).toBe('?')
+    expect(formatFleetRecordField(record, 'beams')).toBe('0')
+  })
 })

--- a/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
+++ b/packages/frontend/src/analytics/fleet/fleetRecordDisplay.ts
@@ -58,6 +58,17 @@ export function alternateBuildOptionSets(record: FleetTableRecord): FleetBuildOp
   return record.buildOptionSets.filter((_, index) => index !== defaultIndex)
 }
 
+function resolvedOptionSetComponentId(
+  optionSet: FleetBuildOptionSet,
+  field: 'hull' | 'engine'
+): number | null {
+  const componentId = field === 'hull' ? optionSet.hullId : optionSet.engineId
+  if (componentId == null || componentId <= 0) {
+    return null
+  }
+  return componentId
+}
+
 function optionSetFieldFallback(
   optionSet: FleetBuildOptionSet | null,
   field: FleetRecordFieldKey
@@ -66,10 +77,20 @@ function optionSetFieldFallback(
     return null
   }
   switch (field) {
-    case 'hull':
-      return optionSet.hullId != null ? String(optionSet.hullId) : null
-    case 'engine':
-      return optionSet.engineId != null ? String(optionSet.engineId) : null
+    case 'hull': {
+      const hullId = resolvedOptionSetComponentId(optionSet, 'hull')
+      if (hullId != null) {
+        return String(hullId)
+      }
+      if (optionSet.label.length > 0) {
+        return optionSet.label
+      }
+      return null
+    }
+    case 'engine': {
+      const engineId = resolvedOptionSetComponentId(optionSet, 'engine')
+      return engineId != null ? String(engineId) : null
+    }
     case 'beams':
       return String(optionSet.beamCount)
     case 'launchers':

--- a/packages/frontend/src/analytics/fleet/fleetTableWireSchema.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTableWireSchema.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod'
+import { fleetComponentCatalogSchema } from './fleetComponentCatalog'
 import {
   fleetBuildOptionSetSchema,
   fleetFieldConstraintSchema,
@@ -82,6 +83,7 @@ export const fleetTableWireSchema = z
   .object({
     analyticId: z.literal('fleet'),
     defaultActiveOnly: z.literal(true),
+    componentCatalog: fleetComponentCatalogSchema.optional(),
     players: z.array(fleetTablePlayerSchema),
   })
   .strict()
@@ -90,6 +92,9 @@ export type FleetTableRecord = z.infer<typeof fleetTableRecordSchema>
 export type FleetCountDiscrepancy = z.infer<typeof fleetCountDiscrepancySchema>
 export type FleetTablePlayer = z.infer<typeof fleetTablePlayerSchema>
 export type FleetTableWire = z.infer<typeof fleetTableWireSchema>
+
+export type { FleetComponentCatalog } from './fleetComponentCatalog'
+export { EMPTY_FLEET_COMPONENT_CATALOG } from './fleetComponentCatalog'
 
 /** Map stable validation failures to messages consumed by the SPA and tests. */
 export function formatFleetTableWireValidationError(error: z.ZodError): string {


### PR DESCRIPTION
Abort multi-turn gap-fill when concurrent snapshot invalidation advances, with bounded retries. Ship component catalog on fleet table wire for hull names/icons and fitted weapon labels; omit zero hull/engine ids on generic freighter inference rows.