### PR TITLE
Fleet gap-fill: abort-on-invalidate for snapshot chain concurrency (#139)

### DIFF
--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -149,6 +149,7 @@ When scoreboard implies fewer ships than **active** rows:
 | **Baseline** | Turn 1: empty ledger or sightings-only seed |
 | **Events** | Copied forward; new events appended; corrections add events at `T` without erasing `T-1` |
 | **Invalidation** | Turn document replace at `T`: drop fleet snapshots `>= T` at that **perspective**; re-chain. Scores inference invalidation: re-chain from first affected host turn (exact coupling in implementation ticket) |
+| **Invalidation generation** | Each `(gameId, perspective)` has a monotonic counter bumped on every fleet snapshot invalidation. Multi-turn gap-fill records the counter at chain start and aborts (then retries from a fresh anchor, bounded max retries) when the counter advances mid-materialization. Invalidation callbacks only bump the counter and delete stored snapshots; they do not block on an in-progress gap-fill |
 
 ---
 

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from api.analytics.fleet.constants import ANALYTIC_ID, GAP_FILL_MAX_RETRIES
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
@@ -18,6 +19,33 @@ from api.models.game import TurnInfo
 
 class _FleetSnapshotInvalidated(Exception):
     """Gap-fill observed a concurrent fleet snapshot invalidation."""
+
+
+@dataclass
+class _GapFillCoherence:
+    """Guard gap-fill puts against concurrent fleet snapshot invalidation."""
+
+    persistence: FleetSnapshotPersistenceService
+    game_id: int
+    perspective: int
+    generation: int
+
+    def put_snapshot(self, turn_number: int, snapshot: FleetTurnSnapshot) -> None:
+        self._assert_unchanged()
+        self.persistence.put_snapshot(
+            self.game_id,
+            self.perspective,
+            turn_number,
+            snapshot,
+        )
+        self._assert_unchanged()
+
+    def _assert_unchanged(self) -> None:
+        if (
+            self.persistence.invalidation_generation(self.game_id, self.perspective)
+            != self.generation
+        ):
+            raise _FleetSnapshotInvalidated()
 
 
 def ensure_fleet_baseline(
@@ -108,25 +136,13 @@ def _first_stored_rst_turn(
     return None
 
 
-def _assert_invalidation_generation_unchanged(
-    persistence: FleetSnapshotPersistenceService,
-    *,
-    game_id: int,
-    perspective: int,
-    generation: int,
-) -> None:
-    if persistence.invalidation_generation(game_id, perspective) != generation:
-        raise _FleetSnapshotInvalidated()
-
-
 def _materialize_and_persist_turn(
-    persistence: FleetSnapshotPersistenceService,
+    coherence: _GapFillCoherence,
     *,
     materialize_turn: int,
     prior_snapshot: FleetTurnSnapshot,
     turn_info: TurnInfo,
     inference_materialization: FleetInferenceMaterialization | None = None,
-    invalidation_generation: int,
 ) -> FleetTurnSnapshot:
     snapshot = advance_snapshot_to_turn(
         prior_snapshot,
@@ -139,18 +155,7 @@ def _materialize_and_persist_turn(
         turn_info,
         inference_materialization=inference_materialization,
     )
-    persistence.put_snapshot(
-        snapshot.game_id,
-        snapshot.perspective,
-        materialize_turn,
-        snapshot,
-    )
-    _assert_invalidation_generation_unchanged(
-        persistence,
-        game_id=snapshot.game_id,
-        perspective=snapshot.perspective,
-        generation=invalidation_generation,
-    )
+    coherence.put_snapshot(materialize_turn, snapshot)
     return snapshot
 
 
@@ -162,7 +167,7 @@ def _materialize_fleet_snapshot_chain(
     *,
     load_turn: Callable[[int], TurnInfo | None],
     inference_materialization: FleetInferenceMaterialization | None = None,
-    invalidation_generation: int,
+    coherence: _GapFillCoherence,
 ) -> FleetTurnSnapshot:
     """Gap-fill fleet snapshots from the latest anchor through turn T."""
     turn_number = turn.settings.turn
@@ -243,13 +248,7 @@ def _materialize_fleet_snapshot_chain(
             turn_one,
             inference_materialization=resolved_inference_materialization,
         )
-        persistence.put_snapshot(game_id, perspective, 1, turn_one_snapshot)
-        _assert_invalidation_generation_unchanged(
-            persistence,
-            game_id=game_id,
-            perspective=perspective,
-            generation=invalidation_generation,
-        )
+        coherence.put_snapshot(1, turn_one_snapshot)
         current_snapshot = turn_one_snapshot
         if turn_number == 1:
             return turn_one_snapshot
@@ -262,12 +261,11 @@ def _materialize_fleet_snapshot_chain(
         )
         turn_info = require_turn(materialize_turn)
         current_snapshot = _materialize_and_persist_turn(
-            persistence,
+            coherence,
             materialize_turn=materialize_turn,
             prior_snapshot=current_snapshot,
             turn_info=turn_info,
             inference_materialization=resolved_inference_materialization,
-            invalidation_generation=invalidation_generation,
         )
 
     return current_snapshot
@@ -289,7 +287,12 @@ def get_or_materialize_fleet_snapshot(
         return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):
-        invalidation_generation = persistence.invalidation_generation(game_id, perspective)
+        coherence = _GapFillCoherence(
+            persistence,
+            game_id,
+            perspective,
+            persistence.invalidation_generation(game_id, perspective),
+        )
         try:
             return _materialize_fleet_snapshot_chain(
                 persistence,
@@ -298,7 +301,7 @@ def get_or_materialize_fleet_snapshot(
                 turn,
                 load_turn=load_turn,
                 inference_materialization=inference_materialization,
-                invalidation_generation=invalidation_generation,
+                coherence=coherence,
             )
         except _FleetSnapshotInvalidated:
             if attempt + 1 >= GAP_FILL_MAX_RETRIES:

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import copy
 from collections.abc import Callable
 
-from api.analytics.fleet.constants import ANALYTIC_ID
+from api.analytics.fleet.constants import ANALYTIC_ID, GAP_FILL_MAX_RETRIES
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.inferred_acquisition_ingest import ingest_turn_inferred_acquisitions
 from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
 from api.analytics.turn_roster import iter_turn_players
-from api.errors import NotFoundError
+from api.errors import ConflictError, NotFoundError
 from api.models.game import TurnInfo
+
+
+class _FleetSnapshotInvalidated(Exception):
+    """Gap-fill observed a concurrent fleet snapshot invalidation."""
 
 
 def ensure_fleet_baseline(
@@ -104,6 +108,17 @@ def _first_stored_rst_turn(
     return None
 
 
+def _assert_invalidation_generation_unchanged(
+    persistence: FleetSnapshotPersistenceService,
+    *,
+    game_id: int,
+    perspective: int,
+    generation: int,
+) -> None:
+    if persistence.invalidation_generation(game_id, perspective) != generation:
+        raise _FleetSnapshotInvalidated()
+
+
 def _materialize_and_persist_turn(
     persistence: FleetSnapshotPersistenceService,
     *,
@@ -111,6 +126,7 @@ def _materialize_and_persist_turn(
     prior_snapshot: FleetTurnSnapshot,
     turn_info: TurnInfo,
     inference_materialization: FleetInferenceMaterialization | None = None,
+    invalidation_generation: int,
 ) -> FleetTurnSnapshot:
     snapshot = advance_snapshot_to_turn(
         prior_snapshot,
@@ -129,10 +145,16 @@ def _materialize_and_persist_turn(
         materialize_turn,
         snapshot,
     )
+    _assert_invalidation_generation_unchanged(
+        persistence,
+        game_id=snapshot.game_id,
+        perspective=snapshot.perspective,
+        generation=invalidation_generation,
+    )
     return snapshot
 
 
-def get_or_materialize_fleet_snapshot(
+def _materialize_fleet_snapshot_chain(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
     perspective: int,
@@ -140,12 +162,10 @@ def get_or_materialize_fleet_snapshot(
     *,
     load_turn: Callable[[int], TurnInfo | None],
     inference_materialization: FleetInferenceMaterialization | None = None,
+    invalidation_generation: int,
 ) -> FleetTurnSnapshot:
-    """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
+    """Gap-fill fleet snapshots from the latest anchor through turn T."""
     turn_number = turn.settings.turn
-    cached = persistence.get_snapshot(game_id, perspective, turn_number)
-    if cached is not None:
-        return cached
 
     loaded_turns: dict[int, TurnInfo | None] = {}
 
@@ -224,6 +244,12 @@ def get_or_materialize_fleet_snapshot(
             inference_materialization=resolved_inference_materialization,
         )
         persistence.put_snapshot(game_id, perspective, 1, turn_one_snapshot)
+        _assert_invalidation_generation_unchanged(
+            persistence,
+            game_id=game_id,
+            perspective=perspective,
+            generation=invalidation_generation,
+        )
         current_snapshot = turn_one_snapshot
         if turn_number == 1:
             return turn_one_snapshot
@@ -241,6 +267,45 @@ def get_or_materialize_fleet_snapshot(
             prior_snapshot=current_snapshot,
             turn_info=turn_info,
             inference_materialization=resolved_inference_materialization,
+            invalidation_generation=invalidation_generation,
         )
 
     return current_snapshot
+
+
+def get_or_materialize_fleet_snapshot(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    turn: TurnInfo,
+    *,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None = None,
+) -> FleetTurnSnapshot:
+    """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
+    turn_number = turn.settings.turn
+    cached = persistence.get_snapshot(game_id, perspective, turn_number)
+    if cached is not None:
+        return cached
+
+    for attempt in range(GAP_FILL_MAX_RETRIES):
+        invalidation_generation = persistence.invalidation_generation(game_id, perspective)
+        try:
+            return _materialize_fleet_snapshot_chain(
+                persistence,
+                game_id,
+                perspective,
+                turn,
+                load_turn=load_turn,
+                inference_materialization=inference_materialization,
+                invalidation_generation=invalidation_generation,
+            )
+        except _FleetSnapshotInvalidated:
+            if attempt + 1 >= GAP_FILL_MAX_RETRIES:
+                break
+            continue
+
+    raise ConflictError(
+        f"fleet snapshot gap-fill for game {game_id} perspective {perspective} "
+        f"turn {turn_number} exceeded {GAP_FILL_MAX_RETRIES} invalidation retries"
+    )

--- a/packages/api/api/analytics/fleet/constants.py
+++ b/packages/api/api/analytics/fleet/constants.py
@@ -1,3 +1,6 @@
 """Shared constants for the fleet turn analytic."""
 
 ANALYTIC_ID = "fleet"
+
+# Bounded retries when gap-fill is aborted by concurrent fleet snapshot invalidation.
+GAP_FILL_MAX_RETRIES = 10

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.serialization import (
     fleet_turn_snapshot_from_json,
@@ -26,10 +28,19 @@ class FleetSnapshotPersistenceService:
     Fleet turn-document invalidation (``invalidate_for_turn_write``) is independent
     of scores pair-aware invalidation (turn *T* and *T-1*); both hooks run from
     ``on_turn_stored`` today.
+
+    **Invalidation generation:** Each ``(game_id, perspective)`` pair has a
+    monotonic counter bumped on every ``invalidate_for_turn_write`` call. Gap-fill
+    in ``get_or_materialize_fleet_snapshot`` records the generation at chain start
+    and aborts (then retries from a fresh anchor) when the counter advances during
+    multi-turn materialization. Invalidation does not block on gap-fill; concurrent
+    invalidation callbacks only bump the counter and delete stored snapshots.
     """
 
     def __init__(self, storage: StorageBackend) -> None:
         self._storage = storage
+        self._invalidation_generation: dict[tuple[int, int], int] = {}
+        self._generation_lock = threading.Lock()
 
     @staticmethod
     def document_key(game_id: int, perspective: int, turn_number: int) -> str:
@@ -99,6 +110,11 @@ class FleetSnapshotPersistenceService:
         except NotFoundError:
             pass
 
+    def invalidation_generation(self, game_id: int, perspective: int) -> int:
+        """Return the current invalidation generation for one perspective scope."""
+        with self._generation_lock:
+            return self._invalidation_generation.get((game_id, perspective), 0)
+
     def invalidate_for_turn_write(
         self,
         game_id: int,
@@ -114,7 +130,13 @@ class FleetSnapshotPersistenceService:
                 continue
             self.delete_snapshot(game_id, perspective, stored_turn)
             cleared.add(stored_turn)
+        self._bump_invalidation_generation(game_id, perspective)
         return cleared
+
+    def _bump_invalidation_generation(self, game_id: int, perspective: int) -> None:
+        with self._generation_lock:
+            key = (game_id, perspective)
+            self._invalidation_generation[key] = self._invalidation_generation.get(key, 0) + 1
 
     def _stored_turn_numbers(self, game_id: int, perspective: int) -> list[int]:
         turns_prefix = f"games/{game_id}/{perspective}/turns"

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -301,8 +302,10 @@ def test_invalidate_for_turn_write_drops_snapshots_at_and_after_turn(persistence
                 players=[FleetAcquisitionLedger(player_id=8)],
             ),
         )
+    assert persistence.invalidation_generation(628580, 1) == 0
     cleared = persistence.invalidate_for_turn_write(628580, 1, 111)
     assert cleared == {111, 112}
+    assert persistence.invalidation_generation(628580, 1) == 1
     assert persistence.get_snapshot(628580, 1, 110) is not None
     assert persistence.get_snapshot(628580, 1, 111) is None
     assert persistence.get_snapshot(628580, 1, 112) is None
@@ -527,3 +530,62 @@ def test_held_solutions_scheduler_callback_invalidates_cached_fleet_snapshot(
     scheduler._on_held_solutions_updated(scheduled.session)
 
     assert fleet_persistence.get_snapshot(628580, 1, turn_number) is None
+
+
+def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memory_backend):
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    prior = ensure_fleet_baseline(628580, 1, turn_110)
+    prior.players[0].records.append(
+        FleetShipRecord(record_id="gap-rec", disposition="active"),
+    )
+    persistence.put_snapshot(628580, 1, 110, prior)
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    sync = threading.Barrier(2)
+    put_generations: list[int] = []
+    original_put_snapshot = persistence.put_snapshot
+
+    def hooked_put_snapshot(*args, **kwargs):
+        snapshot = original_put_snapshot(*args, **kwargs)
+        put_generations.append(persistence.invalidation_generation(628580, 1))
+        if len(put_generations) == 1:
+            sync.wait()
+            sync.wait()
+        return snapshot
+
+    persistence.put_snapshot = hooked_put_snapshot  # type: ignore[method-assign]
+
+    gap_fill_error: BaseException | None = None
+    snapshot: FleetTurnSnapshot | None = None
+
+    def run_gap_fill() -> None:
+        nonlocal gap_fill_error, snapshot
+        try:
+            snapshot = get_or_materialize_fleet_snapshot(
+                persistence,
+                628580,
+                1,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            gap_fill_error = exc
+
+    gap_fill_thread = threading.Thread(target=run_gap_fill)
+    gap_fill_thread.start()
+    sync.wait()
+    persistence.invalidate_for_turn_write(628580, 1, 111)
+    sync.wait()
+    gap_fill_thread.join()
+
+    assert gap_fill_error is None
+    assert snapshot is not None
+    assert snapshot.turn == 112
+    assert put_generations[0] == 0
+    assert put_generations[-2:] == [1, 1]
+    assert persistence.get_snapshot(628580, 1, 111) is not None
+    assert persistence.get_snapshot(628580, 1, 112) == snapshot
+    assert len(snapshot.players[0].records) == 6
+    assert snapshot.players[0].records[0].record_id == "gap-rec"

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -6,6 +6,7 @@ import copy
 import json
 import threading
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from api.analytics.fleet.chain import (
@@ -19,7 +20,7 @@ from api.analytics.fleet.types import (
     FleetShipRecord,
     FleetTurnSnapshot,
 )
-from api.errors import NotFoundError, ValidationError
+from api.errors import ConflictError, NotFoundError, ValidationError
 from api.serialization.turn import turn_info_from_json
 from api.services.inference_invalidation_service import InferenceInvalidationService
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
@@ -589,3 +590,100 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
     assert persistence.get_snapshot(628580, 1, 112) == snapshot
     assert len(snapshot.players[0].records) == 6
     assert snapshot.players[0].records[0].record_id == "gap-rec"
+
+
+def test_gap_fill_does_not_persist_torn_tail_after_mid_chain_invalidation(persistence, load_turn):
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    sync = threading.Barrier(2)
+    attempt_puts: list[list[int]] = []
+    current_attempt_puts: list[int] = []
+    mid_chain_intercepted = False
+    original_put_snapshot = persistence.put_snapshot
+
+    def hooked_put_snapshot(
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        snapshot: FleetTurnSnapshot,
+    ) -> None:
+        nonlocal mid_chain_intercepted
+        original_put_snapshot(game_id, perspective, turn_number, snapshot)
+        current_attempt_puts.append(turn_number)
+        if turn_number == 111 and not mid_chain_intercepted:
+            mid_chain_intercepted = True
+            assert persistence.get_snapshot(628580, 1, 112) is None
+            sync.wait()
+            persistence.invalidate_for_turn_write(628580, 1, 111)
+            assert persistence.get_snapshot(628580, 1, 112) is None
+            attempt_puts.append(list(current_attempt_puts))
+            current_attempt_puts.clear()
+            sync.wait()
+
+    persistence.put_snapshot = hooked_put_snapshot  # type: ignore[method-assign]
+
+    gap_fill_error: BaseException | None = None
+    snapshot: FleetTurnSnapshot | None = None
+
+    def run_gap_fill() -> None:
+        nonlocal gap_fill_error, snapshot
+        try:
+            snapshot = get_or_materialize_fleet_snapshot(
+                persistence,
+                628580,
+                1,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            gap_fill_error = exc
+
+    gap_fill_thread = threading.Thread(target=run_gap_fill)
+    gap_fill_thread.start()
+    sync.wait()
+    sync.wait()
+    gap_fill_thread.join()
+
+    assert gap_fill_error is None
+    assert snapshot is not None
+    assert attempt_puts[0] == [111]
+    assert snapshot.turn == 112
+    assert persistence.get_snapshot(628580, 1, 112) == snapshot
+
+
+def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, load_turn):
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
+
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    original_put_snapshot = persistence.put_snapshot
+
+    def put_snapshot_that_invalidates(
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        snapshot: FleetTurnSnapshot,
+    ) -> None:
+        original_put_snapshot(game_id, perspective, turn_number, snapshot)
+        persistence.invalidate_for_turn_write(game_id, perspective, turn_number)
+
+    persistence.put_snapshot = put_snapshot_that_invalidates  # type: ignore[method-assign]
+
+    with patch("api.analytics.fleet.chain.GAP_FILL_MAX_RETRIES", 3):
+        with pytest.raises(ConflictError, match="exceeded 3 invalidation retries"):
+            get_or_materialize_fleet_snapshot(
+                persistence,
+                628580,
+                1,
+                turn_111,
+                load_turn=load_turn,
+            )
+
+    assert persistence.get_snapshot(628580, 1, 111) is None
+    assert persistence.invalidation_generation(628580, 1) == 3


### PR DESCRIPTION
## Summary

- Add a per-`(game_id, perspective)` invalidation generation counter on `FleetSnapshotPersistenceService`, bumped on every `invalidate_for_turn_write` call without blocking gap-fill.
- Abort multi-turn gap-fill when generation advances mid-chain, then retry from a fresh anchor (bounded by `GAP_FILL_MAX_RETRIES`, surfacing `ConflictError` on exhaustion).
- Centralize put guards in `_GapFillCoherence` with pre- and post-invalidation checks so aborted chains cannot persist a torn tail turn.
- Add concurrency tests and document invalidation generation semantics in the fleet design doc.

Closes #139.

## Test plan

- [x] `cd packages/api && uv run pytest tests/test_fleet_persistence.py -q` (18 passed)
- [x] `uv run ruff check api/analytics/fleet/ tests/test_fleet_persistence.py`
- [ ] `make test_api` (full API suite)


Made with [Cursor](https://cursor.com)