### PR TITLE
Scores host-turn export: decouple fleet from accelerated diagnostics (#151)

### DIFF
--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -215,22 +215,12 @@ Example branches (scores):
       "militaryScoreArithmetic": { }
     }
   ],
-  "hostTurnTargets": [
-    {
-      "hostTurn": 1,
-      "status": "exact",
-      "solutionCount": 2,
-      "warshipDelta": 1,
-      "freighterDelta": 0,
-      "solutions": [ ]
-    }
-  ],
   "diagnostics": { },
   "hullCatalogMask": { "enabledHullIds": [1, 2, 3] }
 }
 ```
 
-`$.solutions` uses the same held top-K shape as scores row inference wire/persistence. For each scoreboard turn scope, **`$.solutions`** describes the **host turn implied by that row** (`hostTurn = scoreboardTurn - 1`), including accelerated backfill rows and split segments. **`$.hostTurnTargets`** (persisted as `hostTurnTargets` on inference rows) carries per-host-turn functional payloads when a single scoreboard row materializes multiple accelerated segments; consumers must use **`$.solutions`** at the correct scoreboard turn or **`$.hostTurnTargets`**, not **`$.diagnostics.accelerated_segments`**. **`$.diagnostics`** is optional and for developer panels only; cross-analytic ingest must not depend on it. `$.solutions[0]` is the full top explanation (all `shipBuilds` and `actions` for that rank). `$.meta.searchStatus` carries lifecycle only.
+`$.solutions` uses the same held top-K shape as scores row inference wire/persistence. For each scoreboard turn scope, **`$.solutions`** is the authoritative functional branch: it describes the **host turn implied by that row** (`hostTurn = scoreboardTurn - 1`), including accelerated backfill rows and split segments. Export materialization **normalizes per scope** -- when a persisted inference row carries multiple accelerated segments in **`hostTurnTargets`** (wire/persistence-only on inference rows, **not** an export tree branch), the materializer selects the matching segment and exposes only **`$.solutions`** for the requested scoreboard turn. Cross-analytic consumers query **`$.solutions`** at the correct scoreboard turn (e.g. fleet placeholders map `builtTurn` to `scores@(builtTurn + 1)` for backfill); they must not read **`$.diagnostics.accelerated_segments`** or **`hostTurnTargets`**. **`$.diagnostics`** is optional and for developer panels only; cross-analytic ingest must not depend on it. `$.solutions[0]` is the full top explanation (all `shipBuilds` and `actions` for that rank). `$.meta.searchStatus` carries lifecycle only.
 
 **`objectiveValue` (Plausibility):** each solution's `objectiveValue` is the **inference solution rank weight** shown in the UI as *Plausibility*. Higher integer = more plausible. It is built from **scaled log-probability prior terms** (Laplace-smoothed histogram weights on magnitude bins and ship combos, composed additively in the solver objective) plus **non-likelihood ranking heuristics** (partial weapon-slot fill penalties, tier-overflow penalties). Consumers may treat it as **plausibility on a pseudo log-likelihood scale**: monotonic with prior support and useful for ordering held explanations, but **not** a calibrated probability, percentage, or exact joint log-likelihood (bucketed aggregates use one bin penalty per action, not per-unit iid terms). The wire field name `objectiveValue` is retained from the CP-SAT solver; do not rename without a coordinated contract change.
 
@@ -350,7 +340,7 @@ Do **not** warn on **`complete`** even when all solution paths are **`none`**.
 
 Optional: **`solutionsHeld`**, **`hostTurn`**.
 
-Solver-specific outcomes (`no_exact_solution`, band residual) belong under **`$.diagnostics`** (scores row inference diagnostics), not in **`searchStatus`**. Accelerated segment detail may appear in **`$.diagnostics`** for debugging; functional per-host-turn solutions live in **`$.solutions`** (normalized per scoreboard turn) and **`$.hostTurnTargets`** when persisted from split rows.
+Solver-specific outcomes (`no_exact_solution`, band residual) belong under **`$.diagnostics`** (scores row inference diagnostics), not in **`searchStatus`**. Accelerated segment detail may appear in **`$.diagnostics`** for debugging; functional per-host-turn solutions are exposed only via **`$.solutions`** at the correct scoreboard turn (export normalizes split-row **`hostTurnTargets`** from persistence into scope-local **`$.solutions`**).
 
 ---
 

--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -215,12 +215,22 @@ Example branches (scores):
       "militaryScoreArithmetic": { }
     }
   ],
+  "hostTurnTargets": [
+    {
+      "hostTurn": 1,
+      "status": "exact",
+      "solutionCount": 2,
+      "warshipDelta": 1,
+      "freighterDelta": 0,
+      "solutions": [ ]
+    }
+  ],
   "diagnostics": { },
   "hullCatalogMask": { "enabledHullIds": [1, 2, 3] }
 }
 ```
 
-`$.solutions` uses the same held top-K shape as scores row inference wire/persistence. `$.solutions[0]` is the full top explanation (all `shipBuilds` and `actions` for that rank). `$.meta.searchStatus` carries lifecycle only.
+`$.solutions` uses the same held top-K shape as scores row inference wire/persistence. For each scoreboard turn scope, **`$.solutions`** describes the **host turn implied by that row** (`hostTurn = scoreboardTurn - 1`), including accelerated backfill rows and split segments. **`$.hostTurnTargets`** (persisted as `hostTurnTargets` on inference rows) carries per-host-turn functional payloads when a single scoreboard row materializes multiple accelerated segments; consumers must use **`$.solutions`** at the correct scoreboard turn or **`$.hostTurnTargets`**, not **`$.diagnostics.accelerated_segments`**. **`$.diagnostics`** is optional and for developer panels only; cross-analytic ingest must not depend on it. `$.solutions[0]` is the full top explanation (all `shipBuilds` and `actions` for that rank). `$.meta.searchStatus` carries lifecycle only.
 
 **`objectiveValue` (Plausibility):** each solution's `objectiveValue` is the **inference solution rank weight** shown in the UI as *Plausibility*. Higher integer = more plausible. It is built from **scaled log-probability prior terms** (Laplace-smoothed histogram weights on magnitude bins and ship combos, composed additively in the solver objective) plus **non-likelihood ranking heuristics** (partial weapon-slot fill penalties, tier-overflow penalties). Consumers may treat it as **plausibility on a pseudo log-likelihood scale**: monotonic with prior support and useful for ordering held explanations, but **not** a calibrated probability, percentage, or exact joint log-likelihood (bucketed aggregates use one bin penalty per action, not per-unit iid terms). The wire field name `objectiveValue` is retained from the CP-SAT solver; do not rename without a coordinated contract change.
 
@@ -340,7 +350,7 @@ Do **not** warn on **`complete`** even when all solution paths are **`none`**.
 
 Optional: **`solutionsHeld`**, **`hostTurn`**.
 
-Solver-specific outcomes (`no_exact_solution`, band residual, accelerated segments) belong under **`$.diagnostics`** (scores row inference diagnostics), not in **`searchStatus`**.
+Solver-specific outcomes (`no_exact_solution`, band residual) belong under **`$.diagnostics`** (scores row inference diagnostics), not in **`searchStatus`**. Accelerated segment detail may appear in **`$.diagnostics`** for debugging; functional per-host-turn solutions live in **`$.solutions`** (normalized per scoreboard turn) and **`$.hostTurnTargets`** when persisted from split rows.
 
 ---
 

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -105,7 +105,7 @@ Display default: highest **inference solution rank weight** option set. Row expa
 
 ### 4.2 Inferred row placeholders
 
-When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement queries **scores** at the scoreboard turn for each placeholder `builtTurn` and applies top-level **`$.solutions`** only (no reads of **`$.diagnostics`**). On the first reliable accelerated shell turn, `builtTurn < shellTurn` placeholders resolve from backfill rows (`scores@(builtTurn + 1)`); same-turn placeholders use `scores@shellTurn`.
+When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement queries **scores** at the scoreboard turn for each placeholder `builtTurn` and applies top-level **`$.solutions`** only (no reads of **`$.diagnostics`**). On the first reliable accelerated shell turn, `builtTurn < shellTurn` placeholders resolve from backfill rows (`scores@(builtTurn + 1)`); same-turn placeholders use `scores@shellTurn`. Placeholder metadata (targets, homeworld baselines, accelerated-shell gating) is consumed via `api.analytics.scores.placeholder_targets`.
 
 ### 4.3 Observation-inference merge
 

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -105,7 +105,7 @@ Display default: highest **inference solution rank weight** option set. Row expa
 
 ### 4.2 Inferred row placeholders
 
-When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement currently reads accelerated segment solutions from **scores** row `diagnostics`, pending [#151](https://github.com/SteveDraper/Planets-Console/issues/151) (uniform host-turn scores export).
+When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement queries **scores** at the scoreboard turn for each placeholder `builtTurn` and applies top-level **`$.solutions`** only (no reads of **`$.diagnostics`**). On the first reliable accelerated shell turn, `builtTurn < shellTurn` placeholders resolve from backfill rows (`scores@(builtTurn + 1)`); same-turn placeholders use `scores@shellTurn`.
 
 ### 4.3 Observation-inference merge
 
@@ -121,13 +121,13 @@ When a sighting arrives:
 
 Sequential host ship id allocation: if turn `N-1` had `X` ships globally and turn `N` had `Y` builds, `maxId <= X + Y` (refine when sighting fixes id).
 
-On the first reliable accelerated row (`turn == acceleratedturns`), apply **segment-aware** bounds when tightening inferred rows on that shell turn:
+On the first reliable accelerated row (`turn == acceleratedturns`), apply **built-turn-aware** bounds when tightening inferred rows on that shell turn:
 
 | Row kind | Id bound source |
 |----------|-----------------|
 | Homeworld starting inventory | Global ship count after each player receives starting ships (`players * (baseline freighters + baseline warships)`) |
-| Accelerated window segment (`accel_window`) | Global ship total at end of host turn `N-2` (prior totals from row `N` before reported host-turn deltas) |
-| Reported host-turn segment (`reported_host_turn`) | Current shell-turn bound (`total - net + builds` on row `N`) |
+| Inferred row with `builtTurn < shellTurn - 1` (accelerated window host turn) | Global ship total at end of host turn `N-2` (prior totals from row `N` before reported host-turn deltas) |
+| Inferred row with `builtTurn == shellTurn - 1` (reported host turn on row `N`) | Current shell-turn bound (`total - net + builds` on row `N`) |
 | Normal scoreboard-delta rows | Current shell-turn bound |
 
 Missing or stale bounds are not re-tightened to a looser value when a row already has a tighter `lte` bound.

--- a/docs/design-military-score-inference-solution-modal.md
+++ b/docs/design-military-score-inference-solution-modal.md
@@ -10,7 +10,7 @@ Player-facing UX for inspecting ranked build-inference explanations from the Sco
 
 When build inference is enabled and a scoreboard row holds at least one exact explanation, the player opens a modal to compare ranked alternatives: what actions might explain the row's scoreboard deltas, how each alternative sums to the observed military change, and how plausible each alternative is relative to the others.
 
-The modal is **not** a developer diagnostics surface. Equality strings, raw 2× scale, full `accelerated_segments` arrays, priority-point constraint notes, and spectator delta-source notes belong in the Scores diagnostics panel.
+The modal is **not** a developer diagnostics surface. Equality strings, raw 2× scale, full `accelerated_segments` / `hostTurnTargets` arrays, priority-point constraint notes, and spectator delta-source notes belong in the Scores diagnostics panel.
 
 ---
 

--- a/packages/api/api/analytics/fleet/held_solutions.py
+++ b/packages/api/api/analytics/fleet/held_solutions.py
@@ -10,29 +10,18 @@ from api.analytics.export_types import ExportScope
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.scores.export_precedence import SearchStatus
 from api.analytics.scores.export_services import ScoresExportContext
-from api.analytics.scores.export_wire import ranked_solutions_from_wire
 from api.analytics.scores.exports import held_scores_for_scope
+from api.analytics.scores.host_turn_export import scores_scoreboard_turn_for_placeholder_refine
 from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
 from api.models.game import TurnInfo
 
 
 @dataclass(frozen=True)
-class FleetAcceleratedSegment:
-    """One accelerated-start inference segment with held solutions."""
-
-    segment_id: str
-    host_turn: int
-    solutions: tuple[dict[str, object], ...]
-    search_status: str | None = None
-
-
-@dataclass(frozen=True)
 class FleetHeldInference:
-    """Resolved scores held solutions for one player on one host turn."""
+    """Resolved scores held solutions for one player on one scoreboard turn."""
 
     search_status: SearchStatus
     solutions: tuple[dict[str, object], ...]
-    accelerated_segments: tuple[FleetAcceleratedSegment, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -49,17 +38,21 @@ class FleetInferenceSupport:
 
     scores_services: ScoresExportContext
 
-    def held_inference_for_player(
+    def held_inference_for_scoreboard_turn(
         self,
         *,
         game_id: int,
         perspective: int,
-        host_turn: int,
+        scoreboard_turn: int,
         player_id: int,
         turn: TurnInfo,
         load_turn,
     ) -> FleetHeldInference:
         if self.scores_services.persistence is None:
+            return FleetHeldInference(search_status="not_started", solutions=())
+
+        query_turn = load_turn(scoreboard_turn)
+        if query_turn is None:
             return FleetHeldInference(search_status="not_started", solutions=())
 
         ctx = make_analytic_query_context(
@@ -71,47 +64,36 @@ class FleetInferenceSupport:
         scope = ExportScope(
             game_id=game_id,
             perspective=perspective,
-            turn=host_turn,
+            turn=scoreboard_turn,
             player_id=player_id,
         )
-        resolved = held_scores_for_scope(ctx, scope, turn=turn)
+        resolved = held_scores_for_scope(ctx, scope, turn=query_turn)
         payload = resolved.payload
         return FleetHeldInference(
             search_status=resolved.decision.search_status,
             solutions=tuple(payload.solutions),
-            accelerated_segments=_accelerated_segments_from_diagnostics(payload.diagnostics),
         )
 
-
-def _accelerated_segments_from_diagnostics(
-    diagnostics: dict[str, object] | None,
-) -> tuple[FleetAcceleratedSegment, ...]:
-    if diagnostics is None:
-        return ()
-    raw_segments = diagnostics.get("accelerated_segments")
-    if not isinstance(raw_segments, list):
-        return ()
-    segments: list[FleetAcceleratedSegment] = []
-    for entry in raw_segments:
-        if not isinstance(entry, dict):
-            continue
-        segment_id = entry.get("segmentId")
-        host_turn = entry.get("hostTurn")
-        if (
-            not isinstance(segment_id, str)
-            or not isinstance(host_turn, int)
-            or isinstance(host_turn, bool)
-        ):
-            continue
-        solutions_raw = entry.get("solutions")
-        wire_solutions = solutions_raw if isinstance(solutions_raw, list) else []
-        status = entry.get("status")
-        segments.append(
-            FleetAcceleratedSegment(
-                segment_id=segment_id,
-                host_turn=host_turn,
-                solutions=tuple(ranked_solutions_from_wire(wire_solutions)),
-                search_status=status if isinstance(status, str) else None,
-            )
+    def held_inference_for_placeholder(
+        self,
+        *,
+        game_id: int,
+        perspective: int,
+        shell_turn: int,
+        built_turn: int,
+        player_id: int,
+        turn: TurnInfo,
+        load_turn,
+    ) -> FleetHeldInference:
+        scoreboard_turn = scores_scoreboard_turn_for_placeholder_refine(
+            built_turn=built_turn,
+            shell_turn=shell_turn,
         )
-    return tuple(segments)
+        return self.held_inference_for_scoreboard_turn(
+            game_id=game_id,
+            perspective=perspective,
+            scoreboard_turn=scoreboard_turn,
+            player_id=player_id,
+            turn=turn,
+            load_turn=load_turn,
+        )

--- a/packages/api/api/analytics/fleet/id_bound_ingest.py
+++ b/packages/api/api/analytics/fleet/id_bound_ingest.py
@@ -37,7 +37,6 @@ def tighten_inferred_ship_id_bounds(
             turn,
             shell_turn=shell_turn,
             built_turn=_known_built_turn(record),
-            segment_id=_segment_id_from_event(event),
             is_starting_inventory=_is_homeworld_starting_inventory_event(event),
         )
         if max_bound is None:
@@ -95,11 +94,6 @@ def _scoreboard_acquisition_event(
         if warship_delta > 0 or freighter_delta > 0:
             return event
     return None
-
-
-def _segment_id_from_event(event: FleetEvidenceEvent) -> str | None:
-    segment_id = event.payload.get("segmentId")
-    return segment_id if isinstance(segment_id, str) else None
 
 
 def _is_homeworld_starting_inventory_event(event: FleetEvidenceEvent) -> bool:

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -7,13 +7,9 @@ from typing import Literal
 
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.scoreboard_counts import iter_current_turn_scores
-from api.analytics.fleet.serialization import (
-    append_fleet_evidence_event,
-    fleet_build_option_set_from_inference_ship_build,
-)
+from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
-    FleetBuildOptionSet,
     FleetEvidenceEvent,
     FleetFieldKnown,
     FleetFieldUnknown,
@@ -21,16 +17,6 @@ from api.analytics.fleet.types import (
     FleetShipRecordFields,
     FleetTurnSnapshot,
 )
-from api.analytics.military_score_inference.inference_api_payload import (
-    inference_solution_ship_build_from_wire,
-    inference_wire_ship_build_entries,
-    inference_wire_solution_objective_value,
-)
-from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
-from api.analytics.military_score_inference.ship_build_combos import (
-    is_generic_zero_military_score_combo_id,
-)
-from api.analytics.scores.export_wire import ranked_solutions_from_wire
 from api.analytics.scores.placeholder_targets import (
     ScoreboardPlaceholderTarget,
     homeworld_starting_freighter_hull_id,
@@ -41,7 +27,6 @@ from api.analytics.scores.placeholder_targets import (
 from api.models.game import TurnInfo
 
 SCOREBOARD_SOURCE = "scoreboard"
-INFERENCE_SOURCE = "scores.inference"
 
 FleetShipClass = Literal["warship", "freighter"]
 
@@ -55,7 +40,11 @@ def ingest_turn_inferred_acquisitions(
     """Create scoreboard placeholders and optionally refine them from held solutions."""
     snapshot = _create_scoreboard_placeholders(snapshot, turn)
     if inference_materialization is not None:
-        snapshot = _refine_inferred_acquisitions_from_scores(
+        from api.analytics.fleet.inferred_acquisition_refine import (
+            refine_inferred_acquisitions_from_scores,
+        )
+
+        snapshot = refine_inferred_acquisitions_from_scores(
             snapshot,
             turn,
             inference_materialization=inference_materialization,
@@ -218,55 +207,6 @@ def _ensure_placeholder_target_rows(
     )
 
 
-def _refine_inferred_acquisitions_from_scores(
-    snapshot: FleetTurnSnapshot,
-    turn: TurnInfo,
-    *,
-    inference_materialization: FleetInferenceMaterialization,
-) -> FleetTurnSnapshot:
-    """Attach fleet build option sets from top-K held solutions to placeholder rows."""
-    turn_number = turn.settings.turn
-    inference = inference_materialization.inference
-    load_turn = inference_materialization.load_turn
-    for ledger in snapshot.players:
-        if not _ledger_has_placeholders_for_turn(ledger, turn_number):
-            continue
-        for built_turn in _distinct_placeholder_built_turns(ledger, turn_number):
-            held = inference.held_inference_for_placeholder(
-                game_id=snapshot.game_id,
-                perspective=snapshot.perspective,
-                shell_turn=turn_number,
-                built_turn=built_turn,
-                player_id=ledger.player_id,
-                turn=turn,
-                load_turn=load_turn,
-            )
-            if not held.solutions:
-                continue
-            _refine_player_placeholders_for_built_turn(
-                ledger,
-                shell_turn=turn_number,
-                built_turn=built_turn,
-                solutions=list(held.solutions),
-                search_status=held.search_status,
-            )
-
-    return snapshot
-
-
-def _distinct_placeholder_built_turns(
-    ledger: FleetAcquisitionLedger,
-    shell_turn: int,
-) -> tuple[int, ...]:
-    built_turns: set[int] = set()
-    for ship_class in ("warship", "freighter"):
-        for record in _placeholder_rows_for_turn(ledger, shell_turn, ship_class=ship_class):
-            built_turn = _known_built_turn(record)
-            if built_turn is not None:
-                built_turns.add(built_turn)
-    return tuple(sorted(built_turns))
-
-
 def _ensure_placeholder_rows(
     ledger: FleetAcquisitionLedger,
     *,
@@ -393,170 +333,5 @@ def _scoreboard_delta_event(
         kind="scoreboard_delta",
         turn=turn,
         source=SCOREBOARD_SOURCE,
-        payload=payload,
-    )
-
-
-def _refine_player_placeholders_for_built_turn(
-    ledger: FleetAcquisitionLedger,
-    *,
-    shell_turn: int,
-    built_turn: int,
-    solutions: list[dict[str, object]],
-    search_status: str,
-) -> None:
-    ranked = ranked_solutions_from_wire(solutions)
-    warship_placeholders = _placeholder_rows_for_built_turn(
-        ledger,
-        shell_turn=shell_turn,
-        built_turn=built_turn,
-        ship_class="warship",
-    )
-    freighter_placeholders = _placeholder_rows_for_built_turn(
-        ledger,
-        shell_turn=shell_turn,
-        built_turn=built_turn,
-        ship_class="freighter",
-    )
-    _assign_option_sets_to_placeholders(
-        warship_placeholders,
-        _expanded_builds_by_solution(ranked, ship_class="warship"),
-        shell_turn=shell_turn,
-        search_status=search_status,
-        built_turn=built_turn,
-    )
-    _assign_option_sets_to_placeholders(
-        freighter_placeholders,
-        _expanded_builds_by_solution(ranked, ship_class="freighter"),
-        shell_turn=shell_turn,
-        search_status=search_status,
-        built_turn=built_turn,
-    )
-
-
-def _expanded_builds_by_solution(
-    solutions: list[dict[str, object]],
-    *,
-    ship_class: FleetShipClass,
-) -> list[list[FleetBuildOptionSet]]:
-    per_solution: list[list[FleetBuildOptionSet]] = []
-    for solution in solutions:
-        rank_weight = inference_wire_solution_objective_value(solution)
-        expanded: list[FleetBuildOptionSet] = []
-        for wire_build in inference_wire_ship_build_entries(solution):
-            ship_build = inference_solution_ship_build_from_wire(wire_build)
-            if ship_build is None:
-                continue
-            if _inference_ship_build_class(ship_build) != ship_class:
-                continue
-            option_set = fleet_build_option_set_from_inference_ship_build(
-                ship_build,
-                solution_rank_weight=rank_weight,
-            )
-            expanded.extend([option_set] * ship_build.count)
-        per_solution.append(expanded)
-    return per_solution
-
-
-def _assign_option_sets_to_placeholders(
-    placeholders: list[FleetShipRecord],
-    builds_by_solution: list[list[FleetBuildOptionSet]],
-    *,
-    shell_turn: int,
-    search_status: str,
-    built_turn: int | None = None,
-) -> None:
-    for index, record in enumerate(placeholders):
-        option_sets = _option_sets_for_slot(builds_by_solution, index)
-        if not option_sets:
-            continue
-        prior_sets = tuple(record.build_option_sets)
-        if prior_sets == option_sets:
-            continue
-        record.build_option_sets = list(option_sets)
-        record.display_default_option_set_index = _default_option_set_index(option_sets)
-        _ensure_unknown_spec_fields(record)
-        append_fleet_evidence_event(
-            record,
-            _inference_update_event(
-                turn=shell_turn,
-                search_status=search_status,
-                option_set_count=len(option_sets),
-                built_turn=built_turn,
-            ),
-        )
-
-
-def _option_sets_for_slot(
-    builds_by_solution: list[list[FleetBuildOptionSet]],
-    slot_index: int,
-) -> tuple[FleetBuildOptionSet, ...]:
-    best_by_combo_key: dict[str, FleetBuildOptionSet] = {}
-    for solution_builds in builds_by_solution:
-        if slot_index >= len(solution_builds):
-            continue
-        option_set = solution_builds[slot_index]
-        combo_key = option_set.combo_id or option_set.label
-        existing = best_by_combo_key.get(combo_key)
-        if existing is None or option_set.solution_rank_weight > existing.solution_rank_weight:
-            best_by_combo_key[combo_key] = option_set
-    ordered = sorted(
-        best_by_combo_key.values(),
-        key=lambda option_set: option_set.solution_rank_weight,
-        reverse=True,
-    )
-    return tuple(ordered)
-
-
-def _default_option_set_index(option_sets: tuple[FleetBuildOptionSet, ...]) -> int:
-    best_index = 0
-    best_weight = option_sets[0].solution_rank_weight
-    for index, option_set in enumerate(option_sets[1:], start=1):
-        if option_set.solution_rank_weight > best_weight:
-            best_weight = option_set.solution_rank_weight
-            best_index = index
-    return best_index
-
-
-def _ensure_unknown_spec_fields(record: FleetShipRecord) -> None:
-    if not isinstance(record.fields.ship_id, FleetFieldKnown):
-        record.fields.ship_id = FleetFieldUnknown()
-    if not isinstance(record.fields.hull, FleetFieldKnown):
-        record.fields.hull = FleetFieldUnknown()
-    if not isinstance(record.fields.engine, FleetFieldKnown):
-        record.fields.engine = FleetFieldUnknown()
-    if not isinstance(record.fields.beams, FleetFieldKnown):
-        record.fields.beams = FleetFieldUnknown()
-    if not isinstance(record.fields.launchers, FleetFieldKnown):
-        record.fields.launchers = FleetFieldUnknown()
-    if not isinstance(record.fields.location, FleetFieldKnown):
-        record.fields.location = FleetFieldUnknown()
-
-
-def _inference_ship_build_class(ship_build: InferenceSolutionShipBuild) -> FleetShipClass:
-    if is_generic_zero_military_score_combo_id(ship_build.combo_id):
-        return "freighter"
-    return "warship"
-
-
-def _inference_update_event(
-    *,
-    turn: int,
-    search_status: str,
-    option_set_count: int,
-    built_turn: int | None = None,
-) -> FleetEvidenceEvent:
-    payload: dict[str, object] = {
-        "searchStatus": search_status,
-        "optionSetCount": option_set_count,
-    }
-    if built_turn is not None and built_turn < turn:
-        payload["segmentHostTurn"] = built_turn
-        payload["acceleratedIngest"] = True
-    return FleetEvidenceEvent(
-        event_id=str(uuid.uuid4()),
-        kind="inference_update",
-        turn=turn,
-        source=INFERENCE_SOURCE,
         payload=payload,
     )

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -206,7 +206,6 @@ def _ensure_placeholder_target_rows(
         expected_count=max(0, target.warship_delta),
         warship_delta=target.warship_delta,
         freighter_delta=0,
-        segment_id=target.segment_id,
     )
     _ensure_placeholder_rows(
         ledger,
@@ -216,7 +215,6 @@ def _ensure_placeholder_target_rows(
         expected_count=max(0, target.freighter_delta),
         warship_delta=0,
         freighter_delta=target.freighter_delta,
-        segment_id=target.segment_id,
     )
 
 
@@ -278,7 +276,6 @@ def _ensure_placeholder_rows(
     expected_count: int,
     warship_delta: int,
     freighter_delta: int,
-    segment_id: str | None = None,
 ) -> None:
     if expected_count <= 0:
         return
@@ -302,8 +299,7 @@ def _ensure_placeholder_rows(
                 ship_class=ship_class,
                 warship_delta=warship_delta,
                 freighter_delta=freighter_delta,
-                segment_id=segment_id,
-                segment_host_turn=built_turn if segment_id is not None else None,
+                segment_host_turn=built_turn if built_turn < shell_turn else None,
             ),
         )
         ledger.records.append(record)
@@ -382,7 +378,6 @@ def _scoreboard_delta_event(
     ship_class: FleetShipClass,
     warship_delta: int,
     freighter_delta: int,
-    segment_id: str | None = None,
     segment_host_turn: int | None = None,
 ) -> FleetEvidenceEvent:
     payload: dict[str, object] = {
@@ -390,8 +385,6 @@ def _scoreboard_delta_event(
         "warshipDelta": warship_delta,
         "freighterDelta": freighter_delta,
     }
-    if segment_id is not None:
-        payload["segmentId"] = segment_id
     if segment_host_turn is not None:
         payload["segmentHostTurn"] = segment_host_turn
         payload["acceleratedIngest"] = True

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -5,11 +5,7 @@ from __future__ import annotations
 import uuid
 from typing import Literal
 
-from api.analytics.fleet.held_solutions import (
-    FleetAcceleratedSegment,
-    FleetHeldInference,
-    FleetInferenceMaterialization,
-)
+from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.scoreboard_counts import iter_current_turn_scores
 from api.analytics.fleet.serialization import (
     append_fleet_evidence_event,
@@ -25,13 +21,6 @@ from api.analytics.fleet.types import (
     FleetShipRecordFields,
     FleetTurnSnapshot,
 )
-from api.analytics.military_score_inference.accelerated_start import (
-    HOMEBASE_STARTING_FREIGHTER_HULL_ID,
-    AcceleratedInferenceSegment,
-    accelerated_inference_segments,
-    is_first_reliable_scoreboard_turn,
-    starting_scoreboard_snapshot,
-)
 from api.analytics.military_score_inference.inference_api_payload import (
     inference_solution_ship_build_from_wire,
     inference_wire_ship_build_entries,
@@ -42,6 +31,12 @@ from api.analytics.military_score_inference.ship_build_combos import (
     is_generic_zero_military_score_combo_id,
 )
 from api.analytics.scores.export_wire import ranked_solutions_from_wire
+from api.analytics.scores.scoreboard_placeholder_targets import (
+    ScoreboardPlaceholderTarget,
+    homeworld_starting_freighter_hull_id,
+    homeworld_starting_inventory_counts,
+    scoreboard_placeholder_targets,
+)
 from api.models.game import TurnInfo
 
 SCOREBOARD_SOURCE = "scoreboard"
@@ -67,6 +62,11 @@ def ingest_turn_inferred_acquisitions(
     return snapshot
 
 
+def _is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
+    accelerated = max(0, turn.settings.acceleratedturns)
+    return accelerated > 0 and shell_turn == accelerated
+
+
 def _create_scoreboard_placeholders(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
@@ -74,7 +74,7 @@ def _create_scoreboard_placeholders(
     """Create inferred placeholder rows for positive scoreboard warship/freighter deltas."""
     turn_number = turn.settings.turn
     ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
-    accelerated_first_reliable = is_first_reliable_scoreboard_turn(turn_number, turn.settings)
+    accelerated_first_reliable = _is_first_reliable_accelerated_shell_turn(turn_number, turn)
 
     for score in iter_current_turn_scores(turn):
         ledger = ledgers_by_player_id.get(score.ownerid)
@@ -125,14 +125,14 @@ def _create_accelerated_scoreboard_placeholders(
     turn: TurnInfo,
     shell_turn: int,
 ) -> None:
-    """Create placeholders from accelerated segment ship counts on first reliable turn N."""
-    segments = accelerated_inference_segments(score, turn)
-    if segments is None:
+    """Create placeholders from scores-owned segment build counts on first reliable turn N."""
+    targets = scoreboard_placeholder_targets(score, turn)
+    if targets is None:
         return
-    for segment in segments:
+    for target in targets:
         _ensure_accelerated_segment_placeholders(
             ledger,
-            segment=segment,
+            target=target,
             shell_turn=shell_turn,
         )
 
@@ -144,18 +144,18 @@ def _ensure_homeworld_starting_inventory_rows(
     shell_turn: int,
 ) -> None:
     """Seed homeworld starting ships not represented in accelerated scoreboard deltas."""
-    baseline = starting_scoreboard_snapshot(turn.settings)
+    freighters, warships = homeworld_starting_inventory_counts(turn)
     _ensure_starting_inventory_rows(
         ledger,
         shell_turn=shell_turn,
         ship_class="freighter",
-        expected_count=baseline.freighters,
+        expected_count=freighters,
     )
     _ensure_starting_inventory_rows(
         ledger,
         shell_turn=shell_turn,
         ship_class="warship",
-        expected_count=baseline.capitalships,
+        expected_count=warships,
     )
 
 
@@ -212,7 +212,7 @@ def _starting_inventory_hull_field(
     ship_class: FleetShipClass,
 ) -> FleetFieldKnown | FleetFieldUnknown:
     if ship_class == "freighter":
-        return FleetFieldKnown(HOMEBASE_STARTING_FREIGHTER_HULL_ID)
+        return FleetFieldKnown(homeworld_starting_freighter_hull_id())
     return FleetFieldUnknown()
 
 
@@ -238,28 +238,28 @@ def _homeworld_starting_inventory_event(
 def _ensure_accelerated_segment_placeholders(
     ledger: FleetAcquisitionLedger,
     *,
-    segment: AcceleratedInferenceSegment,
+    target: ScoreboardPlaceholderTarget,
     shell_turn: int,
 ) -> None:
     _ensure_placeholder_rows(
         ledger,
         shell_turn=shell_turn,
-        built_turn=segment.host_turn,
+        built_turn=target.host_turn,
         ship_class="warship",
-        expected_count=max(0, segment.warship_delta),
-        warship_delta=segment.warship_delta,
+        expected_count=max(0, target.warship_delta),
+        warship_delta=target.warship_delta,
         freighter_delta=0,
-        segment_id=segment.segment_id,
+        segment_id=target.segment_id,
     )
     _ensure_placeholder_rows(
         ledger,
         shell_turn=shell_turn,
-        built_turn=segment.host_turn,
+        built_turn=target.host_turn,
         ship_class="freighter",
-        expected_count=max(0, segment.freighter_delta),
+        expected_count=max(0, target.freighter_delta),
         warship_delta=0,
-        freighter_delta=segment.freighter_delta,
-        segment_id=segment.segment_id,
+        freighter_delta=target.freighter_delta,
+        segment_id=target.segment_id,
     )
 
 
@@ -273,73 +273,43 @@ def _refine_inferred_acquisitions_from_scores(
     turn_number = turn.settings.turn
     inference = inference_materialization.inference
     load_turn = inference_materialization.load_turn
-    accelerated_first_reliable = is_first_reliable_scoreboard_turn(turn_number, turn.settings)
     for ledger in snapshot.players:
         if not _ledger_has_placeholders_for_turn(ledger, turn_number):
             continue
-        held = inference.held_inference_for_player(
-            game_id=snapshot.game_id,
-            perspective=snapshot.perspective,
-            host_turn=turn_number,
-            player_id=ledger.player_id,
-            turn=turn,
-            load_turn=load_turn,
-        )
-        if accelerated_first_reliable and held.accelerated_segments:
-            _refine_accelerated_player_placeholders(
+        for built_turn in _distinct_placeholder_built_turns(ledger, turn_number):
+            held = inference.held_inference_for_placeholder(
+                game_id=snapshot.game_id,
+                perspective=snapshot.perspective,
+                shell_turn=turn_number,
+                built_turn=built_turn,
+                player_id=ledger.player_id,
+                turn=turn,
+                load_turn=load_turn,
+            )
+            if not held.solutions:
+                continue
+            _refine_player_placeholders_for_built_turn(
                 ledger,
                 shell_turn=turn_number,
-                held=held,
+                built_turn=built_turn,
+                solutions=list(held.solutions),
+                search_status=held.search_status,
             )
-            continue
-        if not held.solutions:
-            continue
-        _refine_player_placeholders(
-            ledger,
-            shell_turn=turn_number,
-            solutions=list(held.solutions),
-            search_status=held.search_status,
-        )
 
     return snapshot
 
 
-def _refine_accelerated_player_placeholders(
+def _distinct_placeholder_built_turns(
     ledger: FleetAcquisitionLedger,
-    *,
     shell_turn: int,
-    held: FleetHeldInference,
-) -> None:
-    for segment in held.accelerated_segments:
-        if not segment.solutions:
-            continue
-        search_status = segment.search_status or held.search_status
-        warship_placeholders = _placeholder_rows_for_built_turn(
-            ledger,
-            shell_turn=shell_turn,
-            built_turn=segment.host_turn,
-            ship_class="warship",
-        )
-        freighter_placeholders = _placeholder_rows_for_built_turn(
-            ledger,
-            shell_turn=shell_turn,
-            built_turn=segment.host_turn,
-            ship_class="freighter",
-        )
-        _assign_option_sets_to_placeholders(
-            warship_placeholders,
-            _expanded_builds_by_solution(list(segment.solutions), ship_class="warship"),
-            shell_turn=shell_turn,
-            search_status=search_status,
-            segment=segment,
-        )
-        _assign_option_sets_to_placeholders(
-            freighter_placeholders,
-            _expanded_builds_by_solution(list(segment.solutions), ship_class="freighter"),
-            shell_turn=shell_turn,
-            search_status=search_status,
-            segment=segment,
-        )
+) -> tuple[int, ...]:
+    built_turns: set[int] = set()
+    for ship_class in ("warship", "freighter"):
+        for record in _placeholder_rows_for_turn(ledger, shell_turn, ship_class=ship_class):
+            built_turn = _known_built_turn(record)
+            if built_turn is not None:
+                built_turns.add(built_turn)
+    return tuple(sorted(built_turns))
 
 
 def _ensure_placeholder_rows(
@@ -477,22 +447,25 @@ def _scoreboard_delta_event(
     )
 
 
-def _refine_player_placeholders(
+def _refine_player_placeholders_for_built_turn(
     ledger: FleetAcquisitionLedger,
     *,
     shell_turn: int,
+    built_turn: int,
     solutions: list[dict[str, object]],
     search_status: str,
 ) -> None:
     ranked = ranked_solutions_from_wire(solutions)
-    warship_placeholders = _placeholder_rows_for_turn(
+    warship_placeholders = _placeholder_rows_for_built_turn(
         ledger,
-        shell_turn,
+        shell_turn=shell_turn,
+        built_turn=built_turn,
         ship_class="warship",
     )
-    freighter_placeholders = _placeholder_rows_for_turn(
+    freighter_placeholders = _placeholder_rows_for_built_turn(
         ledger,
-        shell_turn,
+        shell_turn=shell_turn,
+        built_turn=built_turn,
         ship_class="freighter",
     )
     _assign_option_sets_to_placeholders(
@@ -500,12 +473,14 @@ def _refine_player_placeholders(
         _expanded_builds_by_solution(ranked, ship_class="warship"),
         shell_turn=shell_turn,
         search_status=search_status,
+        built_turn=built_turn,
     )
     _assign_option_sets_to_placeholders(
         freighter_placeholders,
         _expanded_builds_by_solution(ranked, ship_class="freighter"),
         shell_turn=shell_turn,
         search_status=search_status,
+        built_turn=built_turn,
     )
 
 
@@ -539,7 +514,7 @@ def _assign_option_sets_to_placeholders(
     *,
     shell_turn: int,
     search_status: str,
-    segment: FleetAcceleratedSegment | None = None,
+    built_turn: int | None = None,
 ) -> None:
     for index, record in enumerate(placeholders):
         option_sets = _option_sets_for_slot(builds_by_solution, index)
@@ -557,7 +532,7 @@ def _assign_option_sets_to_placeholders(
                 turn=shell_turn,
                 search_status=search_status,
                 option_set_count=len(option_sets),
-                segment=segment,
+                built_turn=built_turn,
             ),
         )
 
@@ -619,15 +594,14 @@ def _inference_update_event(
     turn: int,
     search_status: str,
     option_set_count: int,
-    segment: FleetAcceleratedSegment | None = None,
+    built_turn: int | None = None,
 ) -> FleetEvidenceEvent:
     payload: dict[str, object] = {
         "searchStatus": search_status,
         "optionSetCount": option_set_count,
     }
-    if segment is not None:
-        payload["segmentId"] = segment.segment_id
-        payload["segmentHostTurn"] = segment.host_turn
+    if built_turn is not None and built_turn < turn:
+        payload["segmentHostTurn"] = built_turn
         payload["acceleratedIngest"] = True
     return FleetEvidenceEvent(
         event_id=str(uuid.uuid4()),

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -31,7 +31,7 @@ from api.analytics.military_score_inference.ship_build_combos import (
     is_generic_zero_military_score_combo_id,
 )
 from api.analytics.scores.export_wire import ranked_solutions_from_wire
-from api.analytics.scores.scoreboard_placeholder_targets import (
+from api.analytics.scores.placeholder_targets import (
     ScoreboardPlaceholderTarget,
     homeworld_starting_freighter_hull_id,
     homeworld_starting_inventory_counts,

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -36,6 +36,7 @@ from api.analytics.scores.scoreboard_placeholder_targets import (
     homeworld_starting_freighter_hull_id,
     homeworld_starting_inventory_counts,
     scoreboard_placeholder_targets,
+    should_seed_homeworld_starting_inventory,
 )
 from api.models.game import TurnInfo
 
@@ -62,11 +63,6 @@ def ingest_turn_inferred_acquisitions(
     return snapshot
 
 
-def _is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
-    accelerated = max(0, turn.settings.acceleratedturns)
-    return accelerated > 0 and shell_turn == accelerated
-
-
 def _create_scoreboard_placeholders(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
@@ -74,67 +70,28 @@ def _create_scoreboard_placeholders(
     """Create inferred placeholder rows for positive scoreboard warship/freighter deltas."""
     turn_number = turn.settings.turn
     ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
-    accelerated_first_reliable = _is_first_reliable_accelerated_shell_turn(turn_number, turn)
 
     for score in iter_current_turn_scores(turn):
         ledger = ledgers_by_player_id.get(score.ownerid)
         if ledger is None:
             continue
-        if accelerated_first_reliable:
+        if should_seed_homeworld_starting_inventory(turn):
             _ensure_homeworld_starting_inventory_rows(
                 ledger,
                 turn=turn,
                 shell_turn=turn_number,
             )
-            _create_accelerated_scoreboard_placeholders(
+        targets = scoreboard_placeholder_targets(score, turn)
+        if targets is None:
+            continue
+        for target in targets:
+            _ensure_placeholder_target_rows(
                 ledger,
-                score=score,
-                turn=turn,
+                target=target,
                 shell_turn=turn_number,
             )
-            continue
-
-        warship_builds = max(0, score.shipchange)
-        freighter_builds = max(0, score.freighterchange)
-        _ensure_placeholder_rows(
-            ledger,
-            shell_turn=turn_number,
-            built_turn=turn_number,
-            ship_class="warship",
-            expected_count=warship_builds,
-            warship_delta=warship_builds,
-            freighter_delta=0,
-        )
-        _ensure_placeholder_rows(
-            ledger,
-            shell_turn=turn_number,
-            built_turn=turn_number,
-            ship_class="freighter",
-            expected_count=freighter_builds,
-            warship_delta=0,
-            freighter_delta=freighter_builds,
-        )
 
     return snapshot
-
-
-def _create_accelerated_scoreboard_placeholders(
-    ledger: FleetAcquisitionLedger,
-    *,
-    score,
-    turn: TurnInfo,
-    shell_turn: int,
-) -> None:
-    """Create placeholders from scores-owned segment build counts on first reliable turn N."""
-    targets = scoreboard_placeholder_targets(score, turn)
-    if targets is None:
-        return
-    for target in targets:
-        _ensure_accelerated_segment_placeholders(
-            ledger,
-            target=target,
-            shell_turn=shell_turn,
-        )
 
 
 def _ensure_homeworld_starting_inventory_rows(
@@ -235,7 +192,7 @@ def _homeworld_starting_inventory_event(
     )
 
 
-def _ensure_accelerated_segment_placeholders(
+def _ensure_placeholder_target_rows(
     ledger: FleetAcquisitionLedger,
     *,
     target: ScoreboardPlaceholderTarget,

--- a/packages/api/api/analytics/fleet/inferred_acquisition_refine.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_refine.py
@@ -1,0 +1,254 @@
+"""Refine inferred fleet acquisition placeholders from held inference solutions."""
+
+from __future__ import annotations
+
+import uuid
+
+from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
+from api.analytics.fleet.inferred_acquisition_ingest import (
+    FleetShipClass,
+    _known_built_turn,
+    _ledger_has_placeholders_for_turn,
+    _placeholder_rows_for_built_turn,
+    _placeholder_rows_for_turn,
+)
+from api.analytics.fleet.serialization import (
+    append_fleet_evidence_event,
+    fleet_build_option_set_from_inference_ship_build,
+)
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetBuildOptionSet,
+    FleetEvidenceEvent,
+    FleetFieldKnown,
+    FleetFieldUnknown,
+    FleetShipRecord,
+    FleetTurnSnapshot,
+)
+from api.analytics.military_score_inference.inference_api_payload import (
+    inference_solution_ship_build_from_wire,
+    inference_wire_ship_build_entries,
+    inference_wire_solution_objective_value,
+)
+from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
+from api.analytics.military_score_inference.ship_build_combos import (
+    is_generic_zero_military_score_combo_id,
+)
+from api.analytics.scores.export_wire import ranked_solutions_from_wire
+from api.models.game import TurnInfo
+
+INFERENCE_SOURCE = "scores.inference"
+
+
+def refine_inferred_acquisitions_from_scores(
+    snapshot: FleetTurnSnapshot,
+    turn: TurnInfo,
+    *,
+    inference_materialization: FleetInferenceMaterialization,
+) -> FleetTurnSnapshot:
+    """Attach fleet build option sets from top-K held solutions to placeholder rows."""
+    turn_number = turn.settings.turn
+    inference = inference_materialization.inference
+    load_turn = inference_materialization.load_turn
+    for ledger in snapshot.players:
+        if not _ledger_has_placeholders_for_turn(ledger, turn_number):
+            continue
+        for built_turn in _distinct_placeholder_built_turns(ledger, turn_number):
+            held = inference.held_inference_for_placeholder(
+                game_id=snapshot.game_id,
+                perspective=snapshot.perspective,
+                shell_turn=turn_number,
+                built_turn=built_turn,
+                player_id=ledger.player_id,
+                turn=turn,
+                load_turn=load_turn,
+            )
+            if not held.solutions:
+                continue
+            _refine_player_placeholders_for_built_turn(
+                ledger,
+                shell_turn=turn_number,
+                built_turn=built_turn,
+                solutions=list(held.solutions),
+                search_status=held.search_status,
+            )
+
+    return snapshot
+
+
+def _distinct_placeholder_built_turns(
+    ledger: FleetAcquisitionLedger,
+    shell_turn: int,
+) -> tuple[int, ...]:
+    built_turns: set[int] = set()
+    for ship_class in ("warship", "freighter"):
+        for record in _placeholder_rows_for_turn(ledger, shell_turn, ship_class=ship_class):
+            built_turn = _known_built_turn(record)
+            if built_turn is not None:
+                built_turns.add(built_turn)
+    return tuple(sorted(built_turns))
+
+
+def _refine_player_placeholders_for_built_turn(
+    ledger: FleetAcquisitionLedger,
+    *,
+    shell_turn: int,
+    built_turn: int,
+    solutions: list[dict[str, object]],
+    search_status: str,
+) -> None:
+    ranked = ranked_solutions_from_wire(solutions)
+    warship_placeholders = _placeholder_rows_for_built_turn(
+        ledger,
+        shell_turn=shell_turn,
+        built_turn=built_turn,
+        ship_class="warship",
+    )
+    freighter_placeholders = _placeholder_rows_for_built_turn(
+        ledger,
+        shell_turn=shell_turn,
+        built_turn=built_turn,
+        ship_class="freighter",
+    )
+    _assign_option_sets_to_placeholders(
+        warship_placeholders,
+        _expanded_builds_by_solution(ranked, ship_class="warship"),
+        shell_turn=shell_turn,
+        search_status=search_status,
+        built_turn=built_turn,
+    )
+    _assign_option_sets_to_placeholders(
+        freighter_placeholders,
+        _expanded_builds_by_solution(ranked, ship_class="freighter"),
+        shell_turn=shell_turn,
+        search_status=search_status,
+        built_turn=built_turn,
+    )
+
+
+def _expanded_builds_by_solution(
+    solutions: list[dict[str, object]],
+    *,
+    ship_class: FleetShipClass,
+) -> list[list[FleetBuildOptionSet]]:
+    per_solution: list[list[FleetBuildOptionSet]] = []
+    for solution in solutions:
+        rank_weight = inference_wire_solution_objective_value(solution)
+        expanded: list[FleetBuildOptionSet] = []
+        for wire_build in inference_wire_ship_build_entries(solution):
+            ship_build = inference_solution_ship_build_from_wire(wire_build)
+            if ship_build is None:
+                continue
+            if _inference_ship_build_class(ship_build) != ship_class:
+                continue
+            option_set = fleet_build_option_set_from_inference_ship_build(
+                ship_build,
+                solution_rank_weight=rank_weight,
+            )
+            expanded.extend([option_set] * ship_build.count)
+        per_solution.append(expanded)
+    return per_solution
+
+
+def _assign_option_sets_to_placeholders(
+    placeholders: list[FleetShipRecord],
+    builds_by_solution: list[list[FleetBuildOptionSet]],
+    *,
+    shell_turn: int,
+    search_status: str,
+    built_turn: int | None = None,
+) -> None:
+    for index, record in enumerate(placeholders):
+        option_sets = _option_sets_for_slot(builds_by_solution, index)
+        if not option_sets:
+            continue
+        prior_sets = tuple(record.build_option_sets)
+        if prior_sets == option_sets:
+            continue
+        record.build_option_sets = list(option_sets)
+        record.display_default_option_set_index = _default_option_set_index(option_sets)
+        _ensure_unknown_spec_fields(record)
+        append_fleet_evidence_event(
+            record,
+            _inference_update_event(
+                turn=shell_turn,
+                search_status=search_status,
+                option_set_count=len(option_sets),
+                built_turn=built_turn,
+            ),
+        )
+
+
+def _option_sets_for_slot(
+    builds_by_solution: list[list[FleetBuildOptionSet]],
+    slot_index: int,
+) -> tuple[FleetBuildOptionSet, ...]:
+    best_by_combo_key: dict[str, FleetBuildOptionSet] = {}
+    for solution_builds in builds_by_solution:
+        if slot_index >= len(solution_builds):
+            continue
+        option_set = solution_builds[slot_index]
+        combo_key = option_set.combo_id or option_set.label
+        existing = best_by_combo_key.get(combo_key)
+        if existing is None or option_set.solution_rank_weight > existing.solution_rank_weight:
+            best_by_combo_key[combo_key] = option_set
+    ordered = sorted(
+        best_by_combo_key.values(),
+        key=lambda option_set: option_set.solution_rank_weight,
+        reverse=True,
+    )
+    return tuple(ordered)
+
+
+def _default_option_set_index(option_sets: tuple[FleetBuildOptionSet, ...]) -> int:
+    best_index = 0
+    best_weight = option_sets[0].solution_rank_weight
+    for index, option_set in enumerate(option_sets[1:], start=1):
+        if option_set.solution_rank_weight > best_weight:
+            best_weight = option_set.solution_rank_weight
+            best_index = index
+    return best_index
+
+
+def _ensure_unknown_spec_fields(record: FleetShipRecord) -> None:
+    if not isinstance(record.fields.ship_id, FleetFieldKnown):
+        record.fields.ship_id = FleetFieldUnknown()
+    if not isinstance(record.fields.hull, FleetFieldKnown):
+        record.fields.hull = FleetFieldUnknown()
+    if not isinstance(record.fields.engine, FleetFieldKnown):
+        record.fields.engine = FleetFieldUnknown()
+    if not isinstance(record.fields.beams, FleetFieldKnown):
+        record.fields.beams = FleetFieldUnknown()
+    if not isinstance(record.fields.launchers, FleetFieldKnown):
+        record.fields.launchers = FleetFieldUnknown()
+    if not isinstance(record.fields.location, FleetFieldKnown):
+        record.fields.location = FleetFieldUnknown()
+
+
+def _inference_ship_build_class(ship_build: InferenceSolutionShipBuild) -> FleetShipClass:
+    if is_generic_zero_military_score_combo_id(ship_build.combo_id):
+        return "freighter"
+    return "warship"
+
+
+def _inference_update_event(
+    *,
+    turn: int,
+    search_status: str,
+    option_set_count: int,
+    built_turn: int | None = None,
+) -> FleetEvidenceEvent:
+    payload: dict[str, object] = {
+        "searchStatus": search_status,
+        "optionSetCount": option_set_count,
+    }
+    if built_turn is not None and built_turn < turn:
+        payload["segmentHostTurn"] = built_turn
+        payload["acceleratedIngest"] = True
+    return FleetEvidenceEvent(
+        event_id=str(uuid.uuid4()),
+        kind="inference_update",
+        turn=turn,
+        source=INFERENCE_SOURCE,
+        payload=payload,
+    )

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from api.analytics.military_score_inference.accelerated_start import (
-    ACCEL_WINDOW_SEGMENT_ID,
-    REPORTED_HOST_TURN_SEGMENT_ID,
-    is_first_reliable_scoreboard_turn,
-    starting_scoreboard_snapshot,
-)
+from api.analytics.scores.scoreboard_placeholder_targets import homeworld_starting_inventory_counts
 from api.analytics.turn_roster import iter_turn_players
 from api.models.game import TurnInfo
 from api.models.player import Score
@@ -88,11 +83,16 @@ def global_ship_count_at_synthetic_prior(turn: TurnInfo) -> int | None:
 
 def global_homeworld_starting_ship_id_bound(turn: TurnInfo) -> int:
     """Upper bound on ids after each player receives homeworld starting ships."""
-    baseline = starting_scoreboard_snapshot(turn.settings)
-    per_player = baseline.capitalships + baseline.freighters
+    freighters, warships = homeworld_starting_inventory_counts(turn)
+    per_player = warships + freighters
     if per_player <= 0:
         return 0
     return per_player * len(list(iter_turn_players(turn)))
+
+
+def _is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
+    accelerated = max(0, turn.settings.acceleratedturns)
+    return accelerated > 0 and shell_turn == accelerated
 
 
 def max_ship_id_bound_for_inferred_record(
@@ -100,7 +100,6 @@ def max_ship_id_bound_for_inferred_record(
     *,
     shell_turn: int,
     built_turn: int | None,
-    segment_id: str | None,
     is_starting_inventory: bool,
 ) -> int | None:
     """Resolve the id upper bound for one inferred placeholder on this shell turn."""
@@ -108,10 +107,11 @@ def max_ship_id_bound_for_inferred_record(
         bound = global_homeworld_starting_ship_id_bound(turn)
         return bound if bound > 0 else None
 
-    if is_first_reliable_scoreboard_turn(shell_turn, turn.settings):
-        if segment_id == ACCEL_WINDOW_SEGMENT_ID:
-            return global_ship_count_at_synthetic_prior(turn)
-        if segment_id == REPORTED_HOST_TURN_SEGMENT_ID:
-            return compute_max_ship_id_bound(turn)
+    if (
+        _is_first_reliable_accelerated_shell_turn(shell_turn, turn)
+        and built_turn is not None
+        and built_turn < shell_turn - 1
+    ):
+        return global_ship_count_at_synthetic_prior(turn)
 
     return compute_max_ship_id_bound(turn)

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from api.analytics.scores.scoreboard_placeholder_targets import homeworld_starting_inventory_counts
+from api.analytics.scores.scoreboard_placeholder_targets import (
+    homeworld_starting_inventory_counts,
+    is_first_reliable_accelerated_shell_turn,
+)
 from api.analytics.turn_roster import iter_turn_players
 from api.models.game import TurnInfo
 from api.models.player import Score
@@ -90,11 +93,6 @@ def global_homeworld_starting_ship_id_bound(turn: TurnInfo) -> int:
     return per_player * len(list(iter_turn_players(turn)))
 
 
-def _is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
-    accelerated = max(0, turn.settings.acceleratedturns)
-    return accelerated > 0 and shell_turn == accelerated
-
-
 def max_ship_id_bound_for_inferred_record(
     turn: TurnInfo,
     *,
@@ -108,7 +106,7 @@ def max_ship_id_bound_for_inferred_record(
         return bound if bound > 0 else None
 
     if (
-        _is_first_reliable_accelerated_shell_turn(shell_turn, turn)
+        is_first_reliable_accelerated_shell_turn(shell_turn, turn)
         and built_turn is not None
         and built_turn < shell_turn - 1
     ):

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from api.analytics.scores.scoreboard_placeholder_targets import (
+from api.analytics.scores.placeholder_targets import (
     homeworld_starting_inventory_counts,
     is_first_reliable_accelerated_shell_turn,
 )

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -20,6 +20,7 @@ from api.analytics.military_score_inference.constraints import (
 )
 from api.analytics.military_score_inference.host_turn_targets import (
     functional_host_turn_target_from_segment_payload,
+    host_turn_functional_target_to_wire_dict,
     host_turn_targets_from_wire_event,
 )
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
@@ -499,7 +500,9 @@ def _try_accelerated_backfill_inference(
             "isComplete": segment_status != STATUS_TIME_LIMITED,
             "solutions": solutions_raw if isinstance(solutions_raw, list) else [],
             "hostTurnTargets": [
-                functional_host_turn_target_from_segment_payload(segment_payload),
+                host_turn_functional_target_to_wire_dict(
+                    functional_host_turn_target_from_segment_payload(segment_payload),
+                ),
             ],
             "diagnostics": build_inference_solver_diagnostics(
                 turn=turn.settings.turn,
@@ -526,8 +529,8 @@ def _segment_payload_for_host_turn(
     host_turn: int,
 ) -> dict[str, object] | None:
     for target in host_turn_targets_from_wire_event(split_payload):
-        if target.get("hostTurn") == host_turn:
-            return target
+        if target.host_turn == host_turn:
+            return host_turn_functional_target_to_wire_dict(target)
 
     diagnostics = split_payload.get("diagnostics")
     if not isinstance(diagnostics, dict):

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -18,6 +18,10 @@ from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
     observation_to_constraints_payload,
 )
+from api.analytics.military_score_inference.host_turn_targets import (
+    functional_host_turn_target_from_segment_payload,
+    host_turn_targets_from_wire_event,
+)
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_accelerated import (
     run_accelerated_split_inference,
@@ -494,6 +498,9 @@ def _try_accelerated_backfill_inference(
             "solutionCount": solution_count,
             "isComplete": segment_status != STATUS_TIME_LIMITED,
             "solutions": solutions_raw if isinstance(solutions_raw, list) else [],
+            "hostTurnTargets": [
+                functional_host_turn_target_from_segment_payload(segment_payload),
+            ],
             "diagnostics": build_inference_solver_diagnostics(
                 turn=turn.settings.turn,
                 observation=segment_observation,
@@ -518,6 +525,10 @@ def _segment_payload_for_host_turn(
     *,
     host_turn: int,
 ) -> dict[str, object] | None:
+    for target in host_turn_targets_from_wire_event(split_payload):
+        if target.get("hostTurn") == host_turn:
+            return target
+
     diagnostics = split_payload.get("diagnostics")
     if not isinstance(diagnostics, dict):
         return None

--- a/packages/api/api/analytics/military_score_inference/host_turn_targets.py
+++ b/packages/api/api/analytics/military_score_inference/host_turn_targets.py
@@ -1,0 +1,47 @@
+"""Functional host-turn target payloads for accelerated inference exports."""
+
+from __future__ import annotations
+
+
+def functional_host_turn_target_from_segment_payload(
+    segment_payload: dict[str, object],
+) -> dict[str, object]:
+    """Strip developer diagnostics from one accelerated segment payload."""
+    return {
+        "hostTurn": segment_payload["hostTurn"],
+        "status": segment_payload["status"],
+        "solutionCount": segment_payload["solutionCount"],
+        "militaryDelta2x": segment_payload["militaryDelta2x"],
+        "warshipDelta": segment_payload["warshipDelta"],
+        "freighterDelta": segment_payload["freighterDelta"],
+        "solutions": segment_payload["solutions"],
+    }
+
+
+def host_turn_targets_from_accelerated_segments(
+    segments_raw: object,
+) -> tuple[dict[str, object], ...]:
+    if not isinstance(segments_raw, list):
+        return ()
+    targets: list[dict[str, object]] = []
+    for entry in segments_raw:
+        if not isinstance(entry, dict):
+            continue
+        if "hostTurn" not in entry or "solutions" not in entry:
+            continue
+        targets.append(functional_host_turn_target_from_segment_payload(entry))
+    return tuple(targets)
+
+
+def host_turn_targets_from_wire_event(
+    wire_event: dict[str, object],
+) -> tuple[dict[str, object], ...]:
+    wire_targets = wire_event.get("hostTurnTargets")
+    if isinstance(wire_targets, list):
+        return tuple(entry for entry in wire_targets if isinstance(entry, dict))
+    diagnostics = wire_event.get("diagnostics")
+    if isinstance(diagnostics, dict):
+        return host_turn_targets_from_accelerated_segments(
+            diagnostics.get("accelerated_segments"),
+        )
+    return ()

--- a/packages/api/api/analytics/military_score_inference/host_turn_targets.py
+++ b/packages/api/api/analytics/military_score_inference/host_turn_targets.py
@@ -2,28 +2,130 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HostTurnFunctionalTarget:
+    """Held solutions and scoreboard deltas for one accelerated host turn."""
+
+    host_turn: int
+    status: str
+    solution_count: int
+    military_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    solutions: list[dict[str, object]]
+
+
+def _required_int(data: dict[str, object], *keys: str) -> int:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, int):
+            return value
+    raise ValueError(f"missing or invalid integer field (tried {keys!r})")
+
+
+def _required_str(data: dict[str, object], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str):
+            return value
+    raise ValueError(f"missing or invalid string field (tried {keys!r})")
+
+
+def _required_solutions(data: dict[str, object]) -> list[dict[str, object]]:
+    solutions = data.get("solutions")
+    if not isinstance(solutions, list):
+        raise ValueError("missing or invalid solutions field")
+    return [entry for entry in solutions if isinstance(entry, dict)]
+
+
+def host_turn_functional_target_from_wire_dict(
+    data: dict[str, object],
+) -> HostTurnFunctionalTarget:
+    return HostTurnFunctionalTarget(
+        host_turn=_required_int(data, "hostTurn"),
+        status=_required_str(data, "status"),
+        solution_count=_required_int(data, "solutionCount"),
+        military_delta_2x=_required_int(data, "militaryDelta2x"),
+        warship_delta=_required_int(data, "warshipDelta"),
+        freighter_delta=_required_int(data, "freighterDelta"),
+        solutions=_required_solutions(data),
+    )
+
+
+def host_turn_functional_target_from_persistence_dict(
+    data: dict[str, object],
+) -> HostTurnFunctionalTarget:
+    return HostTurnFunctionalTarget(
+        host_turn=_required_int(data, "host_turn", "hostTurn"),
+        status=_required_str(data, "status"),
+        solution_count=_required_int(data, "solution_count", "solutionCount"),
+        military_delta_2x=_required_int(data, "military_delta_2x", "militaryDelta2x"),
+        warship_delta=_required_int(data, "warship_delta", "warshipDelta"),
+        freighter_delta=_required_int(data, "freighter_delta", "freighterDelta"),
+        solutions=_required_solutions(data),
+    )
+
+
+def host_turn_functional_target_to_wire_dict(
+    target: HostTurnFunctionalTarget,
+) -> dict[str, object]:
+    return {
+        "hostTurn": target.host_turn,
+        "status": target.status,
+        "solutionCount": target.solution_count,
+        "militaryDelta2x": target.military_delta_2x,
+        "warshipDelta": target.warship_delta,
+        "freighterDelta": target.freighter_delta,
+        "solutions": target.solutions,
+    }
+
+
+def host_turn_functional_target_to_persistence_dict(
+    target: HostTurnFunctionalTarget,
+) -> dict[str, object]:
+    return {
+        "host_turn": target.host_turn,
+        "status": target.status,
+        "solution_count": target.solution_count,
+        "military_delta_2x": target.military_delta_2x,
+        "warship_delta": target.warship_delta,
+        "freighter_delta": target.freighter_delta,
+        "solutions": target.solutions,
+    }
+
 
 def functional_host_turn_target_from_segment_payload(
     segment_payload: dict[str, object],
-) -> dict[str, object]:
+) -> HostTurnFunctionalTarget:
     """Strip developer diagnostics from one accelerated segment payload."""
-    return {
-        "hostTurn": segment_payload["hostTurn"],
-        "status": segment_payload["status"],
-        "solutionCount": segment_payload["solutionCount"],
-        "militaryDelta2x": segment_payload["militaryDelta2x"],
-        "warshipDelta": segment_payload["warshipDelta"],
-        "freighterDelta": segment_payload["freighterDelta"],
-        "solutions": segment_payload["solutions"],
-    }
+    return host_turn_functional_target_from_wire_dict(segment_payload)
+
+
+def host_turn_functional_targets_from_wire_list(
+    wire_targets: object,
+) -> list[HostTurnFunctionalTarget] | None:
+    if not isinstance(wire_targets, list):
+        return None
+    targets: list[HostTurnFunctionalTarget] = []
+    for entry in wire_targets:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            targets.append(host_turn_functional_target_from_wire_dict(entry))
+        except ValueError:
+            continue
+    return targets or None
 
 
 def host_turn_targets_from_accelerated_segments(
     segments_raw: object,
-) -> tuple[dict[str, object], ...]:
+) -> tuple[HostTurnFunctionalTarget, ...]:
     if not isinstance(segments_raw, list):
         return ()
-    targets: list[dict[str, object]] = []
+    targets: list[HostTurnFunctionalTarget] = []
     for entry in segments_raw:
         if not isinstance(entry, dict):
             continue
@@ -35,10 +137,12 @@ def host_turn_targets_from_accelerated_segments(
 
 def host_turn_targets_from_wire_event(
     wire_event: dict[str, object],
-) -> tuple[dict[str, object], ...]:
+) -> tuple[HostTurnFunctionalTarget, ...]:
     wire_targets = wire_event.get("hostTurnTargets")
     if isinstance(wire_targets, list):
-        return tuple(entry for entry in wire_targets if isinstance(entry, dict))
+        parsed = host_turn_functional_targets_from_wire_list(wire_targets)
+        if parsed:
+            return tuple(parsed)
     diagnostics = wire_event.get("diagnostics")
     if isinstance(diagnostics, dict):
         return host_turn_targets_from_accelerated_segments(

--- a/packages/api/api/analytics/military_score_inference/inference_accelerated.py
+++ b/packages/api/api/analytics/military_score_inference/inference_accelerated.py
@@ -18,6 +18,7 @@ from api.analytics.military_score_inference.actions import (
 )
 from api.analytics.military_score_inference.host_turn_targets import (
     functional_host_turn_target_from_segment_payload,
+    host_turn_functional_target_to_wire_dict,
 )
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import (
@@ -63,7 +64,9 @@ def payload_with_host_turn_targets(
     return {
         **payload,
         "hostTurnTargets": [
-            functional_host_turn_target_from_segment_payload(segment)
+            host_turn_functional_target_to_wire_dict(
+                functional_host_turn_target_from_segment_payload(segment),
+            )
             for segment in segment_payloads
         ],
     }
@@ -423,11 +426,7 @@ def build_accelerated_backfill_stream_row_complete(
         },
     )
     target_payload = target.payload
-    segment_targets = (
-        [functional_host_turn_target_from_segment_payload(target_payload)]
-        if target_payload is not None
-        else []
-    )
+    segment_payloads_for_targets = [target_payload] if target_payload is not None else []
     api_payload = payload_with_host_turn_targets(
         inference_result_to_api_payload(
             result,
@@ -445,7 +444,7 @@ def build_accelerated_backfill_stream_row_complete(
                 "accelerated_segments": segment_payloads,
             },
         ),
-        segment_targets,
+        segment_payloads_for_targets,
     )
     return RowComplete(
         result=result,

--- a/packages/api/api/analytics/military_score_inference/inference_accelerated.py
+++ b/packages/api/api/analytics/military_score_inference/inference_accelerated.py
@@ -16,6 +16,9 @@ from api.analytics.military_score_inference.actions import (
     DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     ActionCatalog,
 )
+from api.analytics.military_score_inference.host_turn_targets import (
+    functional_host_turn_target_from_segment_payload,
+)
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import (
     STATUS_NO_PRIOR_TURN,
@@ -49,6 +52,21 @@ from api.models.game import TurnInfo
 from api.models.player import Score
 
 AcceleratedSegmentArtifacts = tuple[InferenceObservation, ActionCatalog | None]
+
+
+def payload_with_host_turn_targets(
+    payload: dict[str, object],
+    segment_payloads: list[dict[str, object]],
+) -> dict[str, object]:
+    if not segment_payloads:
+        return payload
+    return {
+        **payload,
+        "hostTurnTargets": [
+            functional_host_turn_target_from_segment_payload(segment)
+            for segment in segment_payloads
+        ],
+    }
 
 
 @dataclass(frozen=True)
@@ -279,15 +297,18 @@ def run_accelerated_split_inference(
     )
 
     return (
-        inference_result_to_api_payload(
-            primary_result,
-            reported_catalog,
-            reported_observation,
-            turn,
-            reported_problem,
-            policy_steps_attempted=reported_policy_steps,
-            step_diagnostics=reported_step_diagnostics,
-            extra_diagnostics={"accelerated_segments": segment_payloads},
+        payload_with_host_turn_targets(
+            inference_result_to_api_payload(
+                primary_result,
+                reported_catalog,
+                reported_observation,
+                turn,
+                reported_problem,
+                policy_steps_attempted=reported_policy_steps,
+                step_diagnostics=reported_step_diagnostics,
+                extra_diagnostics={"accelerated_segments": segment_payloads},
+            ),
+            segment_payloads,
         ),
         reported_observation,
         reported_catalog,
@@ -343,18 +364,22 @@ def build_accelerated_split_stream_row_complete(
             "accelerated_segments": segment_payloads,
         },
     )
-    return RowComplete(
-        result=result,
-        wire_payload=build_row_complete_wire_payload(
+    api_payload = payload_with_host_turn_targets(
+        inference_result_to_api_payload(
             result,
-            observation=reported.observation,
-            turn=turn,
-            catalog=reported.catalog,
-            problem=reported.problem,
+            reported.catalog,
+            reported.observation,
+            turn,
+            reported.problem,
             policy_steps_attempted=reported.policy_steps_attempted,
             step_diagnostics=reported.step_diagnostics,
             extra_diagnostics={"accelerated_segments": segment_payloads},
         ),
+        segment_payloads,
+    )
+    return RowComplete(
+        result=result,
+        wire_payload=row_complete_wire_payload_from_api_payload(api_payload),
     )
 
 
@@ -397,14 +422,19 @@ def build_accelerated_backfill_stream_row_complete(
             "accelerated_segments": segment_payloads,
         },
     )
-    return RowComplete(
-        result=result,
-        wire_payload=build_row_complete_wire_payload(
+    target_payload = target.payload
+    segment_targets = (
+        [functional_host_turn_target_from_segment_payload(target_payload)]
+        if target_payload is not None
+        else []
+    )
+    api_payload = payload_with_host_turn_targets(
+        inference_result_to_api_payload(
             result,
-            observation=target.observation,
-            turn=source_turn,
-            catalog=target.catalog,
-            problem=target.problem,
+            target.catalog,
+            target.observation,
+            source_turn,
+            target.problem,
             policy_steps_attempted=target.policy_steps_attempted,
             step_diagnostics=target.step_diagnostics,
             extra_diagnostics={
@@ -415,4 +445,9 @@ def build_accelerated_backfill_stream_row_complete(
                 "accelerated_segments": segment_payloads,
             },
         ),
+        segment_targets,
+    )
+    return RowComplete(
+        result=result,
+        wire_payload=row_complete_wire_payload_from_api_payload(api_payload),
     )

--- a/packages/api/api/analytics/military_score_inference/inference_stream_domain_events.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_domain_events.py
@@ -35,6 +35,7 @@ class RowCompleteWirePayload:
     is_complete: bool
     solutions: list[dict[str, object]]
     diagnostics: dict[str, object] | None = None
+    host_turn_targets: list[dict[str, object]] | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/api/api/analytics/military_score_inference/inference_stream_domain_events.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_domain_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.host_turn_targets import HostTurnFunctionalTarget
 from api.analytics.military_score_inference.models import (
     InferenceObservation,
     InferenceResult,
@@ -35,7 +36,7 @@ class RowCompleteWirePayload:
     is_complete: bool
     solutions: list[dict[str, object]]
     diagnostics: dict[str, object] | None = None
-    host_turn_targets: list[dict[str, object]] | None = None
+    host_turn_targets: list[HostTurnFunctionalTarget] | None = None
 
 
 @dataclass(frozen=True)

--- a/packages/api/api/analytics/military_score_inference/row_complete_factory.py
+++ b/packages/api/api/analytics/military_score_inference/row_complete_factory.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.host_turn_targets import (
+    host_turn_functional_targets_from_wire_list,
+)
 from api.analytics.military_score_inference.inference_api_payload import (
     format_inference_summary,
     inference_api_payload,
@@ -32,7 +35,7 @@ def row_complete_wire_payload_from_api_payload(
         payload = {**payload, "isComplete": force_is_complete}
     diagnostics = payload.get("diagnostics")
     wire_solutions = payload.get("solutions")
-    host_turn_targets = payload.get("hostTurnTargets")
+    host_turn_targets = host_turn_functional_targets_from_wire_list(payload.get("hostTurnTargets"))
     return RowCompleteWirePayload(
         status=str(payload.get("status", "")),
         summary=str(payload.get("summary", "")),
@@ -40,7 +43,7 @@ def row_complete_wire_payload_from_api_payload(
         is_complete=bool(payload.get("isComplete", True)),
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
-        host_turn_targets=(host_turn_targets if isinstance(host_turn_targets, list) else None),
+        host_turn_targets=host_turn_targets,
     )
 
 

--- a/packages/api/api/analytics/military_score_inference/row_complete_factory.py
+++ b/packages/api/api/analytics/military_score_inference/row_complete_factory.py
@@ -32,6 +32,7 @@ def row_complete_wire_payload_from_api_payload(
         payload = {**payload, "isComplete": force_is_complete}
     diagnostics = payload.get("diagnostics")
     wire_solutions = payload.get("solutions")
+    host_turn_targets = payload.get("hostTurnTargets")
     return RowCompleteWirePayload(
         status=str(payload.get("status", "")),
         summary=str(payload.get("summary", "")),
@@ -39,6 +40,7 @@ def row_complete_wire_payload_from_api_payload(
         is_complete=bool(payload.get("isComplete", True)),
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
+        host_turn_targets=(host_turn_targets if isinstance(host_turn_targets, list) else None),
     )
 
 

--- a/packages/api/api/analytics/scores/export_precedence.py
+++ b/packages/api/api/analytics/scores/export_precedence.py
@@ -111,7 +111,8 @@ class ScoresExportResolved:
 def classify_scores_export_branch(
     snapshot: ScoresInferenceSnapshot,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    resolution_context: ScoresExportResolutionContext,
+    functional_payload: FunctionalHostTurnPayload | None,
 ) -> ScoresExportPrecedenceBranch:
     """Classify precedence branch from gathered state without materializing payloads."""
     persisted_row = snapshot.persisted_row
@@ -128,14 +129,7 @@ def classify_scores_export_branch(
     if persisted_row is not None:
         return "fallback_persisted"
 
-    if (
-        resolution_context is not None
-        and _functional_backfill_payload(
-            snapshot,
-            resolution_context=resolution_context,
-        )
-        is not None
-    ):
+    if functional_payload is not None:
         return "functional_backfill"
 
     return "empty"
@@ -144,12 +138,14 @@ def classify_scores_export_branch(
 def classify_scores_export_decision(
     snapshot: ScoresInferenceSnapshot,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    resolution_context: ScoresExportResolutionContext,
+    functional_payload: FunctionalHostTurnPayload | None,
 ) -> ScoresExportDecision:
     """Resolve branch and lifecycle status without materializing solution payloads."""
     branch = classify_scores_export_branch(
         snapshot,
         resolution_context=resolution_context,
+        functional_payload=functional_payload,
     )
     if branch == "priority_persisted":
         persisted_row = snapshot.persisted_row
@@ -191,14 +187,10 @@ def classify_scores_export_decision(
         )
 
     if branch == "functional_backfill":
-        functional = _functional_backfill_payload(
-            snapshot,
-            resolution_context=resolution_context,
-        )
-        assert functional is not None
+        assert functional_payload is not None
         return ScoresExportDecision(
             branch,
-            functional.search_status,
+            functional_payload.search_status,
             needs_ensure_work=False,
         )
 
@@ -208,19 +200,21 @@ def classify_scores_export_decision(
 def is_scores_export_ensure_satisfied_from_snapshot(
     snapshot: ScoresInferenceSnapshot,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    resolution_context: ScoresExportResolutionContext,
 ) -> bool:
     """True when probe/ensure walks should skip this scope (no further ensure work)."""
+    functional_payload = _resolve_functional_payload(snapshot, resolution_context)
     return not classify_scores_export_decision(
         snapshot,
         resolution_context=resolution_context,
+        functional_payload=functional_payload,
     ).needs_ensure_work
 
 
 def resolve_scores_export(
     snapshot: ScoresInferenceSnapshot,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    resolution_context: ScoresExportResolutionContext,
 ) -> ScoresExportResolved:
     decision, payload = _resolve_scores_export_ladder(
         snapshot,
@@ -270,28 +264,27 @@ def _search_status_from_scheduler(
 def _resolve_scores_export_ladder(
     snapshot: ScoresInferenceSnapshot,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    resolution_context: ScoresExportResolutionContext,
 ) -> tuple[ScoresExportDecision, ScoresExportPayload]:
     """Single precedence ladder: branch, lifecycle status, and wire payload."""
+    functional_payload = _resolve_functional_payload(snapshot, resolution_context)
     decision = classify_scores_export_decision(
         snapshot,
         resolution_context=resolution_context,
+        functional_payload=functional_payload,
     )
     payload = _materialize_scores_export_payload(
         snapshot,
         decision.branch,
-        resolution_context=resolution_context,
+        functional_payload=functional_payload,
     )
     return decision, payload
 
 
-def _functional_backfill_payload(
+def _resolve_functional_payload(
     snapshot: ScoresInferenceSnapshot,
-    *,
-    resolution_context: ScoresExportResolutionContext | None,
+    resolution_context: ScoresExportResolutionContext,
 ) -> FunctionalHostTurnPayload | None:
-    if resolution_context is None:
-        return None
     return resolve_functional_host_turn_payload(
         scoreboard_turn=resolution_context.scoreboard_turn,
         turn=resolution_context.turn,
@@ -302,42 +295,21 @@ def _functional_backfill_payload(
     )
 
 
-def _normalize_persisted_payload(
-    persisted_row: PersistedInferenceRow,
-    *,
-    resolution_context: ScoresExportResolutionContext | None,
-) -> tuple[list[dict[str, object]], dict[str, object] | None, int] | None:
-    if resolution_context is None:
-        return None
-    functional = resolve_functional_host_turn_payload(
-        scoreboard_turn=resolution_context.scoreboard_turn,
-        turn=resolution_context.turn,
-        score=resolution_context.player_score,
-        persisted_row=persisted_row,
-        load_scoreboard_turn=resolution_context.load_scoreboard_turn,
-        get_persisted_row=resolution_context.get_persisted_row,
-    )
-    if functional is None:
-        return None
-    return functional.solutions, None, functional.solutions_held
-
-
 def _materialize_scores_export_payload(
     snapshot: ScoresInferenceSnapshot,
     branch: ScoresExportPrecedenceBranch,
     *,
-    resolution_context: ScoresExportResolutionContext | None = None,
+    functional_payload: FunctionalHostTurnPayload | None,
 ) -> ScoresExportPayload:
     persisted_row = snapshot.persisted_row
     if branch == "priority_persisted":
         assert persisted_row is not None
-        normalized = _normalize_persisted_payload(
-            persisted_row,
-            resolution_context=resolution_context,
-        )
-        if normalized is not None:
-            solutions, diagnostics, solutions_held = normalized
-            return ScoresExportPayload(solutions, diagnostics, solutions_held)
+        if functional_payload is not None:
+            return ScoresExportPayload(
+                functional_payload.solutions,
+                None,
+                functional_payload.solutions_held,
+            )
         solutions, diagnostics, solutions_held = solutions_from_persisted_row(persisted_row)
         return ScoresExportPayload(solutions, diagnostics, solutions_held)
 
@@ -355,26 +327,21 @@ def _materialize_scores_export_payload(
 
     if branch == "fallback_persisted":
         assert persisted_row is not None
-        normalized = _normalize_persisted_payload(
-            persisted_row,
-            resolution_context=resolution_context,
-        )
-        if normalized is not None:
-            solutions, diagnostics, solutions_held = normalized
-            return ScoresExportPayload(solutions, diagnostics, solutions_held)
+        if functional_payload is not None:
+            return ScoresExportPayload(
+                functional_payload.solutions,
+                None,
+                functional_payload.solutions_held,
+            )
         solutions, diagnostics, solutions_held = solutions_from_persisted_row(persisted_row)
         return ScoresExportPayload(solutions, diagnostics, solutions_held)
 
     if branch == "functional_backfill":
-        functional = _functional_backfill_payload(
-            snapshot,
-            resolution_context=resolution_context,
-        )
-        assert functional is not None
+        assert functional_payload is not None
         return ScoresExportPayload(
-            functional.solutions,
+            functional_payload.solutions,
             None,
-            functional.solutions_held,
+            functional_payload.solutions_held,
         )
 
     return ScoresExportPayload([], None, 0)

--- a/packages/api/api/analytics/scores/export_precedence.py
+++ b/packages/api/api/analytics/scores/export_precedence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -25,6 +26,13 @@ from api.analytics.scores.export_wire import (
     solutions_from_terminal_admission,
     wire_complete_event_from_terminal_admission,
 )
+from api.analytics.scores.host_turn_export import (
+    FunctionalHostTurnPayload,
+    resolve_functional_host_turn_payload,
+)
+from api.models.game import TurnInfo
+from api.models.player import Score
+from api.serialization.inference_row_persistence import PersistedInferenceRow
 
 SearchStatus = Literal["not_started", "in_progress", "paused", "stopped", "complete"]
 ScoresExportPrecedenceBranch = Literal[
@@ -32,6 +40,7 @@ ScoresExportPrecedenceBranch = Literal[
     "terminal_admission",
     "scheduler",
     "fallback_persisted",
+    "functional_backfill",
     "empty",
 ]
 
@@ -70,6 +79,18 @@ def is_persistable_inference_status(status: str) -> bool:
 
 
 @dataclass(frozen=True)
+class ScoresExportResolutionContext:
+    """Turn and persistence context for host-turn functional export normalization."""
+
+    scoreboard_turn: int
+    turn: TurnInfo
+    player_id: int | None
+    load_scoreboard_turn: Callable[[int], TurnInfo | None]
+    get_persisted_row: Callable[[int, int], PersistedInferenceRow | None] | None = None
+    player_score: Score | None = None
+
+
+@dataclass(frozen=True)
 class ScoresExportPayload:
     """Resolved solution payload for a scores inference snapshot."""
 
@@ -89,6 +110,8 @@ class ScoresExportResolved:
 
 def classify_scores_export_branch(
     snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
 ) -> ScoresExportPrecedenceBranch:
     """Classify precedence branch from gathered state without materializing payloads."""
     persisted_row = snapshot.persisted_row
@@ -105,12 +128,29 @@ def classify_scores_export_branch(
     if persisted_row is not None:
         return "fallback_persisted"
 
+    if (
+        resolution_context is not None
+        and _functional_backfill_payload(
+            snapshot,
+            resolution_context=resolution_context,
+        )
+        is not None
+    ):
+        return "functional_backfill"
+
     return "empty"
 
 
-def classify_scores_export_decision(snapshot: ScoresInferenceSnapshot) -> ScoresExportDecision:
+def classify_scores_export_decision(
+    snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
+) -> ScoresExportDecision:
     """Resolve branch and lifecycle status without materializing solution payloads."""
-    branch = classify_scores_export_branch(snapshot)
+    branch = classify_scores_export_branch(
+        snapshot,
+        resolution_context=resolution_context,
+    )
     if branch == "priority_persisted":
         persisted_row = snapshot.persisted_row
         assert persisted_row is not None
@@ -150,16 +190,42 @@ def classify_scores_export_decision(snapshot: ScoresInferenceSnapshot) -> Scores
             needs_ensure_work=False,
         )
 
+    if branch == "functional_backfill":
+        functional = _functional_backfill_payload(
+            snapshot,
+            resolution_context=resolution_context,
+        )
+        assert functional is not None
+        return ScoresExportDecision(
+            branch,
+            functional.search_status,
+            needs_ensure_work=False,
+        )
+
     return ScoresExportDecision("empty", "not_started", needs_ensure_work=True)
 
 
-def is_scores_export_ensure_satisfied_from_snapshot(snapshot: ScoresInferenceSnapshot) -> bool:
+def is_scores_export_ensure_satisfied_from_snapshot(
+    snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
+) -> bool:
     """True when probe/ensure walks should skip this scope (no further ensure work)."""
-    return not classify_scores_export_decision(snapshot).needs_ensure_work
+    return not classify_scores_export_decision(
+        snapshot,
+        resolution_context=resolution_context,
+    ).needs_ensure_work
 
 
-def resolve_scores_export(snapshot: ScoresInferenceSnapshot) -> ScoresExportResolved:
-    decision, payload = _resolve_scores_export_ladder(snapshot)
+def resolve_scores_export(
+    snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
+) -> ScoresExportResolved:
+    decision, payload = _resolve_scores_export_ladder(
+        snapshot,
+        resolution_context=resolution_context,
+    )
     return ScoresExportResolved(
         snapshot=snapshot,
         decision=decision,
@@ -203,20 +269,75 @@ def _search_status_from_scheduler(
 
 def _resolve_scores_export_ladder(
     snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
 ) -> tuple[ScoresExportDecision, ScoresExportPayload]:
     """Single precedence ladder: branch, lifecycle status, and wire payload."""
-    decision = classify_scores_export_decision(snapshot)
-    payload = _materialize_scores_export_payload(snapshot, decision.branch)
+    decision = classify_scores_export_decision(
+        snapshot,
+        resolution_context=resolution_context,
+    )
+    payload = _materialize_scores_export_payload(
+        snapshot,
+        decision.branch,
+        resolution_context=resolution_context,
+    )
     return decision, payload
+
+
+def _functional_backfill_payload(
+    snapshot: ScoresInferenceSnapshot,
+    *,
+    resolution_context: ScoresExportResolutionContext | None,
+) -> FunctionalHostTurnPayload | None:
+    if resolution_context is None:
+        return None
+    return resolve_functional_host_turn_payload(
+        scoreboard_turn=resolution_context.scoreboard_turn,
+        turn=resolution_context.turn,
+        score=resolution_context.player_score,
+        persisted_row=snapshot.persisted_row,
+        load_scoreboard_turn=resolution_context.load_scoreboard_turn,
+        get_persisted_row=resolution_context.get_persisted_row,
+    )
+
+
+def _normalize_persisted_payload(
+    persisted_row: PersistedInferenceRow,
+    *,
+    resolution_context: ScoresExportResolutionContext | None,
+) -> tuple[list[dict[str, object]], dict[str, object] | None, int] | None:
+    if resolution_context is None:
+        return None
+    functional = resolve_functional_host_turn_payload(
+        scoreboard_turn=resolution_context.scoreboard_turn,
+        turn=resolution_context.turn,
+        score=resolution_context.player_score,
+        persisted_row=persisted_row,
+        load_scoreboard_turn=resolution_context.load_scoreboard_turn,
+        get_persisted_row=resolution_context.get_persisted_row,
+    )
+    if functional is None:
+        return None
+    return functional.solutions, None, functional.solutions_held
 
 
 def _materialize_scores_export_payload(
     snapshot: ScoresInferenceSnapshot,
     branch: ScoresExportPrecedenceBranch,
+    *,
+    resolution_context: ScoresExportResolutionContext | None = None,
 ) -> ScoresExportPayload:
     persisted_row = snapshot.persisted_row
     if branch == "priority_persisted":
         assert persisted_row is not None
+        normalized = _normalize_persisted_payload(
+            persisted_row,
+            resolution_context=resolution_context,
+        )
+        if normalized is not None:
+            solutions, diagnostics, solutions_held = normalized
+            return ScoresExportPayload(solutions, diagnostics, solutions_held)
         solutions, diagnostics, solutions_held = solutions_from_persisted_row(persisted_row)
         return ScoresExportPayload(solutions, diagnostics, solutions_held)
 
@@ -234,8 +355,27 @@ def _materialize_scores_export_payload(
 
     if branch == "fallback_persisted":
         assert persisted_row is not None
+        normalized = _normalize_persisted_payload(
+            persisted_row,
+            resolution_context=resolution_context,
+        )
+        if normalized is not None:
+            solutions, diagnostics, solutions_held = normalized
+            return ScoresExportPayload(solutions, diagnostics, solutions_held)
         solutions, diagnostics, solutions_held = solutions_from_persisted_row(persisted_row)
         return ScoresExportPayload(solutions, diagnostics, solutions_held)
+
+    if branch == "functional_backfill":
+        functional = _functional_backfill_payload(
+            snapshot,
+            resolution_context=resolution_context,
+        )
+        assert functional is not None
+        return ScoresExportPayload(
+            functional.solutions,
+            None,
+            functional.solutions_held,
+        )
 
     return ScoresExportPayload([], None, 0)
 

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -17,6 +17,7 @@ from api.analytics.military_score_inference.inference_stream_rows import (
 )
 from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
 from api.analytics.scores.export_precedence import (
+    ScoresExportResolutionContext,
     ScoresExportResolved,
     is_persistable_inference_status,
     is_scores_export_authoritatively_persisted,
@@ -36,7 +37,10 @@ from api.analytics.scores_assets import ANALYTIC_ID
 from api.errors import ValidationError
 from api.models.game import TurnInfo
 from api.models.player import Score
-from api.serialization.inference_row_persistence import persisted_inference_row_from_wire_complete
+from api.serialization.inference_row_persistence import (
+    PersistedInferenceRow,
+    persisted_inference_row_from_wire_complete,
+)
 from api.transport.inference_stream_wire import inference_api_payload_to_wire_complete
 
 PATH_PREFIX_SCOPE_RULES = (
@@ -92,6 +96,36 @@ def _scores_row_ensure_inputs(
     )
 
 
+def _scores_resolution_context(
+    ctx: AnalyticQueryContext,
+    services: ScoresExportContext,
+    scope: ExportScope,
+    turn: TurnInfo,
+) -> ScoresExportResolutionContext | None:
+    if scope.player_id is None:
+        return None
+
+    def get_persisted_row(scoreboard_turn: int, player_id: int) -> PersistedInferenceRow | None:
+        if services.persistence is None:
+            return None
+        return services.persistence.get_row(
+            scope.game_id,
+            scope.perspective,
+            scoreboard_turn,
+            player_id,
+        )
+
+    score = next((row for row in turn.scores if row.ownerid == scope.player_id), None)
+    return ScoresExportResolutionContext(
+        scoreboard_turn=scope.turn,
+        turn=turn,
+        player_id=scope.player_id,
+        load_scoreboard_turn=ctx.load_turn,
+        get_persisted_row=get_persisted_row,
+        player_score=score,
+    )
+
+
 def _scores_resolved(
     ctx: AnalyticQueryContext,
     scope: ExportScope,
@@ -103,7 +137,15 @@ def _scores_resolved(
 
     def gather() -> ScoresExportResolved:
         snapshot = gather_scores_inference_snapshot(ctx, services, scope, resolved_turn)
-        return resolve_scores_export(snapshot)
+        resolution_context = (
+            _scores_resolution_context(ctx, services, scope, resolved_turn)
+            if resolved_turn is not None
+            else None
+        )
+        return resolve_scores_export(
+            snapshot,
+            resolution_context=resolution_context,
+        )
 
     resolved = ctx.export_snapshot_for(ANALYTIC_ID, scope, gather)
     return services, resolved
@@ -143,7 +185,14 @@ def is_scores_export_ensure_satisfied(ctx: AnalyticQueryContext, scope: ExportSc
         scope,
         ctx.load_turn(scope.turn),
     )
-    return is_scores_export_ensure_satisfied_from_snapshot(snapshot)
+    turn = ctx.load_turn(scope.turn)
+    resolution_context = (
+        _scores_resolution_context(ctx, services, scope, turn) if turn is not None else None
+    )
+    return is_scores_export_ensure_satisfied_from_snapshot(
+        snapshot,
+        resolution_context=resolution_context,
+    )
 
 
 def _run_prior_turn_sync_ensure(

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -101,9 +101,8 @@ def _scores_resolution_context(
     services: ScoresExportContext,
     scope: ExportScope,
     turn: TurnInfo,
-) -> ScoresExportResolutionContext | None:
-    if scope.player_id is None:
-        return None
+) -> ScoresExportResolutionContext:
+    assert scope.player_id is not None
 
     def get_persisted_row(scoreboard_turn: int, player_id: int) -> PersistedInferenceRow | None:
         if services.persistence is None:
@@ -134,14 +133,12 @@ def _scores_resolved(
 ) -> tuple[ScoresExportContext, ScoresExportResolved]:
     services = resolve_scores_services(ctx)
     resolved_turn = turn if turn is not None else ctx.load_turn(scope.turn)
+    if resolved_turn is None:
+        raise ValidationError(f"Turn {scope.turn} is not stored")
 
     def gather() -> ScoresExportResolved:
         snapshot = gather_scores_inference_snapshot(ctx, services, scope, resolved_turn)
-        resolution_context = (
-            _scores_resolution_context(ctx, services, scope, resolved_turn)
-            if resolved_turn is not None
-            else None
-        )
+        resolution_context = _scores_resolution_context(ctx, services, scope, resolved_turn)
         return resolve_scores_export(
             snapshot,
             resolution_context=resolution_context,
@@ -179,16 +176,17 @@ def is_scores_export_ensure_satisfied(ctx: AnalyticQueryContext, scope: ExportSc
         return True
 
     services = resolve_scores_services(ctx)
+    turn = ctx.load_turn(scope.turn)
+    if turn is None:
+        return True
+
     snapshot = gather_scores_ensure_probe_snapshot(
         ctx,
         services,
         scope,
-        ctx.load_turn(scope.turn),
+        turn,
     )
-    turn = ctx.load_turn(scope.turn)
-    resolution_context = (
-        _scores_resolution_context(ctx, services, scope, turn) if turn is not None else None
-    )
+    resolution_context = _scores_resolution_context(ctx, services, scope, turn)
     return is_scores_export_ensure_satisfied_from_snapshot(
         snapshot,
         resolution_context=resolution_context,

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -1,0 +1,169 @@
+"""Functional host-turn export resolution for scores analytics."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from api.analytics.military_score_inference.accelerated_start import (
+    first_reliable_accelerated_scoreboard_turn,
+    needs_accelerated_backfill,
+    scoreboard_host_turn,
+)
+from api.analytics.military_score_inference.host_turn_targets import (
+    host_turn_targets_from_accelerated_segments,
+)
+from api.analytics.military_score_inference.solver import (
+    STATUS_EXACT,
+    STATUS_NO_EXACT_SOLUTION,
+    STATUS_STOPPED,
+)
+from api.analytics.scores.export_wire import ranked_solutions_from_wire
+from api.models.game import TurnInfo
+from api.models.player import Score
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+SearchStatus = Literal["not_started", "in_progress", "paused", "stopped", "complete"]
+
+_COMPLETE_TARGET_STATUSES = frozenset({STATUS_EXACT, STATUS_NO_EXACT_SOLUTION})
+
+
+def scores_scoreboard_turn_for_placeholder_refine(*, built_turn: int, shell_turn: int) -> int:
+    """Map fleet placeholder built_turn to the scoreboard turn that holds its inference."""
+    if built_turn < shell_turn:
+        return built_turn + 1
+    return built_turn
+
+
+def host_turn_targets_from_persisted_row(
+    row: PersistedInferenceRow,
+) -> tuple[dict[str, object], ...]:
+    if row.host_turn_targets:
+        return tuple(row.host_turn_targets)
+    if row.diagnostics is not None:
+        return host_turn_targets_from_accelerated_segments(
+            row.diagnostics.get("accelerated_segments"),
+        )
+    return ()
+
+
+def functional_target_for_host_turn(
+    targets: tuple[dict[str, object], ...],
+    host_turn: int,
+) -> dict[str, object] | None:
+    for target in targets:
+        entry_host_turn = target.get("hostTurn")
+        if entry_host_turn == host_turn:
+            return target
+    return None
+
+
+@dataclass(frozen=True)
+class FunctionalHostTurnPayload:
+    """Held solutions and lifecycle status for one scoreboard host turn."""
+
+    solutions: list[dict[str, object]]
+    solutions_held: int
+    search_status: SearchStatus
+
+
+def _search_status_from_persisted_row(row: PersistedInferenceRow) -> SearchStatus:
+    if row.status == STATUS_STOPPED:
+        return "stopped"
+    if row.status in _COMPLETE_TARGET_STATUSES:
+        return "complete"
+    return "not_started"
+
+
+def _search_status_from_target_status(status: object) -> SearchStatus:
+    if status == STATUS_STOPPED:
+        return "stopped"
+    if isinstance(status, str) and status in _COMPLETE_TARGET_STATUSES:
+        return "complete"
+    return "not_started"
+
+
+def _payload_from_functional_target(target: dict[str, object]) -> FunctionalHostTurnPayload:
+    solutions_raw = target.get("solutions")
+    solutions = ranked_solutions_from_wire(
+        solutions_raw if isinstance(solutions_raw, list) else [],
+    )
+    solution_count_raw = target.get("solutionCount", len(solutions))
+    solutions_held = solution_count_raw if isinstance(solution_count_raw, int) else len(solutions)
+    return FunctionalHostTurnPayload(
+        solutions=solutions,
+        solutions_held=solutions_held,
+        search_status=_search_status_from_target_status(target.get("status")),
+    )
+
+
+def _payload_for_host_turn_from_row(
+    row: PersistedInferenceRow,
+    *,
+    scoreboard_turn: int,
+    target_host_turn: int,
+) -> FunctionalHostTurnPayload | None:
+    targets = host_turn_targets_from_persisted_row(row)
+    if targets:
+        target = functional_target_for_host_turn(targets, target_host_turn)
+        if target is None:
+            return None
+        return _payload_from_functional_target(target)
+
+    if scoreboard_host_turn(scoreboard_turn) != target_host_turn:
+        return None
+    return FunctionalHostTurnPayload(
+        solutions=ranked_solutions_from_wire(row.solutions),
+        solutions_held=row.solution_count,
+        search_status=_search_status_from_persisted_row(row),
+    )
+
+
+PersistedRowLoader = Callable[[int, int], PersistedInferenceRow | None]
+
+
+def resolve_functional_host_turn_payload(
+    *,
+    scoreboard_turn: int,
+    turn: TurnInfo,
+    score: Score | None,
+    persisted_row: PersistedInferenceRow | None,
+    load_scoreboard_turn: Callable[[int], TurnInfo | None] | None,
+    get_persisted_row: PersistedRowLoader | None = None,
+) -> FunctionalHostTurnPayload | None:
+    """Resolve functional held solutions for the host turn implied by scoreboard_turn."""
+    target_host_turn = scoreboard_host_turn(scoreboard_turn)
+    if target_host_turn is None:
+        return None
+
+    if persisted_row is not None:
+        payload = _payload_for_host_turn_from_row(
+            persisted_row,
+            scoreboard_turn=scoreboard_turn,
+            target_host_turn=target_host_turn,
+        )
+        if payload is not None:
+            return payload
+
+    if (
+        score is None
+        or load_scoreboard_turn is None
+        or get_persisted_row is None
+        or not needs_accelerated_backfill(scoreboard_turn, turn.settings)
+    ):
+        return None
+
+    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
+    if source_turn_number is None:
+        return None
+
+    source_row = get_persisted_row(source_turn_number, score.ownerid)
+    if source_row is None:
+        return None
+
+    return _payload_for_host_turn_from_row(
+        source_row,
+        scoreboard_turn=source_turn_number,
+        target_host_turn=target_host_turn,
+    )

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -16,6 +16,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_NO_EXACT_SOLUTION,
     STATUS_STOPPED,
+    STATUS_TIME_LIMITED,
 )
 from api.analytics.scores.export_wire import ranked_solutions_from_wire
 from api.models.game import TurnInfo
@@ -62,7 +63,7 @@ class FunctionalHostTurnPayload:
 
 
 def _search_status_from_persisted_row(row: PersistedInferenceRow) -> SearchStatus:
-    if row.status == STATUS_STOPPED:
+    if row.status in (STATUS_STOPPED, STATUS_TIME_LIMITED):
         return "stopped"
     if row.status in _COMPLETE_TARGET_STATUSES:
         return "complete"
@@ -70,7 +71,7 @@ def _search_status_from_persisted_row(row: PersistedInferenceRow) -> SearchStatu
 
 
 def _search_status_from_target_status(status: object) -> SearchStatus:
-    if status == STATUS_STOPPED:
+    if status in (STATUS_STOPPED, STATUS_TIME_LIMITED):
         return "stopped"
     if isinstance(status, str) and status in _COMPLETE_TARGET_STATUSES:
         return "complete"

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -11,6 +11,7 @@ from api.analytics.military_score_inference.accelerated_start import (
     needs_accelerated_backfill,
     scoreboard_host_turn,
 )
+from api.analytics.military_score_inference.host_turn_targets import HostTurnFunctionalTarget
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_NO_EXACT_SOLUTION,
@@ -35,19 +36,18 @@ def scores_scoreboard_turn_for_placeholder_refine(*, built_turn: int, shell_turn
 
 def host_turn_targets_from_persisted_row(
     row: PersistedInferenceRow,
-) -> tuple[dict[str, object], ...]:
+) -> tuple[HostTurnFunctionalTarget, ...]:
     if row.host_turn_targets:
         return tuple(row.host_turn_targets)
     return ()
 
 
 def functional_target_for_host_turn(
-    targets: tuple[dict[str, object], ...],
+    targets: tuple[HostTurnFunctionalTarget, ...],
     host_turn: int,
-) -> dict[str, object] | None:
+) -> HostTurnFunctionalTarget | None:
     for target in targets:
-        entry_host_turn = target.get("hostTurn")
-        if entry_host_turn == host_turn:
+        if target.host_turn == host_turn:
             return target
     return None
 
@@ -77,17 +77,12 @@ def _search_status_from_target_status(status: object) -> SearchStatus:
     return "not_started"
 
 
-def _payload_from_functional_target(target: dict[str, object]) -> FunctionalHostTurnPayload:
-    solutions_raw = target.get("solutions")
-    solutions = ranked_solutions_from_wire(
-        solutions_raw if isinstance(solutions_raw, list) else [],
-    )
-    solution_count_raw = target.get("solutionCount", len(solutions))
-    solutions_held = solution_count_raw if isinstance(solution_count_raw, int) else len(solutions)
+def _payload_from_functional_target(target: HostTurnFunctionalTarget) -> FunctionalHostTurnPayload:
+    solutions = ranked_solutions_from_wire(target.solutions)
     return FunctionalHostTurnPayload(
         solutions=solutions,
-        solutions_held=solutions_held,
-        search_status=_search_status_from_target_status(target.get("status")),
+        solutions_held=target.solution_count,
+        search_status=_search_status_from_target_status(target.status),
     )
 
 

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -11,9 +11,6 @@ from api.analytics.military_score_inference.accelerated_start import (
     needs_accelerated_backfill,
     scoreboard_host_turn,
 )
-from api.analytics.military_score_inference.host_turn_targets import (
-    host_turn_targets_from_accelerated_segments,
-)
 from api.analytics.military_score_inference.solver import (
     STATUS_EXACT,
     STATUS_NO_EXACT_SOLUTION,
@@ -41,10 +38,6 @@ def host_turn_targets_from_persisted_row(
 ) -> tuple[dict[str, object], ...]:
     if row.host_turn_targets:
         return tuple(row.host_turn_targets)
-    if row.diagnostics is not None:
-        return host_turn_targets_from_accelerated_segments(
-            row.diagnostics.get("accelerated_segments"),
-        )
     return ()
 
 

--- a/packages/api/api/analytics/scores/placeholder_targets.py
+++ b/packages/api/api/analytics/scores/placeholder_targets.py
@@ -1,0 +1,23 @@
+"""Public scores boundary for scoreboard placeholder metadata.
+
+Fleet and other analytics consumers should import placeholder-target helpers
+from this module rather than from ``scoreboard_placeholder_targets`` directly.
+"""
+
+from api.analytics.scores.scoreboard_placeholder_targets import (
+    ScoreboardPlaceholderTarget,
+    homeworld_starting_freighter_hull_id,
+    homeworld_starting_inventory_counts,
+    is_first_reliable_accelerated_shell_turn,
+    scoreboard_placeholder_targets,
+    should_seed_homeworld_starting_inventory,
+)
+
+__all__ = (
+    "ScoreboardPlaceholderTarget",
+    "homeworld_starting_freighter_hull_id",
+    "homeworld_starting_inventory_counts",
+    "is_first_reliable_accelerated_shell_turn",
+    "scoreboard_placeholder_targets",
+    "should_seed_homeworld_starting_inventory",
+)

--- a/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
+++ b/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
@@ -21,7 +21,6 @@ class ScoreboardPlaceholderTarget:
     host_turn: int
     warship_delta: int
     freighter_delta: int
-    segment_id: str | None = None
 
 
 def homeworld_starting_freighter_hull_id() -> int:
@@ -56,7 +55,6 @@ def scoreboard_placeholder_targets(
                 host_turn=segment.host_turn,
                 warship_delta=segment.warship_delta,
                 freighter_delta=segment.freighter_delta,
-                segment_id=segment.segment_id,
             )
             for segment in segments
         )

--- a/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
+++ b/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from api.analytics.military_score_inference.accelerated_start import (
     HOMEBASE_STARTING_FREIGHTER_HULL_ID,
     accelerated_inference_segments,
+    is_first_reliable_scoreboard_turn,
     starting_scoreboard_snapshot,
 )
 from api.models.game import TurnInfo
@@ -33,20 +34,51 @@ def homeworld_starting_inventory_counts(turn: TurnInfo) -> tuple[int, int]:
     return baseline.freighters, baseline.capitalships
 
 
+def is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
+    """Return whether this shell turn is the first reliable accelerated scoreboard row."""
+    return is_first_reliable_scoreboard_turn(shell_turn, turn.settings)
+
+
+def should_seed_homeworld_starting_inventory(turn: TurnInfo) -> bool:
+    """Return whether homeworld starting ships should be seeded on this shell turn."""
+    return is_first_reliable_accelerated_shell_turn(turn.settings.turn, turn)
+
+
 def scoreboard_placeholder_targets(
     score: Score,
     turn: TurnInfo,
 ) -> tuple[ScoreboardPlaceholderTarget, ...] | None:
-    """Return accelerated segment placeholder targets on the first reliable row."""
+    """Return placeholder build targets for accelerated segments or normal scoreboard deltas."""
     segments = accelerated_inference_segments(score, turn)
-    if segments is None:
-        return None
-    return tuple(
-        ScoreboardPlaceholderTarget(
-            host_turn=segment.host_turn,
-            warship_delta=segment.warship_delta,
-            freighter_delta=segment.freighter_delta,
-            segment_id=segment.segment_id,
+    if segments is not None:
+        return tuple(
+            ScoreboardPlaceholderTarget(
+                host_turn=segment.host_turn,
+                warship_delta=segment.warship_delta,
+                freighter_delta=segment.freighter_delta,
+                segment_id=segment.segment_id,
+            )
+            for segment in segments
         )
-        for segment in segments
-    )
+
+    turn_number = turn.settings.turn
+    targets: list[ScoreboardPlaceholderTarget] = []
+    warship_builds = max(0, score.shipchange)
+    freighter_builds = max(0, score.freighterchange)
+    if warship_builds > 0:
+        targets.append(
+            ScoreboardPlaceholderTarget(
+                host_turn=turn_number,
+                warship_delta=warship_builds,
+                freighter_delta=0,
+            )
+        )
+    if freighter_builds > 0:
+        targets.append(
+            ScoreboardPlaceholderTarget(
+                host_turn=turn_number,
+                warship_delta=0,
+                freighter_delta=freighter_builds,
+            )
+        )
+    return tuple(targets) if targets else None

--- a/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
+++ b/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
@@ -1,0 +1,52 @@
+"""Scoreboard placeholder build counts exposed through the scores analytic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from api.analytics.military_score_inference.accelerated_start import (
+    HOMEBASE_STARTING_FREIGHTER_HULL_ID,
+    accelerated_inference_segments,
+    starting_scoreboard_snapshot,
+)
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+
+@dataclass(frozen=True)
+class ScoreboardPlaceholderTarget:
+    """One inferred placeholder group keyed by host turn."""
+
+    host_turn: int
+    warship_delta: int
+    freighter_delta: int
+    segment_id: str | None = None
+
+
+def homeworld_starting_freighter_hull_id() -> int:
+    return HOMEBASE_STARTING_FREIGHTER_HULL_ID
+
+
+def homeworld_starting_inventory_counts(turn: TurnInfo) -> tuple[int, int]:
+    """Return (freighters, warships) seeded at game start."""
+    baseline = starting_scoreboard_snapshot(turn.settings)
+    return baseline.freighters, baseline.capitalships
+
+
+def scoreboard_placeholder_targets(
+    score: Score,
+    turn: TurnInfo,
+) -> tuple[ScoreboardPlaceholderTarget, ...] | None:
+    """Return accelerated segment placeholder targets on the first reliable row."""
+    segments = accelerated_inference_segments(score, turn)
+    if segments is None:
+        return None
+    return tuple(
+        ScoreboardPlaceholderTarget(
+            host_turn=segment.host_turn,
+            warship_delta=segment.warship_delta,
+            freighter_delta=segment.freighter_delta,
+            segment_id=segment.segment_id,
+        )
+        for segment in segments
+    )

--- a/packages/api/api/serialization/inference_row_persistence.py
+++ b/packages/api/api/serialization/inference_row_persistence.py
@@ -19,6 +19,7 @@ class PersistedInferenceRow:
     is_complete: bool
     solutions: list[dict[str, object]]
     diagnostics: dict[str, object] | None = None
+    host_turn_targets: list[dict[str, object]] | None = None
 
 
 def persisted_inference_row_from_json(data: dict) -> PersistedInferenceRow:
@@ -36,8 +37,13 @@ def persisted_inference_row_to_json(row: PersistedInferenceRow) -> dict:
 def persisted_inference_row_from_wire_complete(
     wire_event: dict[str, object],
 ) -> PersistedInferenceRow:
+    from api.analytics.military_score_inference.host_turn_targets import (
+        host_turn_targets_from_wire_event,
+    )
+
     diagnostics = wire_event.get("diagnostics")
     wire_solutions = wire_event.get("solutions")
+    host_turn_targets = list(host_turn_targets_from_wire_event(wire_event))
     return PersistedInferenceRow(
         status=str(wire_event.get("status", "")),
         summary=str(wire_event.get("summary", "")),
@@ -45,6 +51,7 @@ def persisted_inference_row_from_wire_complete(
         is_complete=bool(wire_event.get("isComplete", True)),
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
+        host_turn_targets=host_turn_targets or None,
     )
 
 
@@ -59,4 +66,6 @@ def wire_complete_from_persisted_row(row: PersistedInferenceRow) -> dict[str, ob
     }
     if row.diagnostics is not None:
         payload["diagnostics"] = row.diagnostics
+    if row.host_turn_targets is not None:
+        payload["hostTurnTargets"] = row.host_turn_targets
     return payload

--- a/packages/api/api/serialization/inference_row_persistence.py
+++ b/packages/api/api/serialization/inference_row_persistence.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from dacite import from_dict
 
+from api.analytics.military_score_inference.host_turn_targets import (
+    host_turn_targets_from_accelerated_segments,
+)
 from api.serialization.codecs import DACITE_CONFIG, dataclass_to_json
+
+INFERENCE_ROW_PERSISTENCE_VERSION = 2
 
 
 @dataclass
@@ -20,6 +25,7 @@ class PersistedInferenceRow:
     solutions: list[dict[str, object]]
     diagnostics: dict[str, object] | None = None
     host_turn_targets: list[dict[str, object]] | None = None
+    persistence_version: int | None = None
 
 
 def persisted_inference_row_from_json(data: dict) -> PersistedInferenceRow:
@@ -32,6 +38,32 @@ def persisted_inference_row_from_json(data: dict) -> PersistedInferenceRow:
 
 def persisted_inference_row_to_json(row: PersistedInferenceRow) -> dict:
     return dataclass_to_json(row)
+
+
+def upgrade_persisted_inference_row(
+    row: PersistedInferenceRow,
+) -> tuple[PersistedInferenceRow, bool]:
+    """Migrate legacy v1 rows to v2 functional host-turn targets on read."""
+    if (
+        row.persistence_version is not None
+        and row.persistence_version >= INFERENCE_ROW_PERSISTENCE_VERSION
+    ):
+        return row, False
+
+    host_turn_targets = row.host_turn_targets
+    if not host_turn_targets and row.diagnostics is not None:
+        upgraded_targets = host_turn_targets_from_accelerated_segments(
+            row.diagnostics.get("accelerated_segments"),
+        )
+        if upgraded_targets:
+            host_turn_targets = list(upgraded_targets)
+
+    upgraded = replace(
+        row,
+        host_turn_targets=host_turn_targets,
+        persistence_version=INFERENCE_ROW_PERSISTENCE_VERSION,
+    )
+    return upgraded, upgraded != row
 
 
 def persisted_inference_row_from_wire_complete(
@@ -52,6 +84,7 @@ def persisted_inference_row_from_wire_complete(
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
         host_turn_targets=host_turn_targets or None,
+        persistence_version=INFERENCE_ROW_PERSISTENCE_VERSION,
     )
 
 

--- a/packages/api/api/serialization/inference_row_persistence.py
+++ b/packages/api/api/serialization/inference_row_persistence.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass, replace
 from dacite import from_dict
 
 from api.analytics.military_score_inference.host_turn_targets import (
+    HostTurnFunctionalTarget,
+    host_turn_functional_target_from_persistence_dict,
+    host_turn_functional_target_to_persistence_dict,
+    host_turn_functional_target_to_wire_dict,
     host_turn_targets_from_accelerated_segments,
+    host_turn_targets_from_wire_event,
 )
 from api.serialization.codecs import DACITE_CONFIG, dataclass_to_json
 
@@ -24,20 +29,38 @@ class PersistedInferenceRow:
     is_complete: bool
     solutions: list[dict[str, object]]
     diagnostics: dict[str, object] | None = None
-    host_turn_targets: list[dict[str, object]] | None = None
+    host_turn_targets: list[HostTurnFunctionalTarget] | None = None
     persistence_version: int | None = None
 
 
 def persisted_inference_row_from_json(data: dict) -> PersistedInferenceRow:
-    return from_dict(
+    payload = dict(data)
+    raw_targets = payload.pop("host_turn_targets", None)
+    row = from_dict(
         data_class=PersistedInferenceRow,
-        data=data,
+        data=payload,
         config=DACITE_CONFIG,
     )
+    if not isinstance(raw_targets, list):
+        return row
+    targets = [
+        host_turn_functional_target_from_persistence_dict(entry)
+        for entry in raw_targets
+        if isinstance(entry, dict)
+    ]
+    if not targets:
+        return row
+    return replace(row, host_turn_targets=targets)
 
 
 def persisted_inference_row_to_json(row: PersistedInferenceRow) -> dict:
-    return dataclass_to_json(row)
+    payload = dataclass_to_json(row)
+    if row.host_turn_targets is not None:
+        payload["host_turn_targets"] = [
+            host_turn_functional_target_to_persistence_dict(target)
+            for target in row.host_turn_targets
+        ]
+    return payload
 
 
 def upgrade_persisted_inference_row(
@@ -69,10 +92,6 @@ def upgrade_persisted_inference_row(
 def persisted_inference_row_from_wire_complete(
     wire_event: dict[str, object],
 ) -> PersistedInferenceRow:
-    from api.analytics.military_score_inference.host_turn_targets import (
-        host_turn_targets_from_wire_event,
-    )
-
     diagnostics = wire_event.get("diagnostics")
     wire_solutions = wire_event.get("solutions")
     host_turn_targets = list(host_turn_targets_from_wire_event(wire_event))
@@ -100,5 +119,7 @@ def wire_complete_from_persisted_row(row: PersistedInferenceRow) -> dict[str, ob
     if row.diagnostics is not None:
         payload["diagnostics"] = row.diagnostics
     if row.host_turn_targets is not None:
-        payload["hostTurnTargets"] = row.host_turn_targets
+        payload["hostTurnTargets"] = [
+            host_turn_functional_target_to_wire_dict(target) for target in row.host_turn_targets
+        ]
     return payload

--- a/packages/api/api/services/inference_row_persistence_service.py
+++ b/packages/api/api/services/inference_row_persistence_service.py
@@ -19,6 +19,7 @@ from api.serialization.inference_row_persistence import (
     persisted_inference_row_from_json,
     persisted_inference_row_from_wire_complete,
     persisted_inference_row_to_json,
+    upgrade_persisted_inference_row,
     wire_complete_from_persisted_row,
 )
 from api.storage.base import StorageBackend
@@ -68,7 +69,11 @@ class InferenceRowPersistenceService:
             return None
         if not isinstance(data, dict):
             raise ValidationError("stored inference row must be a JSON object")
-        return persisted_inference_row_from_json(data)
+        row = persisted_inference_row_from_json(data)
+        upgraded, changed = upgrade_persisted_inference_row(row)
+        if changed:
+            self.put_row(game_id, perspective, host_turn, player_id, upgraded)
+        return upgraded
 
     def wire_complete_for_row(
         self,

--- a/packages/api/api/transport/inference_stream.py
+++ b/packages/api/api/transport/inference_stream.py
@@ -59,6 +59,7 @@ def inference_complete_event(
     is_complete: bool = True,
     diagnostics: dict[str, object] | None = None,
     solutions: list[dict[str, object]] | None = None,
+    host_turn_targets: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "type": "complete",
@@ -71,6 +72,8 @@ def inference_complete_event(
         payload["solutions"] = solutions
     if diagnostics is not None:
         payload["diagnostics"] = diagnostics
+    if host_turn_targets is not None:
+        payload["hostTurnTargets"] = host_turn_targets
     return payload
 
 

--- a/packages/api/api/transport/inference_stream_wire.py
+++ b/packages/api/api/transport/inference_stream_wire.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from api.analytics.military_score_inference.host_turn_targets import (
+    host_turn_functional_target_to_wire_dict,
+    host_turn_functional_targets_from_wire_list,
+)
 from api.analytics.military_score_inference.inference_api_payload import (
     serialize_solutions_with_arithmetic,
 )
@@ -24,13 +28,21 @@ from api.transport.inference_stream import (
 )
 
 
+def _wire_host_turn_targets(
+    host_turn_targets: object,
+) -> list[dict[str, object]] | None:
+    parsed = host_turn_functional_targets_from_wire_list(host_turn_targets)
+    if parsed is None:
+        return None
+    return [host_turn_functional_target_to_wire_dict(target) for target in parsed]
+
+
 def inference_api_payload_to_wire_complete(
     payload: dict[str, object],
 ) -> dict[str, object]:
     """Shape a scores row inference API payload into a terminal wire ``complete`` event."""
     wire_solutions = payload.get("solutions")
     diagnostics = payload.get("diagnostics")
-    host_turn_targets = payload.get("hostTurnTargets")
     return inference_complete_event(
         status=str(payload.get("status", "")),
         summary=str(payload.get("summary", "")),
@@ -38,7 +50,7 @@ def inference_api_payload_to_wire_complete(
         is_complete=bool(payload.get("isComplete", True)),
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
-        host_turn_targets=(host_turn_targets if isinstance(host_turn_targets, list) else None),
+        host_turn_targets=_wire_host_turn_targets(payload.get("hostTurnTargets")),
     )
 
 
@@ -49,6 +61,11 @@ def row_complete_to_complete_wire_event(
     turn: TurnInfo,
 ) -> dict[str, object]:
     payload = event.wire_payload
+    wire_targets = None
+    if payload.host_turn_targets is not None:
+        wire_targets = [
+            host_turn_functional_target_to_wire_dict(target) for target in payload.host_turn_targets
+        ]
     return inference_complete_event(
         status=payload.status,
         summary=payload.summary,
@@ -56,7 +73,7 @@ def row_complete_to_complete_wire_event(
         is_complete=payload.is_complete,
         diagnostics=payload.diagnostics,
         solutions=payload.solutions,
-        host_turn_targets=payload.host_turn_targets,
+        host_turn_targets=wire_targets,
     )
 
 

--- a/packages/api/api/transport/inference_stream_wire.py
+++ b/packages/api/api/transport/inference_stream_wire.py
@@ -30,6 +30,7 @@ def inference_api_payload_to_wire_complete(
     """Shape a scores row inference API payload into a terminal wire ``complete`` event."""
     wire_solutions = payload.get("solutions")
     diagnostics = payload.get("diagnostics")
+    host_turn_targets = payload.get("hostTurnTargets")
     return inference_complete_event(
         status=str(payload.get("status", "")),
         summary=str(payload.get("summary", "")),
@@ -37,6 +38,7 @@ def inference_api_payload_to_wire_complete(
         is_complete=bool(payload.get("isComplete", True)),
         diagnostics=diagnostics if isinstance(diagnostics, dict) else None,
         solutions=wire_solutions if isinstance(wire_solutions, list) else [],
+        host_turn_targets=(host_turn_targets if isinstance(host_turn_targets, list) else None),
     )
 
 
@@ -54,6 +56,7 @@ def row_complete_to_complete_wire_event(
         is_complete=payload.is_complete,
         diagnostics=payload.diagnostics,
         solutions=payload.solutions,
+        host_turn_targets=payload.host_turn_targets,
     )
 
 

--- a/packages/api/tests/scores_exports_helpers.py
+++ b/packages/api/tests/scores_exports_helpers.py
@@ -19,6 +19,7 @@ from api.analytics.military_score_inference.models import (
 )
 from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
 from api.analytics.options import TurnAnalyticsOptions
+from api.analytics.scores.export_precedence import ScoresExportResolutionContext
 from api.analytics.scores.export_services import ScoresExportContext
 from api.analytics.scores.exports import EXPORT_CATALOG
 from api.serialization.inference_row_persistence import PersistedInferenceRow
@@ -50,6 +51,29 @@ def perspective(sample_turn) -> int:
 
 def first_player_id(sample_turn) -> int:
     return sample_turn.scores[0].ownerid
+
+
+def minimal_scores_export_resolution_context(
+    sample_turn,
+    *,
+    scoreboard_turn: int = 1,
+    player_id: int | None = None,
+) -> ScoresExportResolutionContext:
+    """Context for unit tests that do not exercise functional host-turn backfill.
+
+    scoreboard_turn defaults to 1 so scoreboard_host_turn is None and functional
+    resolution is skipped unless a test overrides scoreboard_turn.
+    """
+    pid = player_id if player_id is not None else first_player_id(sample_turn)
+    score = next((row for row in sample_turn.scores if row.ownerid == pid), None)
+    return ScoresExportResolutionContext(
+        scoreboard_turn=scoreboard_turn,
+        turn=sample_turn,
+        player_id=pid,
+        load_scoreboard_turn=lambda _: None,
+        get_persisted_row=None,
+        player_score=score,
+    )
 
 
 def stream_scope_for_turn(

--- a/packages/api/tests/test_fleet_inference_ingest.py
+++ b/packages/api/tests/test_fleet_inference_ingest.py
@@ -14,10 +14,6 @@ from api.analytics.fleet.types import (
     FleetFieldKnown,
     FleetFieldUnknown,
 )
-from api.analytics.military_score_inference.accelerated_start import (
-    ACCEL_WINDOW_SEGMENT_ID,
-    REPORTED_HOST_TURN_SEGMENT_ID,
-)
 from api.analytics.military_score_inference.analytic import infer_military_score_build
 from api.analytics.military_score_inference.host_turn_targets import (
     host_turn_targets_from_wire_event,
@@ -723,10 +719,6 @@ def test_accelerated_first_reliable_turn_creates_segment_placeholders_for_root()
         event = next(event for event in record.events if event.kind == "scoreboard_delta")
         assert event.payload["acceleratedIngest"] is True
         assert event.payload["segmentHostTurn"] == _known_built_turn(record)
-        assert event.payload["segmentId"] in {
-            ACCEL_WINDOW_SEGMENT_ID,
-            REPORTED_HOST_TURN_SEGMENT_ID,
-        }
 
 
 def test_accelerated_first_reliable_refines_segment_option_sets_for_root():
@@ -826,11 +818,7 @@ def test_accelerated_first_reliable_window_freighter_placeholder():
     window_row = next(
         record
         for record in freighter_rows
-        if any(
-            event.kind == "scoreboard_delta"
-            and event.payload.get("segmentId") == ACCEL_WINDOW_SEGMENT_ID
-            for event in record.events
-        )
+        if record not in starting_rows and _known_built_turn(record) == 1
     )
     assert _known_built_turn(window_row) == 1
 

--- a/packages/api/tests/test_fleet_inference_ingest.py
+++ b/packages/api/tests/test_fleet_inference_ingest.py
@@ -19,6 +19,9 @@ from api.analytics.military_score_inference.accelerated_start import (
     REPORTED_HOST_TURN_SEGMENT_ID,
 )
 from api.analytics.military_score_inference.analytic import infer_military_score_build
+from api.analytics.military_score_inference.host_turn_targets import (
+    host_turn_targets_from_wire_event,
+)
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
     reset_inference_row_scheduler_for_tests,
@@ -29,6 +32,7 @@ from api.analytics.scores.export_services import ScoresExportContext
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.storage.memory_asset import MemoryAssetBackend
+from api.transport.inference_stream_wire import inference_api_payload_to_wire_complete
 
 from tests.fleet_fixtures import ledger_for_player, single_ship_turn
 from tests.inference_corpus.fixtures import load_turn_fixture
@@ -763,6 +767,47 @@ def test_accelerated_first_reliable_refines_segment_option_sets_for_root():
         inference_event = next(event for event in record.events if event.kind == "inference_update")
         assert inference_event.payload["acceleratedIngest"] is True
         assert inference_event.payload["segmentHostTurn"] == _known_built_turn(record)
+
+
+def test_accelerated_first_reliable_refines_without_scores_diagnostics():
+    turn = load_turn_fixture("628580/1/turns/3.json")
+    player_id = 11
+    score = next(entry for entry in turn.scores if entry.ownerid == player_id)
+    inference_payload = infer_military_score_build(score, turn)
+    wire_complete = inference_api_payload_to_wire_complete(inference_payload)
+    host_turn_targets = list(host_turn_targets_from_wire_event(wire_complete))
+    assert host_turn_targets
+    persistence = InferenceRowPersistenceService(MemoryAssetBackend(initial={}))
+    persistence.put_row(
+        628580,
+        1,
+        3,
+        player_id,
+        PersistedInferenceRow(
+            status=str(inference_payload["status"]),
+            summary=str(inference_payload["summary"]),
+            solution_count=int(inference_payload["solutionCount"]),
+            is_complete=True,
+            solutions=inference_payload["solutions"],
+            diagnostics=None,
+            host_turn_targets=host_turn_targets,
+        ),
+    )
+    snapshot = apply_fleet_turn_delta(
+        ensure_fleet_baseline(628580, 1, turn),
+        turn,
+        inference_materialization=_inference_materialization(
+            FleetInferenceSupport(scores_services=ScoresExportContext(persistence=persistence)),
+            turn,
+        ),
+    )
+
+    ledger = ledger_for_player(snapshot, player_id)
+    warship_rows = _inferred_warship_rows(ledger, shell_turn=3)
+    assert len(warship_rows) == 2
+    for record in warship_rows:
+        assert len(record.build_option_sets) == 1
+        assert record.build_option_sets[0].combo_id == "combo_96_9_5_6_4_2"
 
 
 def test_accelerated_first_reliable_window_freighter_placeholder():

--- a/packages/api/tests/test_host_turn_functional_target.py
+++ b/packages/api/tests/test_host_turn_functional_target.py
@@ -1,0 +1,120 @@
+"""Tests for typed HostTurnFunctionalTarget codecs."""
+
+from __future__ import annotations
+
+from api.analytics.military_score_inference.analytic import infer_military_score_build
+from api.analytics.military_score_inference.host_turn_targets import (
+    HostTurnFunctionalTarget,
+    functional_host_turn_target_from_segment_payload,
+    host_turn_functional_target_from_persistence_dict,
+    host_turn_functional_target_from_wire_dict,
+    host_turn_functional_target_to_persistence_dict,
+    host_turn_functional_target_to_wire_dict,
+    host_turn_targets_from_wire_event,
+)
+from api.analytics.scores.host_turn_export import (
+    functional_target_for_host_turn,
+    host_turn_targets_from_persisted_row,
+)
+from api.serialization.inference_row_persistence import (
+    INFERENCE_ROW_PERSISTENCE_VERSION,
+    PersistedInferenceRow,
+    persisted_inference_row_from_json,
+    persisted_inference_row_to_json,
+)
+from api.transport.inference_stream_wire import inference_api_payload_to_wire_complete
+
+from tests.inference_corpus.fixtures import load_turn_fixture
+
+
+def _sample_wire_target() -> dict[str, object]:
+    turn = load_turn_fixture("628580/1/turns/3.json")
+    score = next(entry for entry in turn.scores if entry.ownerid == 11)
+    wire_complete = inference_api_payload_to_wire_complete(infer_military_score_build(score, turn))
+    targets = host_turn_targets_from_wire_event(wire_complete)
+    assert targets
+    return host_turn_functional_target_to_wire_dict(targets[0])
+
+
+def test_host_turn_functional_target_wire_round_trip():
+    wire = _sample_wire_target()
+    target = host_turn_functional_target_from_wire_dict(wire)
+    assert isinstance(target, HostTurnFunctionalTarget)
+    assert host_turn_functional_target_to_wire_dict(target) == wire
+
+
+def test_host_turn_functional_target_persistence_round_trip():
+    target = host_turn_functional_target_from_wire_dict(_sample_wire_target())
+    persisted = host_turn_functional_target_to_persistence_dict(target)
+    restored = host_turn_functional_target_from_persistence_dict(persisted)
+    assert restored == target
+
+
+def test_persisted_inference_row_host_turn_targets_round_trip():
+    target = host_turn_functional_target_from_wire_dict(_sample_wire_target())
+    row = PersistedInferenceRow(
+        status="exact",
+        summary="ok",
+        solution_count=target.solution_count,
+        is_complete=True,
+        solutions=target.solutions,
+        host_turn_targets=[target],
+        persistence_version=INFERENCE_ROW_PERSISTENCE_VERSION,
+    )
+    restored = persisted_inference_row_from_json(persisted_inference_row_to_json(row))
+    assert restored == row
+    stored_targets = persisted_inference_row_to_json(row)["host_turn_targets"]
+    assert stored_targets
+    assert "host_turn" in stored_targets[0]
+    assert "hostTurn" not in stored_targets[0]
+
+
+def test_legacy_camel_case_persistence_dict_still_loads():
+    wire = _sample_wire_target()
+    row = persisted_inference_row_from_json(
+        {
+            "status": "exact",
+            "summary": "ok",
+            "solution_count": 1,
+            "is_complete": True,
+            "solutions": [],
+            "host_turn_targets": [wire],
+            "persistence_version": INFERENCE_ROW_PERSISTENCE_VERSION,
+        },
+    )
+    assert row.host_turn_targets
+    assert row.host_turn_targets[0].host_turn == wire["hostTurn"]
+
+
+def test_functional_target_for_host_turn_uses_typed_fields():
+    target = host_turn_functional_target_from_wire_dict(_sample_wire_target())
+    row = PersistedInferenceRow(
+        status="exact",
+        summary="ok",
+        solution_count=target.solution_count,
+        is_complete=True,
+        solutions=[],
+        host_turn_targets=[target],
+        persistence_version=INFERENCE_ROW_PERSISTENCE_VERSION,
+    )
+    targets = host_turn_targets_from_persisted_row(row)
+    resolved = functional_target_for_host_turn(targets, target.host_turn)
+    assert resolved is target
+
+
+def test_functional_host_turn_target_strips_segment_diagnostics():
+    segment = {
+        "segmentId": "seg-1",
+        "hostTurn": 2,
+        "status": "exact",
+        "solutionCount": 1,
+        "militaryDelta2x": 10,
+        "warshipDelta": 1,
+        "freighterDelta": 0,
+        "policyStepsAttempted": ["baseline"],
+        "solutions": [{"objectiveValue": 1.0, "actions": [], "shipBuilds": []}],
+    }
+    target = functional_host_turn_target_from_segment_payload(segment)
+    wire = host_turn_functional_target_to_wire_dict(target)
+    assert "segmentId" not in wire
+    assert "policyStepsAttempted" not in wire

--- a/packages/api/tests/test_host_turn_functional_target.py
+++ b/packages/api/tests/test_host_turn_functional_target.py
@@ -12,7 +12,9 @@ from api.analytics.military_score_inference.host_turn_targets import (
     host_turn_functional_target_to_wire_dict,
     host_turn_targets_from_wire_event,
 )
+from api.analytics.military_score_inference.solver import STATUS_TIME_LIMITED
 from api.analytics.scores.host_turn_export import (
+    _payload_from_functional_target,
     functional_target_for_host_turn,
     host_turn_targets_from_persisted_row,
 )
@@ -100,6 +102,21 @@ def test_functional_target_for_host_turn_uses_typed_fields():
     targets = host_turn_targets_from_persisted_row(row)
     resolved = functional_target_for_host_turn(targets, target.host_turn)
     assert resolved is target
+
+
+def test_functional_target_time_limited_maps_to_stopped_search_status():
+    target = host_turn_functional_target_from_wire_dict(_sample_wire_target())
+    time_limited = HostTurnFunctionalTarget(
+        host_turn=target.host_turn,
+        status=STATUS_TIME_LIMITED,
+        solution_count=target.solution_count,
+        military_delta_2x=target.military_delta_2x,
+        warship_delta=target.warship_delta,
+        freighter_delta=target.freighter_delta,
+        solutions=target.solutions,
+    )
+    payload = _payload_from_functional_target(time_limited)
+    assert payload.search_status == "stopped"
 
 
 def test_functional_host_turn_target_strips_segment_diagnostics():

--- a/packages/api/tests/test_inference_row_persistence.py
+++ b/packages/api/tests/test_inference_row_persistence.py
@@ -19,7 +19,11 @@ from api.analytics.military_score_inference.inference_table_stream_registry impo
     reset_inference_table_stream_registry_for_tests,
 )
 from api.analytics.military_score_inference.solver import STATUS_EXACT
-from api.serialization.inference_row_persistence import PersistedInferenceRow
+from api.serialization.inference_row_persistence import (
+    INFERENCE_ROW_PERSISTENCE_VERSION,
+    PersistedInferenceRow,
+    upgrade_persisted_inference_row,
+)
 from api.services.inference_invalidation_service import InferenceInvalidationService
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.services.stack import build_service_stack
@@ -51,6 +55,7 @@ def test_persistence_row_round_trip(persistence):
         is_complete=True,
         solutions=[{"objectiveValue": 1.0, "actions": [], "shipBuilds": []}],
         diagnostics={"playerId": 8},
+        persistence_version=INFERENCE_ROW_PERSISTENCE_VERSION,
     )
     persistence.put_row(628580, 1, 111, 8, row)
     loaded = persistence.get_row(628580, 1, 111, 8)
@@ -189,3 +194,119 @@ def test_reschedule_without_active_stream_is_noop():
     reset_inference_table_stream_registry_for_tests()
     scope = InferenceStreamScope(game_id=628580, perspective=1, turn_number=111)
     assert reschedule_inference_row(scope, 8) is False
+
+
+def _legacy_v1_split_row_from_turn_three():
+    from api.analytics.military_score_inference.analytic import infer_military_score_build
+    from api.transport.inference_stream_wire import inference_api_payload_to_wire_complete
+
+    from tests.inference_corpus.fixtures import load_turn_fixture
+
+    turn_three = load_turn_fixture("628580/1/turns/3.json")
+    player_id = 11
+    score = next(entry for entry in turn_three.scores if entry.ownerid == player_id)
+    inference_payload = infer_military_score_build(score, turn_three)
+    wire_complete = inference_api_payload_to_wire_complete(inference_payload)
+    diagnostics = wire_complete.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    assert diagnostics.get("accelerated_segments")
+    return (
+        turn_three,
+        player_id,
+        PersistedInferenceRow(
+            status=str(inference_payload["status"]),
+            summary=str(inference_payload["summary"]),
+            solution_count=int(inference_payload["solutionCount"]),
+            is_complete=True,
+            solutions=inference_payload["solutions"],
+            diagnostics=diagnostics,
+            host_turn_targets=None,
+            persistence_version=None,
+        ),
+    )
+
+
+def test_upgrade_persisted_inference_row_copies_accelerated_segments():
+    _, _, legacy_row = _legacy_v1_split_row_from_turn_three()
+    upgraded, changed = upgrade_persisted_inference_row(legacy_row)
+    assert changed is True
+    assert upgraded.persistence_version == INFERENCE_ROW_PERSISTENCE_VERSION
+    assert upgraded.host_turn_targets
+    assert all(isinstance(target, dict) for target in upgraded.host_turn_targets)
+    assert "accelerated_segments" not in (upgraded.host_turn_targets[0] or {})
+
+
+def test_get_row_upgrades_legacy_v1_split_row_with_write_back(memory_backend):
+    turn_three, player_id, legacy_row = _legacy_v1_split_row_from_turn_three()
+    persistence = InferenceRowPersistenceService(memory_backend)
+    persistence.put_row(628580, 1, turn_three.settings.turn, player_id, legacy_row)
+
+    store_key = persistence.row_store_key(
+        628580,
+        1,
+        turn_three.settings.turn,
+        player_id,
+    )
+    stored_before = memory_backend.get(store_key)
+    assert stored_before is not None
+    assert stored_before.get("host_turn_targets") is None
+    assert stored_before.get("persistence_version") is None
+
+    loaded = persistence.get_row(628580, 1, turn_three.settings.turn, player_id)
+    assert loaded is not None
+    assert loaded.persistence_version == INFERENCE_ROW_PERSISTENCE_VERSION
+    assert loaded.host_turn_targets
+
+    stored_after = memory_backend.get(store_key)
+    assert stored_after is not None
+    assert stored_after.get("persistence_version") == INFERENCE_ROW_PERSISTENCE_VERSION
+    assert stored_after.get("host_turn_targets")
+
+    reloaded = persistence.get_row(628580, 1, turn_three.settings.turn, player_id)
+    assert reloaded == loaded
+
+
+def test_legacy_v1_upgrade_enables_functional_backfill_without_diagnostics():
+    from dataclasses import replace
+
+    from api.analytics.export_context import make_analytic_query_context
+    from api.analytics.export_types import ExportScope
+    from api.analytics.options import TurnAnalyticsOptions
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.analytics.scores.exports import held_scores_for_scope
+    from api.analytics.scores.host_turn_export import host_turn_targets_from_persisted_row
+
+    turn_three, player_id, legacy_row = _legacy_v1_split_row_from_turn_three()
+    turn_two = replace(turn_three, settings=replace(turn_three.settings, turn=2))
+    turn_two = replace(
+        turn_two,
+        scores=[replace(score, turn=2) for score in turn_two.scores],
+    )
+    persistence = InferenceRowPersistenceService(MemoryAssetBackend(initial={}))
+    persistence.put_row(628580, 1, turn_three.settings.turn, player_id, legacy_row)
+    loaded = persistence.get_row(628580, 1, turn_three.settings.turn, player_id)
+    assert loaded is not None
+    assert host_turn_targets_from_persisted_row(loaded)
+
+    def load_turn(turn_number: int):
+        if turn_number == 2:
+            return turn_two
+        if turn_number == 3:
+            return turn_three
+        return None
+
+    ctx = make_analytic_query_context(
+        turn_two,
+        TurnAnalyticsOptions(),
+        load_turn=load_turn,
+        export_services={"scores": ScoresExportContext(persistence=persistence)},
+    )
+    resolved = held_scores_for_scope(
+        ctx,
+        ExportScope(game_id=628580, perspective=1, turn=2, player_id=player_id),
+        turn=turn_two,
+    )
+    assert resolved.decision.branch == "functional_backfill"
+    assert resolved.payload.diagnostics is None
+    assert resolved.payload.solutions
+    assert resolved.payload.solutions_held > 0

--- a/packages/api/tests/test_inference_row_persistence.py
+++ b/packages/api/tests/test_inference_row_persistence.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import pytest
+from api.analytics.military_score_inference.host_turn_targets import HostTurnFunctionalTarget
 from api.analytics.military_score_inference.inference_scheduler import (
     get_inference_row_scheduler,
     reset_inference_row_scheduler_for_tests,
@@ -232,8 +233,10 @@ def test_upgrade_persisted_inference_row_copies_accelerated_segments():
     assert changed is True
     assert upgraded.persistence_version == INFERENCE_ROW_PERSISTENCE_VERSION
     assert upgraded.host_turn_targets
-    assert all(isinstance(target, dict) for target in upgraded.host_turn_targets)
-    assert "accelerated_segments" not in (upgraded.host_turn_targets[0] or {})
+    assert all(
+        isinstance(target, HostTurnFunctionalTarget) for target in upgraded.host_turn_targets
+    )
+    assert upgraded.host_turn_targets[0].host_turn
 
 
 def test_get_row_upgrades_legacy_v1_split_row_with_write_back(memory_backend):

--- a/packages/api/tests/test_scores_export_precedence.py
+++ b/packages/api/tests/test_scores_export_precedence.py
@@ -391,3 +391,76 @@ def test_scheduler_branch_surfaces_ladder_diagnostics_from_snapshot(sample_turn)
     assert payload.diagnostics is not None
     assert payload.diagnostics["turn"] == sample_turn.settings.turn
     assert payload.diagnostics["solver"]["source"] == "scheduler_ladder"
+
+
+def test_functional_backfill_resolves_host_turn_targets_without_diagnostics(sample_turn):
+    from dataclasses import replace
+
+    from api.analytics.export_context import make_analytic_query_context
+    from api.analytics.export_types import ExportScope
+    from api.analytics.military_score_inference.analytic import infer_military_score_build
+    from api.analytics.military_score_inference.host_turn_targets import (
+        host_turn_targets_from_wire_event,
+    )
+    from api.analytics.options import TurnAnalyticsOptions
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.analytics.scores.exports import held_scores_for_scope
+    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+    from api.storage.memory_asset import MemoryAssetBackend
+    from api.transport.inference_stream_wire import inference_api_payload_to_wire_complete
+
+    from tests.inference_corpus.fixtures import load_turn_fixture
+
+    turn_three = load_turn_fixture("628580/1/turns/3.json")
+    turn_two = replace(turn_three, settings=replace(turn_three.settings, turn=2))
+    turn_two = replace(
+        turn_two,
+        scores=[replace(score, turn=2) for score in turn_two.scores],
+    )
+    player_id = 11
+    score = next(entry for entry in turn_three.scores if entry.ownerid == player_id)
+    inference_payload = infer_military_score_build(score, turn_three)
+    host_turn_targets = list(
+        host_turn_targets_from_wire_event(
+            inference_api_payload_to_wire_complete(inference_payload),
+        ),
+    )
+    persistence = InferenceRowPersistenceService(MemoryAssetBackend(initial={}))
+    persistence.put_row(
+        628580,
+        1,
+        3,
+        player_id,
+        PersistedInferenceRow(
+            status=str(inference_payload["status"]),
+            summary=str(inference_payload["summary"]),
+            solution_count=int(inference_payload["solutionCount"]),
+            is_complete=True,
+            solutions=inference_payload["solutions"],
+            diagnostics=None,
+            host_turn_targets=host_turn_targets,
+        ),
+    )
+
+    def load_turn(turn_number: int):
+        if turn_number == 2:
+            return turn_two
+        if turn_number == 3:
+            return turn_three
+        return None
+
+    ctx = make_analytic_query_context(
+        turn_two,
+        TurnAnalyticsOptions(),
+        load_turn=load_turn,
+        export_services={"scores": ScoresExportContext(persistence=persistence)},
+    )
+    resolved = held_scores_for_scope(
+        ctx,
+        ExportScope(game_id=628580, perspective=1, turn=2, player_id=player_id),
+        turn=turn_two,
+    )
+    assert resolved.decision.branch == "functional_backfill"
+    assert resolved.payload.diagnostics is None
+    assert resolved.payload.solutions
+    assert resolved.payload.solutions_held > 0

--- a/packages/api/tests/test_scores_export_precedence.py
+++ b/packages/api/tests/test_scores_export_precedence.py
@@ -24,6 +24,7 @@ from api.serialization.inference_row_persistence import PersistedInferenceRow
 from tests.scores_exports_helpers import (
     first_player_id,
     inference_solution,
+    minimal_scores_export_resolution_context,
     schedule_row_with_ladder,
     ship_build_wire,
     stream_scope_for_turn,
@@ -40,6 +41,7 @@ from tests.scores_exports_helpers import (
 )
 def test_fallback_persisted_terminal_statuses_resolve_complete_without_live_state(
     persisted_status: str,
+    sample_turn,
 ):
     snapshot = ScoresInferenceSnapshot(
         persisted_row=PersistedInferenceRow(
@@ -54,7 +56,10 @@ def test_fallback_persisted_terminal_statuses_resolve_complete_without_live_stat
         scheduler_run=None,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     payload = resolved.payload
     assert resolved.decision.search_status == "complete"
     assert payload.solutions == []
@@ -87,7 +92,10 @@ def test_active_scheduler_overrides_fallback_persisted_terminal_status(sample_tu
         scheduler_run=run,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     payload = resolved.payload
     assert resolved.decision.search_status == "in_progress"
     assert payload.solutions_held == 1
@@ -113,7 +121,10 @@ def test_scheduler_branch_search_status_in_progress(sample_turn):
         scheduler_run=run,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     assert resolved.decision.search_status == "in_progress"
     _ = resolved.payload
 
@@ -138,10 +149,16 @@ def test_decision_search_status_available_without_payload_materialization(sample
         scheduler_run=run,
         globally_paused=False,
     )
-    assert resolve_scores_export(snapshot).decision.search_status == "in_progress"
+    assert (
+        resolve_scores_export(
+            snapshot,
+            resolution_context=minimal_scores_export_resolution_context(sample_turn),
+        ).decision.search_status
+        == "in_progress"
+    )
 
 
-def test_cached_complete_admission_resolves_payload_from_event():
+def test_cached_complete_admission_resolves_payload_from_event(sample_turn):
     wire_event = {
         "type": "complete",
         "status": STATUS_EXACT,
@@ -171,7 +188,10 @@ def test_cached_complete_admission_resolves_payload_from_event():
         scheduler_run=None,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     payload = resolved.payload
     assert resolved.decision.search_status == "complete"
     assert payload.solutions_held == 1
@@ -179,7 +199,7 @@ def test_cached_complete_admission_resolves_payload_from_event():
     assert payload.diagnostics == {"source": "cached_admission"}
 
 
-def test_stopped_terminal_admission_resolves_stopped_search_status():
+def test_stopped_terminal_admission_resolves_stopped_search_status(sample_turn):
     wire_event = {
         "type": "complete",
         "status": STATUS_STOPPED,
@@ -196,12 +216,15 @@ def test_stopped_terminal_admission_resolves_stopped_search_status():
         scheduler_run=None,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     assert resolved.decision.branch == "terminal_admission"
     assert resolved.decision.search_status == "stopped"
 
 
-def test_ensure_sync_admission_overrides_stream_admission_for_terminal_resolution():
+def test_ensure_sync_admission_overrides_stream_admission_for_terminal_resolution(sample_turn):
     stream_event = {
         "type": "complete",
         "status": STATUS_EXACT,
@@ -226,7 +249,10 @@ def test_ensure_sync_admission_overrides_stream_admission_for_terminal_resolutio
         scheduler_run=None,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     assert resolved.decision.branch == "terminal_admission"
     assert resolved.decision.search_status == "stopped"
     assert resolved.payload.diagnostics == {"source": "ensure_sync"}
@@ -328,8 +354,12 @@ def test_ensure_satisfied_tracks_precedence_branch(
     ensure_satisfied: bool,
     needs_ensure_work: bool,
     search_status: str,
+    sample_turn,
 ):
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     assert resolved.decision.branch == expected_branch
     assert resolved.decision.needs_ensure_work is needs_ensure_work
     assert resolved.decision.is_ensure_satisfied is ensure_satisfied
@@ -357,7 +387,10 @@ def test_scheduler_branch_ensure_satisfied_without_complete(sample_turn):
         scheduler_run=run,
         globally_paused=False,
     )
-    resolved = resolve_scores_export(snapshot)
+    resolved = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    )
     assert resolved.decision.branch == "scheduler"
     assert resolved.decision.needs_ensure_work is False
     assert resolved.decision.is_ensure_satisfied is True
@@ -387,7 +420,10 @@ def test_scheduler_branch_surfaces_ladder_diagnostics_from_snapshot(sample_turn)
         scheduler_run=run,
         globally_paused=False,
     )
-    payload = resolve_scores_export(snapshot).payload
+    payload = resolve_scores_export(
+        snapshot,
+        resolution_context=minimal_scores_export_resolution_context(sample_turn),
+    ).payload
     assert payload.diagnostics is not None
     assert payload.diagnostics["turn"] == sample_turn.settings.turn
     assert payload.diagnostics["solver"]["source"] == "scheduler_ladder"
@@ -464,3 +500,41 @@ def test_functional_backfill_resolves_host_turn_targets_without_diagnostics(samp
     assert resolved.payload.diagnostics is None
     assert resolved.payload.solutions
     assert resolved.payload.solutions_held > 0
+
+
+def test_resolve_scores_export_resolves_functional_payload_once(monkeypatch, sample_turn):
+    from api.analytics.scores import export_precedence
+
+    call_count = 0
+    original = export_precedence.resolve_functional_host_turn_payload
+
+    def counting_resolve(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        export_precedence,
+        "resolve_functional_host_turn_payload",
+        counting_resolve,
+    )
+
+    snapshot = ScoresInferenceSnapshot(
+        persisted_row=PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="exact",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+        stream_admission=None,
+        ensure_sync_admission=None,
+        scheduler_run=None,
+        globally_paused=False,
+    )
+    context = minimal_scores_export_resolution_context(
+        sample_turn,
+        scoreboard_turn=sample_turn.settings.turn,
+    )
+    resolve_scores_export(snapshot, resolution_context=context)
+    assert call_count == 1


### PR DESCRIPTION
## Summary

- Expose first-class host-turn functional inference via `hostTurnTargets` (wire/persistence) and `host_turn_export` resolution, so scores export normalizes `$.solutions` per scoreboard scope including accelerated backfill rows.
- Decouple fleet from `diagnostics.accelerated_segments`: uniform refine loop queries `scores@(builtTurn + 1)` through the export surface; accelerated placeholder metadata moves behind `scores.placeholder_targets`.
- Migrate legacy v1 inference rows to v2 on read (`host_turn_targets` from diagnostics when present); fleet materialization succeeds with diagnostics absent.
- Map `time_limited` host-turn export status to `stopped` for consistency with scores export lifecycle rules.

Closes #151.

## Test plan

- [x] `make test_api` (1011 passed, 6 skipped)
- [x] `test_fleet_inference_ingest.py` accelerated cases (628580 turn 3, diagnostics-free refine)
- [x] `test_scores_export_precedence.py` functional backfill without diagnostics
- [x] `test_inference_row_persistence.py` v1 upgrade on read
- [x] `test_host_turn_functional_target.py` including `time_limited` -> `stopped`


Made with [Cursor](https://cursor.com)