### PR TITLE
Fleet F6.6: Composition export branch for inference overlay consumers (#154)

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -31,6 +31,8 @@ The system is structured as four layers, each only ever depending on the layer(s
 **Do not leak UI concerns into the Core REST API layer.**
 **Do not put business logic in the BFF layer.**
 **Do not reference a concrete storage implementation outside `packages/api/storage/`.**
+**Shared primitives live below features.** If two analytics need the same lookup, codec, or scope filter, extract to `concepts/`, `serialization/`, or a dedicated shared module -- never import analytic A from analytic B for convenience.
+**One policy, one encoding.** Branching precedence, export classification, and similar policy must not be duplicated in parallel functions; share a decision record or table.
 
 ## Repo Structure
 

--- a/.cursor/rules/core-api.mdc
+++ b/.cursor/rules/core-api.mdc
@@ -29,6 +29,8 @@ packages/api/
 
 **Race-specific rules:** Anything keyed to a Planets.nu `raceid` lives in `concepts/races.py`. Analytic modules (including `analytics/military_score_inference/`) import helpers from there; they do not define new per-race constants locally. Game-wide rules (homeworld baselines, accelerated start) stay in the module that owns that behavior.
 
+**Placement before adding helpers:** Before adding helpers under `analytics/<feature>/`, check whether the operation is game-domain (`concepts/`), wire-shape (`serialization/`), or truly feature-specific. Wrong placement forces cross-feature imports later. See `implementation-quality.mdc`.
+
 ## Data Model
 
 - All domain objects defined as plain `@dataclass` classes in `packages/api/models/`

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -41,6 +41,7 @@ When investigating bugs, flaky tests, or unexplained behavior, read and follow `
 - **Never introduce tech debt silently.** A hack with no comment, a workaround that papers over a real problem, or a "temporary" fix that will never be revisited are all worse than stopping to discuss. If you can't do it right right now, surface it.
 - **Never add backward-compatibility shims unless explicitly asked.** Backward compatibility locks in old patterns and adds complexity. Use the current best approach. If you're unsure whether compatibility is required, ask.
 - **Move forward, not sideways.** When making a change, don't replicate the old pattern in a new location. Fix the pattern.
+- **Search, reuse, extract.** Before adding logic, follow `implementation-quality.mdc` (grep for existing helpers, respect layer boundaries, extract shared code in the same PR). "Move forward, not sideways" includes not leaving duplicate helpers for review to find later.
 
 ## Collaboration
 

--- a/.cursor/rules/implementation-quality.mdc
+++ b/.cursor/rules/implementation-quality.mdc
@@ -1,0 +1,61 @@
+---
+description: Implementation discipline -- reuse discovery, boundaries, DRY, and error handling. Apply when implementing any feature or fix.
+alwaysApply: true
+---
+
+# Implementation Quality
+
+These rules apply during implementation, not only at review. The goal is to ship the first diff with the structure a thermo-nuclear review would ask for.
+
+## 1. Search before you write
+
+Before adding a function, helper, filter, codec, or test fixture:
+
+1. **Grep and semantic-search** the repo for the operation by name and by behavior (e.g. "filter ledgers by scope", "max tech level", "histogram accumulate").
+2. **Check canonical homes** per `architecture.mdc` and package rules:
+   - `api/concepts/` -- game rules shared across analytics
+   - `api/serialization/` -- wire to domain codecs
+   - `packages/api/tests/*_helpers.py`, `*_fixtures.py` -- shared test utilities
+   - Frontend: `src/analytics/<id>/`, shared `components/`, existing Zod parsers
+3. If something exists or is **>80% similar**, **reuse or extend it** (parametrize, callback, small shared module) instead of copying.
+4. If reuse needs a new shared module, put it at the **lowest layer that owns the concept** and import upward -- do not import across analytic siblings for convenience.
+
+**Stop and discuss** only when extraction scope is large (new package, moving many call sites). Do not silently duplicate and defer to review.
+
+## 2. One owner per concept; no cross-boundary leakage
+
+- Respect layer rules in `architecture.mdc` (Frontend to BFF to API to storage).
+- **Do not import feature A from feature B** when both need the same primitive -- extract to `concepts/`, `serialization/`, or a neutral shared module.
+- BFF imports from API must stay on the **allowed surface** (metadata/catalog), never pull compute paths. Lazy imports are a smell -- fix the ownership model.
+- Keep modules **single-purpose**: precedence classifies; ensure persists; materialize builds trees. Do not let one file absorb unrelated concerns because it was already open in the editor.
+- UI semantics stay out of Core API; business logic stays out of BFF.
+
+## 3. Do not duplicate logic -- in the repo or in the diff
+
+- **Within the change:** if you write similar code a second time in the same PR, extract before merge (shared helper, table-driven loop, shared decision record).
+- **Parallel ladders:** if two functions encode the same branch order (classify vs build, probe vs ensure), share one decision structure or precedence table -- they will drift otherwise.
+- **Tests:** unit tests own pure logic and edge cases; integration tests own wiring and end-to-end contracts. Do not repeat unit assertions at integration level. Extract shared fixtures when the same setup appears in 2+ files.
+
+## 4. Errors are contracts, not assertions
+
+- **Production / library code:** invalid caller input, missing resources, and violated invariants use typed exceptions per `server-exceptions.mdc` (API/BFF) or explicit error returns at internal boundaries. See `core-api.mdc` for deserialize-then-validate -- not raw `dict` walks.
+- **`assert` is for:** tests; truly impossible internal states after prior validation (document why); debug-only checks. Never `assert` on user data, wire payloads, or scope/query parameters.
+- Prefer **explicit types** over `Union`/`Optional`/casts that hide invalid combinations. If a function accepts only a resolved snapshot, say so -- do not accept a union and branch at runtime.
+
+## 5. Prefer table-driven and data-driven over copy-paste
+
+When three or more branches differ only by field name, catalog key, or axis id, use a declarative table (list of specs, schema fragments, dispatch map) instead of copy-pasted blocks. This applies to histogram axes, export branches, and similar.
+
+## 6. Pre-merge self-check (implementer)
+
+Before calling work done, verify:
+
+- [ ] Grepped for existing helpers; reused or extracted shared code where found
+- [ ] No new cross-analytic imports for shared primitives
+- [ ] No parallel policy ladders without a shared decision source
+- [ ] No production `assert` on external or caller-controlled input
+- [ ] Tests split correctly (unit edges vs integration wiring); fixtures shared
+- [ ] Touched files still under ~1k lines, or decomposition done in this PR
+- [ ] `make test` (or package equivalent) passes for affected packages
+
+If any item fails, fix in this PR unless the user explicitly scoped it out.

--- a/.cursor/rules/planning.mdc
+++ b/.cursor/rules/planning.mdc
@@ -51,6 +51,16 @@ Never silently absorb scope. Every unplanned fix is a decision point.
 Before analysing code first analyse existing design documents.  Only analyse code if you need
 to clarify finer points that are ambiguous in the documentation in order to formulate the plan.
 
+## Reuse discovery (required before coding each phase)
+
+Each implementation phase must start with:
+
+1. Grep / search for existing helpers, codecs, fixtures, and patterns for the operations in that phase.
+2. Note in the plan: **reuse** (what), **extend** (how), or **extract** (new module and why nothing existing fits).
+3. Identify the **canonical layer** for any new shared code (`concepts/`, `serialization/`, neutral test fixtures, etc.).
+
+If the plan skips this, call that out and justify it. See `implementation-quality.mdc` for the full implementer checklist.
+
 ## Communicate the plan before executing
 
 Before starting any phase, confirm the user has seen and approved the plan for that phase. Don't begin implementation while the plan is still being discussed. A plan that isn't agreed on is just a guess.

--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -468,10 +468,17 @@ top_build = prior.paths["$.solutions[0]"].value  # full top explanation when pre
 ```python
 composition = ctx.query(
     "fleet",
-    paths=["$.composition.launcherTypes"],
+    paths=[
+        "$.composition.launcherTypes",
+        "$.composition.beamTypes",
+        "$.composition.hullTypes",
+        "$.composition.maxTechLevel",
+    ],
     scope={"turn": turn - 1, "player_id": player_id},
 )
 ```
+
+Fleet `$.composition` summarizes **known** fitted components on **active** ledger rows (histograms keyed by stringified host component id) plus `maxTechLevel` per axis (`hulls`, `engines`, `launchers`, `beams`) from the turn component catalog. Unknown or option-set-only rows are omitted from histograms; `torpedoTypesLoaded` stays empty until loaded-torp evidence is persisted on records.
 
 ---
 

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -349,6 +349,20 @@ Critical path: `0 -> 1 -> 2 -> 3 -> 4 -> 5`.
 | Feature | Use |
 |---------|-----|
 | **Homeworld locator** | SB / planet positions for **region** constraints on inferred builds |
-| **Scores** `#87` | Launcher/torp histogram overlay from `$.composition` export branch |
+| **Scores** `#87` | Component histogram and `maxTechLevel` overlay from `$.composition` (`hullTypes`, `beamTypes`, `launcherTypes`, `maxTechLevel`; `torpedoTypesLoaded` when ledger stores loaded ammo) |
 | Reports ingest | Strong evidence for loss/trade row selection |
 | Export ensure orchestration (#109) | Background unwind when fleet@N requires deep scores chain |
+
+### `$.composition` export branch (#154)
+
+Per-player, scoped by `player_id`. Materialized from active `FleetShipRecord` rows for the scoped player(s):
+
+| Path | Shape | Rule |
+|------|-------|------|
+| `$.composition.hullTypes` | `{ "<hullId>": <shipCount>, ... }` | Known `fields.hull` only |
+| `$.composition.beamTypes` | `{ "<beamId>": <shipCount>, ... }` | Known `fields.beams` with positive id |
+| `$.composition.launcherTypes` | `{ "<torpId>": <shipCount>, ... }` | Known `fields.launchers` (torp type id) with positive id |
+| `$.composition.torpedoTypesLoaded` | same histogram shape | Empty in v1 until loaded-torp evidence is on ledger rows |
+| `$.composition.maxTechLevel` | `{ "hulls"?, "engines"?, "launchers"?, "beams"? }` | Max `techlevel` from turn catalog for ids present in the histograms (engines from known `fields.engine` on rows). Axes with no catalog-resolvable ids omitted. |
+
+Unknown, bounded, options, and region field constraints are excluded from histograms. Known zero for beams/launchers (no fitted weapons) is excluded. Turn 1 baseline: empty histograms and `{}` `maxTechLevel`.

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Protocol
 
 from api.analytics.export_types import ExportScope
@@ -45,22 +46,8 @@ def _increment_component_histogram(
     histogram[key] = histogram.get(key, 0) + 1
 
 
-def _max_tech_level_for_histogram(
-    histogram: dict[str, int],
-    catalog: dict[int, _TechLevelComponent],
-) -> int | None:
-    max_level: int | None = None
-    for key in histogram:
-        component = catalog.get(int(key))
-        if component is None:
-            continue
-        if max_level is None or component.techlevel > max_level:
-            max_level = component.techlevel
-    return max_level
-
-
-def _max_tech_level_for_component_ids(
-    component_ids: list[int],
+def _max_tech_level(
+    component_ids: Iterable[int],
     catalog: dict[int, _TechLevelComponent],
 ) -> int | None:
     max_level: int | None = None
@@ -110,13 +97,15 @@ def build_fleet_composition_branch(
     torp_catalog = torpedos_by_id(turn)
 
     max_tech_level: dict[str, int] = {}
-    if hull_max := _max_tech_level_for_histogram(hull_types, hull_catalog):
+    if hull_max := _max_tech_level((int(key) for key in hull_types), hull_catalog):
         max_tech_level["hulls"] = hull_max
-    if engine_max := _max_tech_level_for_component_ids(engine_ids, engine_catalog):
+    if engine_max := _max_tech_level(engine_ids, engine_catalog):
         max_tech_level["engines"] = engine_max
-    if launcher_max := _max_tech_level_for_histogram(launcher_types, torp_catalog):
+    if launcher_max := _max_tech_level(
+        (int(key) for key in launcher_types), torp_catalog
+    ):
         max_tech_level["launchers"] = launcher_max
-    if beam_max := _max_tech_level_for_histogram(beam_types, beam_catalog):
+    if beam_max := _max_tech_level((int(key) for key in beam_types), beam_catalog):
         max_tech_level["beams"] = beam_max
 
     return {

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -1,0 +1,131 @@
+"""Fleet export composition branch: component histograms and max tech levels."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.types import (
+    FleetFieldConstraint,
+    FleetFieldKnown,
+    FleetShipRecord,
+    FleetTurnSnapshot,
+)
+from api.analytics.military_score_inference.ship_inventory import (
+    beams_by_id,
+    engines_by_id,
+    hulls_by_id,
+    torpedos_by_id,
+)
+from api.models.game import TurnInfo
+
+
+class _TechLevelComponent(Protocol):
+    techlevel: int
+
+
+def _known_positive_component_id(field: FleetFieldConstraint) -> int | None:
+    if not isinstance(field, FleetFieldKnown):
+        return None
+    value = field.value
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value
+
+
+def _increment_component_histogram(
+    histogram: dict[str, int],
+    field: FleetFieldConstraint,
+) -> None:
+    component_id = _known_positive_component_id(field)
+    if component_id is None:
+        return
+    key = str(component_id)
+    histogram[key] = histogram.get(key, 0) + 1
+
+
+def _max_tech_level_for_histogram(
+    histogram: dict[str, int],
+    catalog: dict[int, _TechLevelComponent],
+) -> int | None:
+    max_level: int | None = None
+    for key in histogram:
+        component = catalog.get(int(key))
+        if component is None:
+            continue
+        if max_level is None or component.techlevel > max_level:
+            max_level = component.techlevel
+    return max_level
+
+
+def _max_tech_level_for_component_ids(
+    component_ids: list[int],
+    catalog: dict[int, _TechLevelComponent],
+) -> int | None:
+    max_level: int | None = None
+    for component_id in component_ids:
+        component = catalog.get(component_id)
+        if component is None:
+            continue
+        if max_level is None or component.techlevel > max_level:
+            max_level = component.techlevel
+    return max_level
+
+
+def _active_records_for_scope(
+    snapshot: FleetTurnSnapshot,
+    scope: ExportScope,
+) -> list[FleetShipRecord]:
+    if scope.player_id is None:
+        ledgers = snapshot.players
+    else:
+        ledgers = [ledger for ledger in snapshot.players if ledger.player_id == scope.player_id]
+    records: list[FleetShipRecord] = []
+    for ledger in ledgers:
+        for record in ledger.records:
+            if record.disposition == "active":
+                records.append(record)
+    return records
+
+
+def build_fleet_composition_branch(
+    snapshot: FleetTurnSnapshot,
+    scope: ExportScope,
+    *,
+    turn: TurnInfo,
+) -> dict[str, object]:
+    hull_types: dict[str, int] = {}
+    beam_types: dict[str, int] = {}
+    launcher_types: dict[str, int] = {}
+    engine_ids: list[int] = []
+
+    for record in _active_records_for_scope(snapshot, scope):
+        _increment_component_histogram(hull_types, record.fields.hull)
+        _increment_component_histogram(beam_types, record.fields.beams)
+        _increment_component_histogram(launcher_types, record.fields.launchers)
+        engine_id = _known_positive_component_id(record.fields.engine)
+        if engine_id is not None:
+            engine_ids.append(engine_id)
+
+    hull_catalog = hulls_by_id(turn)
+    engine_catalog = engines_by_id(turn)
+    beam_catalog = beams_by_id(turn)
+    torp_catalog = torpedos_by_id(turn)
+
+    max_tech_level: dict[str, int] = {}
+    if hull_max := _max_tech_level_for_histogram(hull_types, hull_catalog):
+        max_tech_level["hulls"] = hull_max
+    if engine_max := _max_tech_level_for_component_ids(engine_ids, engine_catalog):
+        max_tech_level["engines"] = engine_max
+    if launcher_max := _max_tech_level_for_histogram(launcher_types, torp_catalog):
+        max_tech_level["launchers"] = launcher_max
+    if beam_max := _max_tech_level_for_histogram(beam_types, beam_catalog):
+        max_tech_level["beams"] = beam_max
+
+    return {
+        "hullTypes": hull_types,
+        "beamTypes": beam_types,
+        "launcherTypes": launcher_types,
+        "torpedoTypesLoaded": {},
+        "maxTechLevel": max_tech_level,
+    }

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -99,12 +99,31 @@ def _component_ids_for_axis(
     return (int(key) for key in histograms[axis.histogram_output_key])
 
 
+def _empty_fleet_composition_branch() -> dict[str, object]:
+    return {
+        "hullTypes": {},
+        "beamTypes": {},
+        "launcherTypes": {},
+        "torpedoTypesLoaded": {},
+        "maxTechLevel": {},
+    }
+
+
 def build_fleet_composition_branch(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
     *,
     turn: TurnInfo,
 ) -> dict[str, object]:
+    """Per-player composition histograms and max tech levels.
+
+    When ``scope.player_id`` is unset, returns an empty branch rather than
+    aggregating across all players. Unscoped composition paths are rejected at
+    query time; this keeps materialized trees safe for unscoped meta reads.
+    """
+    if scope.player_id is None:
+        return _empty_fleet_composition_branch()
+
     histograms: dict[str, dict[str, int]] = {
         axis.histogram_output_key: {}
         for axis in _COMPOSITION_AXIS_SPECS

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from api.analytics.export_types import ExportScope
+from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.types import (
     FleetFieldConstraint,
     FleetFieldKnown,
@@ -76,12 +77,8 @@ def _active_records_for_scope(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
 ) -> list[FleetShipRecord]:
-    if scope.player_id is None:
-        ledgers = snapshot.players
-    else:
-        ledgers = [ledger for ledger in snapshot.players if ledger.player_id == scope.player_id]
     records: list[FleetShipRecord] = []
-    for ledger in ledgers:
+    for ledger in ledgers_for_scope(snapshot, scope):
         for record in ledger.records:
             if record.disposition == "active":
                 records.append(record)

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Protocol
 
 from api.analytics.export_types import ExportScope
@@ -20,6 +21,22 @@ from api.concepts.turn_component_catalog import (
     torpedos_by_id,
 )
 from api.models.game import TurnInfo
+
+
+@dataclass(frozen=True, slots=True)
+class _CompositionAxisSpec:
+    field_name: str
+    histogram_output_key: str | None
+    max_tech_key: str
+    catalog_key: str
+
+
+_COMPOSITION_AXIS_SPECS: tuple[_CompositionAxisSpec, ...] = (
+    _CompositionAxisSpec("hull", "hullTypes", "hulls", "hulls"),
+    _CompositionAxisSpec("beams", "beamTypes", "beams", "beams"),
+    _CompositionAxisSpec("launchers", "launcherTypes", "launchers", "launchers"),
+    _CompositionAxisSpec("engine", None, "engines", "engines"),
+)
 
 
 class _TechLevelComponent(Protocol):
@@ -72,46 +89,56 @@ def _active_records_for_scope(
     return records
 
 
+def _component_ids_for_axis(
+    axis: _CompositionAxisSpec,
+    histograms: dict[str, dict[str, int]],
+    engine_ids: list[int],
+) -> Iterable[int]:
+    if axis.histogram_output_key is None:
+        return engine_ids
+    return (int(key) for key in histograms[axis.histogram_output_key])
+
+
 def build_fleet_composition_branch(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
     *,
     turn: TurnInfo,
 ) -> dict[str, object]:
-    hull_types: dict[str, int] = {}
-    beam_types: dict[str, int] = {}
-    launcher_types: dict[str, int] = {}
+    histograms: dict[str, dict[str, int]] = {
+        axis.histogram_output_key: {}
+        for axis in _COMPOSITION_AXIS_SPECS
+        if axis.histogram_output_key is not None
+    }
     engine_ids: list[int] = []
 
     for record in _active_records_for_scope(snapshot, scope):
-        _increment_component_histogram(hull_types, record.fields.hull)
-        _increment_component_histogram(beam_types, record.fields.beams)
-        _increment_component_histogram(launcher_types, record.fields.launchers)
-        engine_id = _known_positive_component_id(record.fields.engine)
-        if engine_id is not None:
-            engine_ids.append(engine_id)
+        for axis in _COMPOSITION_AXIS_SPECS:
+            field = getattr(record.fields, axis.field_name)
+            if axis.histogram_output_key is None:
+                component_id = _known_positive_component_id(field)
+                if component_id is not None:
+                    engine_ids.append(component_id)
+            else:
+                _increment_component_histogram(histograms[axis.histogram_output_key], field)
 
-    hull_catalog = hulls_by_id(turn)
-    engine_catalog = engines_by_id(turn)
-    beam_catalog = beams_by_id(turn)
-    torp_catalog = torpedos_by_id(turn)
+    catalogs: dict[str, dict[int, _TechLevelComponent]] = {
+        "hulls": hulls_by_id(turn),
+        "engines": engines_by_id(turn),
+        "beams": beams_by_id(turn),
+        "launchers": torpedos_by_id(turn),
+    }
 
     max_tech_level: dict[str, int] = {}
-    if hull_max := _max_tech_level((int(key) for key in hull_types), hull_catalog):
-        max_tech_level["hulls"] = hull_max
-    if engine_max := _max_tech_level(engine_ids, engine_catalog):
-        max_tech_level["engines"] = engine_max
-    if launcher_max := _max_tech_level(
-        (int(key) for key in launcher_types), torp_catalog
-    ):
-        max_tech_level["launchers"] = launcher_max
-    if beam_max := _max_tech_level((int(key) for key in beam_types), beam_catalog):
-        max_tech_level["beams"] = beam_max
+    for axis in _COMPOSITION_AXIS_SPECS:
+        if axis_max := _max_tech_level(
+            _component_ids_for_axis(axis, histograms, engine_ids),
+            catalogs[axis.catalog_key],
+        ):
+            max_tech_level[axis.max_tech_key] = axis_max
 
     return {
-        "hullTypes": hull_types,
-        "beamTypes": beam_types,
-        "launcherTypes": launcher_types,
+        **histograms,
         "torpedoTypesLoaded": {},
         "maxTechLevel": max_tech_level,
     }

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -11,7 +11,7 @@ from api.analytics.fleet.types import (
     FleetShipRecord,
     FleetTurnSnapshot,
 )
-from api.analytics.military_score_inference.ship_inventory import (
+from api.concepts.turn_component_catalog import (
     beams_by_id,
     engines_by_id,
     hulls_by_id,

--- a/packages/api/api/analytics/fleet/export_schema.py
+++ b/packages/api/api/analytics/fleet/export_schema.py
@@ -172,6 +172,95 @@ _PLAYER_LEDGER_SCHEMA: dict[str, Any] = {
     },
 }
 
+_COMPOSITION_HISTOGRAM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Histogram of host component ids keyed by stringified id. Each value is the count of "
+        "active fleet ship records with that known fitted component type."
+    ),
+    "additionalProperties": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Number of active fleet ship records with this component id.",
+    },
+}
+
+_MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Maximum host tech level per component axis, derived from known component ids in the "
+        "histograms and engine field values. Axes with no catalog-resolvable known components "
+        "are omitted."
+    ),
+    "properties": {
+        "hulls": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Highest techlevel among known hull ids in hullTypes.",
+        },
+        "engines": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Highest techlevel among known engine ids on active ship records.",
+        },
+        "launchers": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Highest techlevel among known torpedo ids in launcherTypes.",
+        },
+        "beams": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Highest techlevel among known beam ids in beamTypes.",
+        },
+    },
+}
+
+_COMPOSITION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Per-player aggregated fleet composition derived from the acquisition ledger. Counts "
+        "only active ship records with known component fields; unknown or option-set-only rows "
+        "are omitted."
+    ),
+    "properties": {
+        "hullTypes": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Histogram of known hull types on active ships. Keys are host hull ids as "
+                "strings; values are ship counts. Rows with unknown, bounded, options, or region "
+                "hull constraints are excluded."
+            ),
+        },
+        "beamTypes": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Histogram of known fitted beam weapon types on active ships. Keys are host beam "
+                "ids as strings; values are ship counts. Rows with unknown, bounded, options, or "
+                "region beam constraints are excluded. Known zero (no beams) is excluded."
+            ),
+        },
+        "launcherTypes": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Histogram of known fitted torpedo-tube types on active ships. Keys are host "
+                "torpedo ids as strings; values are ship counts. Rows with unknown, bounded, "
+                "options, or region launcher constraints are excluded. Known zero (no tubes) is "
+                "excluded."
+            ),
+        },
+        "torpedoTypesLoaded": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Histogram of known torpedo types currently loaded on active ships when the "
+                "ledger has observation evidence for loaded ammo. Empty when loaded-torp "
+                "evidence is not persisted on ship records."
+            ),
+        },
+        "maxTechLevel": _MAX_TECH_LEVEL_SCHEMA,
+    },
+}
+
 _META_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
@@ -215,6 +304,7 @@ EXPORT_VALUE_SCHEMA: dict[str, Any] = {
     ),
     "properties": {
         "meta": _META_SCHEMA,
+        "composition": _COMPOSITION_SCHEMA,
         "players": {
             "type": "array",
             "description": (

--- a/packages/api/api/analytics/fleet/export_scope.py
+++ b/packages/api/api/analytics/fleet/export_scope.py
@@ -1,0 +1,15 @@
+"""Shared export scope helpers for fleet materialization."""
+
+from __future__ import annotations
+
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
+
+
+def ledgers_for_scope(
+    snapshot: FleetTurnSnapshot,
+    scope: ExportScope,
+) -> list[FleetAcquisitionLedger]:
+    if scope.player_id is None:
+        return list(snapshot.players)
+    return [ledger for ledger in snapshot.players if ledger.player_id == scope.player_id]

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -10,10 +10,10 @@ from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.meta_wire import build_export_meta_branch
 from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
 from api.analytics.fleet.composition_export import build_fleet_composition_branch
-from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.compute_services import resolve_fleet_services
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.export_schema import EXPORT_VALUE_SCHEMA
+from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.serialization import fleet_acquisition_ledger_to_json
 from api.analytics.fleet.types import FleetTurnSnapshot
 from api.analytics.scores.export_precedence import SearchStatus

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -9,6 +9,7 @@ from api.analytics.export_types import EnsureDependency, ExportScope, PathPrefix
 from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.meta_wire import build_export_meta_branch
 from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+from api.analytics.fleet.composition_export import build_fleet_composition_branch
 from api.analytics.fleet.compute_services import resolve_fleet_services
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.export_schema import EXPORT_VALUE_SCHEMA
@@ -21,6 +22,7 @@ from api.models.game import TurnInfo
 
 PATH_PREFIX_SCOPE_RULES = (
     PathPrefixScopeRule(prefix="$.players", requires=("player_id",)),
+    PathPrefixScopeRule(prefix="$.composition", requires=("player_id",)),
     PathPrefixScopeRule(prefix="$.meta.searchStatus", requires=("player_id",)),
     PathPrefixScopeRule(prefix="$.meta.solutionsHeld", requires=("player_id",)),
 )
@@ -99,6 +101,7 @@ def _build_fleet_export_materialized_tree(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
     *,
+    turn: TurnInfo,
     search_status: SearchStatus | None,
     solutions_held: int,
 ) -> dict[str, Any]:
@@ -108,6 +111,7 @@ def _build_fleet_export_materialized_tree(
             search_status=search_status,
             solutions_held=solutions_held,
         ),
+        "composition": build_fleet_composition_branch(snapshot, scope, turn=turn),
         "players": [
             fleet_acquisition_ledger_to_json(player_ledger)
             for player_ledger in _players_for_scope(snapshot, scope)
@@ -136,6 +140,7 @@ def materialize_fleet_export_tree(ctx: AnalyticQueryContext, scope: ExportScope)
     return _build_fleet_export_materialized_tree(
         snapshot,
         scope,
+        turn=turn,
         search_status=search_status,
         solutions_held=solutions_held,
     )

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -10,11 +10,12 @@ from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.meta_wire import build_export_meta_branch
 from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
 from api.analytics.fleet.composition_export import build_fleet_composition_branch
+from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.compute_services import resolve_fleet_services
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.export_schema import EXPORT_VALUE_SCHEMA
 from api.analytics.fleet.serialization import fleet_acquisition_ledger_to_json
-from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
+from api.analytics.fleet.types import FleetTurnSnapshot
 from api.analytics.scores.export_precedence import SearchStatus
 from api.analytics.scores.exports import held_scores_for_scope
 from api.errors import ValidationError
@@ -88,15 +89,6 @@ def _scores_search_status_for_scope(
     return resolved.decision.search_status, resolved.payload.solutions_held
 
 
-def _players_for_scope(
-    snapshot: FleetTurnSnapshot,
-    scope: ExportScope,
-) -> list[FleetAcquisitionLedger]:
-    if scope.player_id is None:
-        return list(snapshot.players)
-    return [ledger for ledger in snapshot.players if ledger.player_id == scope.player_id]
-
-
 def _build_fleet_export_materialized_tree(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
@@ -114,7 +106,7 @@ def _build_fleet_export_materialized_tree(
         "composition": build_fleet_composition_branch(snapshot, scope, turn=turn),
         "players": [
             fleet_acquisition_ledger_to_json(player_ledger)
-            for player_ledger in _players_for_scope(snapshot, scope)
+            for player_ledger in ledgers_for_scope(snapshot, scope)
         ],
     }
 

--- a/packages/api/api/analytics/military_score_inference/ship_inventory.py
+++ b/packages/api/api/analytics/military_score_inference/ship_inventory.py
@@ -12,25 +12,15 @@ from api.analytics.military_score_inference.ship_build_combos import (
 from api.analytics.military_score_inference.ship_build_scoring import (
     ship_build_has_zero_military_score,
 )
-from api.models.components import Beam, Engine, Hull, Torpedo
+from api.concepts.turn_component_catalog import (
+    beams_by_id,
+    engines_by_id,
+    hulls_by_id,
+    torpedos_by_id,
+)
+from api.models.components import Hull
 from api.models.game import TurnInfo
 from api.models.ship import Ship
-
-
-def hulls_by_id(turn: TurnInfo) -> dict[int, Hull]:
-    return {hull.id: hull for hull in turn.hulls}
-
-
-def engines_by_id(turn: TurnInfo) -> dict[int, Engine]:
-    return {engine.id: engine for engine in turn.engines}
-
-
-def beams_by_id(turn: TurnInfo) -> dict[int, Beam]:
-    return {beam.id: beam for beam in turn.beams}
-
-
-def torpedos_by_id(turn: TurnInfo) -> dict[int, Torpedo]:
-    return {torp.id: torp for torp in turn.torpedos}
 
 
 def owned_active_ships(turn: TurnInfo, player_id: int) -> list[Ship]:

--- a/packages/api/api/concepts/turn_component_catalog.py
+++ b/packages/api/api/concepts/turn_component_catalog.py
@@ -1,0 +1,22 @@
+"""Turn-scoped component catalog indexes from ``TurnInfo`` snapshots."""
+
+from __future__ import annotations
+
+from api.models.components import Beam, Engine, Hull, Torpedo
+from api.models.game import TurnInfo
+
+
+def hulls_by_id(turn: TurnInfo) -> dict[int, Hull]:
+    return {hull.id: hull for hull in turn.hulls}
+
+
+def engines_by_id(turn: TurnInfo) -> dict[int, Engine]:
+    return {engine.id: engine for engine in turn.engines}
+
+
+def beams_by_id(turn: TurnInfo) -> dict[int, Beam]:
+    return {beam.id: beam for beam in turn.beams}
+
+
+def torpedos_by_id(turn: TurnInfo) -> dict[int, Torpedo]:
+    return {torp.id: torp for torp in turn.torpedos}

--- a/packages/api/tests/fleet_fixtures.py
+++ b/packages/api/tests/fleet_fixtures.py
@@ -20,6 +20,9 @@ def single_ship_turn(
     x: int,
     y: int,
     hull_id: int = 13,
+    engine_id: int = 9,
+    beam_id: int = 3,
+    torpedoid: int = 6,
 ) -> TurnInfo:
     with open(ASSETS_DIR / "turn_sample.json") as handle:
         turn_data = json.load(handle)
@@ -65,11 +68,11 @@ def single_ship_turn(
             "heading": 0,
             "turn": 1,
             "turnkilled": 0,
-            "beamid": 3,
-            "engineid": 9,
+            "beamid": beam_id,
+            "engineid": engine_id,
             "hullid": hull_id,
             "ownerid": owner_id,
-            "torpedoid": 6,
+            "torpedoid": torpedoid,
             "experience": 0,
             "infoturn": turn_number,
             "podhullid": 0,

--- a/packages/api/tests/test_fleet_composition_export.py
+++ b/packages/api/tests/test_fleet_composition_export.py
@@ -160,3 +160,35 @@ def test_build_composition_skips_unknown_catalog_ids_for_max_tech_level():
     assert composition["hullTypes"] == {"13": 1}
     assert composition["launcherTypes"] == {"6": 1}
     assert composition["maxTechLevel"] == {"beams": 2}
+
+
+def test_build_composition_excludes_known_zero_beams_and_launchers():
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=1,
+        owner_id=8,
+        x=100,
+        y=100,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    composition = _composition_for_records(
+        [
+            FleetShipRecord(
+                record_id="no-beams-or-launchers",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldKnown(15),
+                    engine=FleetFieldKnown(3),
+                    beams=FleetFieldKnown(0),
+                    launchers=FleetFieldKnown(0),
+                ),
+            ),
+        ],
+        turn=turn,
+    )
+    assert composition["hullTypes"] == {"15": 1}
+    assert composition["beamTypes"] == {}
+    assert composition["launcherTypes"] == {}

--- a/packages/api/tests/test_fleet_composition_export.py
+++ b/packages/api/tests/test_fleet_composition_export.py
@@ -1,0 +1,115 @@
+"""Unit tests for fleet composition export materialization."""
+
+from __future__ import annotations
+
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.composition_export import build_fleet_composition_branch
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetFieldKnown,
+    FleetFieldUnknown,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+)
+
+from tests.fleet_fixtures import single_ship_turn
+
+
+def _composition_for_records(records, *, turn, player_id=8):
+    snapshot = FleetTurnSnapshot(
+        players=[FleetAcquisitionLedger(player_id=player_id, records=records)]
+    )
+    scope = ExportScope(
+        game_id=628580,
+        perspective=1,
+        turn=turn.settings.turn,
+        player_id=player_id,
+    )
+    return build_fleet_composition_branch(snapshot, scope, turn=turn)
+
+
+def test_build_composition_omits_non_active_and_unknown_fields():
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=1,
+        owner_id=8,
+        x=100,
+        y=100,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    composition = _composition_for_records(
+        [
+            FleetShipRecord(
+                record_id="active",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldKnown(15),
+                    engine=FleetFieldKnown(3),
+                    beams=FleetFieldKnown(3),
+                    launchers=FleetFieldKnown(3),
+                ),
+            ),
+            FleetShipRecord(
+                record_id="lost",
+                disposition="lost",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldKnown(15),
+                    launchers=FleetFieldKnown(3),
+                ),
+            ),
+            FleetShipRecord(
+                record_id="placeholder",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldUnknown(),
+                    launchers=FleetFieldUnknown(),
+                ),
+            ),
+        ],
+        turn=turn,
+    )
+    assert composition["hullTypes"] == {"15": 1}
+    assert composition["beamTypes"] == {"3": 1}
+    assert composition["launcherTypes"] == {"3": 1}
+    assert composition["maxTechLevel"] == {
+        "hulls": 1,
+        "engines": 3,
+        "launchers": 3,
+        "beams": 2,
+    }
+
+
+def test_build_composition_skips_unknown_catalog_ids_for_max_tech_level():
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=1,
+        owner_id=8,
+        x=100,
+        y=100,
+        hull_id=13,
+        engine_id=9,
+        beam_id=3,
+        torpedoid=6,
+    )
+    composition = _composition_for_records(
+        [
+            FleetShipRecord(
+                record_id="active",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldKnown(13),
+                    engine=FleetFieldKnown(9),
+                    beams=FleetFieldKnown(3),
+                    launchers=FleetFieldKnown(6),
+                ),
+            ),
+        ],
+        turn=turn,
+    )
+    assert composition["hullTypes"] == {"13": 1}
+    assert composition["launcherTypes"] == {"6": 1}
+    assert composition["maxTechLevel"] == {"beams": 2}

--- a/packages/api/tests/test_fleet_composition_export.py
+++ b/packages/api/tests/test_fleet_composition_export.py
@@ -83,6 +83,53 @@ def test_build_composition_omits_non_active_and_unknown_fields():
     }
 
 
+def test_build_composition_returns_empty_when_unscoped():
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=1,
+        owner_id=8,
+        x=100,
+        y=100,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    snapshot = FleetTurnSnapshot(
+        players=[
+            FleetAcquisitionLedger(
+                player_id=8,
+                records=[
+                    FleetShipRecord(
+                        record_id="active",
+                        disposition="active",
+                        fields=FleetShipRecordFields(
+                            hull=FleetFieldKnown(15),
+                            engine=FleetFieldKnown(3),
+                            beams=FleetFieldKnown(3),
+                            launchers=FleetFieldKnown(3),
+                        ),
+                    ),
+                ],
+            ),
+        ],
+    )
+    scope = ExportScope(
+        game_id=628580,
+        perspective=1,
+        turn=turn.settings.turn,
+        player_id=None,
+    )
+    composition = build_fleet_composition_branch(snapshot, scope, turn=turn)
+    assert composition == {
+        "hullTypes": {},
+        "beamTypes": {},
+        "launcherTypes": {},
+        "torpedoTypesLoaded": {},
+        "maxTechLevel": {},
+    }
+
+
 def test_build_composition_skips_unknown_catalog_ids_for_max_tech_level():
     turn = single_ship_turn(
         turn_number=1,

--- a/packages/api/tests/test_fleet_exports.py
+++ b/packages/api/tests/test_fleet_exports.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from api.analytics.export_dependency_walk import walk_dependency_tree
 from api.analytics.export_types import EnsureDependency, ExportScope
 from api.analytics.fleet.compute_services import resolve_fleet_services, turn_chain_through
@@ -19,6 +21,7 @@ from tests.fleet_exports_helpers import (
     materialize_fleet_tree,
     turn_with_score_delta,
 )
+from tests.fleet_fixtures import single_ship_turn
 from tests.scores_exports_helpers import (
     GAME_ID,
     ensure_missing_step,
@@ -54,6 +57,130 @@ def test_invalid_scope_without_player_id_for_players_path(sample_turn):
     result = ctx.query("fleet", ["$.players"])
     assert result.status == "unavailable"
     assert result.reason == "invalid_scope"
+
+
+def test_invalid_scope_without_player_id_for_composition_path(sample_turn):
+    ctx = export_chain_query_context(sample_turn)
+    result = ctx.query("fleet", ["$.composition.launcherTypes"])
+    assert result.status == "unavailable"
+    assert result.reason == "invalid_scope"
+
+
+def test_materialized_tree_turn_one_empty_composition(sample_turn):
+    player_id = first_player_id(sample_turn)
+    turn_one = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=1),
+        game=replace(sample_turn.game, turn=1),
+        ships=[],
+    )
+    ctx = export_chain_query_context(turn_one, stored_turns={1: turn_one})
+    tree, _scope = materialize_fleet_tree(ctx, player_id, turn=1)
+    assert tree["composition"] == {
+        "hullTypes": {},
+        "beamTypes": {},
+        "launcherTypes": {},
+        "torpedoTypesLoaded": {},
+        "maxTechLevel": {},
+    }
+
+
+def test_materialized_tree_composition_counts_known_component_types_from_sightings():
+    player_id = 8
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=42,
+        owner_id=player_id,
+        x=1000,
+        y=2000,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    stored_turns = {1: turn}
+    ctx = export_chain_query_context(turn, stored_turns=stored_turns)
+    tree, _scope = materialize_fleet_tree(ctx, player_id, turn=1)
+    assert tree["composition"]["hullTypes"] == {"15": 1}
+    assert tree["composition"]["beamTypes"] == {"3": 1}
+    assert tree["composition"]["launcherTypes"] == {"3": 1}
+    assert tree["composition"]["torpedoTypesLoaded"] == {}
+    assert tree["composition"]["maxTechLevel"] == {
+        "hulls": 1,
+        "engines": 3,
+        "launchers": 3,
+        "beams": 2,
+    }
+
+
+def test_materialized_tree_composition_omits_unknown_placeholder_launchers(sample_turn):
+    player_id = first_player_id(sample_turn)
+    sighting = single_ship_turn(turn_number=5, ship_id=99, owner_id=player_id, x=100, y=100)
+    turn = turn_with_score_delta(sighting, turn_number=5, owner_id=player_id, shipchange=1)
+    turn = replace(turn, ships=sighting.ships)
+    stored_turns = turn_chain_through(turn)
+    stored_turns[5] = turn
+
+    ctx = export_chain_query_context(
+        turn,
+        stored_turns=stored_turns,
+        scheduler=InferenceRowScheduler(worker_count=0),
+    )
+    tree, _scope = materialize_fleet_tree(ctx, player_id, turn=5)
+    ledger = tree["players"][0]
+    assert len(ledger["records"]) == 2
+    known_launcher_records = [
+        record
+        for record in ledger["records"]
+        if record["fields"]["launchers"].get("kind") == "known"
+    ]
+    unknown_launcher_records = [
+        record
+        for record in ledger["records"]
+        if record["fields"]["launchers"].get("kind") == "unknown"
+    ]
+    assert len(known_launcher_records) == 1
+    assert len(unknown_launcher_records) == 1
+    assert tree["composition"]["hullTypes"] == {"13": 1}
+    assert tree["composition"]["beamTypes"] == {"3": 1}
+    assert tree["composition"]["launcherTypes"] == {"6": 1}
+    assert tree["composition"]["torpedoTypesLoaded"] == {}
+    assert tree["composition"]["maxTechLevel"] == {"beams": 2}
+
+
+def test_query_composition_launcher_types_path():
+    player_id = 8
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=42,
+        owner_id=player_id,
+        x=1000,
+        y=2000,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    ctx = export_chain_query_context(turn, stored_turns={1: turn})
+    result = ctx.query(
+        "fleet",
+        [
+            "$.composition.launcherTypes",
+            "$.composition.hullTypes",
+            "$.composition.maxTechLevel",
+        ],
+        {"turn": 1, "player_id": player_id},
+        force_inline_ensure=True,
+    )
+    assert result.status == "ok"
+    assert result.paths["$.composition.launcherTypes"].value == {"3": 1}
+    assert result.paths["$.composition.hullTypes"].value == {"15": 1}
+    assert result.paths["$.composition.maxTechLevel"].value == {
+        "hulls": 1,
+        "engines": 3,
+        "launchers": 3,
+        "beams": 2,
+    }
 
 
 def test_materialized_tree_includes_meta_host_turn(sample_turn):

--- a/packages/api/tests/test_fleet_exports.py
+++ b/packages/api/tests/test_fleet_exports.py
@@ -85,34 +85,6 @@ def test_materialized_tree_turn_one_empty_composition(sample_turn):
     }
 
 
-def test_materialized_tree_composition_counts_known_component_types_from_sightings():
-    player_id = 8
-    turn = single_ship_turn(
-        turn_number=1,
-        ship_id=42,
-        owner_id=player_id,
-        x=1000,
-        y=2000,
-        hull_id=15,
-        engine_id=3,
-        beam_id=3,
-        torpedoid=3,
-    )
-    stored_turns = {1: turn}
-    ctx = export_chain_query_context(turn, stored_turns=stored_turns)
-    tree, _scope = materialize_fleet_tree(ctx, player_id, turn=1)
-    assert tree["composition"]["hullTypes"] == {"15": 1}
-    assert tree["composition"]["beamTypes"] == {"3": 1}
-    assert tree["composition"]["launcherTypes"] == {"3": 1}
-    assert tree["composition"]["torpedoTypesLoaded"] == {}
-    assert tree["composition"]["maxTechLevel"] == {
-        "hulls": 1,
-        "engines": 3,
-        "launchers": 3,
-        "beams": 2,
-    }
-
-
 def test_materialized_tree_composition_omits_unknown_placeholder_launchers(sample_turn):
     player_id = first_player_id(sample_turn)
     sighting = single_ship_turn(turn_number=5, ship_id=99, owner_id=player_id, x=100, y=100)


### PR DESCRIPTION
## Summary

- Add fleet `$.composition` export branch with per-player histograms (`hullTypes`, `beamTypes`, `launcherTypes`) and `maxTechLevel` derived from active ledger rows with known component fields; `torpedoTypesLoaded` is documented and materialized as empty in v1.
- Extract shared primitives (`turn_component_catalog`, `export_scope.ledgers_for_scope`) and table-drive composition materialization; reject unscoped `$.composition` queries via path-prefix rules.
- Update design docs and add `implementation-quality.mdc` rules to encode reuse/boundary discipline for future work.

Closes #154.

## Test plan

- [x] `make test_api` (1020 passed, 6 skipped)
- [x] Unit tests: empty baseline, unscoped empty branch, known/unknown/known-zero field handling, catalog-id omission for max tech
- [x] Integration tests: invalid scope without `player_id`, turn-1 empty composition, placeholder launcher omission, JSONPath query for `$.composition.*` paths


Made with [Cursor](https://cursor.com)