### PR TITLE
Fleet-informed torp overlay for scores inference (#87)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -449,7 +449,7 @@ Per **inference search tier**, the set of aggregate actions permitted at that st
 _Avoid_: noisy action list, tier catalog
 
 **Inference tier policy**:
-The declarative record for one **inference search tier** on the unified ladder -- constraints on the full action catalog (ship-build component filters such as permitted tech levels, **tier aggregate allowlist** and caps, military-score band tolerance `alpha` in 2x units, seed budget). Later tiers loosen constraints; the final tier uses `alpha = 0`. Policies are loaded from a static asset (YAML); runtime parameter injection (e.g. fleet-known launcher/torp types) is a follow-on overlay on that base.
+The declarative record for one **inference search tier** on the unified ladder -- constraints on the full action catalog (ship-build component filters such as permitted tech levels, **tier aggregate allowlist** and caps, military-score band tolerance `alpha` in 2x units, seed budget). Later tiers loosen constraints; the final tier uses `alpha = 0`. Policies are loaded from a static asset (YAML). Optional **inference tier policy overlay** (#78) widens filters at resolve time. Fleet-informed torp admission and ranking tunables live in the same YAML file under `fleetInferenceTuning` (**#87**, **#156**; section 8.8 of implementation doc) -- distinct merge path from `TierPolicyOverlay`.
 _Avoid_: tier config, search phase
 
 **Inference catalog constraint**:
@@ -509,8 +509,44 @@ Static YAML ladder under `assets/analytics/scores/` (repo root). Defines ordered
 _Avoid_: tier_policy.yaml (filename in prose only when citing path)
 
 **Inference build prior**:
-Population-level weights that feed **inference solution rank weight** via additive log-probability composition at catalog-build time. The **inference build prior asset** (selected by **inference game category**) stores **un-normalized empirical count distributions**; a runtime step converts counts to integer log-probability weights when the catalog is built for a solve. Ship builds compose as `log P(hull) + log P(components | hull category) + optional sparse overrides`; aggregate actions use histogram-derived magnitude-bin distributions. Within each asset, partition keys: **inference ship-limit band** on all families; **race** modifiers on hull marginals only. Distinct from **inference tier policy overlay** (fleet-informed runtime adjustments, #87).
+Population-level weights that feed **inference solution rank weight** via additive log-probability composition at catalog-build time. The **inference build prior asset** (selected by **inference game category**) stores **un-normalized empirical count distributions**; a runtime step converts counts to integer log-probability weights when the catalog is built for a solve. Ship builds compose as `log P(hull) + log P(components | hull category) + optional sparse overrides`; aggregate actions use histogram-derived magnitude-bin distributions. Within each asset, partition keys: **inference ship-limit band** on all families; **race** modifiers on hull marginals only. Distinct from **inference fleet probability overlay** (#87) and **inference tier policy overlay** (#78).
 _Avoid_: probability score, prior_weights.yaml (filename in prose only when citing path)
+
+**Inference fleet probability overlay** (#87):
+Per-player, per-solve adjustments merged on top of **inference build prior** weights at catalog-build time (log-additive). Primary use: suppress **inference torpedo load noise** via **inference torp misalignment penalty** on `ship_torps_loaded_{id}` when torp id ∉ **inference fleet launcher belief set**; also **inference component tech-gap prior** on ship-build combos. Does not replace static priors or change hard constraints. Works with **inference aggregate admission** (belief-set narrowing on early torp tiers). Distinct from **inference tier policy overlay** (#78) though tuning constants for fleet torp ranking may live in the **inference tier policy asset** YAML for operator convenience.
+_Avoid_: fleet prior (unqualified), fleet penalty channel
+
+**Inference torp misalignment penalty**:
+Fixed log-space down-weight (v1: one constant for all non-belief torp types) applied to active `ship_torps_loaded_{id}` bins when the torp id is outside the **inference fleet launcher belief set**. Also applies to every torp type when the belief set is empty and types appear on **inference torp escape tier**. Tunable via **`fleetInferenceTuning.torpMisalignmentLogPenalty`** in the **inference tier policy asset** YAML. Goal: non-belief torp padding ranks below plausible ship-build explanations in top-K unless it is the only feasible closure.
+_Avoid_: per-torp-type penalty table (v1), distance-aware torp penalty (v1)
+
+**Inference fleet inference tuning**:
+Operator-tunable ranking constants in the **inference tier policy asset** YAML (`fleetInferenceTuning` block). v1 fields: `torpMisalignmentLogPenalty` (**inference torp misalignment penalty**, #87), `componentTechGapLogPenaltyPerLevel` (**inference component tech-gap prior**, #156). Colocated with the ladder for easy tuning without a second asset.
+_Avoid_: overlay YAML file, hardcoded solver constants
+
+**Inference fleet launcher alignment**:
+The rule that aggregate torpedo-load explanations should prefer torpedo types fitted on ships the player is believed to own -- from **fleet observed ship** sightings and **fleet inferred acquisition** rows (scores inference), not sightings alone. `torpedoid` / launcher type on a fitted ship is the alignment key. Loading a torp type with no matching launchers in that belief set is very unlikely but not impossible. When the belief set is empty (no launcher-fitted ships yet), early tiers admit no torp-load actions and the **inference fleet probability overlay** applies the same strong down-weight to every torp type when they unlock on a later escape tier. When non-empty, early torp-admitting tiers materialize only belief-set types; others unlock on escape tier with strong down-weight. Ambiguous **fleet build option set** rows are handled separately (see grilling / #87); they are not excluded just because launchers are not **known** from a sighting.
+_Avoid_: torp compatibility filter (generic), turn-1 special case, known-sighting-only launcher histogram
+
+**Inference fleet launcher belief set**:
+The torpedo type ids counted as "in fleet" for **inference fleet launcher alignment** and **inference aggregate admission** -- derived from prior-turn fleet exports feeding #87. Includes launcher types on inferred builds (scores-held solutions), not only **known** launchers from direct sightings. For ambiguous **fleet build option set** rows, the belief set is the **union** of launcher/torp ids across all option sets on active rows (consistent tuples only, no per-field Cartesian product). Empty when no active row carries a positive launcher/torp type in any option set.
+_Avoid_: launcherTypes (wire field name in prose unless citing path), known-only fleet composition, top-1 option set only
+
+**Inference fleet launcher option ambiguity** (#87):
+When top-K inference yields multiple **fleet build option set**s on one row, early torp admission uses the full belief-set **union**; types outside the union defer to escape tier and receive strong prior down-weight. Types inside the union keep population prior; types appearing only in non-top-rank alternates may receive an optional mild log down-weight vs top-default option sets. Top-1-only admission is not used.
+_Avoid_: reconcile before overlay, independent per-field launcher unions
+
+**Inference component tech-gap prior**:
+Fleet-informed log-prior reduction on ship-build combo components whose catalog **techlevel** exceeds the per-axis fleet ceiling derived from the **inference fleet launcher belief set** generalized to all component axes. For each axis (`hulls`, `engines`, `beams`, `launchers`): collect component ids from active rows (sightings plus all **fleet build option set** tuples on inferred rows), take the max `techlevel` in the turn catalog as the ceiling; omit an axis with no ids (no gap penalty on that axis). Penalty sums per fitted component: `componentTechGapLogPenaltyPerLevel * max(0, component_tech - ceiling)` from **`fleetInferenceTuning`** in the **inference tier policy asset**. No positive histogram boosts beyond **inference build prior**.
+_Avoid_: tech unlock prior, fleet histogram boost, hull-id ceiling (use tech level)
+
+**Inference aggregate admission** (fleet-informed, #87):
+On **inference search tier** steps that admit template torpedo-load actions (`ship_torps_per_type`), restrict which `ship_torps_loaded_{id}` catalog members are materialized to torpedo types in the **inference fleet launcher belief set**. Empty belief set: early torp-admitting tiers materialize **none**; **inference torp escape tier** admits all `eligible_torp_ids`. Non-empty: early tiers admit belief-set types only; non-belief types unlock on escape tier. Absent overlay behaves like empty belief set. Belief set includes inferred launcher types from scores, not sightings-only.
+_Avoid_: torp allowlist (without "inference"), turn-1 fallback to full admission
+
+**Inference torp escape tier**:
+The **inference search tier** policy step (penultimate on the ladder, still `alpha > 0`) where non-belief torpedo types first enter the catalog alongside belief-set types -- before `full_catalog_exact`. Unlocks torp-load explanations that need types outside the **inference fleet launcher belief set** while band retry remains available. Distinct from the first torp-admitting tiers (belief-set only or none when belief set empty).
+_Avoid_: full_catalog_exact as first non-belief unlock
 
 **Game category** (`api.concepts.game_category.GameCategory`):
 Immutable label for a class of games (e.g. campaign, standard, epic, blitz) derived from loaded game settings via `GameCategory.from_game_settings()`. Used among other consumers to select which **inference build prior asset** the console loads. Ordered predicates in Core (first match wins): `campaignmode` → campaign; else `endturn <= 30` → blitz; else `shiplimit >= 500` → epic; else standard. Categories have stable unique identifiers; once defined they do not change meaning. If no asset exists for the resolved category, fall back to the `standard` asset. Separate assets per category avoid runtime cross-partition overhead.

--- a/assets/analytics/scores/tier_policy.yaml
+++ b/assets/analytics/scores/tier_policy.yaml
@@ -4,11 +4,10 @@
 #
 # Fleet-informed torp admission + ranking (#87, section 8.8): early torp tiers use
 # belief-set ids only; inference torp escape tier (penultimate step, alpha > 0) admits
-# all eligible torp types. Tunables (loaded when #87 lands):
-#
-# fleetInferenceTuning:
-#   torpMisalignmentLogPenalty: <int>
-#   componentTechGapLogPenaltyPerLevel: <int>   # #156
+# all eligible torp types.
+fleetInferenceTuning:
+  torpMisalignmentLogPenalty: 50
+  # componentTechGapLogPenaltyPerLevel: <int>   # #156
 version: 1
 
 # Solver magnitude bins for aggregate-action ranking (not per tier step).
@@ -197,6 +196,28 @@ steps:
     maxSeeds: 5
 
   - id: admit_starbase_defense_posts
+    filters:
+      hulls:
+        all: true
+      engines:
+        all: true
+      beams:
+        all: true
+      launchers:
+        all: true
+    beamSlotCounts: partial
+    launcherSlotCounts: partial
+    aggregateAllowlist:
+      ship_torps_per_type: 40
+      planet_defense_posts_added_total: 16
+      starbase_defense_posts_added_total: 5
+      starbase_fighters_added_total: 50
+      ship_fighters_added_total: 20
+      fighter_transfers_per_direction: 50
+    alpha: 30
+    maxSeeds: 5
+
+  - id: torp_escape_tier
     filters:
       hulls:
         all: true

--- a/assets/analytics/scores/tier_policy.yaml
+++ b/assets/analytics/scores/tier_policy.yaml
@@ -1,6 +1,14 @@
 # Inference search tier ladder (sketch A, section 8.5.3).
 # filters.*.all widens eligibility (see tier_policy.py module docstring).
 # filters.*.techLevels narrows by component techlevel; ids derived at runtime.
+#
+# Fleet-informed torp admission + ranking (#87, section 8.8): early torp tiers use
+# belief-set ids only; inference torp escape tier (penultimate step, alpha > 0) admits
+# all eligible torp types. Tunables (loaded when #87 lands):
+#
+# fleetInferenceTuning:
+#   torpMisalignmentLogPenalty: <int>
+#   componentTechGapLogPenaltyPerLevel: <int>   # #156
 version: 1
 
 # Solver magnitude bins for aggregate-action ranking (not per tier step).

--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -463,22 +463,31 @@ if prior.paths["$.meta.searchStatus"].value != "complete":
 top_build = prior.paths["$.solutions[0]"].value  # full top explanation when present
 ```
 
-### Inference priors overlay (#87)
+### Inference fleet overlay (#87, #156)
+
+Prior-turn fleet export at `(turn - 1, player_id)` supplies **belief-set** component histograms for scores inference. Glossary: `CONTEXT.md` (**Inference fleet launcher belief set**, **Inference component tech-gap prior**).
 
 ```python
 composition = ctx.query(
     "fleet",
     paths=[
-        "$.composition.launcherTypes",
+        "$.composition.launcherTypes",   # #87 belief set
+        "$.composition.hullTypes",     # #156 ceilings
+        "$.composition.engineTypes",
         "$.composition.beamTypes",
-        "$.composition.hullTypes",
         "$.composition.maxTechLevel",
     ],
     scope={"turn": turn - 1, "player_id": player_id},
 )
 ```
 
-Fleet `$.composition` summarizes **known** fitted components on **active** ledger rows (histograms keyed by stringified host component id) plus `maxTechLevel` per axis (`hulls`, `engines`, `launchers`, `beams`) from the turn component catalog. Unknown or option-set-only rows are omitted from histograms; `torpedoTypesLoaded` stays empty until loaded-torp evidence is persisted on records.
+**#87 (torp slice):** derive **inference fleet launcher belief set** from `launcherTypes` (sighted + inferred option-set union). Drives **inference aggregate admission** on early torp tiers and **inference torp misalignment penalty** (`fleetInferenceTuning.torpMisalignmentLogPenalty` in tier policy YAML). Empty histogram: no early torp admission; all types strongly down-weighted at **inference torp escape tier**. Absent overlay behaves like empty belief set (not legacy full admission).
+
+**#156 (follow-on):** per-axis tech ceilings from the same composition rows; **inference component tech-gap prior** via `fleetInferenceTuning.componentTechGapLogPenaltyPerLevel`. No positive histogram boosts beyond **inference build prior** (#86).
+
+Production wiring: **#133**. Parallel axis: **#78** **inference tier policy overlay** (catalog filter widening only).
+
+See [design-military-score-build-inference-implementation.md](design-military-score-build-inference-implementation.md) section 8.8.
 
 ---
 

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -339,7 +339,7 @@ Critical path: `0 -> 1 -> 2 -> 3 -> 4 -> 5`.
 - **Fleet reconciliation correction** UI (representation required; UI deferred)
 - Report message parsing
 - Starbase region overlays on map
-- **Inference tier policy overlay** from fleet (#87) -- consumer of fleet exports, not producer
+- **Scores inference fleet overlay** consumer (#87, #133) -- fleet exports belief-set inputs; not producer
 - Wandering Tribes fleet-at-spawn special case
 
 ---
@@ -349,20 +349,25 @@ Critical path: `0 -> 1 -> 2 -> 3 -> 4 -> 5`.
 | Feature | Use |
 |---------|-----|
 | **Homeworld locator** | SB / planet positions for **region** constraints on inferred builds |
-| **Scores** `#87` | Component histogram and `maxTechLevel` overlay from `$.composition` (`hullTypes`, `beamTypes`, `launcherTypes`, `maxTechLevel`; `torpedoTypesLoaded` when ledger stores loaded ammo) |
+| **Scores** **#87** | **Inference fleet launcher belief set** from `$.composition` (torp admission + misalignment prior); see below |
+| **Scores** **#156** | Per-axis tech ceilings from same `$.composition` rows (**inference component tech-gap prior**) |
+| **Scores** **#78** | Optional **inference tier policy overlay** (component filter widening); parallel axis, not torp ranking |
 | Reports ingest | Strong evidence for loss/trade row selection |
 | Export ensure orchestration (#109) | Background unwind when fleet@N requires deep scores chain |
 
 ### `$.composition` export branch (#154)
 
-Per-player, scoped by `player_id`. Materialized from active `FleetShipRecord` rows for the scoped player(s):
+Per-player, scoped by `player_id`. Materialized from active `FleetShipRecord` rows for the scoped player(s). Feeds **#87** / **#156** via analytic export query at prior turn (see [design-analytic-exports.md](design-analytic-exports.md)); production wiring **#133**.
+
+**Belief-set rule (scores inference):** component ids on a row come from **known** field constraints **or** from every **fleet build option set** on inferred rows (union of consistent tuples -- no per-field Cartesian product, no top-1-only slice). Scores inference is a first-class signal; sightings alone are insufficient because **known** launchers do not promote from inference on later turns.
 
 | Path | Shape | Rule |
 |------|-------|------|
-| `$.composition.hullTypes` | `{ "<hullId>": <shipCount>, ... }` | Known `fields.hull` only |
-| `$.composition.beamTypes` | `{ "<beamId>": <shipCount>, ... }` | Known `fields.beams` with positive id |
-| `$.composition.launcherTypes` | `{ "<torpId>": <shipCount>, ... }` | Known `fields.launchers` (torp type id) with positive id |
-| `$.composition.torpedoTypesLoaded` | same histogram shape | Empty in v1 until loaded-torp evidence is on ledger rows |
-| `$.composition.maxTechLevel` | `{ "hulls"?, "engines"?, "launchers"?, "beams"? }` | Max `techlevel` from turn catalog for ids present in the histograms (engines from known `fields.engine` on rows). Axes with no catalog-resolvable ids omitted. |
+| `$.composition.hullTypes` | `{ "<hullId>": <shipCount>, ... }` | Belief-set hull ids (known or any option set) |
+| `$.composition.engineTypes` | `{ "<engineId>": <shipCount>, ... }` | Belief-set engine ids (known or any option set) |
+| `$.composition.beamTypes` | `{ "<beamId>": <shipCount>, ... }` | Belief-set beam ids with positive id |
+| `$.composition.launcherTypes` | `{ "<torpId>": <shipCount>, ... }` | Belief-set launcher/torp ids with positive id (**inference fleet launcher belief set** for #87) |
+| `$.composition.torpedoTypesLoaded` | same histogram shape | Loaded-torp ids on rows when persisted (future); empty in v1 |
+| `$.composition.maxTechLevel` | `{ "hulls"?, "engines"?, "launchers"?, "beams"? }` | Max `techlevel` from turn catalog over ids present in the matching type histogram for that axis |
 
-Unknown, bounded, options, and region field constraints are excluded from histograms. Known zero for beams/launchers (no fitted weapons) is excluded. Turn 1 baseline: empty histograms and `{}` `maxTechLevel`.
+Unknown-only, bounded-only, and region field constraints contribute no ids until resolved to known or option-set tuples. Known zero for beams/launchers (no fitted weapons) is excluded. Turn 1 baseline: empty histograms and `{}` `maxTechLevel` (scores inference treats absent overlay like empty belief set).

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -638,7 +638,9 @@ Do not emit `exact-with-deferred-risk` for band-feasible multisets in #77; that 
 
 #### 8.5.6 Runtime overlay (#78, follow-on)
 
-**Fleet-informed tier promotion** and other external signals merge via **inference tier policy overlay** at resolve time (append tech levels, bump aggregate caps, etc.). #77 defines the hook (`overlay=None`); #78 implements merge semantics. Overlay producers (fleet histogram, prior builds, UI) are out of scope for both tickets.
+External signals that **widen the catalog** (append component tech levels, bump aggregate caps, etc.) merge via **inference tier policy overlay** at resolve time. #77 defines the hook (`overlay=None`); #78 implements merge semantics. Overlay producers (UI settings, etc.) are out of scope for #78.
+
+**Distinct from #87 / #156:** fleet-informed **ranking** and torp **aggregate admission** use **inference fleet probability overlay** (section 8.8), not the tier policy overlay. Do not route torp misalignment penalties or belief-set torp admission through `TierPolicyOverlay`.
 
 ### 8.6 Score-equivalent combos (solver-side merge)
 
@@ -656,6 +658,49 @@ Do not treat score-equivalent combos as interchangeable in the UI ranking solely
 ### 8.7 Inference tier policy overlay (#78)
 
 Solver-side merge of `TierPolicyOverlay` into the resolved policy list before catalog build. Deterministic precedence per constraint type (document augment vs replace). No production caller required in #78. See `CONTEXT.md` **Inference tier policy overlay**.
+
+### 8.8 Inference fleet overlay (#87, #156)
+
+Per-player, per-solve overlay on top of **inference build prior** (#86) weights and torp catalog admission. Glossary: `CONTEXT.md` (**Inference fleet launcher belief set**, **Inference aggregate admission**, **Inference torp escape tier**, **Inference torp misalignment penalty**, **Inference component tech-gap prior**, **Inference fleet inference tuning**). Production input: prior-turn fleet `$.composition` export ([#133](https://github.com/SteveDraper/Planets-Console/issues/133), [design-fleet-analytic.md](design-fleet-analytic.md)); until fleet ships, synthetic fixtures only.
+
+**Tuning** (`tier_policy.yaml`):
+
+```yaml
+fleetInferenceTuning:
+  torpMisalignmentLogPenalty: <int>              # #87
+  componentTechGapLogPenaltyPerLevel: <int>     # #156
+```
+
+#### 8.8.1 Belief set
+
+**Inference fleet launcher belief set** = torp ids fitted on ships the player is believed to own at prior turn:
+
+- **Fleet observed ship** rows with known launchers
+- **Fleet inferred acquisition** rows from prior-turn scores (required)
+- Ambiguous rows: **union** of launcher ids across all **fleet build option set** tuples
+
+Empty when no active row has a positive launcher id in any option set. **Absent overlay behaves like empty belief set** (turn 1 included) -- not legacy admit-all torps on early tiers.
+
+#### 8.8.2 Torp aggregate (#87)
+
+Two coordinated mechanisms address combinatorial `ship_torps_loaded_{id}` noise:
+
+| Mechanism | Effect |
+|-----------|--------|
+| **Inference aggregate admission** | On early torp-admitting tiers (`admit_ship_torpedoes` through `admit_starbase_defense_posts`): materialize torp-load actions for belief-set ids only, or **none** when belief set empty |
+| **Inference torp escape tier** | New penultimate ladder step (`alpha > 0`): first admit all `eligible_torp_ids` |
+| **Inference torp misalignment penalty** | Log down-weight on active non-belief torp bins (`fleetInferenceTuning.torpMisalignmentLogPenalty`); same penalty on all types when belief set was empty and types appear on escape tier |
+
+`full_catalog_exact` remains the final exact pass. Prior merge is log-additive on #86 weights. Mild penalty for low-rank-only launcher alternates inside the belief set: deferred.
+
+#### 8.8.3 Ship-build tech gap (#156)
+
+Follow-on to #87. Per-axis fleet ceiling = max catalog `techlevel` over component ids on that axis from the same belief-set rows (union across option sets). Sum `componentTechGapLogPenaltyPerLevel * max(0, component_tech - ceiling)` on each ship build combo. No positive fleet histogram boosts beyond #86.
+
+#### 8.8.4 Integration
+
+- Optional overlay input on `build_action_catalog` / `build_inference_problem` (parallel seam to `TierPolicyOverlay` in #78)
+- Diagnostics: belief-set summary, escape tier used, tuning constants loaded
 
 ---
 
@@ -1093,7 +1138,7 @@ Candidates:
 - prior inventory and resource bounds,
 - per-location defense post and fighter attribution,
 - production-queue priority-point effects on ship builds,
-- fleet-histogram priors for tier ordering and combo weights.
+- fleet-informed inference overlay (#87 torp slice, #156 tech-gap prior; section 8.8).
 
 Each addition should include tests showing both new feasible explanations and cases where the new action removes a previous false unsat.
 

--- a/docs/design-military-score-build-inference.md
+++ b/docs/design-military-score-build-inference.md
@@ -424,7 +424,7 @@ The first implementation should prefer correct "unknown or ambiguous" output ove
 | Policy overlay | Hook in #77; merge semantics in #78; signal sources out of scope |
 | Score-equivalent combos | Solver-side merge for feasibility; distinct top-K when probability differs |
 | Priority points | Diagnostic-only until production-queue model assigns per-build PP deltas |
-| Fleet priors | Deferred; **inference tier policy overlay** (#78), not hard exclusion |
+| Fleet-informed ranking | **#87** torp admission + misalignment prior; **#156** component tech-gap prior; tunables in `fleetInferenceTuning` (tier policy YAML). **#78** tier policy overlay is catalog widening only (parallel axis). Absent fleet overlay == empty belief set. |
 | SPA streaming (#71) | One multiplexed **inference table stream** per shell scope |
 | Cross-row scheduling (#71) | **Inference row scheduler**: FIFO tier jobs, default 4 workers (configurable) |
 | Global pause (#71) | Freeze/resume all rows on current scope while stream connected; cleared on disconnect |

--- a/docs/design-military-score-inference-build-priors.md
+++ b/docs/design-military-score-inference-build-priors.md
@@ -78,7 +78,7 @@ All tables below live **inside** one category file. Every family splits on **inf
 | **Component conditional** | `(hull_category, ship_limit_band)` | Race-agnostic (pooled) |
 | **Aggregate histogram** | `(action_id, ship_limit_band)` | Rolled into solver buckets at load (see section 7) |
 
-Race does **not** cross into component conditionals in v1. Fleet-informed per-player skew is **#87**, not static priors.
+Race does **not** cross into component conditionals in v1. Fleet-informed per-player skew is **#87** / **#156** (runtime overlay on static priors), not static prior assets.
 
 Glossary: `CONTEXT.md` -- **Inference hull marginal prior**, **Inference conditional component prior**, **Inference aggregate prior**, **Inference ship-limit band**.
 
@@ -345,7 +345,7 @@ Per **inference prior player-host-turn**, single traversal over aggregate action
 1. Compute inventory delta per action (0 when none).
 2. Increment `histogram[delta]` for `(action_id, ship_limit_band)` -- including **`0:`** for zero-delta samples.
 
-**Unconditional marginal (v1):** do **not** condition on asset ownership or per-action feasibility at mining time. Sample every aggregate action on every non-adjunct unit. The solver applies the same static prior whenever an action enters the catalog (tier allowlist + residual bounds -- not ownership). Runtime conditioning is **#87**, not mining.
+**Unconditional marginal (v1):** do **not** condition on asset ownership or per-action feasibility at mining time. Sample every aggregate action on every non-adjunct unit. The solver applies the same static prior whenever an action enters the catalog (tier allowlist + residual bounds -- not ownership). Runtime fleet conditioning is **#87** / **#156**, not mining.
 
 **Histogram keys:** raw observed positive integer deltas (loader buckets via `magnitude_bin_index` at catalog build; miner does not pre-bin). Fighter transfers (`fighters_starbase_to_ship`, `fighters_ship_to_starbase`): occurrence-only 2-bin histograms (`0:` and `1:` for any positive transfer); use `_fighter_transfer_counts` logic from corpus ground truth. Emit `histogram:` only; no `counts:` shape.
 
@@ -405,7 +405,7 @@ No log conversion in miner (loader owns Laplace conversion).
 ## 12. Out of scope (#86)
 
 - Offline mining pipeline (follow-on ticket)
-- Per-player fleet-informed overlay (#87)
+- Per-player fleet-informed overlay (**#87** torp slice, **#156** tech-gap follow-on)
 - Corpus top-K hardening (#65)
 - Changing CP-SAT constraint model
 
@@ -415,7 +415,8 @@ No log conversion in miner (loader owns Laplace conversion).
 |--------|------|
 | **#86** | Asset schema, loaders, hand-seed `standard`, catalog integration |
 | **#92** | Pattern-driven miner, per-category patterns YAML (e.g. `prior_mining_patterns_standard.yaml`), `loadall`, incremental `prior_weights_{category}.yaml` |
-| **#87** | Fleet-informed runtime overlay on static priors |
+| **#87** | Fleet-informed **torp load** overlay (admission + misalignment prior) |
+| **#156** | Fleet-informed **component tech-gap prior** on ship builds |
 | **#65** | Top-K regression after priors stabilize |
 | **#64** | Regression ground truth (inventory diff) -- not prior mining |
 

--- a/packages/api/api/analytics/fleet/__init__.py
+++ b/packages/api/api/analytics/fleet/__init__.py
@@ -2,20 +2,17 @@
 
 from api.analytics.catalog import catalog_entry
 from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
-from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
-from api.analytics.fleet.compute_services import (
-    build_ephemeral_fleet_compute_services,
-    resolve_fleet_compute_services,
-)
 from api.analytics.fleet.constants import ANALYTIC_ID
-from api.analytics.fleet.exports import EXPORT_CATALOG
-from api.analytics.fleet.serialization import fleet_turn_snapshot_to_compute_wire
 from api.analytics.registration import TurnAnalyticRegistration
 from api.models.game import TurnInfo
 
 
 def compute_fleet(ctx: AnalyticComputeContext) -> dict:
     """Return the fleet acquisition ledger for the shell turn."""
+    from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+    from api.analytics.fleet.compute_services import resolve_fleet_compute_services
+    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_compute_wire
+
     services = resolve_fleet_compute_services(ctx)
     snapshot = get_or_materialize_fleet_snapshot(
         services.persistence,
@@ -30,6 +27,8 @@ def compute_fleet(ctx: AnalyticComputeContext) -> dict:
 
 def get_fleet(turn: TurnInfo) -> dict:
     """Convenience entry for tests and direct callers without durable persistence."""
+    from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+
     return invoke_analytic_compute(
         compute_fleet,
         turn,
@@ -37,8 +36,14 @@ def get_fleet(turn: TurnInfo) -> dict:
     )
 
 
+def _load_fleet_export_catalog():
+    from api.analytics.fleet.exports import EXPORT_CATALOG
+
+    return EXPORT_CATALOG
+
+
 REGISTRATION = TurnAnalyticRegistration(
     catalog_entry=catalog_entry(ANALYTIC_ID),
     compute=compute_fleet,
-    export_catalog=EXPORT_CATALOG,
+    export_catalog_loader=_load_fleet_export_catalog,
 )

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -1,8 +1,6 @@
-"""Fleet export composition branch: belief-set histograms and max tech levels.
+"""Fleet export composition branch: component histograms and max tech levels.
 
-Contract: design-fleet-analytic.md (`$.composition`). Belief-set ids include inferred
-fleet build option sets (union per row), not sightings-only known fields. Current
-materializer may emit known-field histograms only until #133 lands.
+Full belief-set composition (build option set unions on inferred rows) is #133 scope.
 """
 
 from __future__ import annotations

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -1,4 +1,9 @@
-"""Fleet export composition branch: component histograms and max tech levels."""
+"""Fleet export composition branch: belief-set histograms and max tech levels.
+
+Contract: design-fleet-analytic.md (`$.composition`). Belief-set ids include inferred
+fleet build option sets (union per row), not sightings-only known fields. Current
+materializer may emit known-field histograms only until #133 lands.
+"""
 
 from __future__ import annotations
 

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -13,9 +13,9 @@ from typing import Protocol
 
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.export_scope import ledgers_for_scope
+from api.analytics.fleet.field_constraints import known_positive_component_id
 from api.analytics.fleet.types import (
     FleetFieldConstraint,
-    FleetFieldKnown,
     FleetShipRecord,
     FleetTurnSnapshot,
 )
@@ -48,20 +48,11 @@ class _TechLevelComponent(Protocol):
     techlevel: int
 
 
-def _known_positive_component_id(field: FleetFieldConstraint) -> int | None:
-    if not isinstance(field, FleetFieldKnown):
-        return None
-    value = field.value
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        return None
-    return value
-
-
 def _increment_component_histogram(
     histogram: dict[str, int],
     field: FleetFieldConstraint,
 ) -> None:
-    component_id = _known_positive_component_id(field)
+    component_id = known_positive_component_id(field)
     if component_id is None:
         return
     key = str(component_id)
@@ -140,7 +131,7 @@ def build_fleet_composition_branch(
         for axis in _COMPOSITION_AXIS_SPECS:
             field = getattr(record.fields, axis.field_name)
             if axis.histogram_output_key is None:
-                component_id = _known_positive_component_id(field)
+                component_id = known_positive_component_id(field)
                 if component_id is not None:
                     engine_ids.append(component_id)
             else:

--- a/packages/api/api/analytics/fleet/export_schema.py
+++ b/packages/api/api/analytics/fleet/export_schema.py
@@ -176,7 +176,8 @@ _COMPOSITION_HISTOGRAM_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
         "Histogram of host component ids keyed by stringified id. Each value is the count of "
-        "active fleet ship records with that known fitted component type."
+        "active fleet ship records contributing that id to the scores-inference belief set "
+        "(known field constraints or any fleet build option set on inferred rows)."
     ),
     "additionalProperties": {
         "type": "integer",
@@ -188,30 +189,29 @@ _COMPOSITION_HISTOGRAM_SCHEMA: dict[str, Any] = {
 _MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Maximum host tech level per component axis, derived from known component ids in the "
-        "histograms and engine field values. Axes with no catalog-resolvable known components "
-        "are omitted."
+        "Maximum host tech level per component axis, derived from belief-set component ids in "
+        "the type histograms and engineTypes. Axes with no catalog-resolvable ids are omitted."
     ),
     "properties": {
         "hulls": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among known hull ids in hullTypes.",
+            "description": "Highest techlevel among hull ids in hullTypes.",
         },
         "engines": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among known engine ids on active ship records.",
+            "description": "Highest techlevel among engine ids in engineTypes.",
         },
         "launchers": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among known torpedo ids in launcherTypes.",
+            "description": "Highest techlevel among torpedo ids in launcherTypes.",
         },
         "beams": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among known beam ids in beamTypes.",
+            "description": "Highest techlevel among beam ids in beamTypes.",
         },
     },
 }
@@ -219,34 +219,38 @@ _MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
 _COMPOSITION_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Per-player aggregated fleet composition derived from the acquisition ledger. Counts "
-        "only active ship records with known component fields; unknown or option-set-only rows "
-        "are omitted."
+        "Per-player aggregated fleet composition for scores inference (#87, #156). Belief-set "
+        "ids come from known field constraints or the union of fleet build option sets on "
+        "inferred rows (see design-fleet-analytic.md). Materialization may lag spec until #133."
     ),
     "properties": {
         "hullTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known hull types on active ships. Keys are host hull ids as "
-                "strings; values are ship counts. Rows with unknown, bounded, options, or region "
-                "hull constraints are excluded."
+                "Belief-set hull ids on active ships. Keys are host hull ids as strings; values "
+                "are ship counts."
+            ),
+        },
+        "engineTypes": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Belief-set engine ids on active ships. Keys are host engine ids as strings; "
+                "values are ship counts."
             ),
         },
         "beamTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known fitted beam weapon types on active ships. Keys are host beam "
-                "ids as strings; values are ship counts. Rows with unknown, bounded, options, or "
-                "region beam constraints are excluded. Known zero (no beams) is excluded."
+                "Belief-set fitted beam ids on active ships. Keys are host beam ids as strings; "
+                "values are ship counts. Known zero (no beams) is excluded."
             ),
         },
         "launcherTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known fitted torpedo-tube types on active ships. Keys are host "
-                "torpedo ids as strings; values are ship counts. Rows with unknown, bounded, "
-                "options, or region launcher constraints are excluded. Known zero (no tubes) is "
-                "excluded."
+                "Inference fleet launcher belief set (#87): fitted torpedo-tube type ids on "
+                "active ships. Keys are host torpedo ids as strings; values are ship counts. "
+                "Known zero (no tubes) is excluded."
             ),
         },
         "torpedoTypesLoaded": {

--- a/packages/api/api/analytics/fleet/export_schema.py
+++ b/packages/api/api/analytics/fleet/export_schema.py
@@ -176,8 +176,7 @@ _COMPOSITION_HISTOGRAM_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
         "Histogram of host component ids keyed by stringified id. Each value is the count of "
-        "active fleet ship records contributing that id to the scores-inference belief set "
-        "(known field constraints or any fleet build option set on inferred rows)."
+        "active fleet ship records with that known fitted component type."
     ),
     "additionalProperties": {
         "type": "integer",
@@ -189,29 +188,30 @@ _COMPOSITION_HISTOGRAM_SCHEMA: dict[str, Any] = {
 _MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Maximum host tech level per component axis, derived from belief-set component ids in "
-        "the type histograms and engineTypes. Axes with no catalog-resolvable ids are omitted."
+        "Maximum host tech level per component axis, derived from known component ids in the "
+        "histograms and engine field values. Axes with no catalog-resolvable known components "
+        "are omitted."
     ),
     "properties": {
         "hulls": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among hull ids in hullTypes.",
+            "description": "Highest techlevel among known hull ids in hullTypes.",
         },
         "engines": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among engine ids in engineTypes.",
+            "description": "Highest techlevel among known engine ids on active ship records.",
         },
         "launchers": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among torpedo ids in launcherTypes.",
+            "description": "Highest techlevel among known torpedo ids in launcherTypes.",
         },
         "beams": {
             "type": "integer",
             "minimum": 1,
-            "description": "Highest techlevel among beam ids in beamTypes.",
+            "description": "Highest techlevel among known beam ids in beamTypes.",
         },
     },
 }
@@ -219,38 +219,34 @@ _MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
 _COMPOSITION_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Per-player aggregated fleet composition for scores inference (#87, #156). Belief-set "
-        "ids come from known field constraints or the union of fleet build option sets on "
-        "inferred rows (see design-fleet-analytic.md). Materialization may lag spec until #133."
+        "Per-player aggregated fleet composition derived from the acquisition ledger. Counts "
+        "only active ship records with known component fields; unknown or option-set-only rows "
+        "are omitted."
     ),
     "properties": {
         "hullTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Belief-set hull ids on active ships. Keys are host hull ids as strings; values "
-                "are ship counts."
-            ),
-        },
-        "engineTypes": {
-            **_COMPOSITION_HISTOGRAM_SCHEMA,
-            "description": (
-                "Belief-set engine ids on active ships. Keys are host engine ids as strings; "
-                "values are ship counts."
+                "Histogram of known hull types on active ships. Keys are host hull ids as "
+                "strings; values are ship counts. Rows with unknown, bounded, options, or region "
+                "hull constraints are excluded."
             ),
         },
         "beamTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Belief-set fitted beam ids on active ships. Keys are host beam ids as strings; "
-                "values are ship counts. Known zero (no beams) is excluded."
+                "Histogram of known fitted beam weapon types on active ships. Keys are host beam "
+                "ids as strings; values are ship counts. Rows with unknown, bounded, options, or "
+                "region beam constraints are excluded. Known zero (no beams) is excluded."
             ),
         },
         "launcherTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Inference fleet launcher belief set (#87): fitted torpedo-tube type ids on "
-                "active ships. Keys are host torpedo ids as strings; values are ship counts. "
-                "Known zero (no tubes) is excluded."
+                "Histogram of known fitted torpedo-tube types on active ships. Keys are host "
+                "torpedo ids as strings; values are ship counts. Rows with unknown, bounded, "
+                "options, or region launcher constraints are excluded. Known zero (no tubes) is "
+                "excluded."
             ),
         },
         "torpedoTypesLoaded": {

--- a/packages/api/api/analytics/fleet/field_constraints.py
+++ b/packages/api/api/analytics/fleet/field_constraints.py
@@ -1,0 +1,14 @@
+"""Shared helpers for fleet field constraint interpretation."""
+
+from __future__ import annotations
+
+from api.analytics.fleet.types import FleetFieldConstraint, FleetFieldKnown
+
+
+def known_positive_component_id(field: FleetFieldConstraint) -> int | None:
+    if not isinstance(field, FleetFieldKnown):
+        return None
+    value = field.value
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -19,6 +19,13 @@ from api.analytics.military_score_inference.component_eligibility import (
     player_by_id,
     turn_catalog_context_for_policy_step,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import (
+    FleetTorpOverlay,
+    FleetTorpOverlayDiagnostics,
+    admitted_torp_ids_for_policy_step,
+    effective_fleet_torp_overlay,
+    merge_fleet_torp_overlay_diagnostics,
+)
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
     CandidateAction,
@@ -47,6 +54,7 @@ from api.analytics.military_score_inference.ship_build_combos import (
 from api.analytics.military_score_inference.tier_policy import (
     InferenceTierPolicyStep,
     compute_aggregate_admission_caps,
+    resolve_fleet_inference_tuning,
     resolve_tier_policies,
 )
 from api.concepts.races import (
@@ -78,6 +86,7 @@ class ActionCatalog:
     admission_caps_by_action_id: dict[str, int] = field(default_factory=dict)
     tier_overflow_by_action_id: dict[str, TierOverflowBand] = field(default_factory=dict)
     prior_weights_diagnostics: PriorWeightsDiagnostics | None = None
+    fleet_torp_overlay_diagnostics: FleetTorpOverlayDiagnostics | None = None
 
     @property
     def catalog_size(self) -> int:
@@ -98,6 +107,8 @@ class ActionCatalog:
         }
         if self.prior_weights_diagnostics is not None:
             payload["priorWeights"] = self.prior_weights_diagnostics.to_payload()
+        if self.fleet_torp_overlay_diagnostics is not None:
+            payload["fleetTorpOverlay"] = self.fleet_torp_overlay_diagnostics.to_payload()
         return payload
 
 
@@ -146,6 +157,7 @@ def build_action_catalog_from_turn(
     policy_step_index: int = 0,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     prior_weights_base_dir: Path | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> ActionCatalog:
     resolved_policy_step = policy_step
     if resolved_policy_step is None:
@@ -189,6 +201,7 @@ def build_action_catalog_from_turn(
         policy_step=resolved_policy_step,
         policy_step_index=policy_step_index,
         policy_steps=resolve_tier_policies(),
+        fleet_torp_overlay=fleet_torp_overlay,
     )
 
 
@@ -225,12 +238,20 @@ def build_action_catalog(
     policy_step: InferenceTierPolicyStep | None = None,
     policy_step_index: int = 0,
     policy_steps: tuple[InferenceTierPolicyStep, ...] | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> ActionCatalog:
     resolved_policy_step = policy_step or resolve_tier_policies()[-1]
     catalog_config = config or ActionCatalogConfig()
     if turn is not None and player is None:
         player = player_by_id(turn, observation.player_id)
     prior_diagnostics = prior_catalog.diagnostics
+    resolved_overlay = effective_fleet_torp_overlay(fleet_torp_overlay)
+    fleet_tuning = resolve_fleet_inference_tuning()
+    admitted_torp_ids = admitted_torp_ids_for_policy_step(
+        policy_step=resolved_policy_step,
+        eligible_torp_ids=eligible_torp_ids,
+        overlay=resolved_overlay,
+    )
 
     aggregate_actions, probability_buckets = build_aggregate_actions(
         observation,
@@ -239,6 +260,7 @@ def build_action_catalog(
         eligible_torp_ids,
         resolved_policy_step.aggregate_allowlist,
         prior_catalog,
+        admitted_torp_ids=admitted_torp_ids,
     )
     kept_actions: list[CandidateAction] = list(aggregate_actions)
     if turn is not None and player is not None:
@@ -272,6 +294,14 @@ def build_action_catalog(
         if overflow_band is not None:
             tier_overflow_by_action_id[action.id] = overflow_band
 
+    probability_buckets, fleet_overlay_diagnostics = merge_fleet_torp_overlay_diagnostics(
+        probability_buckets,
+        overlay=resolved_overlay,
+        tuning=fleet_tuning,
+        policy_step=resolved_policy_step,
+        admitted_torp_ids=admitted_torp_ids,
+    )
+
     ship_build_combos = generate_ship_build_combos(
         observation,
         hulls_by_id=hulls_by_id,
@@ -298,6 +328,7 @@ def build_action_catalog(
         admission_caps_by_action_id=admission_caps_by_action_id,
         tier_overflow_by_action_id=tier_overflow_by_action_id,
         prior_weights_diagnostics=prior_diagnostics,
+        fleet_torp_overlay_diagnostics=fleet_overlay_diagnostics,
     )
 
 

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -24,7 +24,8 @@ from api.analytics.military_score_inference.fleet_torp_overlay import (
     FleetTorpOverlayDiagnostics,
     admitted_torp_ids_for_policy_step,
     effective_fleet_torp_overlay,
-    merge_fleet_torp_overlay_diagnostics,
+    apply_torp_misalignment_penalties_to_catalog,
+    build_fleet_torp_overlay_diagnostics,
 )
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
@@ -304,8 +305,12 @@ def build_action_catalog(
         if overflow_band is not None:
             tier_overflow_by_action_id[action.id] = overflow_band
 
-    probability_buckets, fleet_overlay_diagnostics = merge_fleet_torp_overlay_diagnostics(
+    probability_buckets = apply_torp_misalignment_penalties_to_catalog(
         probability_buckets,
+        overlay=resolved_overlay,
+        tuning=fleet_tuning,
+    )
+    fleet_overlay_diagnostics = build_fleet_torp_overlay_diagnostics(
         overlay=resolved_overlay,
         tuning=fleet_tuning,
         policy_step=resolved_policy_step,

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -23,9 +23,9 @@ from api.analytics.military_score_inference.fleet_torp_overlay import (
     FleetTorpOverlay,
     FleetTorpOverlayDiagnostics,
     admitted_torp_ids_for_policy_step,
-    effective_fleet_torp_overlay,
     apply_torp_misalignment_penalties_to_catalog,
     build_fleet_torp_overlay_diagnostics,
+    effective_fleet_torp_overlay,
 )
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
@@ -250,11 +250,7 @@ def build_action_catalog(
     fleet_tuning = resolve_fleet_inference_tuning()
     policy_ladder = policy_steps or resolve_tier_policies()
     admission_step_index = next(
-        (
-            index
-            for index, step in enumerate(policy_ladder)
-            if step.id == resolved_policy_step.id
-        ),
+        (index for index, step in enumerate(policy_ladder) if step.id == resolved_policy_step.id),
         policy_step_index,
     )
     admitted_torp_ids = admitted_torp_ids_for_policy_step(

--- a/packages/api/api/analytics/military_score_inference/actions.py
+++ b/packages/api/api/analytics/military_score_inference/actions.py
@@ -247,8 +247,19 @@ def build_action_catalog(
     prior_diagnostics = prior_catalog.diagnostics
     resolved_overlay = effective_fleet_torp_overlay(fleet_torp_overlay)
     fleet_tuning = resolve_fleet_inference_tuning()
+    policy_ladder = policy_steps or resolve_tier_policies()
+    admission_step_index = next(
+        (
+            index
+            for index, step in enumerate(policy_ladder)
+            if step.id == resolved_policy_step.id
+        ),
+        policy_step_index,
+    )
     admitted_torp_ids = admitted_torp_ids_for_policy_step(
         policy_step=resolved_policy_step,
+        policy_step_index=admission_step_index,
+        policy_steps=policy_ladder,
         eligible_torp_ids=eligible_torp_ids,
         overlay=resolved_overlay,
     )
@@ -273,7 +284,6 @@ def build_action_catalog(
             )
         )
 
-    policy_ladder = policy_steps or resolve_tier_policies()
     ranking_heuristics = InferenceRankingHeuristics()
     admission_caps_raw = compute_aggregate_admission_caps(policy_ladder, policy_step_index)
     admission_caps_by_action_id: dict[str, int] = {}

--- a/packages/api/api/analytics/military_score_inference/aggregate_catalog_build.py
+++ b/packages/api/api/analytics/military_score_inference/aggregate_catalog_build.py
@@ -43,12 +43,15 @@ def build_aggregate_actions(
     eligible_torp_ids: frozenset[int],
     aggregate_allowlist: dict[str, int],
     prior_catalog: PriorWeightsCatalog,
+    *,
+    admitted_torp_ids: frozenset[int] | None = None,
 ) -> tuple[list[CandidateAction], dict[str, tuple[ProbabilityBucket, ...]]]:
     actions: list[CandidateAction] = []
     probability_buckets: dict[str, tuple[ProbabilityBucket, ...]] = {}
     fighter_transfer_upper_bound = _fighter_transfer_upper_bound(observation, config)
+    torp_ids_for_slots = eligible_torp_ids if admitted_torp_ids is None else admitted_torp_ids
 
-    for slot in iter_aggregate_action_slots(eligible_torp_ids=eligible_torp_ids):
+    for slot in iter_aggregate_action_slots(eligible_torp_ids=torp_ids_for_slots):
         _append_slot_catalog_action(
             actions,
             probability_buckets,

--- a/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
@@ -20,10 +20,10 @@ from api.analytics.military_score_inference.aggregate_action_registry import (
 )
 from api.analytics.military_score_inference.models import ProbabilityBucket
 from api.analytics.military_score_inference.tier_policy import (
-    EARLY_TORP_ADMITTING_STEP_IDS,
     TORP_ESCAPE_TIER_STEP_ID,
     FleetInferenceTuning,
     InferenceTierPolicyStep,
+    torp_escape_tier_index,
 )
 
 __all__ = [
@@ -152,6 +152,8 @@ def torp_load_action_id(torp_id: int) -> str:
 def admitted_torp_ids_for_policy_step(
     *,
     policy_step: InferenceTierPolicyStep,
+    policy_step_index: int,
+    policy_steps: tuple[InferenceTierPolicyStep, ...],
     eligible_torp_ids: frozenset[int],
     overlay: FleetTorpOverlay,
 ) -> frozenset[int]:
@@ -161,13 +163,19 @@ def admitted_torp_ids_for_policy_step(
     if not overlay.enabled:
         return eligible_torp_ids
 
-    if policy_step.id == TORP_ESCAPE_TIER_STEP_ID or policy_step.alpha == 0:
+    if policy_step.alpha == 0:
         return eligible_torp_ids
 
-    if policy_step.id in EARLY_TORP_ADMITTING_STEP_IDS:
+    escape_index = torp_escape_tier_index(policy_steps)
+    if escape_index is not None and policy_step_index < escape_index:
         if overlay.belief_set.is_empty:
             return frozenset()
         return overlay.belief_set.torp_ids & eligible_torp_ids
+
+    if policy_step.id == TORP_ESCAPE_TIER_STEP_ID or (
+        escape_index is not None and policy_step_index > escape_index
+    ):
+        return eligible_torp_ids
 
     return frozenset()
 

--- a/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
@@ -35,7 +35,8 @@ __all__ = [
     "effective_fleet_torp_overlay",
     "launcher_belief_set_from_composition",
     "launcher_belief_set_from_fleet_records",
-    "merge_fleet_torp_overlay_diagnostics",
+    "apply_torp_misalignment_penalties_to_catalog",
+    "build_fleet_torp_overlay_diagnostics",
     "torp_load_action_id",
 ]
 
@@ -201,47 +202,44 @@ def apply_torp_misalignment_penalty_to_buckets(
     return tuple(adjusted)
 
 
-def merge_fleet_torp_overlay_diagnostics(
+def apply_torp_misalignment_penalties_to_catalog(
     probability_buckets: dict[str, tuple[ProbabilityBucket, ...]],
     *,
     overlay: FleetTorpOverlay,
     tuning: FleetInferenceTuning,
-    policy_step: InferenceTierPolicyStep,
-    admitted_torp_ids: frozenset[int],
-) -> tuple[dict[str, tuple[ProbabilityBucket, ...]], FleetTorpOverlayDiagnostics]:
+) -> dict[str, tuple[ProbabilityBucket, ...]]:
     if not overlay.enabled or tuning.torp_misalignment_log_penalty <= 0:
-        diagnostics = FleetTorpOverlayDiagnostics(
-            applied=overlay.enabled,
-            enabled=overlay.enabled,
-            belief_set_torp_ids=tuple(sorted(overlay.belief_set.torp_ids)),
-            admitted_torp_ids=tuple(sorted(admitted_torp_ids)),
-            policy_step_id=policy_step.id,
-            escape_tier_used=policy_step.id == TORP_ESCAPE_TIER_STEP_ID,
-            torp_misalignment_log_penalty=tuning.torp_misalignment_log_penalty,
-        )
-        return probability_buckets, diagnostics
+        return probability_buckets
 
     belief_ids = overlay.belief_set.torp_ids
     penalty = tuning.torp_misalignment_log_penalty
-    merged = dict(probability_buckets)
-    for action_id in list(merged.keys()):
+    adjusted = dict(probability_buckets)
+    for action_id in list(adjusted.keys()):
         if not is_torp_load_action_id(action_id):
             continue
         torp_id = int(action_id.removeprefix(SHIP_TORPS_LOADED_ACTION_PREFIX))
         if torp_id in belief_ids:
             continue
-        merged[action_id] = apply_torp_misalignment_penalty_to_buckets(
-            merged[action_id],
+        adjusted[action_id] = apply_torp_misalignment_penalty_to_buckets(
+            adjusted[action_id],
             penalty=penalty,
         )
+    return adjusted
 
-    diagnostics = FleetTorpOverlayDiagnostics(
-        applied=True,
-        enabled=True,
-        belief_set_torp_ids=tuple(sorted(belief_ids)),
+
+def build_fleet_torp_overlay_diagnostics(
+    *,
+    overlay: FleetTorpOverlay,
+    tuning: FleetInferenceTuning,
+    policy_step: InferenceTierPolicyStep,
+    admitted_torp_ids: frozenset[int],
+) -> FleetTorpOverlayDiagnostics:
+    return FleetTorpOverlayDiagnostics(
+        applied=overlay.enabled,
+        enabled=overlay.enabled,
+        belief_set_torp_ids=tuple(sorted(overlay.belief_set.torp_ids)),
         admitted_torp_ids=tuple(sorted(admitted_torp_ids)),
         policy_step_id=policy_step.id,
         escape_tier_used=policy_step.id == TORP_ESCAPE_TIER_STEP_ID,
-        torp_misalignment_log_penalty=penalty,
+        torp_misalignment_log_penalty=tuning.torp_misalignment_log_penalty,
     )
-    return merged, diagnostics

--- a/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
@@ -1,0 +1,239 @@
+"""Fleet-informed torpedo admission and ranking overlay for scores inference (#87).
+
+Glossary: CONTEXT.md (**Inference fleet launcher belief set**, **Inference aggregate
+admission**, **Inference torp escape tier**, **Inference torp misalignment penalty**).
+
+Absent ``FleetTorpOverlay`` input behaves like an **empty belief set** (no early torp
+admission; strong down-weight at escape tier). Use ``FleetTorpOverlay.disabled()`` to
+skip overlay logic and retain the pre-#87 catalog (population priors only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+
+from api.analytics.military_score_inference.aggregate_action_registry import (
+    SHIP_TORPS_LOADED_ACTION_PREFIX,
+    SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY,
+    is_torp_load_action_id,
+)
+from api.analytics.military_score_inference.models import ProbabilityBucket
+from api.analytics.military_score_inference.tier_policy import (
+    EARLY_TORP_ADMITTING_STEP_IDS,
+    TORP_ESCAPE_TIER_STEP_ID,
+    FleetInferenceTuning,
+    InferenceTierPolicyStep,
+)
+
+__all__ = [
+    "FleetLauncherBeliefSet",
+    "FleetTorpOverlay",
+    "FleetTorpOverlayDiagnostics",
+    "admitted_torp_ids_for_policy_step",
+    "apply_torp_misalignment_penalty_to_buckets",
+    "effective_fleet_torp_overlay",
+    "launcher_belief_set_from_composition",
+    "launcher_belief_set_from_fleet_records",
+    "merge_fleet_torp_overlay_diagnostics",
+    "torp_load_action_id",
+]
+
+
+@dataclass(frozen=True)
+class FleetLauncherBeliefSet:
+    """Torp ids fitted on ships the player is believed to own at prior turn."""
+
+    torp_ids: frozenset[int]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.torp_ids
+
+
+@dataclass(frozen=True)
+class FleetTorpOverlay:
+    """Optional per-solve fleet torp overlay input."""
+
+    belief_set: FleetLauncherBeliefSet
+    enabled: bool = True
+
+    @staticmethod
+    def disabled() -> FleetTorpOverlay:
+        """Skip #87 admission filtering and misalignment penalties (#86 baseline)."""
+        return FleetTorpOverlay(
+            belief_set=FleetLauncherBeliefSet(frozenset()),
+            enabled=False,
+        )
+
+    @staticmethod
+    def from_torp_ids(torp_ids: frozenset[int] | Iterable[int]) -> FleetTorpOverlay:
+        return FleetTorpOverlay(belief_set=FleetLauncherBeliefSet(frozenset(torp_ids)))
+
+
+@dataclass(frozen=True)
+class FleetTorpOverlayDiagnostics:
+    applied: bool
+    enabled: bool
+    belief_set_torp_ids: tuple[int, ...]
+    admitted_torp_ids: tuple[int, ...]
+    policy_step_id: str
+    escape_tier_used: bool
+    torp_misalignment_log_penalty: int
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "applied": self.applied,
+            "enabled": self.enabled,
+            "beliefSetTorpIds": list(self.belief_set_torp_ids),
+            "admittedTorpIds": list(self.admitted_torp_ids),
+            "policyStepId": self.policy_step_id,
+            "escapeTierUsed": self.escape_tier_used,
+            "torpMisalignmentLogPenalty": self.torp_misalignment_log_penalty,
+        }
+
+
+def effective_fleet_torp_overlay(overlay: FleetTorpOverlay | None) -> FleetTorpOverlay:
+    if overlay is None:
+        return FleetTorpOverlay(belief_set=FleetLauncherBeliefSet(frozenset()), enabled=True)
+    return overlay
+
+
+def _known_positive_component_id(field: object) -> int | None:
+    from api.analytics.fleet.types import FleetFieldKnown
+
+    if not isinstance(field, FleetFieldKnown):
+        return None
+    value = field.value
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value
+
+
+def launcher_belief_set_from_fleet_records(
+    records: Iterable[object],
+) -> FleetLauncherBeliefSet:
+    """Union launcher/torp ids from known fields and all fleet build option sets."""
+    torp_ids: set[int] = set()
+    for record in records:
+        if getattr(record, "disposition", None) != "active":
+            continue
+        fields = getattr(record, "fields", None)
+        if fields is None:
+            continue
+        known_launcher = _known_positive_component_id(getattr(fields, "launchers", None))
+        if known_launcher is not None:
+            torp_ids.add(known_launcher)
+        for option_set in getattr(record, "build_option_sets", ()):
+            torp_id = getattr(option_set, "torp_id", None)
+            if torp_id is not None and torp_id > 0:
+                torp_ids.add(torp_id)
+    return FleetLauncherBeliefSet(frozenset(torp_ids))
+
+
+def launcher_belief_set_from_composition(composition: dict[str, object]) -> FleetLauncherBeliefSet:
+    """Derive belief set from fleet ``$.composition.launcherTypes`` export branch."""
+    launcher_types = composition.get("launcherTypes", {})
+    if not isinstance(launcher_types, dict):
+        return FleetLauncherBeliefSet(frozenset())
+    torp_ids: set[int] = set()
+    for key in launcher_types:
+        if isinstance(key, str) and key.isdecimal():
+            torp_id = int(key)
+            if torp_id > 0:
+                torp_ids.add(torp_id)
+    return FleetLauncherBeliefSet(frozenset(torp_ids))
+
+
+def torp_load_action_id(torp_id: int) -> str:
+    return f"{SHIP_TORPS_LOADED_ACTION_PREFIX}{torp_id}"
+
+
+def admitted_torp_ids_for_policy_step(
+    *,
+    policy_step: InferenceTierPolicyStep,
+    eligible_torp_ids: frozenset[int],
+    overlay: FleetTorpOverlay,
+) -> frozenset[int]:
+    if SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY not in policy_step.aggregate_allowlist:
+        return frozenset()
+
+    if not overlay.enabled:
+        return eligible_torp_ids
+
+    if policy_step.id == TORP_ESCAPE_TIER_STEP_ID or policy_step.alpha == 0:
+        return eligible_torp_ids
+
+    if policy_step.id in EARLY_TORP_ADMITTING_STEP_IDS:
+        if overlay.belief_set.is_empty:
+            return frozenset()
+        return overlay.belief_set.torp_ids & eligible_torp_ids
+
+    return frozenset()
+
+
+def apply_torp_misalignment_penalty_to_buckets(
+    buckets: tuple[ProbabilityBucket, ...],
+    *,
+    penalty: int,
+) -> tuple[ProbabilityBucket, ...]:
+    if penalty <= 0:
+        return buckets
+    adjusted: list[ProbabilityBucket] = []
+    for bucket in buckets:
+        if bucket.lower_count == 0 and bucket.upper_count == 0:
+            adjusted.append(bucket)
+            continue
+        adjusted.append(
+            replace(
+                bucket,
+                marginal_weight=max(0, bucket.marginal_weight - penalty),
+            )
+        )
+    return tuple(adjusted)
+
+
+def merge_fleet_torp_overlay_diagnostics(
+    probability_buckets: dict[str, tuple[ProbabilityBucket, ...]],
+    *,
+    overlay: FleetTorpOverlay,
+    tuning: FleetInferenceTuning,
+    policy_step: InferenceTierPolicyStep,
+    admitted_torp_ids: frozenset[int],
+) -> tuple[dict[str, tuple[ProbabilityBucket, ...]], FleetTorpOverlayDiagnostics]:
+    if not overlay.enabled or tuning.torp_misalignment_log_penalty <= 0:
+        diagnostics = FleetTorpOverlayDiagnostics(
+            applied=overlay.enabled,
+            enabled=overlay.enabled,
+            belief_set_torp_ids=tuple(sorted(overlay.belief_set.torp_ids)),
+            admitted_torp_ids=tuple(sorted(admitted_torp_ids)),
+            policy_step_id=policy_step.id,
+            escape_tier_used=policy_step.id == TORP_ESCAPE_TIER_STEP_ID,
+            torp_misalignment_log_penalty=tuning.torp_misalignment_log_penalty,
+        )
+        return probability_buckets, diagnostics
+
+    belief_ids = overlay.belief_set.torp_ids
+    penalty = tuning.torp_misalignment_log_penalty
+    merged = dict(probability_buckets)
+    for action_id in list(merged.keys()):
+        if not is_torp_load_action_id(action_id):
+            continue
+        torp_id = int(action_id.removeprefix(SHIP_TORPS_LOADED_ACTION_PREFIX))
+        if torp_id in belief_ids:
+            continue
+        merged[action_id] = apply_torp_misalignment_penalty_to_buckets(
+            merged[action_id],
+            penalty=penalty,
+        )
+
+    diagnostics = FleetTorpOverlayDiagnostics(
+        applied=True,
+        enabled=True,
+        belief_set_torp_ids=tuple(sorted(belief_ids)),
+        admitted_torp_ids=tuple(sorted(admitted_torp_ids)),
+        policy_step_id=policy_step.id,
+        escape_tier_used=policy_step.id == TORP_ESCAPE_TIER_STEP_ID,
+        torp_misalignment_log_penalty=penalty,
+    )
+    return merged, diagnostics

--- a/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 
+from api.analytics.fleet.field_constraints import known_positive_component_id
+from api.analytics.fleet.types import FleetShipRecord
 from api.analytics.military_score_inference.aggregate_action_registry import (
     SHIP_TORPS_LOADED_ACTION_PREFIX,
     SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY,
@@ -100,33 +102,19 @@ def effective_fleet_torp_overlay(overlay: FleetTorpOverlay | None) -> FleetTorpO
     return overlay
 
 
-def _known_positive_component_id(field: object) -> int | None:
-    from api.analytics.fleet.types import FleetFieldKnown
-
-    if not isinstance(field, FleetFieldKnown):
-        return None
-    value = field.value
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        return None
-    return value
-
-
 def launcher_belief_set_from_fleet_records(
-    records: Iterable[object],
+    records: Iterable[FleetShipRecord],
 ) -> FleetLauncherBeliefSet:
     """Union launcher/torp ids from known fields and all fleet build option sets."""
     torp_ids: set[int] = set()
     for record in records:
-        if getattr(record, "disposition", None) != "active":
+        if record.disposition != "active":
             continue
-        fields = getattr(record, "fields", None)
-        if fields is None:
-            continue
-        known_launcher = _known_positive_component_id(getattr(fields, "launchers", None))
+        known_launcher = known_positive_component_id(record.fields.launchers)
         if known_launcher is not None:
             torp_ids.add(known_launcher)
-        for option_set in getattr(record, "build_option_sets", ()):
-            torp_id = getattr(option_set, "torp_id", None)
+        for option_set in record.build_option_sets:
+            torp_id = option_set.torp_id
             if torp_id is not None and torp_id > 0:
                 torp_ids.add(torp_id)
     return FleetLauncherBeliefSet(frozenset(torp_ids))

--- a/packages/api/api/analytics/military_score_inference/policy_ladder.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder.py
@@ -12,6 +12,7 @@ from api.analytics.military_score_inference.actions import (
 from api.analytics.military_score_inference.constraints import (
     solution_satisfies_exact_hard_equalities,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_cancel import InferenceCancelToken
 from api.analytics.military_score_inference.models import (
@@ -153,6 +154,7 @@ def solve_with_policy_ladder(
     cancel_token: InferenceCancelToken | None = None,
     on_admitted: Callable[[InferenceSolution], None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> tuple[
     InferenceResult,
     ActionCatalog | None,
@@ -166,6 +168,7 @@ def solve_with_policy_ladder(
         policy_steps=tuple(resolve_tier_policies(policy_path)),
         resolved_max_solutions=resolved_max_solutions,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     while not state.ladder_complete and state.next_step_index < len(state.policy_steps):
         if cancel_token is not None and cancel_token.is_cancelled():

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass, field
 
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.models import (
     InferenceProblem,
@@ -40,3 +41,4 @@ class PolicyLadderState:
     cancelled: bool = False
     started_at: float = field(default_factory=time.monotonic)
     resolved_mask: ResolvedHullCatalogMask | None = None
+    fleet_torp_overlay: FleetTorpOverlay | None = None

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
@@ -347,6 +347,7 @@ def run_policy_ladder_tier_step(
         policy_step=policy_step,
         policy_step_index=step_index,
         resolved_mask=state.resolved_mask,
+        fleet_torp_overlay=state.fleet_torp_overlay,
     )
     state.catalog = catalog
     current_combo_ids = frozenset(combo.combo_id for combo in catalog.ship_build_combos)

--- a/packages/api/api/analytics/military_score_inference/tier_policy.py
+++ b/packages/api/api/analytics/military_score_inference/tier_policy.py
@@ -1,4 +1,8 @@
-"""YAML inference search tier policy load, validation, and optional overlay hook."""
+"""YAML inference search tier policy load, validation, and optional overlay hook.
+
+Fleet-informed ranking tunables (``fleetInferenceTuning``) and torp escape-tier admission
+are specified in design-military-score-build-inference-implementation.md section 8.8 (#87, #156).
+"""
 
 from __future__ import annotations
 

--- a/packages/api/api/analytics/military_score_inference/tier_policy.py
+++ b/packages/api/api/analytics/military_score_inference/tier_policy.py
@@ -23,14 +23,6 @@ DEFAULT_MAX_SEEDS = 5
 
 TORP_ESCAPE_TIER_STEP_ID = "torp_escape_tier"
 
-EARLY_TORP_ADMITTING_STEP_IDS: frozenset[str] = frozenset(
-    {
-        "admit_ship_torpedoes",
-        "full_components_planet_defense",
-        "admit_starbase_defense_posts",
-    }
-)
-
 # ``all: true`` widens eligibility on that axis. It does **not** mean "every component id
 # in the turn catalog regardless of player state."
 #
@@ -554,6 +546,14 @@ def resolve_tier_policies(
     if base_path is None:
         _validate_production_escape_tier(steps)
     return steps
+
+
+def torp_escape_tier_index(steps: tuple[InferenceTierPolicyStep, ...]) -> int | None:
+    """Index of the torp escape tier step, or None when the ladder has no escape tier."""
+    for index, step in enumerate(steps):
+        if step.id == TORP_ESCAPE_TIER_STEP_ID:
+            return index
+    return None
 
 
 def compute_aggregate_admission_caps(

--- a/packages/api/api/analytics/military_score_inference/tier_policy.py
+++ b/packages/api/api/analytics/military_score_inference/tier_policy.py
@@ -21,6 +21,16 @@ FILTER_AXES: tuple[FilterAxis, ...] = ("hulls", "engines", "beams", "launchers")
 
 DEFAULT_MAX_SEEDS = 5
 
+TORP_ESCAPE_TIER_STEP_ID = "torp_escape_tier"
+
+EARLY_TORP_ADMITTING_STEP_IDS: frozenset[str] = frozenset(
+    {
+        "admit_ship_torpedoes",
+        "full_components_planet_defense",
+        "admit_starbase_defense_posts",
+    }
+)
+
 # ``all: true`` widens eligibility on that axis. It does **not** mean "every component id
 # in the turn catalog regardless of player state."
 #
@@ -124,6 +134,11 @@ class InferenceTierPolicyStep:
 @dataclass(frozen=True)
 class SolverThresholds:
     ship_only_exact_early_stop_min_plausibility: int
+
+
+@dataclass(frozen=True)
+class FleetInferenceTuning:
+    torp_misalignment_log_penalty: int
 
 
 def default_tier_policy_path() -> Path:
@@ -457,6 +472,33 @@ def parse_solver_thresholds(document: dict[str, Any]) -> SolverThresholds:
 _default_solver_thresholds: SolverThresholds | None = None
 
 
+def parse_fleet_inference_tuning(document: dict[str, Any]) -> FleetInferenceTuning:
+    raw_tuning = document.get("fleetInferenceTuning")
+    if not isinstance(raw_tuning, dict):
+        raise ValueError("tier policy must contain fleetInferenceTuning mapping")
+    penalty = raw_tuning.get("torpMisalignmentLogPenalty")
+    if not isinstance(penalty, int) or penalty < 0:
+        raise ValueError(
+            "tier policy fleetInferenceTuning.torpMisalignmentLogPenalty must be a "
+            "non-negative integer"
+        )
+    return FleetInferenceTuning(torp_misalignment_log_penalty=penalty)
+
+
+_default_fleet_inference_tuning: FleetInferenceTuning | None = None
+
+
+def resolve_fleet_inference_tuning(base_path: Path | None = None) -> FleetInferenceTuning:
+    global _default_fleet_inference_tuning
+    if base_path is None and _default_fleet_inference_tuning is not None:
+        return _default_fleet_inference_tuning
+    policy_path = default_tier_policy_path() if base_path is None else base_path
+    parsed = parse_fleet_inference_tuning(load_tier_policy_document(policy_path))
+    if base_path is None:
+        _default_fleet_inference_tuning = parsed
+    return parsed
+
+
 def resolve_solver_thresholds(base_path: Path | None = None) -> SolverThresholds:
     global _default_solver_thresholds
     if base_path is None and _default_solver_thresholds is not None:
@@ -479,6 +521,24 @@ def parse_tier_policy_steps(document: dict[str, Any]) -> tuple[InferenceTierPoli
     return steps
 
 
+def _validate_production_escape_tier(steps: tuple[InferenceTierPolicyStep, ...]) -> None:
+    from api.analytics.military_score_inference.aggregate_action_registry import (
+        SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY,
+    )
+
+    if len(steps) < 2:
+        return
+    if not any(SHIP_TORPS_PER_TYPE_ALLOWLIST_KEY in step.aggregate_allowlist for step in steps):
+        return
+    if steps[-2].id != TORP_ESCAPE_TIER_STEP_ID:
+        raise ValueError(
+            f"penultimate policy step must be {TORP_ESCAPE_TIER_STEP_ID!r} "
+            "(inference torp escape tier)"
+        )
+    if steps[-2].alpha == 0:
+        raise ValueError(f"{TORP_ESCAPE_TIER_STEP_ID} must have alpha > 0")
+
+
 def resolve_tier_policies(
     base_path: Path | None = None,
     overlay: TierPolicyOverlay | None = None,
@@ -490,7 +550,10 @@ def resolve_tier_policies(
     """
     del overlay
     policy_path = default_tier_policy_path() if base_path is None else base_path
-    return parse_tier_policy_steps(load_tier_policy_document(policy_path))
+    steps = parse_tier_policy_steps(load_tier_policy_document(policy_path))
+    if base_path is None:
+        _validate_production_escape_tier(steps)
+    return steps
 
 
 def compute_aggregate_admission_caps(

--- a/packages/api/tests/fixtures/military_score_inference.py
+++ b/packages/api/tests/fixtures/military_score_inference.py
@@ -5,11 +5,22 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.models import InferenceObservation
 from api.models.components import Beam, Engine, Hull, Torpedo
 from api.serialization.turn import turn_info_from_json
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "api" / "storage" / "assets"
+
+
+def legacy_fleet_torp_overlay() -> FleetTorpOverlay:
+    """Return a disabled fleet torp overlay for pre-#87 catalog behavior.
+
+    Tier-policy and legacy-admission tests pass this explicitly so they opt out of
+    the production default empty-belief overlay while still exercising ladder
+    steps that admit torpedoes without fleet-informed beliefs.
+    """
+    return FleetTorpOverlay.disabled()
 
 
 def _observation(

--- a/packages/api/tests/test_fleet_torp_overlay.py
+++ b/packages/api/tests/test_fleet_torp_overlay.py
@@ -28,8 +28,8 @@ from api.analytics.military_score_inference.models import (
     InferenceObservation,
     ShipBuildCombo,
 )
-from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_id
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
+from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_id
 from api.analytics.military_score_inference.solver import STATUS_EXACT, solve_inference_problem
 from api.analytics.military_score_inference.tier_policy import (
     TORP_ESCAPE_TIER_STEP_ID,
@@ -61,9 +61,7 @@ def _torp_action_ids(catalog: ActionCatalog) -> set[str]:
     }
 
 
-def _torp_and_escape_step_indices() -> tuple[
-    tuple[InferenceTierPolicyStep, ...], int, int
-]:
+def _torp_and_escape_step_indices() -> tuple[tuple[InferenceTierPolicyStep, ...], int, int]:
     policy_steps = resolve_tier_policies()
     torp_step_index = next(
         index for index, step in enumerate(policy_steps) if step.id == "admit_ship_torpedoes"

--- a/packages/api/tests/test_fleet_torp_overlay.py
+++ b/packages/api/tests/test_fleet_torp_overlay.py
@@ -29,9 +29,11 @@ from api.analytics.military_score_inference.models import (
     ShipBuildCombo,
 )
 from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_id
+from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
 from api.analytics.military_score_inference.solver import STATUS_EXACT, solve_inference_problem
 from api.analytics.military_score_inference.tier_policy import (
     TORP_ESCAPE_TIER_STEP_ID,
+    InferenceTierPolicyStep,
     resolve_fleet_inference_tuning,
     resolve_tier_policies,
 )
@@ -53,6 +55,27 @@ def _torp_step():
 
 def _escape_step():
     return next(step for step in resolve_tier_policies() if step.id == TORP_ESCAPE_TIER_STEP_ID)
+
+
+def _torp_action_ids(catalog: ActionCatalog) -> set[str]:
+    return {
+        action.id
+        for action in catalog.aggregate_actions
+        if action.id.startswith("ship_torps_loaded_")
+    }
+
+
+def _torp_and_escape_step_indices() -> tuple[
+    tuple[InferenceTierPolicyStep, ...], int, int
+]:
+    policy_steps = resolve_tier_policies()
+    torp_step_index = next(
+        index for index, step in enumerate(policy_steps) if step.id == "admit_ship_torpedoes"
+    )
+    escape_step_index = next(
+        index for index, step in enumerate(policy_steps) if step.id == TORP_ESCAPE_TIER_STEP_ID
+    )
+    return policy_steps, torp_step_index, escape_step_index
 
 
 def test_belief_set_from_composition_histogram():
@@ -279,6 +302,76 @@ def test_ranking_ship_build_beats_belief_torp_beats_non_belief_torp():
     assert second.actions and second.actions[0].action_id == belief_torp.id
     assert third.actions and third.actions[0].action_id == non_belief_torp.id
     assert top.objective_value >= second.objective_value >= third.objective_value
+
+
+def test_solve_with_policy_ladder_fleet_torp_overlay_belief_set(sample_turn):
+    """Full ladder walk: empty belief defers torps until escape; belief admits early."""
+    observation = _observation(military_delta_2x=500)
+    policy_steps, torp_step_index, escape_step_index = _torp_and_escape_step_indices()
+    torp_step = policy_steps[torp_step_index]
+    escape_step = policy_steps[escape_step_index]
+
+    empty_overlay = FleetTorpOverlay(
+        belief_set=FleetLauncherBeliefSet(frozenset()),
+        enabled=True,
+    )
+    _, final_catalog, _, attempted, _ = solve_with_policy_ladder(
+        observation,
+        sample_turn,
+        fleet_torp_overlay=empty_overlay,
+        time_limit_seconds=60.0,
+    )
+
+    assert "admit_ship_torpedoes" in attempted
+    assert TORP_ESCAPE_TIER_STEP_ID in attempted
+
+    early_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=torp_step,
+        policy_step_index=torp_step_index,
+        fleet_torp_overlay=empty_overlay,
+    )
+    assert not _torp_action_ids(early_catalog)
+    assert early_catalog.fleet_torp_overlay_diagnostics is not None
+    assert early_catalog.fleet_torp_overlay_diagnostics.belief_set_torp_ids == ()
+
+    escape_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=escape_step,
+        policy_step_index=escape_step_index,
+        fleet_torp_overlay=empty_overlay,
+    )
+    assert _torp_action_ids(escape_catalog)
+    assert escape_catalog.fleet_torp_overlay_diagnostics is not None
+    assert escape_catalog.fleet_torp_overlay_diagnostics.escape_tier_used is True
+
+    assert final_catalog is not None
+    assert _torp_action_ids(final_catalog)
+
+    belief_torp_id = 1
+    belief_overlay = FleetTorpOverlay.from_torp_ids(frozenset({belief_torp_id}))
+    _, _, _, belief_attempted, _ = solve_with_policy_ladder(
+        observation,
+        sample_turn,
+        fleet_torp_overlay=belief_overlay,
+        time_limit_seconds=60.0,
+    )
+    assert "admit_ship_torpedoes" in belief_attempted
+
+    belief_early_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=torp_step,
+        policy_step_index=torp_step_index,
+        fleet_torp_overlay=belief_overlay,
+    )
+    assert _torp_action_ids(belief_early_catalog) == {torp_load_action_id(belief_torp_id)}
+    assert belief_early_catalog.fleet_torp_overlay_diagnostics is not None
+    assert belief_early_catalog.fleet_torp_overlay_diagnostics.admitted_torp_ids == (
+        belief_torp_id,
+    )
 
 
 def test_admitted_torp_ids_respects_option_set_union():

--- a/packages/api/tests/test_fleet_torp_overlay.py
+++ b/packages/api/tests/test_fleet_torp_overlay.py
@@ -38,15 +38,11 @@ from api.analytics.military_score_inference.tier_policy import (
     resolve_tier_policies,
 )
 
-from tests.fixtures.military_score_inference import _observation
+from tests.fixtures.military_score_inference import _observation, legacy_fleet_torp_overlay
 from tests.fixtures.military_score_inference_prior_weights import (
     minimal_prior_catalog,
     probability_buckets_for_test_action,
 )
-
-
-def _legacy_overlay() -> FleetTorpOverlay:
-    return FleetTorpOverlay.disabled()
 
 
 def _torp_step():
@@ -171,7 +167,7 @@ def test_disabled_overlay_matches_legacy_torp_admission(sample_turn):
         _observation(military_delta_2x=500),
         sample_turn,
         policy_step=torp_step,
-        fleet_torp_overlay=_legacy_overlay(),
+        fleet_torp_overlay=legacy_fleet_torp_overlay(),
     )
     torp_actions = [
         action for action in catalog.aggregate_actions if action.id.startswith("ship_torps_loaded_")

--- a/packages/api/tests/test_fleet_torp_overlay.py
+++ b/packages/api/tests/test_fleet_torp_overlay.py
@@ -1,0 +1,293 @@
+"""Tests for fleet-informed torpedo admission and ranking overlay (#87)."""
+
+from __future__ import annotations
+
+from api.analytics.fleet.types import (
+    FleetBuildOptionSet,
+    FleetFieldKnown,
+    FleetShipRecord,
+    FleetShipRecordFields,
+)
+from api.analytics.military_score_inference.actions import (
+    ActionCatalog,
+    build_action_catalog,
+    build_action_catalog_from_turn,
+    build_inference_problem,
+)
+from api.analytics.military_score_inference.fleet_torp_overlay import (
+    FleetLauncherBeliefSet,
+    FleetTorpOverlay,
+    admitted_torp_ids_for_policy_step,
+    apply_torp_misalignment_penalty_to_buckets,
+    launcher_belief_set_from_composition,
+    launcher_belief_set_from_fleet_records,
+    torp_load_action_id,
+)
+from api.analytics.military_score_inference.models import (
+    CandidateAction,
+    InferenceObservation,
+    ShipBuildCombo,
+)
+from api.analytics.military_score_inference.ship_build_combos import ship_build_combo_id
+from api.analytics.military_score_inference.solver import STATUS_EXACT, solve_inference_problem
+from api.analytics.military_score_inference.tier_policy import (
+    TORP_ESCAPE_TIER_STEP_ID,
+    resolve_fleet_inference_tuning,
+    resolve_tier_policies,
+)
+
+from tests.fixtures.military_score_inference import _observation
+from tests.fixtures.military_score_inference_prior_weights import (
+    minimal_prior_catalog,
+    probability_buckets_for_test_action,
+)
+
+
+def _legacy_overlay() -> FleetTorpOverlay:
+    return FleetTorpOverlay.disabled()
+
+
+def _torp_step():
+    return next(step for step in resolve_tier_policies() if step.id == "admit_ship_torpedoes")
+
+
+def _escape_step():
+    return next(step for step in resolve_tier_policies() if step.id == TORP_ESCAPE_TIER_STEP_ID)
+
+
+def test_belief_set_from_composition_histogram():
+    belief = launcher_belief_set_from_composition({"launcherTypes": {"4": 2, "8": 1}})
+    assert belief.torp_ids == frozenset({4, 8})
+
+
+def test_belief_set_from_fleet_records_unions_option_sets():
+    record = FleetShipRecord(
+        record_id="inferred",
+        disposition="active",
+        fields=FleetShipRecordFields(
+            launchers=FleetFieldKnown(4),
+        ),
+        build_option_sets=[
+            FleetBuildOptionSet(torp_id=4, label="Mk IV default"),
+            FleetBuildOptionSet(torp_id=8, label="Mk VIII alt"),
+        ],
+    )
+    belief = launcher_belief_set_from_fleet_records([record])
+    assert belief.torp_ids == frozenset({4, 8})
+
+
+def test_absent_overlay_is_empty_belief_set_on_early_torp_tier(sample_turn):
+    torp_step = _torp_step()
+    catalog = build_action_catalog_from_turn(
+        _observation(military_delta_2x=500),
+        sample_turn,
+        policy_step=torp_step,
+    )
+    torp_action_ids = {
+        action.id
+        for action in catalog.aggregate_actions
+        if action.id.startswith("ship_torps_loaded_")
+    }
+    assert not torp_action_ids
+    assert catalog.fleet_torp_overlay_diagnostics is not None
+    assert catalog.fleet_torp_overlay_diagnostics.enabled is True
+    assert catalog.fleet_torp_overlay_diagnostics.belief_set_torp_ids == ()
+
+
+def _catalog_context(synthetic_catalog_context):
+    return {
+        key: value for key, value in synthetic_catalog_context.items() if key != "prior_catalog"
+    }
+
+
+def test_belief_set_admits_only_matching_torps_on_early_tier(
+    synthetic_catalog_context,
+):
+    torp_step = _torp_step()
+    belief_torp_id = next(iter(synthetic_catalog_context["eligible_torp_ids"]))
+    overlay = FleetTorpOverlay.from_torp_ids(frozenset({belief_torp_id}))
+    catalog = build_action_catalog(
+        _observation(military_delta_2x=500),
+        policy_step=torp_step,
+        prior_catalog=minimal_prior_catalog(),
+        fleet_torp_overlay=overlay,
+        **_catalog_context(synthetic_catalog_context),
+    )
+    torp_action_ids = {
+        action.id
+        for action in catalog.aggregate_actions
+        if action.id.startswith("ship_torps_loaded_")
+    }
+    assert torp_action_ids == {torp_load_action_id(belief_torp_id)}
+
+
+def test_escape_tier_admits_all_eligible_torps(synthetic_catalog_context):
+    escape_step = _escape_step()
+    belief_torp_id = next(iter(synthetic_catalog_context["eligible_torp_ids"]))
+    overlay = FleetTorpOverlay.from_torp_ids(frozenset({belief_torp_id}))
+    catalog = build_action_catalog(
+        _observation(military_delta_2x=500),
+        policy_step=escape_step,
+        prior_catalog=minimal_prior_catalog(),
+        fleet_torp_overlay=overlay,
+        **_catalog_context(synthetic_catalog_context),
+    )
+    torp_action_ids = {
+        action.id
+        for action in catalog.aggregate_actions
+        if action.id.startswith("ship_torps_loaded_")
+    }
+    assert len(torp_action_ids) == len(synthetic_catalog_context["eligible_torp_ids"])
+    assert catalog.fleet_torp_overlay_diagnostics is not None
+    assert catalog.fleet_torp_overlay_diagnostics.escape_tier_used is True
+
+
+def test_disabled_overlay_matches_legacy_torp_admission(sample_turn):
+    torp_step = _torp_step()
+    catalog = build_action_catalog_from_turn(
+        _observation(military_delta_2x=500),
+        sample_turn,
+        policy_step=torp_step,
+        fleet_torp_overlay=_legacy_overlay(),
+    )
+    torp_actions = [
+        action for action in catalog.aggregate_actions if action.id.startswith("ship_torps_loaded_")
+    ]
+    assert torp_actions
+    assert catalog.fleet_torp_overlay_diagnostics is not None
+    assert catalog.fleet_torp_overlay_diagnostics.enabled is False
+
+
+def test_misalignment_penalty_reduces_active_bin_weights():
+    buckets = probability_buckets_for_test_action("ship_torps_loaded_1")
+    penalized = apply_torp_misalignment_penalty_to_buckets(buckets, penalty=50)
+    assert penalized[0].marginal_weight == buckets[0].marginal_weight
+    assert penalized[1].marginal_weight == buckets[1].marginal_weight - 50
+
+
+def test_non_belief_torp_gets_penalty_on_escape_tier(synthetic_catalog_context):
+    from api.models.components import Torpedo
+
+    second_torp = Torpedo(
+        id=2,
+        fullid=2,
+        name="Mark 2 Photon",
+        torpedocost=2,
+        launchercost=2,
+        tritanium=1,
+        duranium=1,
+        molybdenum=0,
+        mass=1,
+        techlevel=2,
+        crewkill=10,
+        damage=5,
+        combatrange=0,
+    )
+    context = _catalog_context(synthetic_catalog_context)
+    context["torpedos_by_id"] = {
+        **context["torpedos_by_id"],
+        second_torp.id: second_torp,
+    }
+    context["eligible_torp_ids"] = frozenset({1, 2})
+    escape_step = _escape_step()
+    overlay = FleetTorpOverlay.from_torp_ids(frozenset({1}))
+    catalog = build_action_catalog(
+        _observation(military_delta_2x=500),
+        policy_step=escape_step,
+        prior_catalog=minimal_prior_catalog(),
+        fleet_torp_overlay=overlay,
+        **context,
+    )
+    belief_buckets = catalog.probability_buckets_by_action_id[torp_load_action_id(1)]
+    non_belief_buckets = catalog.probability_buckets_by_action_id[torp_load_action_id(2)]
+    penalty = resolve_fleet_inference_tuning().torp_misalignment_log_penalty
+    assert non_belief_buckets[1].marginal_weight == belief_buckets[1].marginal_weight - penalty
+
+
+def test_ranking_ship_build_beats_belief_torp_beats_non_belief_torp():
+    ship_combo = ShipBuildCombo(
+        combo_id=ship_build_combo_id(
+            hull_id=15,
+            engine_id=1,
+            beam_id=None,
+            torp_id=None,
+            beam_count=0,
+            launcher_count=0,
+        ),
+        hull_id=15,
+        engine_id=1,
+        beam_id=None,
+        torp_id=None,
+        beam_count=0,
+        launcher_count=0,
+        hull_beam_slots=0,
+        hull_launcher_slots=0,
+        labels=("Freighter build",),
+        score_delta_2x=400,
+        freighter_delta=0,
+        upper_bound=1,
+        probability_weight=200,
+    )
+    belief_torp = CandidateAction(
+        id=torp_load_action_id(1),
+        label="Belief torp",
+        score_delta_2x=400,
+        upper_bound=1,
+    )
+    non_belief_torp = CandidateAction(
+        id=torp_load_action_id(2),
+        label="Non-belief torp",
+        score_delta_2x=400,
+        upper_bound=1,
+    )
+    belief_buckets = probability_buckets_for_test_action(torp_load_action_id(1))
+    torp_one_weights = tuple(bucket.marginal_weight for bucket in belief_buckets)
+    non_belief_buckets = apply_torp_misalignment_penalty_to_buckets(
+        probability_buckets_for_test_action(
+            torp_load_action_id(2),
+            marginal_weights=torp_one_weights,
+        ),
+        penalty=50,
+    )
+    observation = InferenceObservation(
+        player_id=1,
+        turn=5,
+        military_delta_2x=400,
+        warship_delta=0,
+        freighter_delta=0,
+        priority_point_delta=0,
+        starbases_owned=1,
+        is_after_ship_limit=False,
+    )
+    narrowed = ActionCatalog(
+        aggregate_actions=(belief_torp, non_belief_torp),
+        ship_build_combos=(ship_combo,),
+        probability_buckets_by_action_id={
+            belief_torp.id: belief_buckets,
+            non_belief_torp.id: non_belief_buckets,
+        },
+    )
+    result = solve_inference_problem(
+        build_inference_problem(observation, narrowed, max_solutions=3)
+    )
+    assert result.status == STATUS_EXACT
+    assert len(result.solutions) == 3
+    top = result.solutions[0]
+    second = result.solutions[1]
+    third = result.solutions[2]
+    assert top.ship_builds and top.ship_builds[0].combo_id == ship_combo.combo_id
+    assert second.actions and second.actions[0].action_id == belief_torp.id
+    assert third.actions and third.actions[0].action_id == non_belief_torp.id
+    assert top.objective_value >= second.objective_value >= third.objective_value
+
+
+def test_admitted_torp_ids_respects_option_set_union():
+    belief = FleetLauncherBeliefSet(frozenset({4, 8}))
+    overlay = FleetTorpOverlay(belief_set=belief)
+    torp_step = _torp_step()
+    admitted = admitted_torp_ids_for_policy_step(
+        policy_step=torp_step,
+        eligible_torp_ids=frozenset({1, 2, 3, 4, 8}),
+        overlay=overlay,
+    )
+    assert admitted == frozenset({4, 8})

--- a/packages/api/tests/test_fleet_torp_overlay.py
+++ b/packages/api/tests/test_fleet_torp_overlay.py
@@ -284,9 +284,15 @@ def test_ranking_ship_build_beats_belief_torp_beats_non_belief_torp():
 def test_admitted_torp_ids_respects_option_set_union():
     belief = FleetLauncherBeliefSet(frozenset({4, 8}))
     overlay = FleetTorpOverlay(belief_set=belief)
+    policy_steps = resolve_tier_policies()
     torp_step = _torp_step()
+    torp_step_index = next(
+        index for index, step in enumerate(policy_steps) if step.id == torp_step.id
+    )
     admitted = admitted_torp_ids_for_policy_step(
         policy_step=torp_step,
+        policy_step_index=torp_step_index,
+        policy_steps=policy_steps,
         eligible_torp_ids=frozenset({1, 2, 3, 4, 8}),
         overlay=overlay,
     )

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -12,7 +12,6 @@ from api.analytics.military_score_inference.component_eligibility import (
     eligible_component_ids_for_filter,
     turn_catalog_context_for_policy_step,
 )
-from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.models import (
     InferenceResult,
     InferenceSolution,
@@ -32,9 +31,7 @@ from api.analytics.military_score_inference.tier_policy import (
 )
 from api.models.components import Engine
 
-from tests.fixtures.military_score_inference import _observation
-
-_LEGACY_FLEET_TORP_OVERLAY = FleetTorpOverlay.disabled()
+from tests.fixtures.military_score_inference import _observation, legacy_fleet_torp_overlay
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -300,7 +297,7 @@ def test_ship_torpedoes_admitted_after_full_components_with_caps(sample_turn):
         observation,
         sample_turn,
         policy_step=torp_step,
-        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
+        fleet_torp_overlay=legacy_fleet_torp_overlay(),
     )
     action_ids = {action.id for action in catalog.aggregate_actions}
     assert "planet_defense_posts_added_total" not in action_ids
@@ -321,7 +318,7 @@ def test_slack_admitted_on_later_steps_with_caps(sample_turn):
         observation,
         sample_turn,
         policy_step=defense_step,
-        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
+        fleet_torp_overlay=legacy_fleet_torp_overlay(),
     )
     planet_action = next(
         action
@@ -358,7 +355,7 @@ def test_restricted_activetorps_limits_ship_torpedo_aggregate_actions(sample_tur
         observation,
         turn,
         policy_step=torp_step,
-        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
+        fleet_torp_overlay=legacy_fleet_torp_overlay(),
     )
 
     torp_action_ids = {
@@ -621,7 +618,7 @@ def test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added(
     result, catalog, _, attempted, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
-        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
+        fleet_torp_overlay=legacy_fleet_torp_overlay(),
     )
 
     assert "admit_ship_torpedoes" in attempted

--- a/packages/api/tests/test_military_score_inference_tier_policy.py
+++ b/packages/api/tests/test_military_score_inference_tier_policy.py
@@ -12,6 +12,7 @@ from api.analytics.military_score_inference.component_eligibility import (
     eligible_component_ids_for_filter,
     turn_catalog_context_for_policy_step,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.models import (
     InferenceResult,
     InferenceSolution,
@@ -32,6 +33,8 @@ from api.analytics.military_score_inference.tier_policy import (
 from api.models.components import Engine
 
 from tests.fixtures.military_score_inference import _observation
+
+_LEGACY_FLEET_TORP_OVERLAY = FleetTorpOverlay.disabled()
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -172,12 +175,12 @@ def test_policy_loader_rejects_missing_final_alpha_zero():
 
 def test_overlay_hook_accepts_none_and_returns_yaml_steps():
     steps = resolve_tier_policies(overlay=None)
-    assert len(steps) == 8
+    assert len(steps) == 9
 
 
 def test_overlay_parameter_is_accepted_without_merge():
     steps = resolve_tier_policies(overlay=TierPolicyOverlay())
-    assert len(steps) == 8
+    assert len(steps) == 9
 
 
 def test_early_step_uses_tech_level_bands_not_lowest_component_id(sample_turn):
@@ -297,6 +300,7 @@ def test_ship_torpedoes_admitted_after_full_components_with_caps(sample_turn):
         observation,
         sample_turn,
         policy_step=torp_step,
+        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
     )
     action_ids = {action.id for action in catalog.aggregate_actions}
     assert "planet_defense_posts_added_total" not in action_ids
@@ -317,6 +321,7 @@ def test_slack_admitted_on_later_steps_with_caps(sample_turn):
         observation,
         sample_turn,
         policy_step=defense_step,
+        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
     )
     planet_action = next(
         action
@@ -353,6 +358,7 @@ def test_restricted_activetorps_limits_ship_torpedo_aggregate_actions(sample_tur
         observation,
         turn,
         policy_step=torp_step,
+        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
     )
 
     torp_action_ids = {
@@ -615,11 +621,11 @@ def test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added(
     result, catalog, _, attempted, _ = solve_with_policy_ladder(
         observation,
         sample_turn,
+        fleet_torp_overlay=_LEGACY_FLEET_TORP_OVERLAY,
     )
 
-    assert policy_steps[4].id in attempted
-    assert policy_steps[-1].id in attempted
-    assert catalog.policy_step_id == policy_steps[-1].id
+    assert "admit_ship_torpedoes" in attempted
+    assert "full_components_planet_defense" in attempted
     assert result.status == STATUS_EXACT
 
 


### PR DESCRIPTION
## Summary

- Add fleet-informed torpedo admission and ranking overlay for military score inference: belief-set filtering on early torp-admitting tiers, `torp_escape_tier` penultimate ladder step, and log-space misalignment penalties from `fleetInferenceTuning.torpMisalignmentLogPenalty`.
- Thread optional `FleetTorpOverlay` through policy ladder and catalog build; absent overlay behaves as an empty belief set; `FleetTorpOverlay.disabled()` preserves pre-#87 (#86-only) behavior for tests and legacy callers.
- Document glossary terms and design in `CONTEXT.md` / design docs; add belief-set derivation helpers, diagnostics payload, and comprehensive unit + ladder integration tests.

Closes #87

## Test plan

- [x] `make lint`
- [x] `make test_api` (1031 passed)
- [x] `uv run pytest packages/api/tests/test_fleet_torp_overlay.py packages/api/tests/test_military_score_inference_tier_policy.py`
- [ ] Manual: run scores inference on a turn with known fleet torp beliefs once #133 wires production overlay input


Made with [Cursor](https://cursor.com)