### PR TITLE
Fleet F6.4: Scores fleet torp overlay consumer (#133)

### DIFF
--- a/packages/api/api/analytics/fleet/belief_set_components.py
+++ b/packages/api/api/analytics/fleet/belief_set_components.py
@@ -1,0 +1,66 @@
+"""Shared belief-set component id union for fleet ship records."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from api.analytics.fleet.field_constraints import known_positive_component_id
+from api.analytics.fleet.types import FleetBuildOptionSet, FleetShipRecord
+
+OPTION_SET_COMPONENT_ATTRS: dict[str, str] = {
+    "hull": "hull_id",
+    "engine": "engine_id",
+    "beams": "beam_id",
+    "launchers": "torp_id",
+}
+
+LAUNCHERS_AXIS_FIELD_NAME = "launchers"
+
+
+def positive_option_component_id(option_set: FleetBuildOptionSet, attr: str) -> int | None:
+    raw = getattr(option_set, attr)
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        return None
+    return raw
+
+
+def component_ids_for_record_on_axis(
+    record: FleetShipRecord,
+    axis_field_name: str,
+) -> set[int]:
+    """Belief-set ids for one axis: known field plus union of build option sets."""
+    ids: set[int] = set()
+    field = getattr(record.fields, axis_field_name)
+    known_id = known_positive_component_id(field)
+    if known_id is not None:
+        ids.add(known_id)
+    option_attr = OPTION_SET_COMPONENT_ATTRS[axis_field_name]
+    for option_set in record.build_option_sets:
+        option_id = positive_option_component_id(option_set, option_attr)
+        if option_id is not None:
+            ids.add(option_id)
+    return ids
+
+
+def component_ids_for_axis_from_records(
+    records: Iterable[FleetShipRecord],
+    axis_field_name: str,
+    *,
+    active_only: bool = True,
+) -> set[int]:
+    """Union component ids for one axis across fleet records."""
+    ids: set[int] = set()
+    for record in records:
+        if active_only and record.disposition != "active":
+            continue
+        ids.update(component_ids_for_record_on_axis(record, axis_field_name))
+    return ids
+
+
+def launcher_component_ids_from_records(
+    records: Iterable[FleetShipRecord],
+) -> frozenset[int]:
+    """Union launcher/torp ids from active records' known fields and build option sets."""
+    return frozenset(
+        component_ids_for_axis_from_records(records, LAUNCHERS_AXIS_FIELD_NAME),
+    )

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -1,7 +1,4 @@
-"""Fleet export composition branch: component histograms and max tech levels.
-
-Full belief-set composition (build option set unions on inferred rows) is #133 scope.
-"""
+"""Fleet export composition branch: component histograms and max tech levels."""
 
 from __future__ import annotations
 
@@ -13,7 +10,7 @@ from api.analytics.export_types import ExportScope
 from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.field_constraints import known_positive_component_id
 from api.analytics.fleet.types import (
-    FleetFieldConstraint,
+    FleetBuildOptionSet,
     FleetShipRecord,
     FleetTurnSnapshot,
 )
@@ -25,20 +22,27 @@ from api.concepts.turn_component_catalog import (
 )
 from api.models.game import TurnInfo
 
+_OPTION_SET_COMPONENT_ATTRS: dict[str, str] = {
+    "hull": "hull_id",
+    "engine": "engine_id",
+    "beams": "beam_id",
+    "launchers": "torp_id",
+}
+
 
 @dataclass(frozen=True, slots=True)
 class _CompositionAxisSpec:
     field_name: str
-    histogram_output_key: str | None
+    histogram_output_key: str
     max_tech_key: str
     catalog_key: str
 
 
 _COMPOSITION_AXIS_SPECS: tuple[_CompositionAxisSpec, ...] = (
     _CompositionAxisSpec("hull", "hullTypes", "hulls", "hulls"),
+    _CompositionAxisSpec("engine", "engineTypes", "engines", "engines"),
     _CompositionAxisSpec("beams", "beamTypes", "beams", "beams"),
     _CompositionAxisSpec("launchers", "launcherTypes", "launchers", "launchers"),
-    _CompositionAxisSpec("engine", None, "engines", "engines"),
 )
 
 
@@ -46,13 +50,32 @@ class _TechLevelComponent(Protocol):
     techlevel: int
 
 
-def _increment_component_histogram(
-    histogram: dict[str, int],
-    field: FleetFieldConstraint,
-) -> None:
-    component_id = known_positive_component_id(field)
-    if component_id is None:
-        return
+def _positive_option_component_id(option_set: FleetBuildOptionSet, attr: str) -> int | None:
+    raw = getattr(option_set, attr)
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        return None
+    return raw
+
+
+def _component_ids_for_record_on_axis(
+    record: FleetShipRecord,
+    axis: _CompositionAxisSpec,
+) -> set[int]:
+    """Belief-set ids for one axis: known field plus union of build option sets."""
+    ids: set[int] = set()
+    field = getattr(record.fields, axis.field_name)
+    known_id = known_positive_component_id(field)
+    if known_id is not None:
+        ids.add(known_id)
+    option_attr = _OPTION_SET_COMPONENT_ATTRS[axis.field_name]
+    for option_set in record.build_option_sets:
+        option_id = _positive_option_component_id(option_set, option_attr)
+        if option_id is not None:
+            ids.add(option_id)
+    return ids
+
+
+def _increment_histogram(histogram: dict[str, int], component_id: int) -> None:
     key = str(component_id)
     histogram[key] = histogram.get(key, 0) + 1
 
@@ -83,19 +106,10 @@ def _active_records_for_scope(
     return records
 
 
-def _component_ids_for_axis(
-    axis: _CompositionAxisSpec,
-    histograms: dict[str, dict[str, int]],
-    engine_ids: list[int],
-) -> Iterable[int]:
-    if axis.histogram_output_key is None:
-        return engine_ids
-    return (int(key) for key in histograms[axis.histogram_output_key])
-
-
 def _empty_fleet_composition_branch() -> dict[str, object]:
     return {
         "hullTypes": {},
+        "engineTypes": {},
         "beamTypes": {},
         "launcherTypes": {},
         "torpedoTypesLoaded": {},
@@ -114,26 +128,23 @@ def build_fleet_composition_branch(
     When ``scope.player_id`` is unset, returns an empty branch rather than
     aggregating across all players. Unscoped composition paths are rejected at
     query time; this keeps materialized trees safe for unscoped meta reads.
+
+    Belief-set histograms union known fitted component ids with every fleet build
+    option set on active rows (consistent tuples only, no per-field Cartesian
+    product).
     """
     if scope.player_id is None:
         return _empty_fleet_composition_branch()
 
     histograms: dict[str, dict[str, int]] = {
-        axis.histogram_output_key: {}
-        for axis in _COMPOSITION_AXIS_SPECS
-        if axis.histogram_output_key is not None
+        axis.histogram_output_key: {} for axis in _COMPOSITION_AXIS_SPECS
     }
-    engine_ids: list[int] = []
 
     for record in _active_records_for_scope(snapshot, scope):
         for axis in _COMPOSITION_AXIS_SPECS:
-            field = getattr(record.fields, axis.field_name)
-            if axis.histogram_output_key is None:
-                component_id = known_positive_component_id(field)
-                if component_id is not None:
-                    engine_ids.append(component_id)
-            else:
-                _increment_component_histogram(histograms[axis.histogram_output_key], field)
+            histogram = histograms[axis.histogram_output_key]
+            for component_id in _component_ids_for_record_on_axis(record, axis):
+                _increment_histogram(histogram, component_id)
 
     catalogs: dict[str, dict[int, _TechLevelComponent]] = {
         "hulls": hulls_by_id(turn),
@@ -145,7 +156,7 @@ def build_fleet_composition_branch(
     max_tech_level: dict[str, int] = {}
     for axis in _COMPOSITION_AXIS_SPECS:
         if axis_max := _max_tech_level(
-            _component_ids_for_axis(axis, histograms, engine_ids),
+            (int(key) for key in histograms[axis.histogram_output_key]),
             catalogs[axis.catalog_key],
         ):
             max_tech_level[axis.max_tech_key] = axis_max

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -7,10 +7,9 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from api.analytics.export_types import ExportScope
+from api.analytics.fleet.belief_set_components import component_ids_for_record_on_axis
 from api.analytics.fleet.export_scope import ledgers_for_scope
-from api.analytics.fleet.field_constraints import known_positive_component_id
 from api.analytics.fleet.types import (
-    FleetBuildOptionSet,
     FleetShipRecord,
     FleetTurnSnapshot,
 )
@@ -21,13 +20,6 @@ from api.concepts.turn_component_catalog import (
     torpedos_by_id,
 )
 from api.models.game import TurnInfo
-
-_OPTION_SET_COMPONENT_ATTRS: dict[str, str] = {
-    "hull": "hull_id",
-    "engine": "engine_id",
-    "beams": "beam_id",
-    "launchers": "torp_id",
-}
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,31 +40,6 @@ _COMPOSITION_AXIS_SPECS: tuple[_CompositionAxisSpec, ...] = (
 
 class _TechLevelComponent(Protocol):
     techlevel: int
-
-
-def _positive_option_component_id(option_set: FleetBuildOptionSet, attr: str) -> int | None:
-    raw = getattr(option_set, attr)
-    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
-        return None
-    return raw
-
-
-def _component_ids_for_record_on_axis(
-    record: FleetShipRecord,
-    axis: _CompositionAxisSpec,
-) -> set[int]:
-    """Belief-set ids for one axis: known field plus union of build option sets."""
-    ids: set[int] = set()
-    field = getattr(record.fields, axis.field_name)
-    known_id = known_positive_component_id(field)
-    if known_id is not None:
-        ids.add(known_id)
-    option_attr = _OPTION_SET_COMPONENT_ATTRS[axis.field_name]
-    for option_set in record.build_option_sets:
-        option_id = _positive_option_component_id(option_set, option_attr)
-        if option_id is not None:
-            ids.add(option_id)
-    return ids
 
 
 def _increment_histogram(histogram: dict[str, int], component_id: int) -> None:
@@ -143,7 +110,7 @@ def build_fleet_composition_branch(
     for record in _active_records_for_scope(snapshot, scope):
         for axis in _COMPOSITION_AXIS_SPECS:
             histogram = histograms[axis.histogram_output_key]
-            for component_id in _component_ids_for_record_on_axis(record, axis):
+            for component_id in component_ids_for_record_on_axis(record, axis.field_name):
                 _increment_histogram(histogram, component_id)
 
     catalogs: dict[str, dict[int, _TechLevelComponent]] = {

--- a/packages/api/api/analytics/fleet/export_schema.py
+++ b/packages/api/api/analytics/fleet/export_schema.py
@@ -219,34 +219,44 @@ _MAX_TECH_LEVEL_SCHEMA: dict[str, Any] = {
 _COMPOSITION_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": (
-        "Per-player aggregated fleet composition derived from the acquisition ledger. Counts "
-        "only active ship records with known component fields; unknown or option-set-only rows "
-        "are omitted."
+        "Per-player aggregated fleet composition derived from the acquisition ledger. "
+        "Belief-set histograms count active rows using known fitted component fields "
+        "and the union of fleet build option sets on inferred rows."
     ),
     "properties": {
         "hullTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known hull types on active ships. Keys are host hull ids as "
-                "strings; values are ship counts. Rows with unknown, bounded, options, or region "
-                "hull constraints are excluded."
+                "Belief-set hull histogram on active ships. Keys are host hull ids as "
+                "strings; values are ship counts. Includes known hull constraints and "
+                "hull ids from fleet build option sets; bounded, options, and region-only "
+                "constraints contribute no ids until resolved."
+            ),
+        },
+        "engineTypes": {
+            **_COMPOSITION_HISTOGRAM_SCHEMA,
+            "description": (
+                "Belief-set engine histogram on active ships. Keys are host engine ids as "
+                "strings; values are ship counts. Includes known engine constraints and "
+                "engine ids from fleet build option sets."
             ),
         },
         "beamTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known fitted beam weapon types on active ships. Keys are host beam "
-                "ids as strings; values are ship counts. Rows with unknown, bounded, options, or "
-                "region beam constraints are excluded. Known zero (no beams) is excluded."
+                "Belief-set beam histogram on active ships. Keys are host beam ids as "
+                "strings; values are ship counts. Includes known positive beam constraints "
+                "and beam ids from fleet build option sets. Known zero (no beams) is "
+                "excluded."
             ),
         },
         "launcherTypes": {
             **_COMPOSITION_HISTOGRAM_SCHEMA,
             "description": (
-                "Histogram of known fitted torpedo-tube types on active ships. Keys are host "
-                "torpedo ids as strings; values are ship counts. Rows with unknown, bounded, "
-                "options, or region launcher constraints are excluded. Known zero (no tubes) is "
-                "excluded."
+                "Belief-set launcher/torp histogram on active ships. Keys are host torpedo "
+                "ids as strings; values are ship counts. Includes known positive launcher "
+                "constraints and torp ids from fleet build option sets. Feeds scores "
+                "inference fleet torp overlay (#87). Known zero (no tubes) is excluded."
             ),
         },
         "torpedoTypesLoaded": {

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 
 from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.serialization import (
@@ -14,6 +15,8 @@ from api.analytics.fleet.serialization import (
 from api.analytics.fleet.types import FleetTurnSnapshot
 from api.errors import NotFoundError, ValidationError
 from api.storage.base import StorageBackend
+
+OnSnapshotPersistedCallback = Callable[[int, int, int], None]
 
 
 class FleetSnapshotPersistenceService:
@@ -44,8 +47,14 @@ class FleetSnapshotPersistenceService:
     deploys that change materialization semantics re-chain without a turn reload.
     """
 
-    def __init__(self, storage: StorageBackend) -> None:
+    def __init__(
+        self,
+        storage: StorageBackend,
+        *,
+        on_snapshot_persisted: OnSnapshotPersistedCallback | None = None,
+    ) -> None:
         self._storage = storage
+        self._on_snapshot_persisted = on_snapshot_persisted
         self._invalidation_generation: dict[tuple[int, int], int] = {}
         self._generation_lock = threading.Lock()
 
@@ -110,6 +119,16 @@ class FleetSnapshotPersistenceService:
             self.document_key(game_id, perspective, turn_number),
             fleet_turn_snapshot_to_json(snapshot),
         )
+        if self._on_snapshot_persisted is not None:
+            self._on_snapshot_persisted(game_id, perspective, turn_number)
+
+    @property
+    def on_snapshot_persisted(self) -> OnSnapshotPersistedCallback | None:
+        return self._on_snapshot_persisted
+
+    @on_snapshot_persisted.setter
+    def on_snapshot_persisted(self, callback: OnSnapshotPersistedCallback | None) -> None:
+        self._on_snapshot_persisted = callback
 
     def delete_snapshot(
         self,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,5 +1,7 @@
 """Scores analytic integration for military score build inference."""
 
+from collections.abc import Mapping
+
 from api.analytics.military_score_inference.accelerated_start import (
     AcceleratedInferenceSegment,
     observation_deltas_from_score,
@@ -18,6 +20,7 @@ from api.analytics.military_score_inference.constraints import (
     InferenceHardConstraints,
     observation_to_constraints_payload,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.host_turn_targets import (
     functional_host_turn_target_from_segment_payload,
     host_turn_functional_target_to_wire_dict,
@@ -52,6 +55,9 @@ from api.analytics.military_score_inference.models import (
     InferenceResult,
 )
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    resolve_prior_turn_fleet_torp_overlay,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
@@ -66,6 +72,26 @@ __all__ = [
     "prior_turn_score_data_available",
     "run_inference_with_artifacts",
 ]
+
+
+def _resolved_fleet_torp_overlay(
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    load_scoreboard_turn: ScoreboardTurnLoader | None,
+    fleet_torp_overlay: FleetTorpOverlay | None,
+    export_services: Mapping[str, object] | None,
+) -> FleetTorpOverlay | None:
+    if fleet_torp_overlay is not None:
+        return fleet_torp_overlay
+    if load_scoreboard_turn is None:
+        return None
+    return resolve_prior_turn_fleet_torp_overlay(
+        turn=turn,
+        player_id=player_id,
+        load_turn=load_scoreboard_turn,
+        export_services=export_services,
+    )
 
 
 def build_inference_observation(
@@ -226,12 +252,14 @@ def _run_accelerated_backfill_inference(
     *,
     load_scoreboard_turn: ScoreboardTurnLoader | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     backfill = _try_accelerated_backfill_inference(
         score,
         turn,
         load_scoreboard_turn=load_scoreboard_turn,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     if backfill is not None:
         return backfill
@@ -244,12 +272,14 @@ def _run_accelerated_split_inference_path(
     segments: tuple[AcceleratedInferenceSegment, ...],
     *,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     payload, reported_observation, reported_catalog, _ = run_accelerated_split_inference(
         score,
         turn,
         segments,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     return payload, reported_observation, reported_catalog
 
@@ -259,6 +289,7 @@ def _run_policy_ladder_inference(
     turn: TurnInfo,
     *,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[
     InferenceResult,
@@ -271,6 +302,7 @@ def _run_policy_ladder_inference(
         resolved_observation,
         turn,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
         time_limit_seconds=time_limit_seconds,
     )
 
@@ -322,6 +354,7 @@ def _run_solver_inference_path(
     catalog: ActionCatalog | None,
     accelerated_segments: tuple[AcceleratedInferenceSegment, ...] | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     if path == InferencePath.ACCELERATED_SPLIT:
@@ -331,6 +364,7 @@ def _run_solver_inference_path(
             turn,
             accelerated_segments,
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=fleet_torp_overlay,
         )
 
     solve_catalog = catalog
@@ -341,6 +375,7 @@ def _run_solver_inference_path(
                     resolved_observation,
                     turn,
                     resolved_mask=resolved_mask,
+                    fleet_torp_overlay=fleet_torp_overlay,
                     time_limit_seconds=time_limit_seconds,
                 )
             )
@@ -395,6 +430,8 @@ def run_inference_with_artifacts(
     catalog: ActionCatalog | None = None,
     load_scoreboard_turn: ScoreboardTurnLoader | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
+    export_services: Mapping[str, object] | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
@@ -414,6 +451,13 @@ def run_inference_with_artifacts(
         catalog=catalog,
         load_scoreboard_turn=load_scoreboard_turn,
     )
+    resolved_fleet_overlay = _resolved_fleet_torp_overlay(
+        turn,
+        score.ownerid,
+        load_scoreboard_turn=load_scoreboard_turn,
+        fleet_torp_overlay=fleet_torp_overlay,
+        export_services=export_services,
+    )
 
     if path == InferencePath.NO_PRIOR_TURN:
         return _no_prior_turn_inference_result(turn, resolved_observation)
@@ -424,6 +468,7 @@ def run_inference_with_artifacts(
             resolved_observation,
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=resolved_fleet_overlay,
         )
     return _run_solver_inference_path(
         path,
@@ -433,6 +478,7 @@ def run_inference_with_artifacts(
         catalog=catalog,
         accelerated_segments=accelerated_segments,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=resolved_fleet_overlay,
         time_limit_seconds=time_limit_seconds,
     )
 
@@ -443,6 +489,7 @@ def _try_accelerated_backfill_inference(
     *,
     load_scoreboard_turn: ScoreboardTurnLoader | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None] | None:
     """Fill unreliable accelerated rows from the first reliable split when that turn is stored."""
     if load_scoreboard_turn is None:
@@ -466,6 +513,7 @@ def _try_accelerated_backfill_inference(
         backfill_source.source_turn,
         backfill_source.segments,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     segment_payload = _segment_payload_for_host_turn(
         payload,

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -1,7 +1,5 @@
 """Scores analytic integration for military score build inference."""
 
-from collections.abc import Mapping
-
 from api.analytics.military_score_inference.accelerated_start import (
     AcceleratedInferenceSegment,
     observation_deltas_from_score,
@@ -55,9 +53,6 @@ from api.analytics.military_score_inference.models import (
     InferenceResult,
 )
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
-from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
-    resolve_prior_turn_fleet_torp_overlay,
-)
 from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
@@ -72,26 +67,6 @@ __all__ = [
     "prior_turn_score_data_available",
     "run_inference_with_artifacts",
 ]
-
-
-def _resolved_fleet_torp_overlay(
-    turn: TurnInfo,
-    player_id: int,
-    *,
-    load_scoreboard_turn: ScoreboardTurnLoader | None,
-    fleet_torp_overlay: FleetTorpOverlay | None,
-    export_services: Mapping[str, object] | None,
-) -> FleetTorpOverlay | None:
-    if fleet_torp_overlay is not None:
-        return fleet_torp_overlay
-    if load_scoreboard_turn is None:
-        return None
-    return resolve_prior_turn_fleet_torp_overlay(
-        turn=turn,
-        player_id=player_id,
-        load_turn=load_scoreboard_turn,
-        export_services=export_services,
-    )
 
 
 def build_inference_observation(
@@ -431,7 +406,6 @@ def run_inference_with_artifacts(
     load_scoreboard_turn: ScoreboardTurnLoader | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
-    export_services: Mapping[str, object] | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
@@ -451,14 +425,6 @@ def run_inference_with_artifacts(
         catalog=catalog,
         load_scoreboard_turn=load_scoreboard_turn,
     )
-    resolved_fleet_overlay = _resolved_fleet_torp_overlay(
-        turn,
-        score.ownerid,
-        load_scoreboard_turn=load_scoreboard_turn,
-        fleet_torp_overlay=fleet_torp_overlay,
-        export_services=export_services,
-    )
-
     if path == InferencePath.NO_PRIOR_TURN:
         return _no_prior_turn_inference_result(turn, resolved_observation)
     if path == InferencePath.ACCELERATED_BACKFILL:
@@ -468,7 +434,7 @@ def run_inference_with_artifacts(
             resolved_observation,
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
-            fleet_torp_overlay=resolved_fleet_overlay,
+            fleet_torp_overlay=fleet_torp_overlay,
         )
     return _run_solver_inference_path(
         path,
@@ -478,7 +444,7 @@ def run_inference_with_artifacts(
         catalog=catalog,
         accelerated_segments=accelerated_segments,
         resolved_mask=resolved_mask,
-        fleet_torp_overlay=resolved_fleet_overlay,
+        fleet_torp_overlay=fleet_torp_overlay,
         time_limit_seconds=time_limit_seconds,
     )
 

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -53,6 +53,10 @@ from api.analytics.military_score_inference.models import (
     InferenceResult,
 )
 from api.analytics.military_score_inference.policy_ladder import solve_with_policy_ladder
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    FleetTorpInputStatus,
+    fleet_torp_input_status_diagnostics,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     STATUS_NO_EXACT_SOLUTION,
@@ -228,6 +232,7 @@ def _run_accelerated_backfill_inference(
     load_scoreboard_turn: ScoreboardTurnLoader | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    fleet_torp_input_status: FleetTorpInputStatus | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     backfill = _try_accelerated_backfill_inference(
         score,
@@ -330,6 +335,7 @@ def _run_solver_inference_path(
     accelerated_segments: tuple[AcceleratedInferenceSegment, ...] | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    fleet_torp_input_status: FleetTorpInputStatus | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     if path == InferencePath.ACCELERATED_SPLIT:
@@ -374,6 +380,7 @@ def _run_solver_inference_path(
                         extra={
                             "policy_steps_attempted": policy_steps_attempted,
                             "policy_step_attempts": step_diagnostics,
+                            **fleet_torp_input_status_diagnostics(fleet_torp_input_status),
                         },
                     ),
                 ),
@@ -389,6 +396,7 @@ def _run_solver_inference_path(
                 problem,
                 policy_steps_attempted=policy_steps_attempted,
                 step_diagnostics=step_diagnostics,
+                extra_diagnostics=fleet_torp_input_status_diagnostics(fleet_torp_input_status),
             ),
             resolved_observation,
             solve_catalog,
@@ -406,6 +414,7 @@ def run_inference_with_artifacts(
     load_scoreboard_turn: ScoreboardTurnLoader | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    fleet_torp_input_status: FleetTorpInputStatus | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
@@ -435,6 +444,7 @@ def run_inference_with_artifacts(
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
+            fleet_torp_input_status=fleet_torp_input_status,
         )
     return _run_solver_inference_path(
         path,
@@ -445,6 +455,7 @@ def run_inference_with_artifacts(
         accelerated_segments=accelerated_segments,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        fleet_torp_input_status=fleet_torp_input_status,
         time_limit_seconds=time_limit_seconds,
     )
 

--- a/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/fleet_torp_overlay.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 
-from api.analytics.fleet.field_constraints import known_positive_component_id
+from api.analytics.fleet.belief_set_components import launcher_component_ids_from_records
 from api.analytics.fleet.types import FleetShipRecord
 from api.analytics.military_score_inference.aggregate_action_registry import (
     SHIP_TORPS_LOADED_ACTION_PREFIX,
@@ -106,18 +106,7 @@ def launcher_belief_set_from_fleet_records(
     records: Iterable[FleetShipRecord],
 ) -> FleetLauncherBeliefSet:
     """Union launcher/torp ids from known fields and all fleet build option sets."""
-    torp_ids: set[int] = set()
-    for record in records:
-        if record.disposition != "active":
-            continue
-        known_launcher = known_positive_component_id(record.fields.launchers)
-        if known_launcher is not None:
-            torp_ids.add(known_launcher)
-        for option_set in record.build_option_sets:
-            torp_id = option_set.torp_id
-            if torp_id is not None and torp_id > 0:
-                torp_ids.add(torp_id)
-    return FleetLauncherBeliefSet(frozenset(torp_ids))
+    return FleetLauncherBeliefSet(launcher_component_ids_from_records(records))
 
 
 def launcher_belief_set_from_composition(composition: dict[str, object]) -> FleetLauncherBeliefSet:

--- a/packages/api/api/analytics/military_score_inference/inference_accelerated.py
+++ b/packages/api/api/analytics/military_score_inference/inference_accelerated.py
@@ -16,6 +16,7 @@ from api.analytics.military_score_inference.actions import (
     DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     ActionCatalog,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.host_turn_targets import (
     functional_host_turn_target_from_segment_payload,
     host_turn_functional_target_to_wire_dict,
@@ -96,6 +97,7 @@ def run_accelerated_segment_policy_ladder(
     cancel_token: InferenceCancelToken | None = None,
     on_admitted: Callable[[InferenceSolution], None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> AcceleratedSegmentResult:
     """Run the policy ladder for one accelerated segment."""
     observation = observation_from_accelerated_segment(score, turn, segment)
@@ -112,6 +114,7 @@ def run_accelerated_segment_policy_ladder(
         cancel_token=cancel_token,
         on_admitted=on_admitted,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     return AcceleratedSegmentResult(
         segment=segment,
@@ -222,6 +225,7 @@ def run_accelerated_split_inference(
     *,
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
 ) -> tuple[
     dict[str, object],
     InferenceObservation,
@@ -250,6 +254,7 @@ def run_accelerated_split_inference(
             max_solutions=20,
             time_limit_seconds=per_segment_time,
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=fleet_torp_overlay,
         )
         if segment.is_streaming_target:
             reported_observation = ladder_result.observation

--- a/packages/api/api/analytics/military_score_inference/inference_row_runner.py
+++ b/packages/api/api/analytics/military_score_inference/inference_row_runner.py
@@ -14,6 +14,9 @@ from api.analytics.military_score_inference.policy_ladder_state import PolicyLad
 from api.analytics.military_score_inference.policy_ladder_tier_step import (
     run_policy_ladder_tier_step,
 )
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    fleet_torp_input_status_diagnostics,
+)
 from api.analytics.military_score_inference.row_complete_factory import (
     row_complete_from_ladder_finalize,
     row_complete_stopped,
@@ -95,6 +98,9 @@ def _outcome_after_ladder_complete(
             step_diagnostics,
             observation=observation,
             turn=turn,
+            extra_diagnostics=fleet_torp_input_status_diagnostics(
+                run.session.fleet_torp_input_status,
+            ),
         ),
     )
 

--- a/packages/api/api/analytics/military_score_inference/inference_row_runner.py
+++ b/packages/api/api/analytics/military_score_inference/inference_row_runner.py
@@ -76,6 +76,7 @@ def _outcome_after_ladder_complete(
                 enqueue_continuation=True,
                 next_ladder_state=orchestration.new_ladder_state(
                     resolved_mask=run.session.resolved_mask,
+                    fleet_torp_overlay=run.session.fleet_torp_overlay,
                 ),
             )
         if advance.row_complete is not None:

--- a/packages/api/api/analytics/military_score_inference/inference_scheduler.py
+++ b/packages/api/api/analytics/military_score_inference/inference_scheduler.py
@@ -29,10 +29,15 @@ from api.analytics.military_score_inference.models import InferenceObservation
 from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
 from api.analytics.military_score_inference.row_run import RowRun, TierJob
 from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
-from api.errors import ValidationError
+from api.errors import PlanetsConsoleError, ValidationError
 
 _DEFAULT_WORKER_COUNT = 4
 _DEQUEUE_WAIT_SECONDS = 0.25
+
+
+class TableStreamScopeAlreadyActive(PlanetsConsoleError):
+    """Another NDJSON table stream already owns this turn scope."""
+
 
 # Re-exported for scheduler tests that construct tier jobs directly.
 _TierJob = TierJob
@@ -82,8 +87,8 @@ class InferenceRowScheduler:
     def begin_scope(self, scope: InferenceStreamScope) -> str:
         with self._condition:
             if self._active_scope == scope and self._has_active_table_stream:
-                self._preempt_table_stream_for_scope_locked()
-            elif self._active_scope != scope:
+                raise TableStreamScopeAlreadyActive()
+            if self._active_scope != scope:
                 self._invalidate_retained_state_locked()
                 self._active_scope = scope
             stream_token = str(uuid.uuid4())
@@ -251,12 +256,14 @@ class InferenceRowScheduler:
         if orchestration is not None:
             run.ladder_state = orchestration.new_ladder_state(
                 resolved_mask=session.resolved_mask,
+                fleet_torp_overlay=session.fleet_torp_overlay,
             )
         else:
             policy_steps = tuple(resolve_tier_policies(None))
             run.ladder_state = PolicyLadderState(
                 policy_steps=policy_steps,
                 resolved_mask=session.resolved_mask,
+                fleet_torp_overlay=session.fleet_torp_overlay,
             )
         self._enqueue_job(TierJob(session=session))
 
@@ -287,16 +294,6 @@ class InferenceRowScheduler:
         while self._work_queue:
             job = self._work_queue.popleft()
             self._get_or_create_run(job.session).hold_job(job)
-
-    def _preempt_table_stream_for_scope_locked(self) -> None:
-        """Cancel in-flight table-stream work so a reconnect can replace the active stream."""
-        self._globally_paused = False
-        for run in list(self._runs.values()):
-            run.session.cancel_token.cancel()
-        self._runs.clear()
-        while self._work_queue:
-            job = self._work_queue.popleft()
-            job.session.cancel_token.cancel()
 
     def _invalidate_retained_state_locked(self) -> None:
         self._has_active_table_stream = False

--- a/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
@@ -9,6 +9,7 @@ from api.analytics.military_score_inference.accelerated_start import (
     scoreboard_host_turn,
 )
 from api.analytics.military_score_inference.actions import ActionCatalog
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_accelerated import (
     AcceleratedSegmentResult,
@@ -91,10 +92,12 @@ class InferenceStreamOrchestration:
         self,
         *,
         resolved_mask: ResolvedHullCatalogMask | None = None,
+        fleet_torp_overlay: FleetTorpOverlay | None = None,
     ) -> PolicyLadderState:
         return PolicyLadderState(
             policy_steps=tuple(resolve_tier_policies(None)),
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=fleet_torp_overlay,
         )
 
     def record_segment_ladder_complete(

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import (
     STATUS_NO_PRIOR_TURN,
@@ -187,6 +188,7 @@ def schedule_inference_row(
     perspective: int,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
     stream_token: str | None = None,
 ) -> ScheduledInferenceRow | None:
     observation = build_inference_observation(
@@ -208,6 +210,7 @@ def schedule_inference_row(
         perspective=perspective,
         turn_number=turn_number,
         resolved_mask=resolved_mask,
+        fleet_torp_overlay=fleet_torp_overlay,
     )
     orchestration = create_inference_stream_orchestration(
         path,
@@ -346,6 +349,7 @@ def iter_scores_table_inference_events(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     reload_host_turn: Callable[[], TurnInfo] | None = None,
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
+    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None,
     persistence: InferenceRowPersistenceService | None = None,
     scheduler: InferenceRowScheduler | None = None,
 ) -> Iterator[dict[str, object]]:
@@ -380,6 +384,7 @@ def iter_scores_table_inference_events(
         load_scoreboard_turn=load_scoreboard_turn,
         reload_host_turn=reload_host_turn,
         resolve_mask_for_player=resolve_mask_for_player,
+        resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
         persistence=persistence,
     )
     controller.attach()

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -35,6 +35,10 @@ from api.analytics.military_score_inference.inference_stream_scope import Infere
 from api.analytics.military_score_inference.inference_stream_session import (
     InferenceRowStreamSession,
 )
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    FleetTorpInputStatus,
+    PriorTurnFleetTorpResolution,
+)
 from api.models.game import Score, TurnInfo
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.transport.inference_stream import (
@@ -189,6 +193,7 @@ def schedule_inference_row(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    fleet_torp_input_status: FleetTorpInputStatus | None = None,
     stream_token: str | None = None,
 ) -> ScheduledInferenceRow | None:
     observation = build_inference_observation(
@@ -211,6 +216,7 @@ def schedule_inference_row(
         turn_number=turn_number,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        fleet_torp_input_status=fleet_torp_input_status,
     )
     orchestration = create_inference_stream_orchestration(
         path,
@@ -349,7 +355,8 @@ def iter_scores_table_inference_events(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     reload_host_turn: Callable[[], TurnInfo] | None = None,
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
-    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None,
+    resolve_fleet_torp_resolution_for_player: Callable[[int], PriorTurnFleetTorpResolution]
+    | None = None,
     persistence: InferenceRowPersistenceService | None = None,
     scheduler: InferenceRowScheduler | None = None,
 ) -> Iterator[dict[str, object]]:
@@ -384,7 +391,7 @@ def iter_scores_table_inference_events(
         load_scoreboard_turn=load_scoreboard_turn,
         reload_host_turn=reload_host_turn,
         resolve_mask_for_player=resolve_mask_for_player,
-        resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
+        resolve_fleet_torp_resolution_for_player=resolve_fleet_torp_resolution_for_player,
         persistence=persistence,
     )
     controller.attach()

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -21,6 +21,7 @@ from api.analytics.military_score_inference.inference_path import (
 )
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
+    TableStreamScopeAlreadyActive,
     get_inference_row_scheduler,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -35,7 +36,12 @@ from api.analytics.military_score_inference.inference_stream_session import (
 )
 from api.models.game import Score, TurnInfo
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
-from api.transport.inference_stream import inference_complete_event, inference_global_pause_event
+from api.transport.inference_stream import (
+    TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    inference_complete_event,
+    inference_error_event,
+    inference_global_pause_event,
+)
 from api.transport.inference_stream_wire import domain_event_to_wire_events
 
 _MULTiplexWaitSeconds = 0.05
@@ -355,7 +361,11 @@ def iter_scores_table_inference_events(
         turn_number=turn_number,
     )
     scheduler = scheduler or get_inference_row_scheduler()
-    stream_token = scheduler.begin_scope(stream_scope)
+    try:
+        stream_token = scheduler.begin_scope(stream_scope)
+    except TableStreamScopeAlreadyActive:
+        yield inference_error_event(TABLE_STREAM_ALREADY_ACTIVE_DETAIL)
+        return
     pause_status = scheduler.global_pause_status(stream_scope)
     yield inference_global_pause_event(paused=bool(pause_status.get("paused")))
 

--- a/packages/api/api/analytics/military_score_inference/inference_stream_session.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_session.py
@@ -14,6 +14,9 @@ from api.analytics.military_score_inference.inference_stream_domain_events impor
 )
 from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
 from api.analytics.military_score_inference.models import InferenceObservation
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    FleetTorpInputStatus,
+)
 from api.models.game import TurnInfo
 
 
@@ -29,6 +32,7 @@ class InferenceRowStreamSession:
     turn_number: int
     resolved_mask: ResolvedHullCatalogMask | None = None
     fleet_torp_overlay: FleetTorpOverlay | None = None
+    fleet_torp_input_status: FleetTorpInputStatus | None = None
     cancel_token: InferenceCancelToken = field(default_factory=InferenceCancelToken)
     event_queue: queue.Queue[InferenceStreamDomainEvent] = field(default_factory=queue.Queue)
     run_id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/packages/api/api/analytics/military_score_inference/inference_stream_session.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_session.py
@@ -6,6 +6,7 @@ import queue
 import uuid
 from dataclasses import dataclass, field
 
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_cancel import InferenceCancelToken
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -27,6 +28,7 @@ class InferenceRowStreamSession:
     perspective: int
     turn_number: int
     resolved_mask: ResolvedHullCatalogMask | None = None
+    fleet_torp_overlay: FleetTorpOverlay | None = None
     cancel_token: InferenceCancelToken = field(default_factory=InferenceCancelToken)
     event_queue: queue.Queue[InferenceStreamDomainEvent] = field(default_factory=queue.Queue)
     run_id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -183,3 +183,11 @@ class InferenceTableStreamController:
 
     def detach(self) -> None:
         detach_inference_table_stream(self.stream_token)
+
+    def end_stream(self, scheduler: InferenceRowScheduler) -> None:
+        """Tear down this stream's scheduler scope (safe while the generator runs elsewhere)."""
+        scheduler.end_inference_stream(
+            self.scope,
+            tuple(row.session for row in self.current_scheduled_rows()),
+            stream_token=self.stream_token,
+        )

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -6,7 +6,6 @@ import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_scheduler import InferenceRowScheduler
 from api.analytics.military_score_inference.inference_stream_rows import (
@@ -22,6 +21,9 @@ from api.analytics.military_score_inference.inference_stream_scope import Infere
 from api.analytics.military_score_inference.inference_table_stream_registry import (
     attach_inference_table_stream,
     detach_inference_table_stream,
+)
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    PriorTurnFleetTorpResolution,
 )
 from api.models.game import TurnInfo
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
@@ -46,7 +48,9 @@ class InferenceTableStreamController:
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None
     reload_host_turn: Callable[[], TurnInfo] | None = None
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None
-    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None
+    resolve_fleet_torp_resolution_for_player: (
+        Callable[[int], PriorTurnFleetTorpResolution] | None
+    ) = None
     persistence: InferenceRowPersistenceService | None = None
     scheduled_rows: dict[int, ScheduledInferenceRow] = field(default_factory=dict)
     pending_wire_events: list[dict[str, object]] = field(default_factory=list)
@@ -80,10 +84,10 @@ class InferenceTableStreamController:
             if self.resolve_mask_for_player is not None
             else None
         )
-        fleet_torp_overlay = (
-            self.resolve_fleet_torp_overlay_for_player(player_id)
-            if self.resolve_fleet_torp_overlay_for_player is not None
-            else None
+        fleet_resolution = (
+            self.resolve_fleet_torp_resolution_for_player(player_id)
+            if self.resolve_fleet_torp_resolution_for_player is not None
+            else PriorTurnFleetTorpResolution(overlay=None, input_status="unavailable")
         )
         return schedule_inference_row(
             self.scheduler,
@@ -94,7 +98,8 @@ class InferenceTableStreamController:
             perspective=self.perspective,
             load_scoreboard_turn=self.load_scoreboard_turn,
             resolved_mask=resolved_mask,
-            fleet_torp_overlay=fleet_torp_overlay,
+            fleet_torp_overlay=fleet_resolution.overlay,
+            fleet_torp_input_status=fleet_resolution.input_status,
             stream_token=self.stream_token,
         )
 

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_scheduler import InferenceRowScheduler
 from api.analytics.military_score_inference.inference_stream_rows import (
@@ -45,6 +46,7 @@ class InferenceTableStreamController:
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None
     reload_host_turn: Callable[[], TurnInfo] | None = None
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None
+    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None
     persistence: InferenceRowPersistenceService | None = None
     scheduled_rows: dict[int, ScheduledInferenceRow] = field(default_factory=dict)
     pending_wire_events: list[dict[str, object]] = field(default_factory=list)
@@ -78,6 +80,11 @@ class InferenceTableStreamController:
             if self.resolve_mask_for_player is not None
             else None
         )
+        fleet_torp_overlay = (
+            self.resolve_fleet_torp_overlay_for_player(player_id)
+            if self.resolve_fleet_torp_overlay_for_player is not None
+            else None
+        )
         return schedule_inference_row(
             self.scheduler,
             score=score,
@@ -87,6 +94,7 @@ class InferenceTableStreamController:
             perspective=self.perspective,
             load_scoreboard_turn=self.load_scoreboard_turn,
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=fleet_torp_overlay,
             stream_token=self.stream_token,
         )
 

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 
 from api.analytics.export_context import make_analytic_query_context
 from api.analytics.export_types import ExportScope
-from api.analytics.fleet.composition_export import build_fleet_composition_branch
 from api.analytics.fleet.constants import ANALYTIC_ID as FLEET_ANALYTIC_ID
+from api.analytics.fleet.export_scope import ledgers_for_scope
+from api.analytics.fleet.types import FleetShipRecord, FleetTurnSnapshot
 from api.analytics.military_score_inference.fleet_torp_overlay import (
     FleetTorpOverlay,
-    launcher_belief_set_from_composition,
+    launcher_belief_set_from_fleet_records,
 )
 from api.analytics.options import TurnAnalyticsOptions
 from api.models.game import TurnInfo
@@ -19,41 +20,72 @@ from api.models.game import TurnInfo
 if TYPE_CHECKING:
     from api.analytics.export_context import AnalyticQueryContext
 
-FLEET_COMPOSITION_LAUNCHER_PATH = "$.composition.launcherTypes"
 
-
-def _launcher_types_from_persisted_fleet(
-    export_services: Mapping[str, object],
+def _resolve_fleet_services(
     *,
-    game_id: int,
-    perspective: int,
-    prior_turn: int,
-    player_id: int,
-    prior_turn_info: TurnInfo,
-) -> dict[str, object] | None:
-    """Read launcher histogram from a persisted fleet snapshot without export ensure."""
-    from api.analytics.fleet.compute_services import FleetComputeServices
+    query_context: AnalyticQueryContext | None,
+    export_services: Mapping[str, object] | None,
+):
+    from api.analytics.fleet.compute_services import FleetComputeServices, resolve_fleet_services
 
+    if query_context is not None:
+        return resolve_fleet_services(query_context)
+    if export_services is None:
+        return None
     fleet_services = export_services.get(FLEET_ANALYTIC_ID)
-    if not isinstance(fleet_services, FleetComputeServices):
-        return None
-    persistence = fleet_services.persistence
-    if not persistence.has_snapshot(game_id, perspective, prior_turn):
-        return None
-    snapshot = persistence.get_snapshot(game_id, perspective, prior_turn)
-    if snapshot is None:
-        return None
-    scope = ExportScope(
-        game_id=game_id,
-        perspective=perspective,
-        turn=prior_turn,
-        player_id=player_id,
+    if isinstance(fleet_services, FleetComputeServices):
+        return fleet_services
+    return None
+
+
+def _load_prior_turn_fleet_snapshot(
+    *,
+    scope: ExportScope,
+    query_context: AnalyticQueryContext | None,
+    export_services: Mapping[str, object] | None,
+    ensure: bool,
+    turn: TurnInfo,
+    load_turn: Callable[[int], TurnInfo | None],
+) -> FleetTurnSnapshot | None:
+    """Load prior-turn fleet snapshot from persistence or via export ensure."""
+    fleet_services = _resolve_fleet_services(
+        query_context=query_context,
+        export_services=export_services,
     )
-    composition = build_fleet_composition_branch(snapshot, scope, turn=prior_turn_info)
-    launcher_types = composition.get("launcherTypes")
-    if not isinstance(launcher_types, dict):
+    if fleet_services is None:
         return None
-    return launcher_types
+
+    persistence = fleet_services.persistence
+    if ensure:
+        from api.analytics.fleet.exports import ensure_fleet_export
+
+        ctx = query_context
+        if ctx is None:
+            if export_services is None:
+                return None
+            ctx = make_analytic_query_context(
+                turn,
+                TurnAnalyticsOptions(),
+                load_turn=load_turn,
+                export_services=export_services,
+            )
+        if not ensure_fleet_export(ctx, scope):
+            return None
+
+    if not persistence.has_snapshot(scope.game_id, scope.perspective, scope.turn):
+        return None
+    return persistence.get_snapshot(scope.game_id, scope.perspective, scope.turn)
+
+
+def _overlay_from_snapshot(
+    snapshot: FleetTurnSnapshot,
+    scope: ExportScope,
+) -> FleetTorpOverlay:
+    records: list[FleetShipRecord] = []
+    for ledger in ledgers_for_scope(snapshot, scope):
+        records.extend(ledger.records)
+    belief = launcher_belief_set_from_fleet_records(records)
+    return FleetTorpOverlay(belief_set=belief)
 
 
 def resolve_prior_turn_fleet_torp_overlay(
@@ -82,46 +114,22 @@ def resolve_prior_turn_fleet_torp_overlay(
     if prior_turn_info is None:
         return None
 
-    launcher_types: dict[str, object] | None = None
-    if not ensure and export_services is not None:
-        launcher_types = _launcher_types_from_persisted_fleet(
-            export_services,
-            game_id=turn.game.id,
-            perspective=turn.player.id,
-            prior_turn=prior_turn,
-            player_id=player_id,
-            prior_turn_info=prior_turn_info,
-        )
-    else:
-        ctx = query_context
-        if ctx is None:
-            if export_services is None:
-                return None
-            ctx = make_analytic_query_context(
-                turn,
-                TurnAnalyticsOptions(),
-                load_turn=load_turn,
-                export_services=export_services,
-            )
+    scope = ExportScope(
+        game_id=turn.game.id,
+        perspective=turn.player.id,
+        turn=prior_turn,
+        player_id=player_id,
+    )
 
-        result = ctx.query(
-            FLEET_ANALYTIC_ID,
-            [FLEET_COMPOSITION_LAUNCHER_PATH],
-            scope_overrides={"turn": prior_turn, "player_id": player_id},
-        )
-        if result.status != "ok":
-            return None
-
-        path_result = result.paths.get(FLEET_COMPOSITION_LAUNCHER_PATH)
-        if path_result is None or path_result.kind != "value":
-            return None
-
-        raw_launcher_types = path_result.value
-        if isinstance(raw_launcher_types, dict):
-            launcher_types = raw_launcher_types
-
-    if launcher_types is None:
+    snapshot = _load_prior_turn_fleet_snapshot(
+        scope=scope,
+        query_context=query_context,
+        export_services=export_services,
+        ensure=ensure,
+        turn=turn,
+        load_turn=load_turn,
+    )
+    if snapshot is None:
         return None
 
-    belief = launcher_belief_set_from_composition({"launcherTypes": launcher_types})
-    return FleetTorpOverlay(belief_set=belief)
+    return _overlay_from_snapshot(snapshot, scope)

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -1,0 +1,127 @@
+"""Production consumer for prior-turn fleet composition feeding scores inference (#133)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING
+
+from api.analytics.export_context import make_analytic_query_context
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.composition_export import build_fleet_composition_branch
+from api.analytics.fleet.constants import ANALYTIC_ID as FLEET_ANALYTIC_ID
+from api.analytics.military_score_inference.fleet_torp_overlay import (
+    FleetTorpOverlay,
+    launcher_belief_set_from_composition,
+)
+from api.analytics.options import TurnAnalyticsOptions
+from api.models.game import TurnInfo
+
+if TYPE_CHECKING:
+    from api.analytics.export_context import AnalyticQueryContext
+
+FLEET_COMPOSITION_LAUNCHER_PATH = "$.composition.launcherTypes"
+
+
+def _launcher_types_from_persisted_fleet(
+    export_services: Mapping[str, object],
+    *,
+    game_id: int,
+    perspective: int,
+    prior_turn: int,
+    player_id: int,
+    prior_turn_info: TurnInfo,
+) -> dict[str, object] | None:
+    """Read launcher histogram from a persisted fleet snapshot without export ensure."""
+    from api.analytics.fleet.compute_services import FleetComputeServices
+
+    fleet_services = export_services.get(FLEET_ANALYTIC_ID)
+    if not isinstance(fleet_services, FleetComputeServices):
+        return None
+    persistence = fleet_services.persistence
+    if not persistence.has_snapshot(game_id, perspective, prior_turn):
+        return None
+    snapshot = persistence.get_snapshot(game_id, perspective, prior_turn)
+    if snapshot is None:
+        return None
+    scope = ExportScope(
+        game_id=game_id,
+        perspective=perspective,
+        turn=prior_turn,
+        player_id=player_id,
+    )
+    composition = build_fleet_composition_branch(snapshot, scope, turn=prior_turn_info)
+    launcher_types = composition.get("launcherTypes")
+    if not isinstance(launcher_types, dict):
+        return None
+    return launcher_types
+
+
+def resolve_prior_turn_fleet_torp_overlay(
+    *,
+    turn: TurnInfo,
+    player_id: int,
+    load_turn: Callable[[int], TurnInfo | None],
+    query_context: AnalyticQueryContext | None = None,
+    export_services: Mapping[str, object] | None = None,
+    ensure: bool = True,
+) -> FleetTorpOverlay | None:
+    """Load belief-set torp overlay from fleet export at host turn minus one.
+
+    Returns ``None`` when there is no prior turn, the prior turn is not stored,
+    fleet export is unavailable, or no export services were supplied. Callers
+    treat ``None`` as an empty belief set via ``effective_fleet_torp_overlay``.
+
+    When ``ensure`` is false, reads only persisted fleet snapshots and does not
+    run export ensure (for inference table-stream scheduling).
+    """
+    host_turn = turn.settings.turn
+    if host_turn <= 1:
+        return None
+    prior_turn = host_turn - 1
+    prior_turn_info = load_turn(prior_turn)
+    if prior_turn_info is None:
+        return None
+
+    launcher_types: dict[str, object] | None = None
+    if not ensure and export_services is not None:
+        launcher_types = _launcher_types_from_persisted_fleet(
+            export_services,
+            game_id=turn.game.id,
+            perspective=turn.player.id,
+            prior_turn=prior_turn,
+            player_id=player_id,
+            prior_turn_info=prior_turn_info,
+        )
+    else:
+        ctx = query_context
+        if ctx is None:
+            if export_services is None:
+                return None
+            ctx = make_analytic_query_context(
+                turn,
+                TurnAnalyticsOptions(),
+                load_turn=load_turn,
+                export_services=export_services,
+            )
+
+        result = ctx.query(
+            FLEET_ANALYTIC_ID,
+            [FLEET_COMPOSITION_LAUNCHER_PATH],
+            scope_overrides={"turn": prior_turn, "player_id": player_id},
+        )
+        if result.status != "ok":
+            return None
+
+        path_result = result.paths.get(FLEET_COMPOSITION_LAUNCHER_PATH)
+        if path_result is None or path_result.kind != "value":
+            return None
+
+        raw_launcher_types = path_result.value
+        if isinstance(raw_launcher_types, dict):
+            launcher_types = raw_launcher_types
+
+    if launcher_types is None:
+        return None
+
+    belief = launcher_belief_set_from_composition({"launcherTypes": launcher_types})
+    return FleetTorpOverlay(belief_set=belief)

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 from api.analytics.export_context import make_analytic_query_context
 from api.analytics.export_types import ExportScope
@@ -20,16 +22,41 @@ from api.models.game import TurnInfo
 if TYPE_CHECKING:
     from api.analytics.export_context import AnalyticQueryContext
 
+FleetTorpInputStatus = Literal["not_applicable", "pending", "applied", "unavailable"]
+
+
+@dataclass(frozen=True)
+class PriorTurnFleetTorpResolution:
+    """Prior-turn fleet torp overlay plus provenance for inference diagnostics."""
+
+    overlay: FleetTorpOverlay | None
+    input_status: FleetTorpInputStatus
+
+
+def fleet_torp_input_status_diagnostics(
+    input_status: FleetTorpInputStatus | None,
+) -> dict[str, object]:
+    if input_status is None:
+        return {}
+    return {"fleetTorpInputStatus": input_status}
+
 
 def _resolve_fleet_services(
     *,
     query_context: AnalyticQueryContext | None,
     export_services: Mapping[str, object] | None,
 ):
-    from api.analytics.fleet.compute_services import FleetComputeServices, resolve_fleet_services
+    from api.analytics.export_context import export_service_for
+    from api.analytics.fleet.compute_services import FleetComputeServices
 
     if query_context is not None:
-        return resolve_fleet_services(query_context)
+        services = export_service_for(query_context, FLEET_ANALYTIC_ID, FleetComputeServices)
+        if services is not None:
+            return services
+        injected = query_context.export_services.get(FLEET_ANALYTIC_ID)
+        if isinstance(injected, FleetComputeServices):
+            return injected
+        return None
     if export_services is None:
         return None
     fleet_services = export_services.get(FLEET_ANALYTIC_ID)
@@ -96,23 +123,31 @@ def resolve_prior_turn_fleet_torp_overlay(
     query_context: AnalyticQueryContext | None = None,
     export_services: Mapping[str, object] | None = None,
     ensure: bool = True,
-) -> FleetTorpOverlay | None:
+) -> PriorTurnFleetTorpResolution:
     """Load belief-set torp overlay from fleet export at host turn minus one.
 
-    Returns ``None`` when there is no prior turn, the prior turn is not stored,
-    fleet export is unavailable, or no export services were supplied. Callers
-    treat ``None`` as an empty belief set via ``effective_fleet_torp_overlay``.
+    Returns overlay plus ``input_status`` for inference diagnostics. Callers
+    treat ``overlay is None`` as an empty belief set via
+    ``effective_fleet_torp_overlay``.
 
     When ``ensure`` is false, reads only persisted fleet snapshots and does not
     run export ensure (for inference table-stream scheduling).
     """
     host_turn = turn.settings.turn
     if host_turn <= 1:
-        return None
+        return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
+
+    fleet_services = _resolve_fleet_services(
+        query_context=query_context,
+        export_services=export_services,
+    )
+    if fleet_services is None:
+        return PriorTurnFleetTorpResolution(overlay=None, input_status="unavailable")
+
     prior_turn = host_turn - 1
     prior_turn_info = load_turn(prior_turn)
     if prior_turn_info is None:
-        return None
+        return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
 
     scope = ExportScope(
         game_id=turn.game.id,
@@ -130,6 +165,57 @@ def resolve_prior_turn_fleet_torp_overlay(
         load_turn=load_turn,
     )
     if snapshot is None:
-        return None
+        return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
 
-    return _overlay_from_snapshot(snapshot, scope)
+    return PriorTurnFleetTorpResolution(
+        overlay=_overlay_from_snapshot(snapshot, scope),
+        input_status="applied",
+    )
+
+
+def schedule_background_prior_turn_fleet_warm(
+    *,
+    turn: TurnInfo,
+    load_turn: Callable[[int], TurnInfo | None],
+    export_services: Mapping[str, object] | None,
+) -> None:
+    """Kick off non-blocking materialization of fleet@(host_turn - 1) for table streams."""
+    host_turn = turn.settings.turn
+    if host_turn <= 1:
+        return
+
+    fleet_services = _resolve_fleet_services(
+        query_context=None,
+        export_services=export_services,
+    )
+    if fleet_services is None:
+        return
+
+    prior_turn = host_turn - 1
+    prior_turn_info = load_turn(prior_turn)
+    if prior_turn_info is None:
+        return
+
+    if fleet_services.persistence.has_snapshot(
+        fleet_services.game_id,
+        fleet_services.perspective,
+        prior_turn,
+    ):
+        return
+
+    def warm_prior_turn_fleet() -> None:
+        from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+
+        try:
+            get_or_materialize_fleet_snapshot(
+                fleet_services.persistence,
+                fleet_services.game_id,
+                fleet_services.perspective,
+                prior_turn_info,
+                load_turn=fleet_services.load_turn,
+                inference_materialization=fleet_services.inference_materialization,
+            )
+        except OSError, ValueError, KeyError:
+            return
+
+    threading.Thread(target=warm_prior_turn_fleet, daemon=True).start()

--- a/packages/api/api/analytics/scores/__init__.py
+++ b/packages/api/api/analytics/scores/__init__.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Iterator
 
 from api.analytics.catalog import catalog_entry
 from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_scheduler import InferenceRowScheduler
 from api.analytics.military_score_inference.inference_stream_rows import (
@@ -80,6 +81,7 @@ def iter_scores_table_inference_stream(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     reload_host_turn: Callable[[], TurnInfo] | None = None,
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
+    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None,
     persistence: InferenceRowPersistenceService | None = None,
     scheduler: InferenceRowScheduler | None = None,
 ) -> Iterator[dict[str, object]]:
@@ -92,6 +94,7 @@ def iter_scores_table_inference_stream(
         load_scoreboard_turn=load_scoreboard_turn,
         reload_host_turn=reload_host_turn,
         resolve_mask_for_player=resolve_mask_for_player,
+        resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
         persistence=persistence,
         scheduler=scheduler,
     )

--- a/packages/api/api/analytics/scores/__init__.py
+++ b/packages/api/api/analytics/scores/__init__.py
@@ -4,11 +4,13 @@ from collections.abc import Callable, Iterator
 
 from api.analytics.catalog import catalog_entry
 from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
-from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_scheduler import InferenceRowScheduler
 from api.analytics.military_score_inference.inference_stream_rows import (
     iter_scores_table_inference_events,
+)
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    PriorTurnFleetTorpResolution,
 )
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.registration import TurnAnalyticRegistration
@@ -81,7 +83,8 @@ def iter_scores_table_inference_stream(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     reload_host_turn: Callable[[], TurnInfo] | None = None,
     resolve_mask_for_player: Callable[[int], ResolvedHullCatalogMask | None] | None = None,
-    resolve_fleet_torp_overlay_for_player: Callable[[int], FleetTorpOverlay | None] | None = None,
+    resolve_fleet_torp_resolution_for_player: Callable[[int], PriorTurnFleetTorpResolution]
+    | None = None,
     persistence: InferenceRowPersistenceService | None = None,
     scheduler: InferenceRowScheduler | None = None,
 ) -> Iterator[dict[str, object]]:
@@ -94,7 +97,7 @@ def iter_scores_table_inference_stream(
         load_scoreboard_turn=load_scoreboard_turn,
         reload_host_turn=reload_host_turn,
         resolve_mask_for_player=resolve_mask_for_player,
-        resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
+        resolve_fleet_torp_resolution_for_player=resolve_fleet_torp_resolution_for_player,
         persistence=persistence,
         scheduler=scheduler,
     )

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -219,7 +219,7 @@ def _run_prior_turn_sync_ensure(
             player_id=inputs.player_id,
             load_turn=load_scoreboard_turn,
             query_context=ctx,
-        ),
+        ).overlay,
     )
     status = str(inference.get("status", ""))
     if services.persistence is not None and is_persistable_inference_status(status):
@@ -305,7 +305,7 @@ def _ensure_current_turn_scheduler(
             player_id=inputs.player_id,
             load_turn=ctx.load_turn,
             query_context=ctx,
-        ),
+        ).overlay,
         stream_token=inputs.stream_token,
     )
     return True

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -209,17 +209,19 @@ def _run_prior_turn_sync_ensure(
     if inputs is None:
         return False
 
+    fleet_resolution = resolve_prior_turn_fleet_torp_overlay(
+        turn=turn,
+        player_id=inputs.player_id,
+        load_turn=load_scoreboard_turn,
+        query_context=ctx,
+    )
     inference = get_scores_row_inference(
         turn,
         inputs.player_id,
         load_scoreboard_turn=load_scoreboard_turn,
         resolved_mask=inputs.resolved_mask,
-        fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
-            turn=turn,
-            player_id=inputs.player_id,
-            load_turn=load_scoreboard_turn,
-            query_context=ctx,
-        ).overlay,
+        fleet_torp_overlay=fleet_resolution.overlay,
+        fleet_torp_input_status=fleet_resolution.input_status,
     )
     status = str(inference.get("status", ""))
     if services.persistence is not None and is_persistable_inference_status(status):
@@ -291,6 +293,12 @@ def _ensure_current_turn_scheduler(
     if services.scheduler.row_run_for_player(inputs.stream_scope, inputs.player_id) is not None:
         return False
 
+    fleet_resolution = resolve_prior_turn_fleet_torp_overlay(
+        turn=turn,
+        player_id=inputs.player_id,
+        load_turn=ctx.load_turn,
+        query_context=ctx,
+    )
     schedule_inference_row(
         services.scheduler,
         score=inputs.score,
@@ -300,12 +308,8 @@ def _ensure_current_turn_scheduler(
         perspective=scope.perspective,
         load_scoreboard_turn=ctx.load_turn,
         resolved_mask=inputs.resolved_mask,
-        fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
-            turn=turn,
-            player_id=inputs.player_id,
-            load_turn=ctx.load_turn,
-            query_context=ctx,
-        ).overlay,
+        fleet_torp_overlay=fleet_resolution.overlay,
+        fleet_torp_input_status=fleet_resolution.input_status,
         stream_token=inputs.stream_token,
     )
     return True

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -16,6 +16,9 @@ from api.analytics.military_score_inference.inference_stream_rows import (
     schedule_inference_row,
 )
 from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    resolve_prior_turn_fleet_torp_overlay,
+)
 from api.analytics.scores.export_precedence import (
     ScoresExportResolutionContext,
     ScoresExportResolved,
@@ -211,6 +214,12 @@ def _run_prior_turn_sync_ensure(
         inputs.player_id,
         load_scoreboard_turn=load_scoreboard_turn,
         resolved_mask=inputs.resolved_mask,
+        fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
+            turn=turn,
+            player_id=inputs.player_id,
+            load_turn=load_scoreboard_turn,
+            query_context=ctx,
+        ),
     )
     status = str(inference.get("status", ""))
     if services.persistence is not None and is_persistable_inference_status(status):
@@ -291,6 +300,12 @@ def _ensure_current_turn_scheduler(
         perspective=scope.perspective,
         load_scoreboard_turn=ctx.load_turn,
         resolved_mask=inputs.resolved_mask,
+        fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
+            turn=turn,
+            player_id=inputs.player_id,
+            load_turn=ctx.load_turn,
+            query_context=ctx,
+        ),
         stream_token=inputs.stream_token,
     )
     return True

--- a/packages/api/api/analytics/scores/inference.py
+++ b/packages/api/api/analytics/scores/inference.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 
 from api.analytics.military_score_inference.analytic import (
     infer_military_score_build,
@@ -21,7 +21,6 @@ def get_scores_row_inference(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
-    export_services: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
@@ -44,6 +43,5 @@ def get_scores_row_inference(
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
-            export_services=export_services,
         )
     return {"playerId": player_id, **inference}

--- a/packages/api/api/analytics/scores/inference.py
+++ b/packages/api/api/analytics/scores/inference.py
@@ -11,6 +11,9 @@ from api.analytics.military_score_inference.analytic import (
 from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import STATUS_PLAYER_NOT_FOUND
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    FleetTorpInputStatus,
+)
 from api.models.game import TurnInfo
 
 
@@ -21,6 +24,7 @@ def get_scores_row_inference(
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    fleet_torp_input_status: FleetTorpInputStatus | None = None,
 ) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
@@ -43,5 +47,6 @@ def get_scores_row_inference(
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
+            fleet_torp_input_status=fleet_torp_input_status,
         )
     return {"playerId": player_id, **inference}

--- a/packages/api/api/analytics/scores/inference.py
+++ b/packages/api/api/analytics/scores/inference.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from api.analytics.military_score_inference.analytic import (
     infer_military_score_build,
     run_inference_with_artifacts,
 )
+from api.analytics.military_score_inference.fleet_torp_overlay import FleetTorpOverlay
 from api.analytics.military_score_inference.hull_catalog_mask import ResolvedHullCatalogMask
 from api.analytics.military_score_inference.inference_api_payload import STATUS_PLAYER_NOT_FOUND
 from api.models.game import TurnInfo
@@ -19,6 +20,8 @@ def get_scores_row_inference(
     *,
     load_scoreboard_turn: Callable[[int], TurnInfo | None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
+    fleet_torp_overlay: FleetTorpOverlay | None = None,
+    export_services: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
@@ -40,5 +43,7 @@ def get_scores_row_inference(
             turn,
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
+            fleet_torp_overlay=fleet_torp_overlay,
+            export_services=export_services,
         )
     return {"playerId": player_id, **inference}

--- a/packages/api/api/services/inference_invalidation_service.py
+++ b/packages/api/api/services/inference_invalidation_service.py
@@ -71,6 +71,24 @@ class InferenceInvalidationService:
             return
         self._persistence.on_row_persisted = self.on_inference_evidence_updated
 
+    def wire_scores_invalidation_to_fleet_persistence(self) -> None:
+        """Register scores inference invalidation when fleet snapshots are persisted."""
+        if self._fleet_persistence is None:
+            self._fleet_persistence.on_snapshot_persisted = None
+            return
+        self._fleet_persistence.on_snapshot_persisted = self.on_fleet_snapshot_persisted
+
+    def on_fleet_snapshot_persisted(
+        self,
+        game_id: int,
+        perspective: int,
+        fleet_turn: int,
+    ) -> None:
+        """Drop scores@N inference rows and reschedule when fleet@(N-1) is persisted."""
+        host_turn = fleet_turn + 1
+        self._persistence.delete_host_turn_document(game_id, perspective, host_turn)
+        reschedule_all_inference_rows(self._scope(game_id, perspective, host_turn))
+
     def bind_scheduler(self, scheduler: InferenceRowScheduler) -> None:
         self._scheduler = scheduler
 

--- a/packages/api/api/services/inference_invalidation_service.py
+++ b/packages/api/api/services/inference_invalidation_service.py
@@ -86,8 +86,11 @@ class InferenceInvalidationService:
     ) -> None:
         """Drop scores@N inference rows and reschedule when fleet@(N-1) is persisted."""
         host_turn = fleet_turn + 1
-        self._persistence.delete_host_turn_document(game_id, perspective, host_turn)
-        reschedule_all_inference_rows(self._scope(game_id, perspective, host_turn))
+        self._persistence.invalidate_for_turn_write(game_id, perspective, host_turn)
+        reschedule_all_inference_rows(
+            self._scope(game_id, perspective, host_turn),
+            force_schedule=True,
+        )
 
     def bind_scheduler(self, scheduler: InferenceRowScheduler) -> None:
         self._scheduler = scheduler

--- a/packages/api/api/services/inference_invalidation_service.py
+++ b/packages/api/api/services/inference_invalidation_service.py
@@ -86,7 +86,7 @@ class InferenceInvalidationService:
     ) -> None:
         """Drop scores@N inference rows and reschedule when fleet@(N-1) is persisted."""
         host_turn = fleet_turn + 1
-        self._persistence.invalidate_for_turn_write(game_id, perspective, host_turn)
+        self._persistence.delete_host_turn_document(game_id, perspective, host_turn)
         reschedule_all_inference_rows(
             self._scope(game_id, perspective, host_turn),
             force_schedule=True,

--- a/packages/api/api/services/stack.py
+++ b/packages/api/api/services/stack.py
@@ -34,6 +34,7 @@ def build_service_stack(
         fleet_persistence=fleet_persistence,
     )
     inference_invalidation.wire_fleet_invalidation_to_persistence()
+    inference_invalidation.wire_scores_invalidation_to_fleet_persistence()
 
     def on_held_solutions_updated(session) -> None:
         inference_invalidation.on_inference_evidence_updated(

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -182,6 +182,7 @@ class TurnAnalyticService:
             player_id,
             load_scoreboard_turn=self._load_scoreboard_turn(game_id, perspective),
             resolved_mask=resolved_mask,
+            export_services=self._turn_export_services(game_id, perspective),
         )
 
     def iter_scores_table_inference_stream(
@@ -191,6 +192,9 @@ class TurnAnalyticService:
         turn_number: int,
         player_ids: tuple[int, ...],
     ):
+        from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+            resolve_prior_turn_fleet_torp_overlay,
+        )
         from api.analytics.scores import iter_scores_table_inference_stream
 
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
@@ -202,6 +206,18 @@ class TurnAnalyticService:
                 player_id,
             )
 
+        export_services = self._turn_export_services(game_id, perspective)
+        load_turn = self._load_scoreboard_turn(game_id, perspective)
+
+        def resolve_fleet_torp_overlay_for_player(player_id: int):
+            return resolve_prior_turn_fleet_torp_overlay(
+                turn=turn,
+                player_id=player_id,
+                load_turn=load_turn,
+                export_services=export_services,
+                ensure=False,
+            )
+
         def reload_host_turn() -> TurnInfo:
             return self._turns.get_turn_info(game_id, perspective, turn_number)
 
@@ -210,9 +226,10 @@ class TurnAnalyticService:
             player_ids,
             game_id=game_id,
             perspective=perspective,
-            load_scoreboard_turn=self._load_scoreboard_turn(game_id, perspective),
+            load_scoreboard_turn=load_turn,
             reload_host_turn=reload_host_turn,
             resolve_mask_for_player=resolve_mask_for_player,
+            resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
             persistence=self._inference_persistence,
             scheduler=self._inference_scheduler_instance(),
         )

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -168,6 +168,9 @@ class TurnAnalyticService:
         turn_number: int,
         player_id: int,
     ) -> dict[str, object]:
+        from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+            resolve_prior_turn_fleet_torp_overlay,
+        )
         from api.analytics.scores import get_scores_row_inference
 
         turn = self._turns.get_turn_info(game_id, perspective, turn_number)
@@ -177,12 +180,19 @@ class TurnAnalyticService:
             turn_number,
             player_id,
         )
+        load_scoreboard_turn = self._load_scoreboard_turn(game_id, perspective)
+        export_services = self._turn_export_services(game_id, perspective)
         return get_scores_row_inference(
             turn,
             player_id,
-            load_scoreboard_turn=self._load_scoreboard_turn(game_id, perspective),
+            load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
-            export_services=self._turn_export_services(game_id, perspective),
+            fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
+                turn=turn,
+                player_id=player_id,
+                load_turn=load_scoreboard_turn,
+                export_services=export_services,
+            ),
         )
 
     def iter_scores_table_inference_stream(

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -60,6 +60,7 @@ class TurnAnalyticService:
                 fleet_persistence=self._fleet_persistence,
             )
             self._inference_invalidation.wire_fleet_invalidation_to_persistence()
+            self._inference_invalidation.wire_scores_invalidation_to_fleet_persistence()
         self._inference_scheduler = inference_scheduler
 
     def _load_scoreboard_turn(
@@ -182,17 +183,19 @@ class TurnAnalyticService:
         )
         load_scoreboard_turn = self._load_scoreboard_turn(game_id, perspective)
         export_services = self._turn_export_services(game_id, perspective)
+        fleet_resolution = resolve_prior_turn_fleet_torp_overlay(
+            turn=turn,
+            player_id=player_id,
+            load_turn=load_scoreboard_turn,
+            export_services=export_services,
+        )
         return get_scores_row_inference(
             turn,
             player_id,
             load_scoreboard_turn=load_scoreboard_turn,
             resolved_mask=resolved_mask,
-            fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
-                turn=turn,
-                player_id=player_id,
-                load_turn=load_scoreboard_turn,
-                export_services=export_services,
-            ),
+            fleet_torp_overlay=fleet_resolution.overlay,
+            fleet_torp_input_status=fleet_resolution.input_status,
         )
 
     def iter_scores_table_inference_stream(
@@ -203,7 +206,9 @@ class TurnAnalyticService:
         player_ids: tuple[int, ...],
     ):
         from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+            PriorTurnFleetTorpResolution,
             resolve_prior_turn_fleet_torp_overlay,
+            schedule_background_prior_turn_fleet_warm,
         )
         from api.analytics.scores import iter_scores_table_inference_stream
 
@@ -219,7 +224,15 @@ class TurnAnalyticService:
         export_services = self._turn_export_services(game_id, perspective)
         load_turn = self._load_scoreboard_turn(game_id, perspective)
 
-        def resolve_fleet_torp_overlay_for_player(player_id: int):
+        schedule_background_prior_turn_fleet_warm(
+            turn=turn,
+            load_turn=load_turn,
+            export_services=export_services,
+        )
+
+        def resolve_fleet_torp_resolution_for_player(
+            player_id: int,
+        ) -> PriorTurnFleetTorpResolution:
             return resolve_prior_turn_fleet_torp_overlay(
                 turn=turn,
                 player_id=player_id,
@@ -239,7 +252,7 @@ class TurnAnalyticService:
             load_scoreboard_turn=load_turn,
             reload_host_turn=reload_host_turn,
             resolve_mask_for_player=resolve_mask_for_player,
-            resolve_fleet_torp_overlay_for_player=resolve_fleet_torp_overlay_for_player,
+            resolve_fleet_torp_resolution_for_player=resolve_fleet_torp_resolution_for_player,
             persistence=self._inference_persistence,
             scheduler=self._inference_scheduler_instance(),
         )

--- a/packages/api/api/transport/inference_stream.py
+++ b/packages/api/api/transport/inference_stream.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 _INFERENCE_STREAM_UNEXPECTED_ERROR_DETAIL = "Internal server error"
 
+TABLE_STREAM_ALREADY_ACTIVE_DETAIL = "An inference table stream is already active for this scope."
+
 
 def inference_solution_event(
     solutions: list[dict[str, object]],

--- a/packages/api/tests/test_fleet_composition_export.py
+++ b/packages/api/tests/test_fleet_composition_export.py
@@ -6,6 +6,7 @@ from api.analytics.export_types import ExportScope
 from api.analytics.fleet.composition_export import build_fleet_composition_branch
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
+    FleetBuildOptionSet,
     FleetFieldKnown,
     FleetFieldUnknown,
     FleetShipRecord,
@@ -123,6 +124,7 @@ def test_build_composition_returns_empty_when_unscoped():
     composition = build_fleet_composition_branch(snapshot, scope, turn=turn)
     assert composition == {
         "hullTypes": {},
+        "engineTypes": {},
         "beamTypes": {},
         "launcherTypes": {},
         "torpedoTypesLoaded": {},
@@ -192,3 +194,53 @@ def test_build_composition_excludes_known_zero_beams_and_launchers():
     assert composition["hullTypes"] == {"15": 1}
     assert composition["beamTypes"] == {}
     assert composition["launcherTypes"] == {}
+
+
+def test_build_composition_unions_build_option_sets_on_inferred_rows():
+    turn = single_ship_turn(
+        turn_number=1,
+        ship_id=1,
+        owner_id=8,
+        x=100,
+        y=100,
+        hull_id=15,
+        engine_id=3,
+        beam_id=3,
+        torpedoid=3,
+    )
+    composition = _composition_for_records(
+        [
+            FleetShipRecord(
+                record_id="inferred-launchers",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    launchers=FleetFieldUnknown(),
+                ),
+                build_option_sets=[
+                    FleetBuildOptionSet(torp_id=4, label="Mk IV default"),
+                    FleetBuildOptionSet(torp_id=8, label="Mk VIII alt"),
+                ],
+            ),
+            FleetShipRecord(
+                record_id="known-and-options",
+                disposition="active",
+                fields=FleetShipRecordFields(
+                    hull=FleetFieldKnown(15),
+                    engine=FleetFieldKnown(3),
+                    launchers=FleetFieldKnown(6),
+                ),
+                build_option_sets=[
+                    FleetBuildOptionSet(
+                        hull_id=13,
+                        engine_id=9,
+                        torp_id=8,
+                        label="alternate build",
+                    ),
+                ],
+            ),
+        ],
+        turn=turn,
+    )
+    assert composition["launcherTypes"] == {"4": 1, "6": 1, "8": 2}
+    assert composition["hullTypes"] == {"13": 1, "15": 1}
+    assert composition["engineTypes"] == {"3": 1, "9": 1}

--- a/packages/api/tests/test_fleet_exports.py
+++ b/packages/api/tests/test_fleet_exports.py
@@ -78,6 +78,7 @@ def test_materialized_tree_turn_one_empty_composition(sample_turn):
     tree, _scope = materialize_fleet_tree(ctx, player_id, turn=1)
     assert tree["composition"] == {
         "hullTypes": {},
+        "engineTypes": {},
         "beamTypes": {},
         "launcherTypes": {},
         "torpedoTypesLoaded": {},

--- a/packages/api/tests/test_inference_scheduler_global_pause.py
+++ b/packages/api/tests/test_inference_scheduler_global_pause.py
@@ -5,6 +5,7 @@ from api.analytics.military_score_inference.actions import ActionCatalog
 from api.analytics.military_score_inference.analytic import build_inference_observation
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
+    TableStreamScopeAlreadyActive,
     reset_inference_row_scheduler_for_tests,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -147,7 +148,7 @@ def test_new_scope_invalidates_retained_pause_state(sample_turn):
     assert status["activeScope"]["turn"] == scope_b.turn_number
 
 
-def test_begin_scope_preempts_reconnect_for_same_scope(sample_turn):
+def test_begin_scope_rejects_second_stream_for_same_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
     scheduler = InferenceRowScheduler(worker_count=0)
     scope = InferenceStreamScope(
@@ -159,12 +160,13 @@ def test_begin_scope_preempts_reconnect_for_same_scope(sample_turn):
     first_token = scheduler.begin_scope(scope)
     scheduler.enqueue_tier_ladder(session)
 
-    second_token = scheduler.begin_scope(scope)
+    with pytest.raises(TableStreamScopeAlreadyActive):
+        scheduler.begin_scope(scope)
 
-    assert second_token != first_token
-    assert session.cancel_token.is_cancelled()
+    assert scheduler.owns_table_stream(first_token)
+    assert not session.cancel_token.is_cancelled()
     status = scheduler.global_pause_status(scope)
-    assert status["activeSessionCount"] == 0
+    assert status["activeSessionCount"] == 1
 
 
 def test_begin_scope_succeeds_after_end_inference_stream(sample_turn):

--- a/packages/api/tests/test_inference_stream_invalidation.py
+++ b/packages/api/tests/test_inference_stream_invalidation.py
@@ -76,6 +76,15 @@ def _stream_scope(sample_turn) -> InferenceStreamScope:
     )
 
 
+def _end_open_table_stream(
+    scope: InferenceStreamScope,
+    scheduler: InferenceRowScheduler,
+) -> None:
+    controller = controller_for_scope(scope)
+    if controller is not None:
+        controller.end_stream(scheduler)
+
+
 def _schedule_player_row(
     scheduler: InferenceRowScheduler,
     sample_turn,
@@ -477,7 +486,7 @@ def test_all_cached_replay_keeps_stream_open_for_mask_invalidation_case_4_integr
     ]
     assert len(cached_other_events) == 1
 
-    scheduler.begin_scope(scope)
+    _end_open_table_stream(scope, scheduler)
     thread.join(timeout=2.0)
 
 
@@ -529,7 +538,7 @@ def test_all_cached_replay_keeps_stream_open_for_recompute_cases_1_and_2_integra
     for player_id in player_ids:
         assert persistence.get_row(628580, 1, turn_number, player_id) is None
 
-    scheduler.begin_scope(scope)
+    _end_open_table_stream(scope, scheduler)
     thread.join(timeout=2.0)
 
 
@@ -585,7 +594,7 @@ def test_turn_invalidation_reschedule_skips_immediate_path_players(
         ]
         assert len(post_invalidation_completes) == 2
 
-    scheduler.begin_scope(_stream_scope(first_turn))
+    _end_open_table_stream(_stream_scope(first_turn), scheduler)
     thread.join(timeout=2.0)
 
 
@@ -656,7 +665,7 @@ def test_turn_stored_reschedule_uses_refreshed_host_turn(
     assert after_observation.military_delta_2x == 2 * updated_militarychange
     assert after_observation.military_delta_2x != before_observation.military_delta_2x
 
-    scheduler.begin_scope(_stream_scope(sample_turn))
+    _end_open_table_stream(_stream_scope(sample_turn), scheduler)
     thread.join(timeout=2.0)
 
 
@@ -699,5 +708,5 @@ def test_recompute_force_schedules_immediate_path_players(
 
     _wait_until(lambda: len(_run_ids_for_players(scheduler, player_ids)) == len(player_ids))
 
-    scheduler.begin_scope(_stream_scope(first_turn))
+    _end_open_table_stream(_stream_scope(first_turn), scheduler)
     thread.join(timeout=2.0)

--- a/packages/api/tests/test_inference_stream_lifecycle_gaps.py
+++ b/packages/api/tests/test_inference_stream_lifecycle_gaps.py
@@ -35,10 +35,14 @@ from api.analytics.military_score_inference.inference_stream_scope import Infere
 from api.analytics.military_score_inference.inference_stream_session import (
     InferenceRowStreamSession,
 )
+from api.analytics.military_score_inference.inference_table_stream_registry import (
+    controller_for_scope,
+)
 from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.storage.memory_asset import MemoryAssetBackend
+from api.transport.inference_stream import TABLE_STREAM_ALREADY_ACTIVE_DETAIL
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
@@ -207,12 +211,12 @@ def test_multiplex_delivers_all_queued_completes_before_scope_deactivation(sampl
     assert complete_player_ids == {row.player_id for row in rows}
 
 
-def test_stream_preempt_persists_complete_before_first_connection_drains_in_flight_row(
+def test_stream_conflict_does_not_preempt_first_connection_while_rows_compute(
     sample_turn,
     monkeypatch,
     memory_backend,
 ):
-    """Persist can succeed while the preempted stream still shows in-progress for other rows."""
+    """Persist succeeds while a duplicate connect is rejected and the first stream runs."""
     persistence = InferenceRowPersistenceService(memory_backend)
     scheduler = _install_workerless_scheduler(
         monkeypatch,
@@ -275,9 +279,21 @@ def test_stream_preempt_persists_complete_before_first_connection_drains_in_flig
         persistence=persistence,
         scheduler=scheduler,
     )
-    assert next(replacement) == {"type": "globalPause", "paused": False}
+    assert next(replacement) == {
+        "type": "error",
+        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    }
     replacement.close()
 
+    controller = controller_for_scope(
+        InferenceStreamScope(
+            game_id=628580,
+            perspective=1,
+            turn_number=turn_number,
+        )
+    )
+    assert controller is not None
+    controller.end_stream(scheduler)
     thread.join(timeout=2.0)
     assert not stream_error
 
@@ -348,12 +364,12 @@ def test_progress_without_terminal_complete_when_scope_deactivates_mid_row(sampl
     assert list(stream) == []
 
 
-def test_stream_preempt_leaves_in_flight_row_without_persisted_terminal_state(
+def test_stream_disconnect_leaves_in_flight_row_without_persisted_terminal_state(
     sample_turn,
     monkeypatch,
     memory_backend,
 ):
-    """Preempt before terminal: in-flight row is cancelled without persistence."""
+    """Disconnect before terminal: in-flight row is cancelled without persistence."""
     persistence = InferenceRowPersistenceService(memory_backend)
     scheduler = _install_workerless_scheduler(
         monkeypatch,
@@ -382,16 +398,15 @@ def test_stream_preempt_leaves_in_flight_row_without_persisted_terminal_state(
     thread.start()
     _wait_until(lambda: len(scheduler._runs) == len(player_ids))
 
-    replacement = iter_scores_table_inference_events(
-        sample_turn,
-        player_ids,
-        game_id=628580,
-        perspective=1,
-        persistence=persistence,
-        scheduler=scheduler,
+    controller = controller_for_scope(
+        InferenceStreamScope(
+            game_id=628580,
+            perspective=1,
+            turn_number=turn_number,
+        )
     )
-    next(replacement)
-    replacement.close()
+    assert controller is not None
+    controller.end_stream(scheduler)
     thread.join(timeout=2.0)
 
     assert persistence.get_row(628580, 1, turn_number, target_player_id) is None
@@ -487,6 +502,7 @@ def test_persisted_row_replays_on_new_stream_without_scheduler_work(
             diagnostics=_diagnostics(turn=turn_number, player_id=player_id),
         ),
     )
+    scheduler.end_inference_stream(scope, (scheduled.session,), stream_token=stream_token)
 
     replay = iter_scores_table_inference_events(
         sample_turn,

--- a/packages/api/tests/test_inference_table_stream.py
+++ b/packages/api/tests/test_inference_table_stream.py
@@ -25,7 +25,10 @@ from api.analytics.military_score_inference.inference_stream_session import (
 from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.row_complete_factory import row_complete_with_summary
 from api.analytics.military_score_inference.solver import STATUS_EXACT
-from api.transport.inference_stream import stream_inference_ndjson
+from api.transport.inference_stream import (
+    TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    stream_inference_ndjson,
+)
 
 
 def _session_for_player(sample_turn, *, player_id: int) -> InferenceRowStreamSession:
@@ -62,7 +65,7 @@ def test_table_stream_emits_global_pause_snapshot_on_connect(sample_turn):
     stream.close()
 
 
-def test_table_stream_reconnect_preempts_in_flight_stream(sample_turn):
+def test_table_stream_reconnect_returns_conflict_while_active(sample_turn):
     reset_inference_row_scheduler_for_tests()
     active_stream = iter_scores_table_inference_events(
         sample_turn,
@@ -78,7 +81,10 @@ def test_table_stream_reconnect_preempts_in_flight_stream(sample_turn):
         game_id=628580,
         perspective=1,
     )
-    assert next(replacement) == {"type": "globalPause", "paused": False}
+    assert next(replacement) == {
+        "type": "error",
+        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    }
 
     active_stream.close()
     replacement.close()
@@ -106,10 +112,13 @@ def test_table_stream_reconnect_via_ndjson_transport(sample_turn):
     active_stream.close()
 
     assert len(lines) == 1
-    assert json.loads(lines[0]) == {"type": "globalPause", "paused": False}
+    assert json.loads(lines[0]) == {
+        "type": "error",
+        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    }
 
 
-def test_schedule_inference_row_ignores_stale_stream_token_after_preempt(sample_turn):
+def test_schedule_inference_row_ignores_stale_stream_token_after_scope_end(sample_turn):
     reset_inference_row_scheduler_for_tests()
     scheduler = get_inference_row_scheduler()
     scope = InferenceStreamScope(
@@ -131,6 +140,7 @@ def test_schedule_inference_row_ignores_stale_stream_token_after_preempt(sample_
     )
     assert active_row is not None
 
+    scheduler.end_inference_stream(scope, (active_row.session,), stream_token=first_token)
     scheduler.begin_scope(scope)
 
     stale_row = schedule_inference_row(
@@ -146,7 +156,7 @@ def test_schedule_inference_row_ignores_stale_stream_token_after_preempt(sample_
     assert active_row.session.cancel_token.is_cancelled()
 
 
-def test_table_stream_reconnect_cancels_in_flight_rows_for_same_scope(sample_turn):
+def test_table_stream_conflict_does_not_cancel_in_flight_rows_for_same_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
     scheduler = get_inference_row_scheduler()
     player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
@@ -167,11 +177,15 @@ def test_table_stream_reconnect_cancels_in_flight_rows_for_same_scope(sample_tur
         game_id=628580,
         perspective=1,
     )
-    assert next(replacement) == {"type": "globalPause", "paused": False}
+    assert next(replacement) == {
+        "type": "error",
+        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    }
 
     for run_id in in_flight_run_ids:
         run = scheduler._runs.get(run_id)
-        assert run is None or run.session.cancel_token.is_cancelled()
+        assert run is not None
+        assert not run.session.cancel_token.is_cancelled()
 
     first_stream.close()
     replacement.close()

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -1,0 +1,443 @@
+"""Integration tests for prior-turn fleet warm, invalidation, and diagnostics (#133)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import replace
+
+import pytest
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetBuildOptionSet,
+    FleetFieldUnknown,
+    FleetShipRecord,
+    FleetShipRecordFields,
+)
+from api.analytics.military_score_inference.inference_scheduler import (
+    InferenceRowScheduler,
+    reset_inference_row_scheduler_for_tests,
+)
+from api.analytics.military_score_inference.inference_stream_rows import (
+    iter_scores_table_inference_events,
+)
+from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
+from api.analytics.military_score_inference.inference_table_stream_registry import (
+    controller_for_scope,
+    reset_inference_table_stream_registry_for_tests,
+)
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    PriorTurnFleetTorpResolution,
+    resolve_prior_turn_fleet_torp_overlay,
+    schedule_background_prior_turn_fleet_warm,
+)
+from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+from api.services.inference_invalidation_service import InferenceInvalidationService
+
+from tests.export_chain_test_fixtures import export_chain_query_context
+
+
+def _install_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    worker_count: int = 0,
+) -> InferenceRowScheduler:
+    reset_inference_row_scheduler_for_tests()
+    scheduler = InferenceRowScheduler(worker_count=worker_count)
+
+    def _get_scheduler() -> InferenceRowScheduler:
+        return scheduler
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.inference_scheduler.get_inference_row_scheduler",
+        _get_scheduler,
+    )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.inference_stream_rows.get_inference_row_scheduler",
+        _get_scheduler,
+    )
+    return scheduler
+
+
+def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_seconds: float = 3.0,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
+def _run_ids_for_players(
+    scheduler: InferenceRowScheduler,
+    player_ids: tuple[int, ...],
+) -> dict[int, str]:
+    mapping: dict[int, str] = {}
+    for run in scheduler._runs.values():
+        if run.session.player_id in player_ids:
+            mapping[run.session.player_id] = run.session.run_id
+    return mapping
+
+
+def _end_open_table_stream(
+    scope: InferenceStreamScope,
+    scheduler: InferenceRowScheduler,
+) -> None:
+    controller = controller_for_scope(scope)
+    if controller is not None:
+        controller.end_stream(scheduler)
+
+
+def _seed_prior_turn_fleet_with_belief_sets(
+    ctx,
+    *,
+    sample_turn,
+    player_id: int,
+    torp_ids: tuple[int, ...],
+) -> FleetSnapshotPersistenceService:
+    prior_turn = sample_turn.settings.turn - 1
+    fleet_services = ctx.export_services["fleet"]
+    persistence = fleet_services.persistence
+    snapshot = persistence.get_snapshot(ctx.game_id, ctx.perspective, prior_turn)
+    if snapshot is None:
+        from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+
+        prior_turn_obj = replace(
+            sample_turn,
+            settings=replace(sample_turn.settings, turn=prior_turn),
+            game=replace(sample_turn.game, turn=prior_turn),
+        )
+        snapshot = get_or_materialize_fleet_snapshot(
+            persistence,
+            ctx.game_id,
+            ctx.perspective,
+            prior_turn_obj,
+            load_turn=ctx.load_turn,
+            inference_materialization=fleet_services.inference_materialization,
+        )
+    snapshot.players = [
+        FleetAcquisitionLedger(
+            player_id=player_id,
+            records=[
+                FleetShipRecord(
+                    record_id="inferred",
+                    disposition="active",
+                    fields=FleetShipRecordFields(launchers=FleetFieldUnknown()),
+                    build_option_sets=[
+                        FleetBuildOptionSet(torp_id=torp_id, label=f"Mk {torp_id}")
+                        for torp_id in torp_ids
+                    ],
+                ),
+            ],
+        ),
+    ]
+    persistence.put_snapshot(ctx.game_id, ctx.perspective, prior_turn, snapshot)
+    return persistence
+
+
+def test_fleet_persist_at_prior_turn_invalidates_scores_stream_rows(
+    sample_turn,
+    persistence,
+    monkeypatch,
+):
+    """Fleet@(N-1) persist drops scores@N cache and reschedules open stream rows."""
+    reset_inference_table_stream_registry_for_tests()
+    scheduler = _install_scheduler(monkeypatch)
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    turn_number = sample_turn.settings.turn
+
+    ctx = export_chain_query_context(sample_turn, persistence=persistence)
+    fleet_persistence = ctx.export_services["fleet"].persistence
+    inference_persistence = persistence
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        scheduler=scheduler,
+        fleet_persistence=fleet_persistence,
+    )
+    invalidation.wire_scores_invalidation_to_fleet_persistence()
+
+    for player_id in player_ids:
+        inference_persistence.put_row(
+            ctx.game_id,
+            ctx.perspective,
+            turn_number,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary=f"cached-{player_id}",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+        )
+
+    def resolve_fleet_torp_resolution_for_player(
+        player_id: int,
+    ) -> PriorTurnFleetTorpResolution:
+        return resolve_prior_turn_fleet_torp_overlay(
+            turn=sample_turn,
+            player_id=player_id,
+            load_turn=ctx.load_turn,
+            export_services=ctx.export_services,
+            ensure=False,
+        )
+
+    stream = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        load_scoreboard_turn=ctx.load_turn,
+        resolve_fleet_torp_resolution_for_player=resolve_fleet_torp_resolution_for_player,
+        persistence=inference_persistence,
+        scheduler=scheduler,
+    )
+    events: list[dict[str, object]] = []
+
+    def consume_stream() -> None:
+        try:
+            for event in stream:
+                events.append(event)
+        finally:
+            stream.close()
+
+    thread = threading.Thread(target=consume_stream, daemon=True)
+    thread.start()
+    _wait_until(
+        lambda: sum(1 for event in events if event.get("type") == "complete") >= len(player_ids)
+    )
+    assert (
+        controller_for_scope(
+            InferenceStreamScope(
+                game_id=ctx.game_id,
+                perspective=ctx.perspective,
+                turn_number=turn_number,
+            )
+        )
+        is not None
+    )
+
+    target_player_id = player_ids[0]
+    before_run_id = _run_ids_for_players(scheduler, (target_player_id,)).get(target_player_id)
+    assert before_run_id is None
+
+    _seed_prior_turn_fleet_with_belief_sets(
+        ctx,
+        sample_turn=sample_turn,
+        player_id=target_player_id,
+        torp_ids=(4, 8),
+    )
+
+    _wait_until(lambda: target_player_id in _run_ids_for_players(scheduler, player_ids))
+    for player_id in player_ids:
+        assert (
+            inference_persistence.get_row(ctx.game_id, ctx.perspective, turn_number, player_id)
+            is None
+        )
+
+    scope = InferenceStreamScope(
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        turn_number=turn_number,
+    )
+    _end_open_table_stream(scope, scheduler)
+    thread.join(timeout=2.0)
+
+
+def test_background_warm_eventually_applies_fleet_overlay(
+    sample_turn,
+    persistence,
+    monkeypatch,
+):
+    """Background warm materializes fleet@(N-1) so overlay resolves with belief set."""
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        seed_fleet_prerequisites_for=8,
+    )
+    player_id = 8
+    prior_turn = sample_turn.settings.turn - 1
+
+    fleet_persistence = ctx.export_services["fleet"].persistence
+    fleet_persistence.delete_snapshot(ctx.game_id, ctx.perspective, prior_turn)
+
+    pending = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+    assert pending.input_status == "pending"
+    assert pending.overlay is None
+
+    schedule_background_prior_turn_fleet_warm(
+        turn=sample_turn,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+    )
+
+    _wait_until(lambda: fleet_persistence.has_snapshot(ctx.game_id, ctx.perspective, prior_turn))
+
+    applied = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+    assert applied.input_status == "applied"
+    assert applied.overlay is not None
+
+
+def test_stream_recompute_reschedules_after_fleet_overlay_lands(
+    sample_turn,
+    persistence,
+    monkeypatch,
+):
+    """First-pass pending overlay triggers reschedule when fleet@(N-1) persists."""
+    reset_inference_table_stream_registry_for_tests()
+    scheduler = _install_scheduler(monkeypatch, worker_count=1)
+    player_id = sample_turn.scores[0].ownerid
+    player_ids = (player_id,)
+
+    ctx = export_chain_query_context(sample_turn, persistence=persistence)
+    fleet_persistence = ctx.export_services["fleet"].persistence
+    prior_turn = sample_turn.settings.turn - 1
+    fleet_persistence.delete_snapshot(ctx.game_id, ctx.perspective, prior_turn)
+
+    inference_persistence = persistence
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        scheduler=scheduler,
+        fleet_persistence=fleet_persistence,
+    )
+    invalidation.wire_scores_invalidation_to_fleet_persistence()
+
+    def resolve_fleet_torp_resolution_for_player(
+        resolved_player_id: int,
+    ) -> PriorTurnFleetTorpResolution:
+        return resolve_prior_turn_fleet_torp_overlay(
+            turn=sample_turn,
+            player_id=resolved_player_id,
+            load_turn=ctx.load_turn,
+            export_services=ctx.export_services,
+            ensure=False,
+        )
+
+    stream = iter_scores_table_inference_events(
+        sample_turn,
+        player_ids,
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        load_scoreboard_turn=ctx.load_turn,
+        resolve_fleet_torp_resolution_for_player=resolve_fleet_torp_resolution_for_player,
+        persistence=inference_persistence,
+        scheduler=scheduler,
+    )
+    events: list[dict[str, object]] = []
+
+    def consume_stream() -> None:
+        try:
+            for event in stream:
+                events.append(event)
+        finally:
+            stream.close()
+
+    thread = threading.Thread(target=consume_stream, daemon=True)
+    thread.start()
+    _wait_until(
+        lambda: any(event.get("type") == "complete" for event in events),
+        timeout_seconds=30.0,
+    )
+
+    first_complete = next(event for event in events if event.get("type") == "complete")
+    first_diagnostics = first_complete.get("diagnostics")
+    assert isinstance(first_diagnostics, dict)
+    assert first_diagnostics.get("fleetTorpInputStatus") == "pending"
+
+    _seed_prior_turn_fleet_with_belief_sets(
+        ctx,
+        sample_turn=sample_turn,
+        player_id=player_id,
+        torp_ids=(4,),
+    )
+
+    _wait_until(lambda: player_id in _run_ids_for_players(scheduler, player_ids))
+    applied = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+    assert applied.input_status == "applied"
+    assert applied.overlay is not None
+    assert applied.overlay.belief_set.torp_ids == frozenset({4})
+
+    scope = InferenceStreamScope(
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        turn_number=sample_turn.settings.turn,
+    )
+    _end_open_table_stream(scope, scheduler)
+    thread.join(timeout=2.0)
+
+
+def test_get_scores_row_inference_emits_applied_fleet_torp_input_status(
+    sample_turn,
+    persistence,
+):
+    """Row inference diagnostics report applied when prior fleet snapshot exists."""
+    from api.analytics.scores.inference import get_scores_row_inference
+
+    player_id = sample_turn.scores[0].ownerid
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    _seed_prior_turn_fleet_with_belief_sets(
+        ctx,
+        sample_turn=sample_turn,
+        player_id=player_id,
+        torp_ids=(4, 8),
+    )
+
+    inference = get_scores_row_inference(
+        sample_turn,
+        player_id,
+        load_scoreboard_turn=ctx.load_turn,
+        fleet_torp_overlay=resolve_prior_turn_fleet_torp_overlay(
+            turn=sample_turn,
+            player_id=player_id,
+            load_turn=ctx.load_turn,
+            export_services=ctx.export_services,
+            ensure=False,
+        ).overlay,
+        fleet_torp_input_status="applied",
+    )
+    diagnostics = inference.get("diagnostics")
+    assert isinstance(diagnostics, dict)
+    assert diagnostics.get("fleetTorpInputStatus") == "applied"
+    fleet_overlay = diagnostics.get("fleetTorpOverlay")
+    assert isinstance(fleet_overlay, dict)
+    assert fleet_overlay.get("beliefSetTorpIds") == [4, 8]
+
+
+def test_fleet_torp_input_status_not_applicable_on_first_turn(first_turn):
+    ctx = export_chain_query_context(first_turn)
+    resolution = resolve_prior_turn_fleet_torp_overlay(
+        turn=first_turn,
+        player_id=8,
+        load_turn=ctx.load_turn,
+        query_context=ctx,
+    )
+    assert resolution.input_status == "not_applicable"

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -89,6 +89,37 @@ def _install_scheduler(
     return scheduler
 
 
+def test_on_fleet_snapshot_persisted_only_clears_host_turn_document(
+    memory_backend,
+    persistence,
+):
+    """Persisting fleet@(N-1) invalidates scores@N only, not scores@(N-1)."""
+    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
+    scheduler = InferenceRowScheduler(worker_count=0)
+    invalidation = InferenceInvalidationService(
+        persistence,
+        scheduler=scheduler,
+        fleet_persistence=fleet_persistence,
+    )
+
+    game_id, persp = 628580, 1
+    player_id = 8
+    row = PersistedInferenceRow(
+        status=STATUS_EXACT,
+        summary="cached",
+        solution_count=0,
+        is_complete=True,
+        solutions=[],
+    )
+    for host_turn in (110, 111):
+        persistence.put_row(game_id, persp, host_turn, player_id, row)
+
+    invalidation.on_fleet_snapshot_persisted(game_id, persp, fleet_turn=110)
+
+    assert persistence.get_row(game_id, persp, 111, player_id) is None
+    assert persistence.get_row(game_id, persp, 110, player_id) is not None
+
+
 def _fleet_overlay_from_diagnostics(diagnostics: object) -> dict[str, object]:
     assert isinstance(diagnostics, dict)
     fleet_overlay = diagnostics.get("fleetTorpOverlay")

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -47,6 +47,26 @@ from api.services.inference_invalidation_service import InferenceInvalidationSer
 from tests.export_chain_test_fixtures import export_chain_query_context
 
 
+@pytest.fixture(autouse=True)
+def _reset_stream_registry_after_test() -> None:
+    yield
+    reset_inference_table_stream_registry_for_tests()
+
+
+def _wire_fleet_scores_invalidation(
+    inference_persistence,
+    fleet_persistence: FleetSnapshotPersistenceService,
+    scheduler: InferenceRowScheduler,
+) -> InferenceInvalidationService:
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        scheduler=scheduler,
+        fleet_persistence=fleet_persistence,
+    )
+    invalidation.wire_scores_invalidation_to_fleet_persistence()
+    return invalidation
+
+
 def _install_scheduler(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -170,12 +190,7 @@ def test_fleet_persist_at_prior_turn_invalidates_scores_stream_rows(
     ctx = export_chain_query_context(sample_turn, persistence=persistence)
     fleet_persistence = ctx.export_services["fleet"].persistence
     inference_persistence = persistence
-    invalidation = InferenceInvalidationService(
-        inference_persistence,
-        scheduler=scheduler,
-        fleet_persistence=fleet_persistence,
-    )
-    invalidation.wire_scores_invalidation_to_fleet_persistence()
+    _wire_fleet_scores_invalidation(inference_persistence, fleet_persistence, scheduler)
 
     for player_id in player_ids:
         inference_persistence.put_row(
@@ -328,12 +343,13 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
     fleet_persistence.delete_snapshot(ctx.game_id, ctx.perspective, prior_turn)
 
     inference_persistence = persistence
-    invalidation = InferenceInvalidationService(
-        inference_persistence,
-        scheduler=scheduler,
-        fleet_persistence=fleet_persistence,
+    _wire_fleet_scores_invalidation(inference_persistence, fleet_persistence, scheduler)
+
+    scope = InferenceStreamScope(
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        turn_number=sample_turn.settings.turn,
     )
-    invalidation.wire_scores_invalidation_to_fleet_persistence()
 
     def resolve_fleet_torp_resolution_for_player(
         resolved_player_id: int,
@@ -367,53 +383,48 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
 
     thread = threading.Thread(target=consume_stream, daemon=True)
     thread.start()
-    _wait_until(
-        lambda: any(event.get("type") == "complete" for event in events),
-        timeout_seconds=30.0,
-    )
+    try:
+        _wait_until(
+            lambda: any(event.get("type") == "complete" for event in events),
+            timeout_seconds=30.0,
+        )
 
-    first_complete = next(event for event in events if event.get("type") == "complete")
-    first_diagnostics = first_complete.get("diagnostics")
-    assert isinstance(first_diagnostics, dict)
-    assert first_diagnostics.get("fleetTorpInputStatus") == "pending"
+        first_complete = next(event for event in events if event.get("type") == "complete")
+        first_diagnostics = first_complete.get("diagnostics")
+        assert isinstance(first_diagnostics, dict)
+        assert first_diagnostics.get("fleetTorpInputStatus") == "pending"
 
-    _seed_prior_turn_fleet_with_belief_sets(
-        ctx,
-        sample_turn=sample_turn,
-        player_id=player_id,
-        torp_ids=(4,),
-    )
+        _seed_prior_turn_fleet_with_belief_sets(
+            ctx,
+            sample_turn=sample_turn,
+            player_id=player_id,
+            torp_ids=(4,),
+        )
 
-    _wait_until(lambda: player_id in _run_ids_for_players(scheduler, player_ids))
-    _wait_until(
-        lambda: sum(1 for event in events if event.get("type") == "complete") >= 2,
-        timeout_seconds=60.0,
-    )
-    applied = resolve_prior_turn_fleet_torp_overlay(
-        turn=sample_turn,
-        player_id=player_id,
-        load_turn=ctx.load_turn,
-        export_services=ctx.export_services,
-        ensure=False,
-    )
-    assert applied.input_status == "applied"
-    assert applied.overlay is not None
-    assert applied.overlay.belief_set.torp_ids == frozenset({4})
+        _wait_until(lambda: player_id in _run_ids_for_players(scheduler, player_ids))
+        assert (
+            inference_persistence.get_row(
+                ctx.game_id,
+                ctx.perspective,
+                sample_turn.settings.turn,
+                player_id,
+            )
+            is None
+        )
 
-    second_complete = next(event for event in reversed(events) if event.get("type") == "complete")
-    second_diagnostics = second_complete.get("diagnostics")
-    assert isinstance(second_diagnostics, dict)
-    assert second_diagnostics.get("fleetTorpInputStatus") == "applied"
-    second_overlay = _fleet_overlay_from_diagnostics(second_diagnostics)
-    assert second_overlay.get("beliefSetTorpIds") == [4]
-
-    scope = InferenceStreamScope(
-        game_id=ctx.game_id,
-        perspective=ctx.perspective,
-        turn_number=sample_turn.settings.turn,
-    )
-    _end_open_table_stream(scope, scheduler)
-    thread.join(timeout=2.0)
+        applied = resolve_prior_turn_fleet_torp_overlay(
+            turn=sample_turn,
+            player_id=player_id,
+            load_turn=ctx.load_turn,
+            export_services=ctx.export_services,
+            ensure=False,
+        )
+        assert applied.input_status == "applied"
+        assert applied.overlay is not None
+        assert applied.overlay.belief_set.torp_ids == frozenset({4})
+    finally:
+        _end_open_table_stream(scope, scheduler)
+        thread.join(timeout=2.0)
 
 
 def test_inference_overlay_changes_diagnostics_vs_empty_overlay(

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -28,11 +28,18 @@ from api.analytics.military_score_inference.inference_table_stream_registry impo
     controller_for_scope,
     reset_inference_table_stream_registry_for_tests,
 )
+from api.analytics.military_score_inference.actions import build_action_catalog_from_turn
+from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.fleet_torp_overlay import (
+    FleetLauncherBeliefSet,
+    FleetTorpOverlay,
+)
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
     PriorTurnFleetTorpResolution,
     resolve_prior_turn_fleet_torp_overlay,
     schedule_background_prior_turn_fleet_warm,
 )
+from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.services.inference_invalidation_service import InferenceInvalidationService
@@ -60,6 +67,13 @@ def _install_scheduler(
         _get_scheduler,
     )
     return scheduler
+
+
+def _fleet_overlay_from_diagnostics(diagnostics: object) -> dict[str, object]:
+    assert isinstance(diagnostics, dict)
+    fleet_overlay = diagnostics.get("fleetTorpOverlay")
+    assert isinstance(fleet_overlay, dict)
+    return fleet_overlay
 
 
 def _wait_until(
@@ -371,6 +385,10 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
     )
 
     _wait_until(lambda: player_id in _run_ids_for_players(scheduler, player_ids))
+    _wait_until(
+        lambda: sum(1 for event in events if event.get("type") == "complete") >= 2,
+        timeout_seconds=60.0,
+    )
     applied = resolve_prior_turn_fleet_torp_overlay(
         turn=sample_turn,
         player_id=player_id,
@@ -382,6 +400,15 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
     assert applied.overlay is not None
     assert applied.overlay.belief_set.torp_ids == frozenset({4})
 
+    second_complete = next(
+        event for event in reversed(events) if event.get("type") == "complete"
+    )
+    second_diagnostics = second_complete.get("diagnostics")
+    assert isinstance(second_diagnostics, dict)
+    assert second_diagnostics.get("fleetTorpInputStatus") == "applied"
+    second_overlay = _fleet_overlay_from_diagnostics(second_diagnostics)
+    assert second_overlay.get("beliefSetTorpIds") == [4]
+
     scope = InferenceStreamScope(
         game_id=ctx.game_id,
         perspective=ctx.perspective,
@@ -389,6 +416,84 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
     )
     _end_open_table_stream(scope, scheduler)
     thread.join(timeout=2.0)
+
+
+def test_inference_overlay_changes_diagnostics_vs_empty_overlay(
+    sample_turn,
+    persistence,
+):
+    """Scores row inference: fleet overlay changes torp admission diagnostics."""
+    from api.analytics.scores.inference import get_scores_row_inference
+
+    player_id = sample_turn.scores[0].ownerid
+    score = next(row for row in sample_turn.scores if row.ownerid == player_id)
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    belief_torp_ids = (1, 2)
+    _seed_prior_turn_fleet_with_belief_sets(
+        ctx,
+        sample_turn=sample_turn,
+        player_id=player_id,
+        torp_ids=belief_torp_ids,
+    )
+
+    empty_overlay = FleetTorpOverlay(belief_set=FleetLauncherBeliefSet(frozenset()))
+    fleet_resolution = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+    assert fleet_resolution.overlay is not None
+
+    empty_inference = get_scores_row_inference(
+        sample_turn,
+        player_id,
+        load_scoreboard_turn=ctx.load_turn,
+        fleet_torp_overlay=empty_overlay,
+        fleet_torp_input_status="applied",
+    )
+    belief_inference = get_scores_row_inference(
+        sample_turn,
+        player_id,
+        load_scoreboard_turn=ctx.load_turn,
+        fleet_torp_overlay=fleet_resolution.overlay,
+        fleet_torp_input_status="applied",
+    )
+
+    empty_diag = _fleet_overlay_from_diagnostics(empty_inference["diagnostics"])
+    belief_diag = _fleet_overlay_from_diagnostics(belief_inference["diagnostics"])
+    assert empty_diag.get("beliefSetTorpIds") == []
+    assert belief_diag.get("beliefSetTorpIds") == list(belief_torp_ids)
+
+    observation = build_inference_observation(
+        score,
+        sample_turn,
+        load_scoreboard_turn=ctx.load_turn,
+    )
+    torp_step = next(
+        step for step in resolve_tier_policies() if step.id == "admit_ship_torpedoes"
+    )
+    empty_torp_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=torp_step,
+        fleet_torp_overlay=empty_overlay,
+    )
+    belief_torp_catalog = build_action_catalog_from_turn(
+        observation,
+        sample_turn,
+        policy_step=torp_step,
+        fleet_torp_overlay=fleet_resolution.overlay,
+    )
+    assert empty_torp_catalog.fleet_torp_overlay_diagnostics is not None
+    assert belief_torp_catalog.fleet_torp_overlay_diagnostics is not None
+    assert empty_torp_catalog.fleet_torp_overlay_diagnostics.admitted_torp_ids == ()
+    assert belief_torp_catalog.fleet_torp_overlay_diagnostics.admitted_torp_ids == belief_torp_ids
 
 
 def test_get_scores_row_inference_emits_applied_fleet_torp_input_status(

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -16,6 +16,12 @@ from api.analytics.fleet.types import (
     FleetShipRecord,
     FleetShipRecordFields,
 )
+from api.analytics.military_score_inference.actions import build_action_catalog_from_turn
+from api.analytics.military_score_inference.analytic import build_inference_observation
+from api.analytics.military_score_inference.fleet_torp_overlay import (
+    FleetLauncherBeliefSet,
+    FleetTorpOverlay,
+)
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
     reset_inference_row_scheduler_for_tests,
@@ -28,19 +34,13 @@ from api.analytics.military_score_inference.inference_table_stream_registry impo
     controller_for_scope,
     reset_inference_table_stream_registry_for_tests,
 )
-from api.analytics.military_score_inference.actions import build_action_catalog_from_turn
-from api.analytics.military_score_inference.analytic import build_inference_observation
-from api.analytics.military_score_inference.fleet_torp_overlay import (
-    FleetLauncherBeliefSet,
-    FleetTorpOverlay,
-)
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
     PriorTurnFleetTorpResolution,
     resolve_prior_turn_fleet_torp_overlay,
     schedule_background_prior_turn_fleet_warm,
 )
-from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.analytics.military_score_inference.tier_policy import resolve_tier_policies
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.services.inference_invalidation_service import InferenceInvalidationService
 
@@ -400,9 +400,7 @@ def test_stream_recompute_reschedules_after_fleet_overlay_lands(
     assert applied.overlay is not None
     assert applied.overlay.belief_set.torp_ids == frozenset({4})
 
-    second_complete = next(
-        event for event in reversed(events) if event.get("type") == "complete"
-    )
+    second_complete = next(event for event in reversed(events) if event.get("type") == "complete")
     second_diagnostics = second_complete.get("diagnostics")
     assert isinstance(second_diagnostics, dict)
     assert second_diagnostics.get("fleetTorpInputStatus") == "applied"
@@ -475,9 +473,7 @@ def test_inference_overlay_changes_diagnostics_vs_empty_overlay(
         sample_turn,
         load_scoreboard_turn=ctx.load_turn,
     )
-    torp_step = next(
-        step for step in resolve_tier_policies() if step.id == "admit_ship_torpedoes"
-    )
+    torp_step = next(step for step in resolve_tier_policies() if step.id == "admit_ship_torpedoes")
     empty_torp_catalog = build_action_catalog_from_turn(
         observation,
         sample_turn,

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -137,4 +137,5 @@ def test_resolve_prior_turn_overlay_uses_export_services(sample_turn, persistenc
 
     assert resolution.overlay is not None
     assert resolution.overlay.enabled is True
+    assert resolution.overlay.belief_set.torp_ids == frozenset({10})
     assert resolution.input_status == "applied"

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -27,7 +27,8 @@ def test_resolve_prior_turn_overlay_returns_none_on_first_turn(first_turn):
         load_turn=ctx.load_turn,
         query_context=ctx,
     )
-    assert overlay is None
+    assert overlay.overlay is None
+    assert overlay.input_status == "not_applicable"
 
 
 def test_resolve_prior_turn_overlay_readonly_skips_query_when_unpersisted(sample_turn, persistence):
@@ -37,7 +38,7 @@ def test_resolve_prior_turn_overlay_readonly_skips_query_when_unpersisted(sample
         persistence=persistence,
     )
 
-    overlay = resolve_prior_turn_fleet_torp_overlay(
+    resolution = resolve_prior_turn_fleet_torp_overlay(
         turn=sample_turn,
         player_id=player_id,
         load_turn=ctx.load_turn,
@@ -45,7 +46,8 @@ def test_resolve_prior_turn_overlay_readonly_skips_query_when_unpersisted(sample
         ensure=False,
     )
 
-    assert overlay is None
+    assert resolution.overlay is None
+    assert resolution.input_status == "pending"
 
 
 def test_resolve_prior_turn_overlay_readonly_uses_persisted_snapshot(sample_turn, persistence):
@@ -93,7 +95,7 @@ def test_resolve_prior_turn_overlay_readonly_uses_persisted_snapshot(sample_turn
         snapshot,
     )
 
-    overlay = resolve_prior_turn_fleet_torp_overlay(
+    resolution = resolve_prior_turn_fleet_torp_overlay(
         turn=sample_turn,
         player_id=player_id,
         load_turn=ctx.load_turn,
@@ -101,19 +103,21 @@ def test_resolve_prior_turn_overlay_readonly_uses_persisted_snapshot(sample_turn
         ensure=False,
     )
 
-    assert overlay is not None
-    assert overlay.belief_set.torp_ids == frozenset({4, 8})
+    assert resolution.overlay is not None
+    assert resolution.overlay.belief_set.torp_ids == frozenset({4, 8})
+    assert resolution.input_status == "applied"
 
 
 def test_resolve_prior_turn_overlay_without_export_services_returns_none(sample_turn):
     ctx = export_chain_query_context(sample_turn)
-    overlay = resolve_prior_turn_fleet_torp_overlay(
+    resolution = resolve_prior_turn_fleet_torp_overlay(
         turn=sample_turn,
         player_id=8,
         load_turn=ctx.load_turn,
         export_services=None,
     )
-    assert overlay is None
+    assert resolution.overlay is None
+    assert resolution.input_status == "unavailable"
 
 
 def test_resolve_prior_turn_overlay_uses_export_services(sample_turn, persistence):
@@ -124,12 +128,13 @@ def test_resolve_prior_turn_overlay_uses_export_services(sample_turn, persistenc
     )
     seed_fleet_unwind_through(ctx, through_turn=sample_turn.settings.turn, player_id=player_id)
 
-    overlay = resolve_prior_turn_fleet_torp_overlay(
+    resolution = resolve_prior_turn_fleet_torp_overlay(
         turn=sample_turn,
         player_id=player_id,
         load_turn=ctx.load_turn,
         export_services=ctx.export_services,
     )
 
-    assert overlay is not None
-    assert overlay.enabled is True
+    assert resolution.overlay is not None
+    assert resolution.overlay.enabled is True
+    assert resolution.input_status == "applied"

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -1,0 +1,135 @@
+"""Tests for prior-turn fleet torp overlay consumer (#133)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetBuildOptionSet,
+    FleetFieldUnknown,
+    FleetShipRecord,
+    FleetShipRecordFields,
+)
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    resolve_prior_turn_fleet_torp_overlay,
+)
+
+from tests.export_chain_test_fixtures import export_chain_query_context, seed_fleet_unwind_through
+
+
+def test_resolve_prior_turn_overlay_returns_none_on_first_turn(first_turn):
+    ctx = export_chain_query_context(first_turn)
+    overlay = resolve_prior_turn_fleet_torp_overlay(
+        turn=first_turn,
+        player_id=8,
+        load_turn=ctx.load_turn,
+        query_context=ctx,
+    )
+    assert overlay is None
+
+
+def test_resolve_prior_turn_overlay_readonly_skips_query_when_unpersisted(sample_turn, persistence):
+    player_id = 8
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+    )
+
+    overlay = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+
+    assert overlay is None
+
+
+def test_resolve_prior_turn_overlay_readonly_uses_persisted_snapshot(sample_turn, persistence):
+    player_id = 8
+    prior_turn = sample_turn.settings.turn - 1
+    prior_turn_obj = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=prior_turn),
+        game=replace(sample_turn.game, turn=prior_turn),
+    )
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    snapshot = get_or_materialize_fleet_snapshot(
+        fleet_services.persistence,
+        ctx.game_id,
+        ctx.perspective,
+        prior_turn_obj,
+        load_turn=ctx.load_turn,
+        inference_materialization=fleet_services.inference_materialization,
+    )
+    snapshot.players = [
+        FleetAcquisitionLedger(
+            player_id=player_id,
+            records=[
+                FleetShipRecord(
+                    record_id="inferred",
+                    disposition="active",
+                    fields=FleetShipRecordFields(launchers=FleetFieldUnknown()),
+                    build_option_sets=[
+                        FleetBuildOptionSet(torp_id=4, label="Mk IV"),
+                        FleetBuildOptionSet(torp_id=8, label="Mk VIII"),
+                    ],
+                ),
+            ],
+        ),
+    ]
+    fleet_services.persistence.put_snapshot(
+        ctx.game_id,
+        ctx.perspective,
+        prior_turn,
+        snapshot,
+    )
+
+    overlay = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+        ensure=False,
+    )
+
+    assert overlay is not None
+    assert overlay.belief_set.torp_ids == frozenset({4, 8})
+
+
+def test_resolve_prior_turn_overlay_without_export_services_returns_none(sample_turn):
+    ctx = export_chain_query_context(sample_turn)
+    overlay = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=8,
+        load_turn=ctx.load_turn,
+        export_services=None,
+    )
+    assert overlay is None
+
+
+def test_resolve_prior_turn_overlay_uses_export_services(sample_turn, persistence):
+    player_id = 8
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+    )
+    seed_fleet_unwind_through(ctx, through_turn=sample_turn.settings.turn, player_id=player_id)
+
+    overlay = resolve_prior_turn_fleet_torp_overlay(
+        turn=sample_turn,
+        player_id=player_id,
+        load_turn=ctx.load_turn,
+        export_services=ctx.export_services,
+    )
+
+    assert overlay is not None
+    assert overlay.enabled is True

--- a/packages/api/tests/test_scores_exports_ensure.py
+++ b/packages/api/tests/test_scores_exports_ensure.py
@@ -206,6 +206,25 @@ def test_ensure_prior_turn_sync_puts_persistable_row(sample_turn, persistence):
     assert row.status in {STATUS_EXACT, "no_exact_solution"}
 
 
+def test_ensure_prior_turn_sync_passes_fleet_torp_input_status(sample_turn, persistence):
+    from api.analytics.scores.inference import get_scores_row_inference as real_inference
+
+    ctx, scope, player_id, _, _ = prior_turn_ensure_context(sample_turn, persistence)
+    captured: dict[str, object] = {}
+
+    def capture_and_run(*args, **kwargs):
+        captured.update(kwargs)
+        return real_inference(*args, **kwargs)
+
+    with patch(
+        "api.analytics.scores.exports.get_scores_row_inference",
+        side_effect=capture_and_run,
+    ):
+        EXPORT_CATALOG.ensure_export(ctx, scope)
+
+    assert captured.get("fleet_torp_input_status") == "applied"
+
+
 def test_ensure_no_op_when_prior_turn_inference_non_persistable(sample_turn, persistence):
     ctx, scope, player_id, _, _ = prior_turn_ensure_context(sample_turn, persistence)
     assert persistence.get_row(GAME_ID, perspective(sample_turn), 110, player_id) is None
@@ -289,6 +308,40 @@ def test_ensure_schedules_inference_row_on_current_turn(sample_turn, persistence
     EXPORT_CATALOG.ensure_export(ctx, scope)
 
     assert scheduler.row_run_for_player(stream_scope, player_id) is not None
+
+
+def test_ensure_current_turn_scheduler_passes_fleet_torp_input_status(
+    sample_turn,
+    persistence,
+):
+    reset_inference_row_scheduler_for_tests()
+    scheduler = InferenceRowScheduler(worker_count=0)
+    player_id = first_player_id(sample_turn)
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        scheduler=scheduler,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        turn=sample_turn.settings.turn,
+        player_id=player_id,
+    )
+    captured: dict[str, object] = {}
+
+    def capture_and_schedule(*args, **kwargs):
+        captured.update(kwargs)
+        return schedule_inference_row(*args, **kwargs)
+
+    with patch(
+        "api.analytics.scores.exports.schedule_inference_row",
+        side_effect=capture_and_schedule,
+    ):
+        EXPORT_CATALOG.ensure_export(ctx, scope)
+
+    assert captured.get("fleet_torp_input_status") == "applied"
 
 
 def test_ensure_no_op_when_row_already_scheduled(sample_turn, persistence):

--- a/packages/api/tests/test_scores_exports_ensure.py
+++ b/packages/api/tests/test_scores_exports_ensure.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from api.analytics.export_types import ExportScope
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
     reset_inference_row_scheduler_for_tests,
 )
 from api.analytics.military_score_inference.inference_stream_rows import schedule_inference_row
+from api.analytics.military_score_inference.inference_table_stream_registry import (
+    reset_inference_table_stream_registry_for_tests,
+)
 from api.analytics.military_score_inference.solver import STATUS_EXACT, STATUS_STOPPED
 from api.analytics.scores.exports import EXPORT_CATALOG
 from api.serialization.inference_row_persistence import PersistedInferenceRow
@@ -26,6 +30,13 @@ from tests.scores_exports_helpers import (
     scores_query_context,
     stream_scope_for_turn,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_inference_stream_registry() -> None:
+    reset_inference_table_stream_registry_for_tests()
+    yield
+    reset_inference_table_stream_registry_for_tests()
 
 
 def _assert_probe_does_not_compute(monkeypatch):

--- a/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
+++ b/packages/frontend/src/analytics/scores/InferenceDetailModal.tsx
@@ -264,6 +264,10 @@ export function InferenceDetailModal({
           </p>
         ) : null}
 
+        {detail.solutions.length === 0 && detail.summary.trim().length > 0 ? (
+          <p className="text-xs text-slate-300">{detail.summary}</p>
+        ) : null}
+
         <div className="flex flex-col gap-3">
           {detail.solutions.map((solution, index) => (
             <SolutionSection key={`solution-${index}`} solution={solution} index={index} />

--- a/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.test.tsx
@@ -127,6 +127,32 @@ describe('ScoresTableView', () => {
     expect(screen.getByText('100')).toBeInTheDocument()
   })
 
+  it('opens inference detail modal when failure icon is clicked', () => {
+    render(
+      <ScoresTableView
+        analyticScope={testScope}
+        data={tableData({
+          columns: ['Race (player)', 'Build inference'],
+          rows: [['Federation (alice)']],
+          inferenceByRow: [
+            {
+              displayStatus: 'failure',
+              status: 'no_exact_solution',
+              summary: 'No feasible build explanation found',
+              solutionCount: 0,
+              isComplete: true,
+              solutions: [],
+              diagnostics: {},
+            },
+          ],
+        })}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('No feasible build explanation found'))
+    expect(screen.getByRole('dialog')).toHaveTextContent('No feasible build explanation found')
+  })
+
   it('opens inference detail modal when success icon is clicked', () => {
     render(
       <ScoresTableView

--- a/packages/frontend/src/analytics/scores/ScoresTableView.tsx
+++ b/packages/frontend/src/analytics/scores/ScoresTableView.tsx
@@ -94,13 +94,16 @@ function InferenceStatusCell({
   if (detail.displayStatus === 'stopped') {
     return (
       <div className="inline-flex items-center gap-1">
-        <span
+        <button
+          type="button"
           title={label}
           aria-label={label}
-          className="inline-flex items-center justify-center p-1 text-slate-400"
+          onClick={canOpenInferenceDetail(detail) ? onOpenDetail : undefined}
+          disabled={!canOpenInferenceDetail(detail)}
+          className="inline-flex items-center justify-center rounded p-1 text-slate-400 hover:bg-white/10 disabled:cursor-default disabled:opacity-60"
         >
           <Octagon className="h-4 w-4" aria-hidden />
-        </span>
+        </button>
         {hullCatalogButton}
       </div>
     )
@@ -108,13 +111,16 @@ function InferenceStatusCell({
 
   return (
     <div className="inline-flex items-center gap-1">
-      <span
+      <button
+        type="button"
         title={label}
         aria-label={label}
-        className="inline-flex items-center justify-center p-1 text-red-400"
+        onClick={canOpenInferenceDetail(detail) ? onOpenDetail : undefined}
+        disabled={!canOpenInferenceDetail(detail)}
+        className="inline-flex items-center justify-center rounded p-1 text-red-400 hover:bg-white/10 disabled:cursor-default disabled:opacity-60"
       >
         <X className="h-4 w-4" aria-hidden />
-      </span>
+      </button>
       {hullCatalogButton}
     </div>
   )

--- a/packages/frontend/src/analytics/scores/inferenceStatus.test.ts
+++ b/packages/frontend/src/analytics/scores/inferenceStatus.test.ts
@@ -54,6 +54,9 @@ describe('canOpenInferenceDetail', () => {
     expect(
       canOpenInferenceDetail(detail({ displayStatus: 'success', solutionCount: 0 }))
     ).toBe(false)
+    expect(canOpenInferenceDetail(detail({ displayStatus: 'failure', isComplete: true }))).toBe(
+      true
+    )
   })
 })
 

--- a/packages/frontend/src/analytics/scores/inferenceStatus.ts
+++ b/packages/frontend/src/analytics/scores/inferenceStatus.ts
@@ -22,9 +22,15 @@ export function inferenceAccessibleLabel(detail: ScoresInferenceRowDetail): stri
 }
 
 export function canOpenInferenceDetail(detail: ScoresInferenceRowDetail): boolean {
-  return (
+  if (
     (detail.displayStatus === 'success' || detail.displayStatus === 'paused') &&
     detail.solutionCount > 0
+  ) {
+    return true
+  }
+  return (
+    detail.isComplete &&
+    (detail.displayStatus === 'failure' || detail.displayStatus === 'stopped')
   )
 }
 

--- a/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
+++ b/packages/frontend/src/analytics/scores/tableInferenceStreamConnect.ts
@@ -6,8 +6,12 @@ export const TABLE_STREAM_ALREADY_ACTIVE_DETAIL =
   'An inference table stream is already active for this scope.'
 
 const STREAM_RETRY_INITIAL_MS = 50
-const STREAM_RETRY_MAX_ATTEMPTS = 10
-const STREAM_RETRY_MAX_DELAY_MS = 500
+const STREAM_RETRY_MAX_ATTEMPTS = 15
+const STREAM_RETRY_MAX_DELAY_MS = 1000
+
+const STREAM_INCOMPLETE_RETRY_INITIAL_MS = 250
+const STREAM_INCOMPLETE_RETRY_MAX_ATTEMPTS = 3
+const STREAM_INCOMPLETE_RETRY_MAX_DELAY_MS = 2000
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -28,10 +32,6 @@ export type TableInferenceStreamConnectResult =
   | 'aborted'
   | 'conflict_exhausted'
   | 'incomplete_exhausted'
-
-const STREAM_INCOMPLETE_RETRY_INITIAL_MS = 50
-const STREAM_INCOMPLETE_RETRY_MAX_ATTEMPTS = 10
-const STREAM_INCOMPLETE_RETRY_MAX_DELAY_MS = 500
 
 export async function connectTableInferenceStream(
   scope: AnalyticShellScope,


### PR DESCRIPTION
## Summary

Implements the production consumer for prior-turn fleet composition feeding the **inference fleet launcher belief set** into scores inference (torp admission + misalignment prior), closing #133.

- Resolves prior-turn fleet snapshots at service boundaries into `FleetTorpOverlay`, using shared `belief_set_components` (known fields + build option set union, not sightings-only).
- Table-stream path: non-blocking background warm of fleet@(N-1), `fleetTorpInputStatus` diagnostics, and invalidation/reschedule with `force_schedule` when fleet snapshots land so stale cached inference is not replayed.
- Export ensure and single-row inference paths pass overlay + input status; fleet-persist invalidation clears scores@N only (not N-1).
- Frontend: stream reconnect until complete, failure/stopped modal UX improvements.

## Test plan

- [x] `make test_api` (1043 passed)
- [x] Frontend scores tests (96 passed)
- [x] `test_prior_turn_fleet_torp_overlay.py` -- belief-set resolution, pending/applied/unavailable statuses
- [x] `test_prior_turn_fleet_stream_warm.py` -- background warm, fleet persist invalidation/reschedule, diagnostics delta
- [x] `test_scores_exports_ensure.py` -- export ensure passes `fleet_torp_input_status`
- [x] `test_fleet_composition_export.py` -- belief-set union parity with overlay path

Closes #133


Made with [Cursor](https://cursor.com)