### PR TITLE
Speed up make ci for faster iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-.PHONY: test lint ci typecheck_frontend check_frontend_api_slices check_frontend_api_no_monolithic_schema test_bff test_api test_server test_scripts test_frontend generate generate_frontend_api inference_corpus inference_corpus_discover inference_corpus_probe
+.PHONY: test lint ci ci_full typecheck_frontend check_frontend_api_slices check_frontend_api_no_monolithic_schema test_bff test_api test_api_full test_server test_scripts test_frontend generate generate_frontend_api inference_corpus inference_corpus_discover inference_corpus_probe
 
 # Use workspace venv (Python 3.14) and ensure dev deps (pytest, ruff) are installed.
-# `test` runs lint and unit tests. `ci` also runs the full frontend `tsc -b` (see `typecheck_frontend`).
+# `test` runs lint and unit tests (API fast suite; see `test_api_full` for solver/corpus integration).
+# `ci` also runs the full frontend `tsc -b` (see `typecheck_frontend`).
 test: lint test_bff test_api test_server test_scripts test_frontend
 
-# Everything CI should run: Python lint, committed schema slice freshness, frontend typecheck, then all test suites.
+# Fast PR/iteration loop: lint, schema checks, typecheck, tests excluding @pytest.mark.slow API cases.
 ci: lint check_frontend_api_slices check_frontend_api_no_monolithic_schema typecheck_frontend test_bff test_api test_server test_scripts test_frontend
+
+# Full validation including slow OR-Tools / inference-corpus integration tests (`test_api_full`).
+ci_full: lint check_frontend_api_slices check_frontend_api_no_monolithic_schema typecheck_frontend test_bff test_api_full test_server test_scripts test_frontend
 
 # Regenerate checked-in artefacts from source (BFF OpenAPI -> frontend TypeScript types).
 generate: generate_frontend_api
@@ -38,6 +42,10 @@ test_bff:
 	PYTHONPATH=packages/bff:packages/api uv run python -m pytest packages/bff/tests
 
 test_api:
+	uv sync --extra dev
+	PYTHONPATH=packages/api uv run python -m pytest packages/api/tests -m "not slow"
+
+test_api_full:
 	uv sync --extra dev
 	PYTHONPATH=packages/api uv run python -m pytest packages/api/tests
 

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -19,3 +19,6 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+markers = [
+    "slow: full inference-corpus or OR-Tools solver integration (excluded from make ci; run make test_api_full)",
+]

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -1,5 +1,7 @@
 """Shared pytest fixtures for API package tests."""
 
+import pytest
+
 from tests.fixtures.hand_seeded_prior_weights import (  # noqa: F401
     HAND_SEEDED_PRIOR_WEIGHTS_DIR,
     HAND_SEEDED_STANDARD_PRIOR_PATH,
@@ -15,3 +17,42 @@ from tests.fixtures.military_score_inference_prior_weights import (  # noqa: F40
 )
 
 pytest_plugins = ["tests.scores_exports_helpers"]
+
+# OR-Tools / inference-corpus integration tests excluded from `make ci` (see Makefile `test_api`).
+_SLOW_TEST_NAMES = frozenset(
+    {
+        "test_628580_accel_window_ranks_ten_planet_defense_first",
+        "test_corpus_case_still_infers_exact_with_accelerated_adjustment",
+        "test_ensure_prior_turn_sync_passes_fleet_torp_input_status",
+        "test_ensure_prior_turn_sync_puts_persistable_row",
+        "test_fixed_corpus_coverage_case_has_ground_truth_available",
+        "test_fixed_corpus_host2_hard_ranking_lock_passes",
+        "test_fixed_inference_corpus_tier1_passes",
+        "test_get_scores_row_inference_emits_applied_fleet_torp_input_status",
+        "test_host2_manifest_runs_tier1_without_coverage_gate",
+        "test_inference_diagnostics_include_policy_ladder_fields",
+        "test_inference_overlay_changes_diagnostics_vs_empty_overlay",
+        "test_listing_for_case_uses_player_perspective_for_ground_truth",
+        "test_manifest_host1_passes_ranking_with_require_top_k",
+        "test_mask_change_integration_via_table_stream_generator_case_3",
+        "test_missouri_host_turn_2_regression_becomes_feasible",
+        "test_missouri_host_turn_2_regression_reports_policy_ladder_diagnostics",
+        "test_p5_host5_discovered_case_passes_coverage_gate",
+        "test_p8_host1_discovered_case_passes_coverage_gate",
+        "test_p9_host1_discovered_case_passes_coverage_gate",
+        "test_row_inference_includes_structured_solver_diagnostics",
+        "test_run_discovered_case_resolves_ground_truth_from_player_perspective",
+        "test_run_local_corpus_discovers_and_passes_seed_case",
+        "test_scores_row_inference_returns_solver_payload",
+        "test_solve_with_policy_ladder_continues_when_aggregate_actions_are_added",
+        "test_solve_with_policy_ladder_fleet_torp_overlay_belief_set",
+        "test_stream_recompute_reschedules_after_fleet_overlay_lands",
+        "test_unreliable_turn2_backfills_host_turn1_when_turn3_stored",
+    }
+)
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    for item in items:
+        if item.name in _SLOW_TEST_NAMES:
+            item.add_marker(pytest.mark.slow)

--- a/packages/api/tests/test_load_all_completeness.py
+++ b/packages/api/tests/test_load_all_completeness.py
@@ -18,14 +18,34 @@ from tests.inference_corpus.storage_loader import (
 )
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+_MINIMAL_GAME_ID = 900_001
+_MINIMAL_LATEST_TURN = 5
+_MINIMAL_PLAYER_COUNT = 2
+
+
+def _minimal_game_info_payload() -> dict:
+    with (ASSETS_DIR / "game_info_sample.json").open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    active_players = [player for player in payload["players"] if player["status"] == 1][
+        :_MINIMAL_PLAYER_COUNT
+    ]
+    for index, player in enumerate(active_players, start=1):
+        player["id"] = index
+    payload["game"]["id"] = _MINIMAL_GAME_ID
+    payload["game"]["turn"] = _MINIMAL_LATEST_TURN
+    payload["players"] = active_players
+    return payload
+
+
+def _minimal_turn_payload(turn_number: int) -> dict:
+    return {"settings": {"turn": turn_number}, "game": {"turn": turn_number}}
 
 
 def _put_turn(storage, game_id: int, perspective: int, turn_number: int) -> None:
-    with (ASSETS_DIR / "turn_sample.json").open(encoding="utf-8") as handle:
-        payload = json.load(handle)
-    payload["settings"]["turn"] = turn_number
-    payload["game"]["turn"] = turn_number
-    storage.put(f"games/{game_id}/{perspective}/turns/{turn_number}", payload)
+    storage.put(
+        f"games/{game_id}/{perspective}/turns/{turn_number}",
+        _minimal_turn_payload(turn_number),
+    )
 
 
 def test_prior_mining_accepts_missing_only_final_turn(tmp_path: Path) -> None:
@@ -33,8 +53,7 @@ def test_prior_mining_accepts_missing_only_final_turn(tmp_path: Path) -> None:
     turn_load = make_turn_load_service(storage)
     game_service = make_game_service(storage)
 
-    with (ASSETS_DIR / "game_info_sample.json").open(encoding="utf-8") as handle:
-        info_payload = json.load(handle)
+    info_payload = _minimal_game_info_payload()
     latest_turn = info_payload["game"]["turn"]
     player_count = len(info_payload["players"])
     game_id = info_payload["game"]["id"]
@@ -55,8 +74,7 @@ def test_prior_mining_rejects_missing_non_final_turn(tmp_path: Path) -> None:
     turn_load = make_turn_load_service(storage)
     game_service = make_game_service(storage)
 
-    with (ASSETS_DIR / "game_info_sample.json").open(encoding="utf-8") as handle:
-        info_payload = json.load(handle)
+    info_payload = _minimal_game_info_payload()
     latest_turn = info_payload["game"]["turn"]
     player_count = len(info_payload["players"])
     game_id = info_payload["game"]["id"]

--- a/packages/api/tests/test_planet_connections.py
+++ b/packages/api/tests/test_planet_connections.py
@@ -256,7 +256,7 @@ def test_flare_bfs_distance_prune_matches_unpruned_on_annulus(sample_planet):
 
     rng = random.Random(42)
     a = _p(sample_planet, 1, 1000, 1000)
-    for _ in range(32):
+    for _ in range(8):
         t = rng.random() * 2 * math.pi
         u = rng.random()
         r0, r1 = d_inner, d_outer


### PR DESCRIPTION
## Summary
- Trim `test_load_all_completeness` fixtures (2 players, 5 turns, minimal turn blobs) -- was ~72s, now under 1s
- Reduce flare BFS prune property-test samples from 32 to 8
- Mark 27 OR-Tools / inference-corpus integration tests with `@pytest.mark.slow` and exclude them from `make ci`
- Add `test_api_full` and `make ci_full` for the complete API suite (~7 min)

**`make ci` drops from ~7.5 min to ~2.8 min** while preserving full regression coverage via `make ci_full`.

## Test plan
- [x] `make ci` passes (~169s)
- [x] `make test_api` runs 1019 tests, deselects 27 slow
- [ ] `make ci_full` passes (full solver/corpus regression)


Made with [Cursor](https://cursor.com)