### PR TITLE
Fleet F7.1: per-player ledger persistence and provenance wire (#164)

### DIFF
--- a/packages/api/api/analytics/fleet/constants.py
+++ b/packages/api/api/analytics/fleet/constants.py
@@ -2,6 +2,8 @@
 
 ANALYTIC_ID = "fleet"
 
+FLEET_LEDGERS_KEY = "ledgers"
+
 # Bounded retries when gap-fill is aborted by concurrent fleet snapshot invalidation.
 GAP_FILL_MAX_RETRIES = 10
 
@@ -9,4 +11,4 @@ GAP_FILL_MAX_RETRIES = 10
 # materialization output would change for the same stored RST + scores inputs
 # (chain/gap-fill rules, inferred acquisition ingest, observation-inference merge).
 # Missing or stale versions on read are deleted and re-materialized on next access.
-FLEET_MATERIALIZATION_VERSION = 4
+FLEET_MATERIALIZATION_VERSION = 5

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 
-from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.constants import (
+    ANALYTIC_ID,
+    FLEET_LEDGERS_KEY,
+    FLEET_MATERIALIZATION_VERSION,
+)
 from api.analytics.fleet.serialization import (
     fleet_materialization_version_from_json,
     fleet_turn_snapshot_from_json,

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 
 from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.serialization import (
+    _LEGACY_FINAL_PROVENANCE,
     fleet_materialization_version_from_json,
     fleet_turn_snapshot_from_json,
     is_current_fleet_materialization_version,
@@ -16,7 +17,6 @@ from api.analytics.fleet.serialization import (
     upgrade_legacy_fleet_turn_document,
 )
 from api.analytics.fleet.types import (
-    FleetMaterializationProvenance,
     FleetTurnSnapshot,
     PersistedFleetLedger,
 )
@@ -24,11 +24,6 @@ from api.errors import NotFoundError, ValidationError
 from api.storage.base import StorageBackend
 
 OnSnapshotPersistedCallback = Callable[[int, int, int], None]
-
-_LEGACY_FINAL_PROVENANCE = FleetMaterializationProvenance(
-    turn_evidence_at_n=True,
-    prior_ledger_at_n_minus_1=True,
-)
 
 
 class FleetSnapshotPersistenceService:

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -130,6 +130,13 @@ class FleetSnapshotPersistenceService:
         turn_number: int,
         player_id: int,
     ) -> bool:
+        """Return whether a usable fleet ledger is stored for this player scope.
+
+        Delegates to ``get_ledger`` -- not a cheap key-exists probe. A call may
+        upgrade legacy monolithic documents to the ``ledgers/`` layout, delete
+        stale ledger entries, write storage, and bump invalidation generation
+        when stale data is removed.
+        """
         return self.get_ledger(game_id, perspective, turn_number, player_id) is not None
 
     def has_final_ledger(

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -107,10 +107,14 @@ class FleetSnapshotPersistenceService:
                 "persisted fleet ledger player_id "
                 f"{persisted.ledger.player_id} does not match key player_id {player_id}",
             )
-        persisted.materialization_version = FLEET_MATERIALIZATION_VERSION
+        to_store = PersistedFleetLedger(
+            ledger=persisted.ledger,
+            provenance=persisted.provenance,
+            materialization_version=FLEET_MATERIALIZATION_VERSION,
+        )
         document = self._load_or_create_document(game_id, perspective, turn_number)
         ledgers = self._ledgers_object(document)
-        ledgers[str(player_id)] = persisted_fleet_ledger_to_json(persisted)
+        ledgers[str(player_id)] = persisted_fleet_ledger_to_json(to_store)
         self._write_document(game_id, perspective, turn_number, document)
         if self._on_snapshot_persisted is not None:
             self._on_snapshot_persisted(game_id, perspective, turn_number)

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -7,9 +7,9 @@ from collections.abc import Callable
 
 from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.serialization import (
-    _LEGACY_FINAL_PROVENANCE,
     fleet_materialization_version_from_json,
     fleet_turn_snapshot_from_json,
+    fleet_turn_snapshot_to_json,
     is_current_fleet_materialization_version,
     is_legacy_fleet_turn_document,
     persisted_fleet_ledger_from_json,
@@ -207,18 +207,12 @@ class FleetSnapshotPersistenceService:
             raise ValidationError(
                 f"fleet snapshot turn {snapshot.turn} does not match key turn_number {turn_number}"
             )
-        document = self._load_or_create_document(game_id, perspective, turn_number)
-        ledgers = self._ledgers_object(document)
-        ledgers.clear()
-        for player_ledger in snapshot.players:
-            ledgers[str(player_ledger.player_id)] = persisted_fleet_ledger_to_json(
-                PersistedFleetLedger(
-                    ledger=player_ledger,
-                    provenance=_LEGACY_FINAL_PROVENANCE,
-                    materialization_version=FLEET_MATERIALIZATION_VERSION,
-                ),
-            )
-        self._write_document(game_id, perspective, turn_number, document)
+        self._write_document(
+            game_id,
+            perspective,
+            turn_number,
+            fleet_turn_snapshot_to_json(snapshot),
+        )
         if self._on_snapshot_persisted is not None:
             self._on_snapshot_persisted(game_id, perspective, turn_number)
 

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -5,18 +5,30 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable
 
-from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.serialization import (
     fleet_materialization_version_from_json,
     fleet_turn_snapshot_from_json,
-    fleet_turn_snapshot_to_json,
     is_current_fleet_materialization_version,
+    is_legacy_fleet_turn_document,
+    persisted_fleet_ledger_from_json,
+    persisted_fleet_ledger_to_json,
+    upgrade_legacy_fleet_turn_document,
 )
-from api.analytics.fleet.types import FleetTurnSnapshot
+from api.analytics.fleet.types import (
+    FleetMaterializationProvenance,
+    FleetTurnSnapshot,
+    PersistedFleetLedger,
+)
 from api.errors import NotFoundError, ValidationError
 from api.storage.base import StorageBackend
 
 OnSnapshotPersistedCallback = Callable[[int, int, int], None]
+
+_LEGACY_FINAL_PROVENANCE = FleetMaterializationProvenance(
+    turn_evidence_at_n=True,
+    prior_ledger_at_n_minus_1=True,
+)
 
 
 class FleetSnapshotPersistenceService:
@@ -24,6 +36,10 @@ class FleetSnapshotPersistenceService:
 
     Logical document path:
     ``games/{gameId}/{perspective}/turns/{turn}/analytics/fleet``
+
+    In-document keys: ``ledgers/{playerId}`` -- each entry is one
+    **fleet acquisition ledger** plus **fleet materialization provenance** and
+    ``materializationVersion``.
 
     Scores-invalidation coupling (F2.x): when scores inference rows are cleared
     for host turn *H*, fleet snapshots at turns ``>= H`` for the same perspective
@@ -41,10 +57,11 @@ class FleetSnapshotPersistenceService:
     multi-turn materialization. Invalidation does not block on gap-fill; concurrent
     invalidation callbacks only bump the counter and delete stored snapshots.
 
-    **Materialization version:** Each persisted snapshot carries
+    **Materialization version:** Each persisted ledger entry carries
     ``materializationVersion`` (see ``FLEET_MATERIALIZATION_VERSION``). On read,
-    mismatched or missing versions are deleted and treated as cache misses so
-    deploys that change materialization semantics re-chain without a turn reload.
+    mismatched or missing versions are deleted and treated as cache misses for that
+    player so deploys that change materialization semantics re-chain without a turn
+    reload.
     """
 
     def __init__(
@@ -62,25 +79,109 @@ class FleetSnapshotPersistenceService:
     def document_key(game_id: int, perspective: int, turn_number: int) -> str:
         return f"games/{game_id}/{perspective}/turns/{turn_number}/analytics/{ANALYTIC_ID}"
 
+    def get_ledger(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> PersistedFleetLedger | None:
+        document = self._load_document(game_id, perspective, turn_number)
+        if document is None:
+            return None
+        ledger_wire = self._ledger_wire_from_document(document, player_id)
+        if ledger_wire is None:
+            return None
+        persisted = persisted_fleet_ledger_from_json(ledger_wire)
+        if not is_current_fleet_materialization_version(persisted.materialization_version):
+            self._delete_ledger_entry(game_id, perspective, turn_number, player_id)
+            self._bump_invalidation_generation(game_id, perspective)
+            return None
+        return persisted
+
+    def put_ledger(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+        persisted: PersistedFleetLedger,
+    ) -> None:
+        if persisted.ledger.player_id != player_id:
+            raise ValidationError(
+                "persisted fleet ledger player_id "
+                f"{persisted.ledger.player_id} does not match key player_id {player_id}",
+            )
+        persisted.materialization_version = FLEET_MATERIALIZATION_VERSION
+        document = self._load_or_create_document(game_id, perspective, turn_number)
+        ledgers = self._ledgers_object(document)
+        ledgers[str(player_id)] = persisted_fleet_ledger_to_json(persisted)
+        self._write_document(game_id, perspective, turn_number, document)
+        if self._on_snapshot_persisted is not None:
+            self._on_snapshot_persisted(game_id, perspective, turn_number)
+
+    def has_ledger(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> bool:
+        return self.get_ledger(game_id, perspective, turn_number, player_id) is not None
+
+    def has_final_ledger(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> bool:
+        persisted = self.get_ledger(game_id, perspective, turn_number, player_id)
+        return persisted is not None and persisted.provenance.is_final
+
+    def delete_ledger(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> None:
+        self._delete_ledger_entry(game_id, perspective, turn_number, player_id)
+
+    def list_ledger_player_ids(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+    ) -> list[int]:
+        document = self._load_document(game_id, perspective, turn_number)
+        if document is None:
+            return []
+        ledgers = self._ledgers_object(document)
+        player_ids: list[int] = []
+        for player_key in ledgers:
+            if not player_key.isdigit():
+                continue
+            player_ids.append(int(player_key))
+        return sorted(player_ids)
+
     def get_snapshot(
         self,
         game_id: int,
         perspective: int,
         turn_number: int,
     ) -> FleetTurnSnapshot | None:
-        try:
-            data = self._storage.get(self.document_key(game_id, perspective, turn_number))
-        except NotFoundError:
+        document = self._load_document(game_id, perspective, turn_number)
+        if document is None:
             return None
-        if data is None:
+        if not self._prune_stale_ledgers(game_id, perspective, turn_number, document):
             return None
-        if not isinstance(data, dict):
-            raise ValidationError("stored fleet turn snapshot must be a JSON object")
-        stored_version = fleet_materialization_version_from_json(data)
-        if not is_current_fleet_materialization_version(stored_version):
-            self._drop_stale_materialization_snapshot(game_id, perspective, turn_number)
+        if not self._ledgers_object(document):
+            self.delete_snapshot(game_id, perspective, turn_number)
             return None
-        return fleet_turn_snapshot_from_json(data)
+        snapshot = fleet_turn_snapshot_from_json(document)
+        snapshot.materialization_version = FLEET_MATERIALIZATION_VERSION
+        return snapshot
 
     def has_snapshot(
         self,
@@ -88,11 +189,7 @@ class FleetSnapshotPersistenceService:
         perspective: int,
         turn_number: int,
     ) -> bool:
-        try:
-            data = self._storage.get(self.document_key(game_id, perspective, turn_number))
-        except NotFoundError:
-            return False
-        return data is not None
+        return self.get_snapshot(game_id, perspective, turn_number) is not None
 
     def put_snapshot(
         self,
@@ -115,10 +212,18 @@ class FleetSnapshotPersistenceService:
             raise ValidationError(
                 f"fleet snapshot turn {snapshot.turn} does not match key turn_number {turn_number}"
             )
-        self._storage.put(
-            self.document_key(game_id, perspective, turn_number),
-            fleet_turn_snapshot_to_json(snapshot),
-        )
+        document = self._load_or_create_document(game_id, perspective, turn_number)
+        ledgers = self._ledgers_object(document)
+        ledgers.clear()
+        for player_ledger in snapshot.players:
+            ledgers[str(player_ledger.player_id)] = persisted_fleet_ledger_to_json(
+                PersistedFleetLedger(
+                    ledger=player_ledger,
+                    provenance=_LEGACY_FINAL_PROVENANCE,
+                    materialization_version=FLEET_MATERIALIZATION_VERSION,
+                ),
+            )
+        self._write_document(game_id, perspective, turn_number, document)
         if self._on_snapshot_persisted is not None:
             self._on_snapshot_persisted(game_id, perspective, turn_number)
 
@@ -157,7 +262,7 @@ class FleetSnapshotPersistenceService:
         for stored_turn in self._stored_turn_numbers(game_id, perspective):
             if stored_turn < turn_number:
                 continue
-            if not self.has_snapshot(game_id, perspective, stored_turn):
+            if not self._document_exists(game_id, perspective, stored_turn):
                 continue
             self.delete_snapshot(game_id, perspective, stored_turn)
             cleared.add(stored_turn)
@@ -169,17 +274,144 @@ class FleetSnapshotPersistenceService:
             key = (game_id, perspective)
             self._invalidation_generation[key] = self._invalidation_generation.get(key, 0) + 1
 
-    def _drop_stale_materialization_snapshot(
+    def _document_exists(
         self,
         game_id: int,
         perspective: int,
         turn_number: int,
+    ) -> bool:
+        try:
+            data = self._storage.get(self.document_key(game_id, perspective, turn_number))
+        except NotFoundError:
+            return False
+        return data is not None
+
+    def _read_document_raw(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+    ) -> dict[str, object] | None:
+        try:
+            data = self._storage.get(self.document_key(game_id, perspective, turn_number))
+        except NotFoundError:
+            return None
+        if data is None:
+            return None
+        if not isinstance(data, dict):
+            raise ValidationError("stored fleet turn snapshot must be a JSON object")
+        return data
+
+    def _load_document(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+    ) -> dict[str, object] | None:
+        data = self._read_document_raw(game_id, perspective, turn_number)
+        if data is None:
+            return None
+        if is_legacy_fleet_turn_document(data):
+            if not is_current_fleet_materialization_version(
+                fleet_materialization_version_from_json(data),
+            ):
+                self.delete_snapshot(game_id, perspective, turn_number)
+                self._bump_invalidation_generation(game_id, perspective)
+                return None
+            upgraded = upgrade_legacy_fleet_turn_document(data)
+            self._write_document(game_id, perspective, turn_number, upgraded)
+            return upgraded
+        return data
+
+    def _load_or_create_document(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+    ) -> dict[str, object]:
+        document = self._load_document(game_id, perspective, turn_number)
+        if document is not None:
+            return document
+        return {
+            "analyticId": ANALYTIC_ID,
+            "gameId": game_id,
+            "perspective": perspective,
+            "turn": turn_number,
+            FLEET_LEDGERS_KEY: {},
+        }
+
+    def _write_document(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        document: dict[str, object],
     ) -> None:
-        """Remove one cached snapshot whose materialization version is outdated."""
-        if not self.has_snapshot(game_id, perspective, turn_number):
+        self._storage.put(self.document_key(game_id, perspective, turn_number), document)
+
+    @staticmethod
+    def _ledgers_object(document: dict[str, object]) -> dict[str, object]:
+        ledgers = document.setdefault(FLEET_LEDGERS_KEY, {})
+        if not isinstance(ledgers, dict):
+            raise ValidationError("fleet turn snapshot ledgers must be an object")
+        return ledgers
+
+    def _ledger_wire_from_document(
+        self,
+        document: dict[str, object],
+        player_id: int,
+    ) -> dict[str, object] | None:
+        ledgers = self._ledgers_object(document)
+        ledger_wire = ledgers.get(str(player_id))
+        if ledger_wire is None:
+            return None
+        if not isinstance(ledger_wire, dict):
+            raise ValidationError("persisted fleet ledger must be an object")
+        return ledger_wire
+
+    def _delete_ledger_entry(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> None:
+        document = self._read_document_raw(game_id, perspective, turn_number)
+        if document is None:
+            return
+        ledgers = self._ledgers_object(document)
+        ledgers.pop(str(player_id), None)
+        if ledgers:
+            self._write_document(game_id, perspective, turn_number, document)
             return
         self.delete_snapshot(game_id, perspective, turn_number)
+
+    def _prune_stale_ledgers(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        document: dict[str, object],
+    ) -> bool:
+        ledgers = self._ledgers_object(document)
+        stale_player_ids: list[int] = []
+        for player_key, ledger_wire in list(ledgers.items()):
+            if not player_key.isdigit() or not isinstance(ledger_wire, dict):
+                continue
+            version = fleet_materialization_version_from_json(ledger_wire)
+            if is_current_fleet_materialization_version(version):
+                continue
+            stale_player_ids.append(int(player_key))
+        if not stale_player_ids:
+            return True
+        for player_id in stale_player_ids:
+            ledgers.pop(str(player_id), None)
+        if ledgers:
+            self._write_document(game_id, perspective, turn_number, document)
+        else:
+            self.delete_snapshot(game_id, perspective, turn_number)
         self._bump_invalidation_generation(game_id, perspective)
+        return False
 
     def _stored_turn_numbers(self, game_id: int, perspective: int) -> list[int]:
         turns_prefix = f"games/{game_id}/{perspective}/turns"

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -188,6 +188,14 @@ class FleetSnapshotPersistenceService:
         perspective: int,
         turn_number: int,
     ) -> bool:
+        """Return whether a usable fleet turn snapshot is stored for this scope.
+
+        Delegates to ``get_snapshot`` -- not a cheap key-exists probe. A call may
+        validate wire shape, upgrade legacy monolithic documents to the
+        ``ledgers/`` layout, prune stale per-player ledger entries, delete the
+        turn document when nothing usable remains, write storage, and bump
+        invalidation generation when stale data is removed.
+        """
         return self.get_snapshot(game_id, perspective, turn_number) is not None
 
     def put_snapshot(

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.types import (
     FLEET_BOUNDED_OPERATORS,
     FLEET_EVIDENCE_EVENT_KINDS,
@@ -22,11 +22,13 @@ from api.analytics.fleet.types import (
     FleetFieldRegionStarbaseCoord,
     FleetFieldUnknown,
     FleetLastSeen,
+    FleetMaterializationProvenance,
     FleetPossiblyLost,
     FleetRowQualifiers,
     FleetShipRecord,
     FleetShipRecordFields,
     FleetTurnSnapshot,
+    PersistedFleetLedger,
 )
 from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
 from api.errors import ValidationError
@@ -574,6 +576,132 @@ def _fleet_turn_snapshot_players_to_json(
     return [fleet_acquisition_ledger_to_json(player_ledger) for player_ledger in snapshot.players]
 
 
+_LEGACY_FINAL_PROVENANCE = FleetMaterializationProvenance(
+    turn_evidence_at_n=True,
+    prior_ledger_at_n_minus_1=True,
+)
+
+
+def is_legacy_fleet_turn_document(data: dict[str, Any]) -> bool:
+    """Return whether ``data`` uses the monolithic ``players`` array wire shape."""
+    return FLEET_LEDGERS_KEY not in data and "players" in data
+
+
+def fleet_materialization_provenance_from_json(data: dict[str, Any]) -> FleetMaterializationProvenance:
+    turn_evidence_at_n = data.get("turnEvidenceAtN", False)
+    prior_ledger_at_n_minus_1 = data.get("priorLedgerAtNMinus1", False)
+    if not isinstance(turn_evidence_at_n, bool):
+        raise ValidationError("fleet materialization provenance turnEvidenceAtN must be a bool")
+    if not isinstance(prior_ledger_at_n_minus_1, bool):
+        raise ValidationError(
+            "fleet materialization provenance priorLedgerAtNMinus1 must be a bool",
+        )
+    return FleetMaterializationProvenance(
+        turn_evidence_at_n=turn_evidence_at_n,
+        prior_ledger_at_n_minus_1=prior_ledger_at_n_minus_1,
+    )
+
+
+def fleet_materialization_provenance_to_json(
+    provenance: FleetMaterializationProvenance,
+) -> dict[str, bool]:
+    return {
+        "turnEvidenceAtN": provenance.turn_evidence_at_n,
+        "priorLedgerAtNMinus1": provenance.prior_ledger_at_n_minus_1,
+    }
+
+
+def persisted_fleet_ledger_from_json(data: dict[str, Any]) -> PersistedFleetLedger:
+    ledger_wire = data.get("ledger")
+    if not isinstance(ledger_wire, dict):
+        raise ValidationError("persisted fleet ledger ledger must be an object")
+    provenance_wire = data.get("provenance", {})
+    if not isinstance(provenance_wire, dict):
+        raise ValidationError("persisted fleet ledger provenance must be an object")
+    return PersistedFleetLedger(
+        ledger=fleet_acquisition_ledger_from_json(ledger_wire),
+        provenance=fleet_materialization_provenance_from_json(provenance_wire),
+        materialization_version=fleet_materialization_version_from_json(data),
+    )
+
+
+def persisted_fleet_ledger_to_json(persisted: PersistedFleetLedger) -> dict[str, Any]:
+    return {
+        "ledger": fleet_acquisition_ledger_to_json(persisted.ledger),
+        "provenance": fleet_materialization_provenance_to_json(persisted.provenance),
+        "materializationVersion": persisted.materialization_version,
+    }
+
+
+def upgrade_legacy_fleet_turn_document(data: dict[str, Any]) -> dict[str, Any]:
+    """Upgrade monolithic ``players`` wire to in-document ``ledgers/{playerId}`` keys."""
+    version = fleet_materialization_version_from_json(data)
+    ledgers: dict[str, Any] = {}
+    for player_wire in _require_object_list(
+        data.get("players", []),
+        field_name="fleet turn snapshot players",
+    ):
+        ledger = fleet_acquisition_ledger_from_json(player_wire)
+        ledgers[str(ledger.player_id)] = persisted_fleet_ledger_to_json(
+            PersistedFleetLedger(
+                ledger=ledger,
+                provenance=_LEGACY_FINAL_PROVENANCE,
+                materialization_version=version,
+            ),
+        )
+    return {
+        "analyticId": data.get("analyticId", ANALYTIC_ID),
+        "gameId": _require_int_field(data, "gameId", field_name="fleet turn snapshot"),
+        "perspective": _require_int_field(data, "perspective", field_name="fleet turn snapshot"),
+        "turn": _require_int_field(data, "turn", field_name="fleet turn snapshot"),
+        FLEET_LEDGERS_KEY: ledgers,
+    }
+
+
+def _fleet_turn_snapshot_ledgers_to_json(snapshot: FleetTurnSnapshot) -> dict[str, Any]:
+    ledgers: dict[str, Any] = {}
+    for player_ledger in snapshot.players:
+        ledgers[str(player_ledger.player_id)] = persisted_fleet_ledger_to_json(
+            PersistedFleetLedger(
+                ledger=player_ledger,
+                provenance=_LEGACY_FINAL_PROVENANCE,
+                materialization_version=snapshot.materialization_version,
+            ),
+        )
+    return ledgers
+
+
+def _fleet_turn_snapshot_from_ledgers_document(data: dict[str, Any]) -> FleetTurnSnapshot:
+    analytic_id = data.get("analyticId", ANALYTIC_ID)
+    if not isinstance(analytic_id, str):
+        raise ValidationError("fleet turn snapshot analyticId must be a string")
+
+    game_id = _require_int_field(data, "gameId", field_name="fleet turn snapshot")
+    perspective = _require_int_field(data, "perspective", field_name="fleet turn snapshot")
+    turn = _require_int_field(data, "turn", field_name="fleet turn snapshot")
+    ledgers_wire = data.get(FLEET_LEDGERS_KEY, {})
+    if not isinstance(ledgers_wire, dict):
+        raise ValidationError("fleet turn snapshot ledgers must be an object")
+
+    persisted_ledgers = [
+        persisted_fleet_ledger_from_json(ledger_wire)
+        for ledger_wire in ledgers_wire.values()
+        if isinstance(ledger_wire, dict)
+    ]
+    materialization_version = 0
+    if persisted_ledgers:
+        materialization_version = persisted_ledgers[0].materialization_version
+
+    return FleetTurnSnapshot(
+        analytic_id=analytic_id,
+        game_id=game_id,
+        perspective=perspective,
+        turn=turn,
+        materialization_version=materialization_version,
+        players=[persisted.ledger for persisted in persisted_ledgers],
+    )
+
+
 def fleet_turn_snapshot_to_compute_wire(snapshot: FleetTurnSnapshot) -> dict[str, Any]:
     """Turn-analytic compute response shape (analytic id + per-player ledgers)."""
     return {
@@ -600,31 +728,33 @@ def fleet_turn_snapshot_to_json(snapshot: FleetTurnSnapshot) -> dict[str, Any]:
         "gameId": snapshot.game_id,
         "perspective": snapshot.perspective,
         "turn": snapshot.turn,
-        "materializationVersion": snapshot.materialization_version,
-        "players": _fleet_turn_snapshot_players_to_json(snapshot),
+        FLEET_LEDGERS_KEY: _fleet_turn_snapshot_ledgers_to_json(snapshot),
     }
 
 
 def fleet_turn_snapshot_from_json(data: dict[str, Any]) -> FleetTurnSnapshot:
-    analytic_id = data.get("analyticId", ANALYTIC_ID)
-    if not isinstance(analytic_id, str):
-        raise ValidationError("fleet turn snapshot analyticId must be a string")
+    if is_legacy_fleet_turn_document(data):
+        analytic_id = data.get("analyticId", ANALYTIC_ID)
+        if not isinstance(analytic_id, str):
+            raise ValidationError("fleet turn snapshot analyticId must be a string")
 
-    game_id = _require_int_field(data, "gameId", field_name="fleet turn snapshot")
-    perspective = _require_int_field(data, "perspective", field_name="fleet turn snapshot")
-    turn = _require_int_field(data, "turn", field_name="fleet turn snapshot")
+        game_id = _require_int_field(data, "gameId", field_name="fleet turn snapshot")
+        perspective = _require_int_field(data, "perspective", field_name="fleet turn snapshot")
+        turn = _require_int_field(data, "turn", field_name="fleet turn snapshot")
 
-    return FleetTurnSnapshot(
-        analytic_id=analytic_id,
-        game_id=game_id,
-        perspective=perspective,
-        turn=turn,
-        materialization_version=fleet_materialization_version_from_json(data),
-        players=[
-            fleet_acquisition_ledger_from_json(player_ledger)
-            for player_ledger in _require_object_list(
-                data.get("players", []),
-                field_name="fleet turn snapshot players",
-            )
-        ],
-    )
+        return FleetTurnSnapshot(
+            analytic_id=analytic_id,
+            game_id=game_id,
+            perspective=perspective,
+            turn=turn,
+            materialization_version=fleet_materialization_version_from_json(data),
+            players=[
+                fleet_acquisition_ledger_from_json(player_ledger)
+                for player_ledger in _require_object_list(
+                    data.get("players", []),
+                    field_name="fleet turn snapshot players",
+                )
+            ],
+        )
+
+    return _fleet_turn_snapshot_from_ledgers_document(data)

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from api.analytics.fleet.constants import ANALYTIC_ID, FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.constants import (
+    ANALYTIC_ID,
+    FLEET_LEDGERS_KEY,
+    FLEET_MATERIALIZATION_VERSION,
+)
 from api.analytics.fleet.types import (
     FLEET_BOUNDED_OPERATORS,
     FLEET_EVIDENCE_EVENT_KINDS,
@@ -587,7 +591,9 @@ def is_legacy_fleet_turn_document(data: dict[str, Any]) -> bool:
     return FLEET_LEDGERS_KEY not in data and "players" in data
 
 
-def fleet_materialization_provenance_from_json(data: dict[str, Any]) -> FleetMaterializationProvenance:
+def fleet_materialization_provenance_from_json(
+    data: dict[str, Any],
+) -> FleetMaterializationProvenance:
     turn_evidence_at_n = data.get("turnEvidenceAtN", False)
     prior_ledger_at_n_minus_1 = data.get("priorLedgerAtNMinus1", False)
     if not isinstance(turn_evidence_at_n, bool):

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -634,7 +634,11 @@ def persisted_fleet_ledger_to_json(persisted: PersistedFleetLedger) -> dict[str,
 
 
 def upgrade_legacy_fleet_turn_document(data: dict[str, Any]) -> dict[str, Any]:
-    """Upgrade monolithic ``players`` wire to in-document ``ledgers/{playerId}`` keys."""
+    """Upgrade monolithic ``players`` wire to in-document ``ledgers/{playerId}`` keys.
+
+    Migrated entries use default (non-final) provenance: the monolithic path never
+    recorded materialization closure, so migration must not claim ensure-closed legs.
+    """
     version = fleet_materialization_version_from_json(data)
     ledgers: dict[str, Any] = {}
     for player_wire in _require_object_list(
@@ -645,7 +649,7 @@ def upgrade_legacy_fleet_turn_document(data: dict[str, Any]) -> dict[str, Any]:
         ledgers[str(ledger.player_id)] = persisted_fleet_ledger_to_json(
             PersistedFleetLedger(
                 ledger=ledger,
-                provenance=_LEGACY_FINAL_PROVENANCE,
+                provenance=FleetMaterializationProvenance(),
                 materialization_version=version,
             ),
         )

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -580,12 +580,6 @@ def _fleet_turn_snapshot_players_to_json(
     return [fleet_acquisition_ledger_to_json(player_ledger) for player_ledger in snapshot.players]
 
 
-_LEGACY_FINAL_PROVENANCE = FleetMaterializationProvenance(
-    turn_evidence_at_n=True,
-    prior_ledger_at_n_minus_1=True,
-)
-
-
 def is_legacy_fleet_turn_document(data: dict[str, Any]) -> bool:
     """Return whether ``data`` uses the monolithic ``players`` array wire shape."""
     return FLEET_LEDGERS_KEY not in data and "players" in data
@@ -674,7 +668,7 @@ def _fleet_turn_snapshot_ledgers_to_json(snapshot: FleetTurnSnapshot) -> dict[st
         ledgers[str(player_ledger.player_id)] = persisted_fleet_ledger_to_json(
             PersistedFleetLedger(
                 ledger=player_ledger,
-                provenance=_LEGACY_FINAL_PROVENANCE,
+                provenance=FleetMaterializationProvenance(),
                 materialization_version=snapshot.materialization_version,
             ),
         )

--- a/packages/api/api/analytics/fleet/types.py
+++ b/packages/api/api/analytics/fleet/types.py
@@ -173,6 +173,29 @@ class FleetAcquisitionLedger:
     discrepancy: FleetCountDiscrepancy | None = None
 
 
+@dataclass(frozen=True)
+class FleetMaterializationProvenance:
+    """Per-player closure flags for fleet@N materialization legs."""
+
+    turn_evidence_at_n: bool = False
+    prior_ledger_at_n_minus_1: bool = False
+
+    @property
+    def is_final(self) -> bool:
+        return self.turn_evidence_at_n and self.prior_ledger_at_n_minus_1
+
+
+@dataclass
+class PersistedFleetLedger:
+    """One player's fleet acquisition ledger at a turn, plus cache metadata."""
+
+    ledger: FleetAcquisitionLedger
+    provenance: FleetMaterializationProvenance = field(
+        default_factory=FleetMaterializationProvenance,
+    )
+    materialization_version: int = 0
+
+
 @dataclass
 class FleetTurnSnapshot:
     analytic_id: str = ANALYTIC_ID

--- a/packages/api/tests/test_fleet_domain.py
+++ b/packages/api/tests/test_fleet_domain.py
@@ -15,10 +15,14 @@ from api.analytics.fleet.serialization import (
     fleet_evidence_event_to_json,
     fleet_field_constraint_from_json,
     fleet_field_constraint_to_json,
+    fleet_materialization_provenance_from_json,
+    fleet_materialization_provenance_to_json,
     fleet_ship_record_from_json,
     fleet_ship_record_to_json,
     fleet_turn_snapshot_from_json,
     fleet_turn_snapshot_to_json,
+    persisted_fleet_ledger_from_json,
+    persisted_fleet_ledger_to_json,
 )
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -33,11 +37,13 @@ from api.analytics.fleet.types import (
     FleetFieldRegionStarbaseCoord,
     FleetFieldUnknown,
     FleetLastSeen,
+    FleetMaterializationProvenance,
     FleetPossiblyLost,
     FleetRowQualifiers,
     FleetShipRecord,
     FleetShipRecordFields,
     FleetTurnSnapshot,
+    PersistedFleetLedger,
 )
 from api.errors import ValidationError
 
@@ -186,6 +192,31 @@ def test_fleet_count_discrepancy_round_trip():
     restored = fleet_count_discrepancy_from_json(wire)
     assert restored == discrepancy
     assert fleet_count_discrepancy_to_json(restored) == wire
+
+
+def test_fleet_materialization_provenance_round_trip():
+    provenance = FleetMaterializationProvenance(
+        turn_evidence_at_n=True,
+        prior_ledger_at_n_minus_1=False,
+    )
+    wire = fleet_materialization_provenance_to_json(provenance)
+    restored = fleet_materialization_provenance_from_json(wire)
+    assert restored == provenance
+    assert restored.is_final is False
+
+
+def test_persisted_fleet_ledger_round_trip():
+    persisted = PersistedFleetLedger(
+        ledger=FleetAcquisitionLedger(player_id=8, player_name="koshling"),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+        materialization_version=FLEET_MATERIALIZATION_VERSION,
+    )
+    wire = persisted_fleet_ledger_to_json(persisted)
+    restored = persisted_fleet_ledger_from_json(wire)
+    assert restored == persisted
 
 
 def test_fleet_turn_snapshot_round_trip():

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -94,6 +94,24 @@ def test_put_ledger_round_trip(persistence, sample_ledger):
     assert loaded.materialization_version == FLEET_MATERIALIZATION_VERSION
 
 
+def test_put_snapshot_stamps_non_final_provenance_per_ledger(persistence, sample_ledger):
+    snapshot = FleetTurnSnapshot(
+        analytic_id="fleet",
+        game_id=628580,
+        perspective=1,
+        turn=111,
+        materialization_version=FLEET_MATERIALIZATION_VERSION,
+        players=[sample_ledger],
+    )
+    persistence.put_snapshot(628580, 1, 111, snapshot)
+
+    loaded = persistence.get_ledger(628580, 1, 111, 8)
+    assert loaded is not None
+    assert loaded.ledger == sample_ledger
+    assert loaded.provenance.is_final is False
+    assert persistence.has_final_ledger(628580, 1, 111, 8) is False
+
+
 def test_has_final_ledger_requires_both_provenance_flags(persistence, sample_ledger):
     partial = PersistedFleetLedger(
         ledger=sample_ledger,

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -22,10 +22,13 @@ from api.analytics.fleet.types import (
     FleetTurnSnapshot,
     PersistedFleetLedger,
 )
-from api.serialization.turn import turn_info_from_json
 from api.storage.memory_asset import MemoryAssetBackend
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+def _legacy_player_wire(ledger: FleetAcquisitionLedger) -> dict:
+    return persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=ledger))["ledger"]
 
 
 @pytest.fixture
@@ -125,7 +128,7 @@ def test_legacy_monolithic_document_migrates_on_has_snapshot(
         "perspective": 1,
         "turn": 111,
         "materializationVersion": FLEET_MATERIALIZATION_VERSION,
-        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+        "players": [_legacy_player_wire(sample_ledger)],
     }
     memory_backend.put(
         persistence.document_key(628580, 1, 111),
@@ -148,7 +151,7 @@ def test_legacy_monolithic_document_migrates_on_read(persistence, memory_backend
         "perspective": 1,
         "turn": 111,
         "materializationVersion": FLEET_MATERIALIZATION_VERSION,
-        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+        "players": [_legacy_player_wire(sample_ledger)],
     }
     memory_backend.put(
         persistence.document_key(628580, 1, 111),
@@ -174,7 +177,7 @@ def test_upgrade_legacy_fleet_turn_document_maps_players_to_ledgers(sample_ledge
         "perspective": 1,
         "turn": 111,
         "materializationVersion": FLEET_MATERIALIZATION_VERSION,
-        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+        "players": [_legacy_player_wire(sample_ledger)],
     }
     upgraded = upgrade_legacy_fleet_turn_document(legacy_document)
     assert "players" not in upgraded

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -114,6 +114,33 @@ def test_has_final_ledger_requires_both_provenance_flags(persistence, sample_led
     assert persistence.has_final_ledger(628580, 1, 111, 8) is True
 
 
+def test_legacy_monolithic_document_migrates_on_has_snapshot(
+    persistence,
+    memory_backend,
+    sample_ledger,
+):
+    legacy_document = {
+        "analyticId": "fleet",
+        "gameId": 628580,
+        "perspective": 1,
+        "turn": 111,
+        "materializationVersion": FLEET_MATERIALIZATION_VERSION,
+        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+    }
+    memory_backend.put(
+        persistence.document_key(628580, 1, 111),
+        legacy_document,
+    )
+
+    assert persistence.has_snapshot(628580, 1, 111) is True
+
+    stored = memory_backend.get(persistence.document_key(628580, 1, 111))
+    assert isinstance(stored, dict)
+    assert "players" not in stored
+    assert FLEET_LEDGERS_KEY in stored
+    assert "8" in stored[FLEET_LEDGERS_KEY]
+
+
 def test_legacy_monolithic_document_migrates_on_read(persistence, memory_backend, sample_ledger):
     legacy_document = {
         "analyticId": "fleet",

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -114,7 +114,7 @@ def test_legacy_monolithic_document_migrates_on_read(persistence, memory_backend
     loaded = persistence.get_ledger(628580, 1, 111, 8)
     assert loaded is not None
     assert loaded.ledger == sample_ledger
-    assert loaded.provenance.is_final is True
+    assert loaded.provenance.is_final is False
 
     stored = memory_backend.get(persistence.document_key(628580, 1, 111))
     assert isinstance(stored, dict)
@@ -135,8 +135,8 @@ def test_upgrade_legacy_fleet_turn_document_maps_players_to_ledgers(sample_ledge
     upgraded = upgrade_legacy_fleet_turn_document(legacy_document)
     assert "players" not in upgraded
     assert upgraded[FLEET_LEDGERS_KEY]["8"]["provenance"] == {
-        "turnEvidenceAtN": True,
-        "priorLedgerAtNMinus1": True,
+        "turnEvidenceAtN": False,
+        "priorLedgerAtNMinus1": False,
     }
 
 

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -1,0 +1,196 @@
+"""Tests for per-player fleet ledger persistence (F7.1)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from api.analytics.fleet.constants import FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.serialization import (
+    fleet_turn_snapshot_to_json,
+    persisted_fleet_ledger_to_json,
+    upgrade_legacy_fleet_turn_document,
+)
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetFieldKnown,
+    FleetMaterializationProvenance,
+    FleetShipRecord,
+    FleetShipRecordFields,
+    FleetTurnSnapshot,
+    PersistedFleetLedger,
+)
+from api.serialization.turn import turn_info_from_json
+from api.storage.memory_asset import MemoryAssetBackend
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as f:
+        backend.put("games/628580/info", json.load(f))
+    with open(ASSETS_DIR / "turn_sample.json") as f:
+        backend.put("games/628580/1/turns/111", json.load(f))
+    return backend
+
+
+@pytest.fixture
+def persistence(memory_backend):
+    return FleetSnapshotPersistenceService(memory_backend)
+
+
+@pytest.fixture
+def sample_ledger():
+    return FleetAcquisitionLedger(
+        player_id=8,
+        player_name="koshling",
+        records=[
+            FleetShipRecord(
+                record_id="rec-1",
+                fields=FleetShipRecordFields(ship_id=FleetFieldKnown(value=301)),
+            ),
+        ],
+    )
+
+
+def test_put_ledger_round_trip(persistence, sample_ledger):
+    persisted = PersistedFleetLedger(
+        ledger=sample_ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=False,
+        ),
+    )
+    persistence.put_ledger(628580, 1, 111, 8, persisted)
+    loaded = persistence.get_ledger(628580, 1, 111, 8)
+    assert loaded is not None
+    assert loaded.ledger == sample_ledger
+    assert loaded.provenance.turn_evidence_at_n is True
+    assert loaded.provenance.prior_ledger_at_n_minus_1 is False
+    assert loaded.materialization_version == FLEET_MATERIALIZATION_VERSION
+
+
+def test_has_final_ledger_requires_both_provenance_flags(persistence, sample_ledger):
+    partial = PersistedFleetLedger(
+        ledger=sample_ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=False,
+        ),
+    )
+    final = PersistedFleetLedger(
+        ledger=sample_ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    persistence.put_ledger(628580, 1, 111, 8, partial)
+    assert persistence.has_ledger(628580, 1, 111, 8) is True
+    assert persistence.has_final_ledger(628580, 1, 111, 8) is False
+
+    persistence.put_ledger(628580, 1, 111, 8, final)
+    assert persistence.has_final_ledger(628580, 1, 111, 8) is True
+
+
+def test_legacy_monolithic_document_migrates_on_read(persistence, memory_backend, sample_ledger):
+    legacy_document = {
+        "analyticId": "fleet",
+        "gameId": 628580,
+        "perspective": 1,
+        "turn": 111,
+        "materializationVersion": FLEET_MATERIALIZATION_VERSION,
+        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+    }
+    memory_backend.put(
+        persistence.document_key(628580, 1, 111),
+        legacy_document,
+    )
+
+    loaded = persistence.get_ledger(628580, 1, 111, 8)
+    assert loaded is not None
+    assert loaded.ledger == sample_ledger
+    assert loaded.provenance.is_final is True
+
+    stored = memory_backend.get(persistence.document_key(628580, 1, 111))
+    assert isinstance(stored, dict)
+    assert "players" not in stored
+    assert FLEET_LEDGERS_KEY in stored
+    assert "8" in stored[FLEET_LEDGERS_KEY]
+
+
+def test_upgrade_legacy_fleet_turn_document_maps_players_to_ledgers(sample_ledger):
+    legacy_document = {
+        "analyticId": "fleet",
+        "gameId": 628580,
+        "perspective": 1,
+        "turn": 111,
+        "materializationVersion": FLEET_MATERIALIZATION_VERSION,
+        "players": [persisted_fleet_ledger_to_json(PersistedFleetLedger(ledger=sample_ledger))["ledger"]],
+    }
+    upgraded = upgrade_legacy_fleet_turn_document(legacy_document)
+    assert "players" not in upgraded
+    assert upgraded[FLEET_LEDGERS_KEY]["8"]["provenance"] == {
+        "turnEvidenceAtN": True,
+        "priorLedgerAtNMinus1": True,
+    }
+
+
+def test_stale_per_ledger_materialization_version_is_deleted_on_read(
+    persistence,
+    memory_backend,
+    sample_ledger,
+):
+    document = fleet_turn_snapshot_to_json(
+        FleetTurnSnapshot(
+            analytic_id="fleet",
+            game_id=628580,
+            perspective=1,
+            turn=111,
+            materialization_version=FLEET_MATERIALIZATION_VERSION,
+            players=[sample_ledger],
+        ),
+    )
+    ledger_wire = document[FLEET_LEDGERS_KEY]["8"]
+    assert isinstance(ledger_wire, dict)
+    ledger_wire["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
+    memory_backend.put(persistence.document_key(628580, 1, 111), document)
+    generation_before = persistence.invalidation_generation(628580, 1)
+
+    assert persistence.get_ledger(628580, 1, 111, 8) is None
+    assert persistence.has_ledger(628580, 1, 111, 8) is False
+    assert persistence.invalidation_generation(628580, 1) == generation_before + 1
+
+
+def test_list_ledger_player_ids_returns_sorted_ids(persistence, sample_ledger):
+    other_ledger = FleetAcquisitionLedger(player_id=3, player_name="other")
+    persistence.put_ledger(
+        628580,
+        1,
+        111,
+        8,
+        PersistedFleetLedger(ledger=sample_ledger),
+    )
+    persistence.put_ledger(
+        628580,
+        1,
+        111,
+        3,
+        PersistedFleetLedger(ledger=other_ledger),
+    )
+    assert persistence.list_ledger_player_ids(628580, 1, 111) == [3, 8]
+
+
+def test_delete_ledger_removes_one_player_entry(persistence, sample_ledger):
+    other_ledger = FleetAcquisitionLedger(player_id=3, player_name="other")
+    persistence.put_ledger(628580, 1, 111, 8, PersistedFleetLedger(ledger=sample_ledger))
+    persistence.put_ledger(628580, 1, 111, 3, PersistedFleetLedger(ledger=other_ledger))
+
+    persistence.delete_ledger(628580, 1, 111, 8)
+
+    assert persistence.get_ledger(628580, 1, 111, 8) is None
+    assert persistence.get_ledger(628580, 1, 111, 3) is not None

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -57,6 +57,23 @@ def sample_ledger():
     )
 
 
+def test_put_ledger_does_not_mutate_caller_persisted_ledger(persistence, sample_ledger):
+    persisted = PersistedFleetLedger(
+        ledger=sample_ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=False,
+        ),
+        materialization_version=0,
+    )
+    persistence.put_ledger(628580, 1, 111, 8, persisted)
+
+    assert persisted.materialization_version == 0
+    loaded = persistence.get_ledger(628580, 1, 111, 8)
+    assert loaded is not None
+    assert loaded.materialization_version == FLEET_MATERIALIZATION_VERSION
+
+
 def test_put_ledger_round_trip(persistence, sample_ledger):
     persisted = PersistedFleetLedger(
         ledger=sample_ledger,

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -764,8 +764,7 @@ def test_missing_materialization_version_is_deleted_on_read(persistence, load_tu
         "perspective": 1,
         "turn": 111,
         "players": [
-            fleet_acquisition_ledger_to_json(player_ledger)
-            for player_ledger in snapshot.players
+            fleet_acquisition_ledger_to_json(player_ledger) for player_ledger in snapshot.players
         ],
     }
     memory_backend.put(

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -13,8 +13,9 @@ from api.analytics.fleet.chain import (
     ensure_fleet_baseline,
     get_or_materialize_fleet_snapshot,
 )
-from api.analytics.fleet.constants import FLEET_MATERIALIZATION_VERSION
+from api.analytics.fleet.constants import FLEET_LEDGERS_KEY, FLEET_MATERIALIZATION_VERSION
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.serialization import fleet_turn_snapshot_to_json
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
     FleetFieldKnown,
@@ -731,13 +732,15 @@ def test_put_snapshot_stamps_current_materialization_version(persistence, load_t
 
 
 def test_stale_materialization_version_is_deleted_on_read(persistence, load_turn, memory_backend):
-    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_json
-
     turn = load_turn(111)
     assert turn is not None
     snapshot = ensure_fleet_baseline(628580, 1, turn)
     stale_payload = fleet_turn_snapshot_to_json(snapshot)
-    stale_payload["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
+    ledger_wire = stale_payload[FLEET_LEDGERS_KEY]
+    for player_key in ledger_wire:
+        player_entry = ledger_wire[player_key]
+        if isinstance(player_entry, dict):
+            player_entry["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
     memory_backend.put(
         persistence.document_key(628580, 1, 111),
         stale_payload,
@@ -750,13 +753,21 @@ def test_stale_materialization_version_is_deleted_on_read(persistence, load_turn
 
 
 def test_missing_materialization_version_is_deleted_on_read(persistence, load_turn, memory_backend):
-    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_json
+    from api.analytics.fleet.serialization import fleet_acquisition_ledger_to_json
 
     turn = load_turn(111)
     assert turn is not None
     snapshot = ensure_fleet_baseline(628580, 1, turn)
-    legacy_payload = fleet_turn_snapshot_to_json(snapshot)
-    del legacy_payload["materializationVersion"]
+    legacy_payload = {
+        "analyticId": "fleet",
+        "gameId": 628580,
+        "perspective": 1,
+        "turn": 111,
+        "players": [
+            fleet_acquisition_ledger_to_json(player_ledger)
+            for player_ledger in snapshot.players
+        ],
+    }
     memory_backend.put(
         persistence.document_key(628580, 1, 111),
         legacy_payload,
@@ -767,8 +778,6 @@ def test_missing_materialization_version_is_deleted_on_read(persistence, load_tu
 
 
 def test_stale_chain_anchor_skipped_during_gap_fill(persistence, load_turn, memory_backend):
-    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_json
-
     turn_110 = load_turn(110)
     assert turn_110 is not None
     stale_anchor = ensure_fleet_baseline(628580, 1, turn_110)
@@ -776,7 +785,11 @@ def test_stale_chain_anchor_skipped_during_gap_fill(persistence, load_turn, memo
         FleetShipRecord(record_id="stale-rec", disposition="active"),
     )
     stale_payload = fleet_turn_snapshot_to_json(stale_anchor)
-    stale_payload["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
+    ledger_wire = stale_payload[FLEET_LEDGERS_KEY]
+    for player_key in ledger_wire:
+        player_entry = ledger_wire[player_key]
+        if isinstance(player_entry, dict):
+            player_entry["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
     memory_backend.put(
         persistence.document_key(628580, 1, 110),
         stale_payload,


### PR DESCRIPTION
## Summary

- Add per-player fleet ledger persistence under `ledgers/{playerId}` with `FleetMaterializationProvenance`, `PersistedFleetLedger`, and persistence APIs (`get_ledger`, `put_ledger`, `has_final_ledger`, etc.).
- Migrate legacy monolithic `players` documents on read; bump `FLEET_MATERIALIZATION_VERSION` to 5 for the new wire shape.
- Stamp conservative non-final provenance on `put_snapshot` writes (and legacy migration) so monolithic materialization does not claim ensure-closed legs before F7.2; document `has_ledger` / `has_snapshot` validation side effects.

Closes #164

## Test plan

- [x] `make test_api` (fleet ledger persistence, domain round-trips, existing fleet persistence/migration tests)
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)