### PR TITLE
Fleet F7.2: per-player materialization chain and provenance on write (#165)

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -92,8 +92,6 @@ def ensure_fleet_baseline_for_player(
     perspective: int,
     turn: TurnInfo,
     player_id: int,
-    *,
-    baseline_turn_number: int | None = None,
 ) -> FleetAcquisitionLedger:
     """Return an empty fleet ledger for one player at the fleet ensure baseline."""
     for player in iter_turn_players(turn):
@@ -353,7 +351,6 @@ def _materialize_fleet_ledger_chain_for_player(
                 perspective,
                 first_rst_turn,
                 player_id,
-                baseline_turn_number=1,
             ),
             first_rst_turn,
         )

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -308,7 +308,7 @@ def _materialize_fleet_ledger_chain_for_player(
             )
         return turn_info
 
-    def turn_context(materialize_turn: int, turn_info: TurnInfo) -> FleetTurnContext:
+    def cached_turn_context_for(materialize_turn: int, turn_info: TurnInfo) -> FleetTurnContext:
         if materialize_turn not in turn_context_cache:
             turn_context_cache[materialize_turn] = FleetTurnContext.from_turn(turn_info)
         return turn_context_cache[materialize_turn]
@@ -372,7 +372,7 @@ def _materialize_fleet_ledger_chain_for_player(
                 player_id,
             ),
             turn_info=turn_one,
-            turn_context=turn_context(1, turn_one),
+            turn_context=cached_turn_context_for(1, turn_one),
             game_id=game_id,
             perspective=perspective,
             load_turn=cached_load,
@@ -398,7 +398,7 @@ def _materialize_fleet_ledger_chain_for_player(
             prior_persisted=current_persisted,
             prior_ledger=current_ledger,
             turn_info=turn_info,
-            turn_context=turn_context(materialize_turn, turn_info),
+            turn_context=cached_turn_context_for(materialize_turn, turn_info),
             game_id=game_id,
             perspective=perspective,
             load_turn=cached_load,

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -9,11 +9,19 @@ from dataclasses import dataclass
 from api.analytics.fleet.constants import ANALYTIC_ID, GAP_FILL_MAX_RETRIES
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.inferred_acquisition_ingest import ingest_turn_inferred_acquisitions
-from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
+from api.analytics.fleet.materialization_provenance import resolve_fleet_materialization_provenance
+from api.analytics.fleet.observation_ingest import (
+    ingest_turn_ship_observations,
+)
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import FleetAcquisitionLedger, FleetTurnSnapshot
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetTurnSnapshot,
+    PersistedFleetLedger,
+)
 from api.analytics.turn_roster import iter_turn_players
-from api.errors import ConflictError, NotFoundError
+from api.errors import ConflictError, NotFoundError, ValidationError
 from api.models.game import TurnInfo
 
 
@@ -30,13 +38,19 @@ class _GapFillCoherence:
     perspective: int
     generation: int
 
-    def put_snapshot(self, turn_number: int, snapshot: FleetTurnSnapshot) -> None:
+    def put_ledger(
+        self,
+        turn_number: int,
+        player_id: int,
+        persisted: PersistedFleetLedger,
+    ) -> None:
         self._assert_unchanged()
-        self.persistence.put_snapshot(
+        self.persistence.put_ledger(
             self.game_id,
             self.perspective,
             turn_number,
-            snapshot,
+            player_id,
+            persisted,
         )
         self._assert_unchanged()
 
@@ -69,6 +83,23 @@ def ensure_fleet_baseline(
     )
 
 
+def ensure_fleet_baseline_for_player(
+    game_id: int,
+    perspective: int,
+    turn: TurnInfo,
+    player_id: int,
+    *,
+    baseline_turn_number: int | None = None,
+) -> FleetAcquisitionLedger:
+    """Return an empty fleet ledger for one player at the fleet ensure baseline."""
+    for player in iter_turn_players(turn):
+        if player.id == player_id:
+            return FleetAcquisitionLedger(player_id=player.id, player_name=player.username)
+    raise ValidationError(
+        f"player_id {player_id} is not on the turn {turn.settings.turn} roster",
+    )
+
+
 def advance_snapshot_to_turn(
     prior: FleetTurnSnapshot,
     turn: TurnInfo,
@@ -96,32 +127,81 @@ def advance_snapshot_to_turn(
     )
 
 
+def advance_ledger_to_turn(
+    prior_ledger: FleetAcquisitionLedger,
+    turn: TurnInfo,
+) -> FleetAcquisitionLedger:
+    """Copy one player's ledger forward to shell turn T."""
+    ledger = copy.deepcopy(prior_ledger)
+    for player in iter_turn_players(turn):
+        if player.id == ledger.player_id:
+            ledger.player_name = player.username
+            break
+    return ledger
+
+
 def apply_fleet_turn_delta(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
     *,
     inference_materialization: FleetInferenceMaterialization | None = None,
+    turn_context: FleetTurnContext | None = None,
 ) -> FleetTurnSnapshot:
     """Apply all turn-T fleet evidence deltas for materialization."""
+    resolved_context = (
+        turn_context if turn_context is not None else FleetTurnContext.from_turn(turn)
+    )
     snapshot = ingest_turn_inferred_acquisitions(
         snapshot,
         turn,
         inference_materialization=inference_materialization,
     )
-    snapshot = ingest_turn_ship_observations(snapshot, turn)
+    snapshot = ingest_turn_ship_observations(snapshot, turn, turn_context=resolved_context)
     return snapshot
 
 
-def _find_chain_anchor(
+def apply_fleet_turn_delta_for_player(
+    ledger: FleetAcquisitionLedger,
+    turn_context: FleetTurnContext,
+    *,
+    game_id: int,
+    perspective: int,
+    inference_materialization: FleetInferenceMaterialization | None = None,
+) -> FleetAcquisitionLedger:
+    """Apply turn-T fleet evidence deltas for one player ledger."""
+    turn = turn_context.turn
+    snapshot = FleetTurnSnapshot(
+        analytic_id=ANALYTIC_ID,
+        game_id=game_id,
+        perspective=perspective,
+        turn=turn.settings.turn,
+        players=[copy.deepcopy(ledger)],
+    )
+    snapshot = apply_fleet_turn_delta(
+        snapshot,
+        turn,
+        inference_materialization=inference_materialization,
+        turn_context=turn_context,
+    )
+    return snapshot.players[0]
+
+
+def _find_chain_anchor_for_player(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
     perspective: int,
+    player_id: int,
     turn_number: int,
-) -> tuple[int, FleetTurnSnapshot | None]:
+) -> tuple[int, PersistedFleetLedger | None]:
     for prior_turn_number in range(turn_number - 1, 0, -1):
-        prior_snapshot = persistence.get_snapshot(game_id, perspective, prior_turn_number)
-        if prior_snapshot is not None:
-            return prior_turn_number, prior_snapshot
+        prior_ledger = persistence.get_ledger(
+            game_id,
+            perspective,
+            prior_turn_number,
+            player_id,
+        )
+        if prior_ledger is not None:
+            return prior_turn_number, prior_ledger
     return 0, None
 
 
@@ -136,41 +216,71 @@ def _first_stored_rst_turn(
     return None
 
 
-def _materialize_and_persist_turn(
+def _roster_player_ids(turn: TurnInfo) -> list[int]:
+    return [player.id for player in iter_turn_players(turn)]
+
+
+def _snapshot_has_all_roster_players(snapshot: FleetTurnSnapshot, turn: TurnInfo) -> bool:
+    roster_ids = set(_roster_player_ids(turn))
+    present_ids = {ledger.player_id for ledger in snapshot.players}
+    return roster_ids <= present_ids
+
+
+def _materialize_and_persist_player_turn(
     coherence: _GapFillCoherence,
     *,
     materialize_turn: int,
-    prior_snapshot: FleetTurnSnapshot,
+    player_id: int,
+    prior_persisted: PersistedFleetLedger | None,
+    prior_ledger: FleetAcquisitionLedger,
     turn_info: TurnInfo,
-    inference_materialization: FleetInferenceMaterialization | None = None,
-) -> FleetTurnSnapshot:
-    snapshot = advance_snapshot_to_turn(
-        prior_snapshot,
-        turn_info,
-        game_id=prior_snapshot.game_id,
-        perspective=prior_snapshot.perspective,
-    )
-    snapshot = apply_fleet_turn_delta(
-        snapshot,
-        turn_info,
+    turn_context: FleetTurnContext,
+    game_id: int,
+    perspective: int,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None,
+) -> PersistedFleetLedger:
+    ledger = advance_ledger_to_turn(prior_ledger, turn_info)
+    ledger = apply_fleet_turn_delta_for_player(
+        ledger,
+        turn_context,
+        game_id=game_id,
+        perspective=perspective,
         inference_materialization=inference_materialization,
     )
-    coherence.put_snapshot(materialize_turn, snapshot)
-    return snapshot
+    provenance = resolve_fleet_materialization_provenance(
+        materialize_turn=materialize_turn,
+        prior_persisted=prior_persisted,
+        turn_context=turn_context,
+        player_id=player_id,
+        game_id=game_id,
+        perspective=perspective,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+    persisted = PersistedFleetLedger(ledger=ledger, provenance=provenance)
+    coherence.put_ledger(materialize_turn, player_id, persisted)
+    return persisted
 
 
-def _materialize_fleet_snapshot_chain(
+def _materialize_fleet_ledger_chain_for_player(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
     perspective: int,
+    player_id: int,
     turn: TurnInfo,
     *,
     load_turn: Callable[[int], TurnInfo | None],
-    inference_materialization: FleetInferenceMaterialization | None = None,
+    inference_materialization: FleetInferenceMaterialization | None,
     coherence: _GapFillCoherence,
-) -> FleetTurnSnapshot:
-    """Gap-fill fleet snapshots from the latest anchor through turn T."""
+    turn_context_cache: dict[int, FleetTurnContext],
+) -> PersistedFleetLedger:
+    """Gap-fill one player's fleet ledger from the latest anchor through turn T."""
     turn_number = turn.settings.turn
+
+    existing = persistence.get_ledger(game_id, perspective, turn_number, player_id)
+    if existing is not None:
+        return existing
 
     loaded_turns: dict[int, TurnInfo | None] = {}
 
@@ -199,6 +309,11 @@ def _materialize_fleet_snapshot_chain(
             )
         return turn_info
 
+    def turn_context(materialize_turn: int, turn_info: TurnInfo) -> FleetTurnContext:
+        if materialize_turn not in turn_context_cache:
+            turn_context_cache[materialize_turn] = FleetTurnContext.from_turn(turn_info)
+        return turn_context_cache[materialize_turn]
+
     def require_prior_rst(materialize_turn: int, *, allow_missing_prefix_rst: bool) -> None:
         if materialize_turn <= 1:
             return
@@ -211,10 +326,11 @@ def _materialize_fleet_snapshot_chain(
                 f"for game {game_id} perspective {perspective}"
             )
 
-    anchor_turn, current_snapshot = _find_chain_anchor(
+    anchor_turn, anchor_persisted = _find_chain_anchor_for_player(
         persistence,
         game_id,
         perspective,
+        player_id,
         turn_number,
     )
     first_stored_rst = _first_stored_rst_turn(cached_load, turn_number)
@@ -225,34 +341,50 @@ def _materialize_fleet_snapshot_chain(
         and first_stored_rst > 1
     )
     start_turn = anchor_turn + 1
+    current_ledger = anchor_persisted.ledger if anchor_persisted is not None else None
+    current_persisted = anchor_persisted
 
     if skip_missing_prefix_rst:
         start_turn = first_stored_rst
+        assert first_stored_rst is not None
         first_rst_turn = require_turn(start_turn)
-        implicit_baseline = ensure_fleet_baseline(
-            game_id,
-            perspective,
+        current_ledger = advance_ledger_to_turn(
+            ensure_fleet_baseline_for_player(
+                game_id,
+                perspective,
+                first_rst_turn,
+                player_id,
+                baseline_turn_number=1,
+            ),
             first_rst_turn,
-            baseline_turn_number=1,
         )
-        current_snapshot = advance_snapshot_to_turn(
-            implicit_baseline,
-            first_rst_turn,
-            game_id=game_id,
-            perspective=perspective,
-        )
+        current_persisted = None
     elif anchor_turn == 0:
         turn_one = require_turn(1)
-        turn_one_snapshot = apply_fleet_turn_delta(
-            ensure_fleet_baseline(game_id, perspective, turn_one),
-            turn_one,
+        current_persisted = _materialize_and_persist_player_turn(
+            coherence,
+            materialize_turn=1,
+            player_id=player_id,
+            prior_persisted=None,
+            prior_ledger=ensure_fleet_baseline_for_player(
+                game_id,
+                perspective,
+                turn_one,
+                player_id,
+            ),
+            turn_info=turn_one,
+            turn_context=turn_context(1, turn_one),
+            game_id=game_id,
+            perspective=perspective,
+            load_turn=cached_load,
             inference_materialization=resolved_inference_materialization,
         )
-        coherence.put_snapshot(1, turn_one_snapshot)
-        current_snapshot = turn_one_snapshot
+        current_ledger = current_persisted.ledger
         if turn_number == 1:
-            return turn_one_snapshot
+            return current_persisted
         start_turn = 2
+
+    assert current_ledger is not None
 
     for materialize_turn in range(start_turn, turn_number + 1):
         require_prior_rst(
@@ -260,15 +392,121 @@ def _materialize_fleet_snapshot_chain(
             allow_missing_prefix_rst=skip_missing_prefix_rst and materialize_turn == start_turn,
         )
         turn_info = require_turn(materialize_turn)
-        current_snapshot = _materialize_and_persist_turn(
+        current_persisted = _materialize_and_persist_player_turn(
             coherence,
             materialize_turn=materialize_turn,
-            prior_snapshot=current_snapshot,
+            player_id=player_id,
+            prior_persisted=current_persisted,
+            prior_ledger=current_ledger,
             turn_info=turn_info,
+            turn_context=turn_context(materialize_turn, turn_info),
+            game_id=game_id,
+            perspective=perspective,
+            load_turn=cached_load,
             inference_materialization=resolved_inference_materialization,
         )
+        current_ledger = current_persisted.ledger
 
-    return current_snapshot
+    assert current_persisted is not None
+    return current_persisted
+
+
+def _materialize_fleet_snapshot_chain(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    turn: TurnInfo,
+    *,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None = None,
+    coherence: _GapFillCoherence,
+) -> FleetTurnSnapshot:
+    """Gap-fill fleet ledgers for every roster player through turn T."""
+    turn_context_cache: dict[int, FleetTurnContext] = {}
+    for player_id in _roster_player_ids(turn):
+        _materialize_fleet_ledger_chain_for_player(
+            persistence,
+            game_id,
+            perspective,
+            player_id,
+            turn,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            coherence=coherence,
+            turn_context_cache=turn_context_cache,
+        )
+    snapshot = persistence.get_snapshot(game_id, perspective, turn.settings.turn)
+    if snapshot is None:
+        raise ConflictError(
+            f"fleet snapshot gap-fill produced no document for game {game_id} "
+            f"perspective {perspective} turn {turn.settings.turn}"
+        )
+    return snapshot
+
+
+def get_or_materialize_fleet_ledger_for_player(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    player_id: int,
+    turn: TurnInfo,
+    *,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None = None,
+) -> PersistedFleetLedger:
+    """Return a cached ledger or materialize turn T for one player."""
+    turn_number = turn.settings.turn
+    cached = persistence.get_ledger(game_id, perspective, turn_number, player_id)
+    if cached is not None:
+        return cached
+
+    for attempt in range(GAP_FILL_MAX_RETRIES):
+        coherence = _GapFillCoherence(
+            persistence,
+            game_id,
+            perspective,
+            persistence.invalidation_generation(game_id, perspective),
+        )
+        turn_context_cache: dict[int, FleetTurnContext] = {}
+        try:
+            return _materialize_fleet_ledger_chain_for_player(
+                persistence,
+                game_id,
+                perspective,
+                player_id,
+                turn,
+                load_turn=load_turn,
+                inference_materialization=inference_materialization,
+                coherence=coherence,
+                turn_context_cache=turn_context_cache,
+            )
+        except _FleetSnapshotInvalidated:
+            cached_after_invalidation = persistence.get_ledger(
+                game_id,
+                perspective,
+                turn_number,
+                player_id,
+            )
+            if cached_after_invalidation is not None:
+                return cached_after_invalidation
+            if attempt + 1 >= GAP_FILL_MAX_RETRIES:
+                break
+            continue
+
+    cached_after_retries = persistence.get_ledger(
+        game_id,
+        perspective,
+        turn_number,
+        player_id,
+    )
+    if cached_after_retries is not None:
+        return cached_after_retries
+
+    raise ConflictError(
+        f"fleet ledger gap-fill for game {game_id} perspective {perspective} "
+        f"player {player_id} turn {turn_number} exceeded {GAP_FILL_MAX_RETRIES} "
+        "invalidation retries"
+    )
 
 
 def get_or_materialize_fleet_snapshot(
@@ -283,7 +521,7 @@ def get_or_materialize_fleet_snapshot(
     """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
     turn_number = turn.settings.turn
     cached = persistence.get_snapshot(game_id, perspective, turn_number)
-    if cached is not None:
+    if cached is not None and _snapshot_has_all_roster_players(cached, turn):
         return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):
@@ -309,14 +547,19 @@ def get_or_materialize_fleet_snapshot(
                 perspective,
                 turn_number,
             )
-            if cached_after_invalidation is not None:
+            if cached_after_invalidation is not None and _snapshot_has_all_roster_players(
+                cached_after_invalidation, turn
+            ):
                 return cached_after_invalidation
             if attempt + 1 >= GAP_FILL_MAX_RETRIES:
                 break
             continue
 
     cached_after_retries = persistence.get_snapshot(game_id, perspective, turn_number)
-    if cached_after_retries is not None:
+    if cached_after_retries is not None and _snapshot_has_all_roster_players(
+        cached_after_retries,
+        turn,
+    ):
         return cached_after_retries
 
     raise ConflictError(

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -8,9 +8,13 @@ from dataclasses import dataclass
 
 from api.analytics.fleet.constants import ANALYTIC_ID, GAP_FILL_MAX_RETRIES
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
-from api.analytics.fleet.inferred_acquisition_ingest import ingest_turn_inferred_acquisitions
+from api.analytics.fleet.inferred_acquisition_ingest import (
+    ingest_player_inferred_acquisitions,
+    ingest_turn_inferred_acquisitions,
+)
 from api.analytics.fleet.materialization_provenance import resolve_fleet_materialization_provenance
 from api.analytics.fleet.observation_ingest import (
+    ingest_player_ship_observations,
     ingest_turn_ship_observations,
 )
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
@@ -170,20 +174,15 @@ def apply_fleet_turn_delta_for_player(
 ) -> FleetAcquisitionLedger:
     """Apply turn-T fleet evidence deltas for one player ledger."""
     turn = turn_context.turn
-    snapshot = FleetTurnSnapshot(
-        analytic_id=ANALYTIC_ID,
+    ingest_player_inferred_acquisitions(
+        ledger,
+        turn,
         game_id=game_id,
         perspective=perspective,
-        turn=turn.settings.turn,
-        players=[copy.deepcopy(ledger)],
-    )
-    snapshot = apply_fleet_turn_delta(
-        snapshot,
-        turn,
         inference_materialization=inference_materialization,
-        turn_context=turn_context,
     )
-    return snapshot.players[0]
+    ingest_player_ship_observations(ledger, turn_context)
+    return ledger
 
 
 def _find_chain_anchor_for_player(

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -25,6 +25,7 @@ from api.analytics.scores.placeholder_targets import (
     should_seed_homeworld_starting_inventory,
 )
 from api.models.game import TurnInfo
+from api.models.player import Score
 
 SCOREBOARD_SOURCE = "scoreboard"
 
@@ -38,32 +39,29 @@ def ingest_turn_inferred_acquisitions(
     inference_materialization: FleetInferenceMaterialization | None = None,
 ) -> FleetTurnSnapshot:
     """Create scoreboard placeholders and optionally refine them from held solutions."""
-    snapshot = _create_scoreboard_placeholders(snapshot, turn)
-    if inference_materialization is not None:
-        from api.analytics.fleet.inferred_acquisition_refine import (
-            refine_inferred_acquisitions_from_scores,
-        )
-
-        snapshot = refine_inferred_acquisitions_from_scores(
-            snapshot,
+    for ledger in snapshot.players:
+        ingest_player_inferred_acquisitions(
+            ledger,
             turn,
+            game_id=snapshot.game_id,
+            perspective=snapshot.perspective,
             inference_materialization=inference_materialization,
         )
     return snapshot
 
 
-def _create_scoreboard_placeholders(
-    snapshot: FleetTurnSnapshot,
+def ingest_player_inferred_acquisitions(
+    ledger: FleetAcquisitionLedger,
     turn: TurnInfo,
-) -> FleetTurnSnapshot:
-    """Create inferred placeholder rows for positive scoreboard warship/freighter deltas."""
+    *,
+    game_id: int,
+    perspective: int,
+    inference_materialization: FleetInferenceMaterialization | None = None,
+) -> None:
+    """Create scoreboard placeholders and optionally refine them for one player ledger."""
     turn_number = turn.settings.turn
-    ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
-
-    for score in iter_current_turn_scores(turn):
-        ledger = ledgers_by_player_id.get(score.ownerid)
-        if ledger is None:
-            continue
+    score = _score_for_player(turn, ledger.player_id)
+    if score is not None:
         if should_seed_homeworld_starting_inventory(turn):
             _ensure_homeworld_starting_inventory_rows(
                 ledger,
@@ -71,16 +69,33 @@ def _create_scoreboard_placeholders(
                 shell_turn=turn_number,
             )
         targets = scoreboard_placeholder_targets(score, turn)
-        if targets is None:
-            continue
-        for target in targets:
-            _ensure_placeholder_target_rows(
-                ledger,
-                target=target,
-                shell_turn=turn_number,
-            )
+        if targets is not None:
+            for target in targets:
+                _ensure_placeholder_target_rows(
+                    ledger,
+                    target=target,
+                    shell_turn=turn_number,
+                )
 
-    return snapshot
+    if inference_materialization is not None:
+        from api.analytics.fleet.inferred_acquisition_refine import (
+            refine_player_inferred_acquisitions_from_scores,
+        )
+
+        refine_player_inferred_acquisitions_from_scores(
+            ledger,
+            turn,
+            game_id=game_id,
+            perspective=perspective,
+            inference_materialization=inference_materialization,
+        )
+
+
+def _score_for_player(turn: TurnInfo, player_id: int) -> Score | None:
+    for score in iter_current_turn_scores(turn):
+        if score.ownerid == player_id:
+            return score
+    return None
 
 
 def _ensure_homeworld_starting_inventory_rows(

--- a/packages/api/api/analytics/fleet/inferred_acquisition_refine.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_refine.py
@@ -47,33 +47,50 @@ def refine_inferred_acquisitions_from_scores(
     inference_materialization: FleetInferenceMaterialization,
 ) -> FleetTurnSnapshot:
     """Attach fleet build option sets from top-K held solutions to placeholder rows."""
+    for ledger in snapshot.players:
+        refine_player_inferred_acquisitions_from_scores(
+            ledger,
+            turn,
+            game_id=snapshot.game_id,
+            perspective=snapshot.perspective,
+            inference_materialization=inference_materialization,
+        )
+    return snapshot
+
+
+def refine_player_inferred_acquisitions_from_scores(
+    ledger: FleetAcquisitionLedger,
+    turn: TurnInfo,
+    *,
+    game_id: int,
+    perspective: int,
+    inference_materialization: FleetInferenceMaterialization,
+) -> None:
+    """Attach fleet build option sets from top-K held solutions for one player ledger."""
     turn_number = turn.settings.turn
+    if not _ledger_has_placeholders_for_turn(ledger, turn_number):
+        return
     inference = inference_materialization.inference
     load_turn = inference_materialization.load_turn
-    for ledger in snapshot.players:
-        if not _ledger_has_placeholders_for_turn(ledger, turn_number):
+    for built_turn in _distinct_placeholder_built_turns(ledger, turn_number):
+        held = inference.held_inference_for_placeholder(
+            game_id=game_id,
+            perspective=perspective,
+            shell_turn=turn_number,
+            built_turn=built_turn,
+            player_id=ledger.player_id,
+            turn=turn,
+            load_turn=load_turn,
+        )
+        if not held.solutions:
             continue
-        for built_turn in _distinct_placeholder_built_turns(ledger, turn_number):
-            held = inference.held_inference_for_placeholder(
-                game_id=snapshot.game_id,
-                perspective=snapshot.perspective,
-                shell_turn=turn_number,
-                built_turn=built_turn,
-                player_id=ledger.player_id,
-                turn=turn,
-                load_turn=load_turn,
-            )
-            if not held.solutions:
-                continue
-            _refine_player_placeholders_for_built_turn(
-                ledger,
-                shell_turn=turn_number,
-                built_turn=built_turn,
-                solutions=list(held.solutions),
-                search_status=held.search_status,
-            )
-
-    return snapshot
+        _refine_player_placeholders_for_built_turn(
+            ledger,
+            shell_turn=turn_number,
+            built_turn=built_turn,
+            solutions=list(held.solutions),
+            search_status=held.search_status,
+        )
 
 
 def _distinct_placeholder_built_turns(

--- a/packages/api/api/analytics/fleet/materialization_provenance.py
+++ b/packages/api/api/analytics/fleet/materialization_provenance.py
@@ -1,0 +1,131 @@
+"""Honest fleet materialization provenance from actual materialization inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+from api.analytics.scores.export_precedence import (
+    ScoresExportResolutionContext,
+    is_scores_export_ensure_satisfied_from_snapshot,
+)
+from api.analytics.scores.export_snapshot import (
+    gather_scores_materialization_probe_snapshot,
+)
+from api.models.game import TurnInfo
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+
+def resolve_fleet_materialization_provenance(
+    *,
+    materialize_turn: int,
+    prior_persisted: PersistedFleetLedger | None,
+    turn_context: FleetTurnContext,
+    player_id: int,
+    game_id: int,
+    perspective: int,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None,
+) -> FleetMaterializationProvenance:
+    """Set provenance flags from legs actually closed at write time."""
+    prior_ledger_at_n_minus_1 = materialize_turn == 1 or (
+        prior_persisted is not None and prior_persisted.provenance.is_final
+    )
+    turn_evidence_at_n = _is_turn_evidence_closed(
+        materialize_turn=materialize_turn,
+        turn_context=turn_context,
+        player_id=player_id,
+        game_id=game_id,
+        perspective=perspective,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+    return FleetMaterializationProvenance(
+        turn_evidence_at_n=turn_evidence_at_n,
+        prior_ledger_at_n_minus_1=prior_ledger_at_n_minus_1,
+    )
+
+
+def _is_turn_evidence_closed(
+    *,
+    materialize_turn: int,
+    turn_context: FleetTurnContext,
+    player_id: int,
+    game_id: int,
+    perspective: int,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None,
+) -> bool:
+    if load_turn(materialize_turn) is None:
+        return False
+    if not _scores_ensure_satisfied_for_player(
+        game_id=game_id,
+        perspective=perspective,
+        turn_number=materialize_turn,
+        player_id=player_id,
+        turn=turn_context.turn,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    ):
+        return False
+    return True
+
+
+def _scores_ensure_satisfied_for_player(
+    *,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_id: int,
+    turn: TurnInfo,
+    load_turn: Callable[[int], TurnInfo | None],
+    inference_materialization: FleetInferenceMaterialization | None,
+) -> bool:
+    if turn_number <= 1:
+        return True
+
+    if inference_materialization is None:
+        return False
+
+    scores_services = inference_materialization.inference.scores_services
+    scope = ExportScope(
+        game_id=game_id,
+        perspective=perspective,
+        turn=turn_number,
+        player_id=player_id,
+    )
+
+    def get_persisted_row(
+        scoreboard_turn: int,
+        row_player_id: int,
+    ) -> PersistedInferenceRow | None:
+        if scores_services.persistence is None:
+            return None
+        return scores_services.persistence.get_row(
+            game_id,
+            perspective,
+            scoreboard_turn,
+            row_player_id,
+        )
+
+    player_score = next((row for row in turn.scores if row.ownerid == player_id), None)
+    snapshot = gather_scores_materialization_probe_snapshot(
+        scores_services,
+        scope,
+        turn,
+    )
+    resolution_context = ScoresExportResolutionContext(
+        scoreboard_turn=turn_number,
+        turn=turn,
+        player_id=player_id,
+        load_scoreboard_turn=load_turn,
+        get_persisted_row=get_persisted_row,
+        player_score=player_score,
+    )
+    return is_scores_export_ensure_satisfied_from_snapshot(
+        snapshot,
+        resolution_context=resolution_context,
+    )

--- a/packages/api/api/analytics/fleet/materialization_provenance.py
+++ b/packages/api/api/analytics/fleet/materialization_provenance.py
@@ -1,4 +1,8 @@
-"""Honest fleet materialization provenance from actual materialization inputs."""
+"""Honest fleet materialization provenance from actual materialization inputs.
+
+Provenance resolution assumes turn-N fleet evidence deltas are already applied
+for the player ledger being persisted; see ``resolve_fleet_materialization_provenance``.
+"""
 
 from __future__ import annotations
 
@@ -30,7 +34,15 @@ def resolve_fleet_materialization_provenance(
     load_turn: Callable[[int], TurnInfo | None],
     inference_materialization: FleetInferenceMaterialization | None,
 ) -> FleetMaterializationProvenance:
-    """Set provenance flags from legs actually closed at write time."""
+    """Set provenance flags from legs actually closed at write time.
+
+    Caller contract: apply turn-*N* fleet evidence deltas for ``player_id``
+    (scoreboard ingest, ship sightings, ship-id bound tightening, and optional
+    scores refinement, e.g. via ``apply_fleet_turn_delta_for_player``) before
+    calling this function. ``turnEvidenceAtN`` checks RST@*N* availability and
+    ``scores@N`` ensure satisfaction only; ingest and sightings are not
+    re-verified here.
+    """
     prior_ledger_at_n_minus_1 = materialize_turn == 1 or (
         prior_persisted is not None and prior_persisted.provenance.is_final
     )

--- a/packages/api/api/analytics/fleet/observation_ingest.py
+++ b/packages/api/api/analytics/fleet/observation_ingest.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import uuid
 
 from api.analytics.fleet.id_bound_ingest import tighten_inferred_ship_id_bounds
-from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
 from api.analytics.fleet.serialization import append_fleet_evidence_event
+from api.analytics.fleet.turn_context import FleetTurnContext
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
     FleetAlibi,
@@ -30,25 +30,35 @@ TURN_SHIPS_SOURCE = "turnInfo.ships"
 def ingest_turn_ship_observations(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
+    *,
+    turn_context: FleetTurnContext | None = None,
 ) -> FleetTurnSnapshot:
     """Apply turn-T ship sightings to every player ledger in the snapshot."""
+    resolved_context = (
+        turn_context if turn_context is not None else FleetTurnContext.from_turn(turn)
+    )
+    for ledger in snapshot.players:
+        ingest_player_ship_observations(ledger, resolved_context)
+    return snapshot
+
+
+def ingest_player_ship_observations(
+    ledger: FleetAcquisitionLedger,
+    turn_context: FleetTurnContext,
+) -> None:
+    """Apply turn-T ship sightings and id-bound tightening for one player ledger."""
+    turn = turn_context.turn
     turn_number = turn.settings.turn
-    ledgers_by_player_id = {ledger.player_id: ledger for ledger in snapshot.players}
-    max_ship_id_bound = compute_max_ship_id_bound(turn)
 
     for ship in turn.ships:
         if ship.turnkilled != 0:
             continue
-        ledger = ledgers_by_player_id.get(ship.ownerid)
-        if ledger is None:
+        if ship.ownerid != ledger.player_id:
             continue
         _ingest_ship_sighting(ledger, ship, turn, turn_number=turn_number)
 
-    if max_ship_id_bound is not None:
-        for ledger in snapshot.players:
-            tighten_inferred_ship_id_bounds(ledger, turn, shell_turn=turn_number)
-
-    return snapshot
+    if turn_context.max_ship_id_bound is not None:
+        tighten_inferred_ship_id_bounds(ledger, turn, shell_turn=turn_number)
 
 
 def _ingest_ship_sighting(

--- a/packages/api/api/analytics/fleet/turn_context.py
+++ b/packages/api/api/analytics/fleet/turn_context.py
@@ -1,0 +1,23 @@
+"""Shared read-only turn inputs for per-player fleet materialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
+from api.models.game import TurnInfo
+
+
+@dataclass(frozen=True)
+class FleetTurnContext:
+    """Global RST-derived inputs computed once per shell turn."""
+
+    turn: TurnInfo
+    max_ship_id_bound: int | None
+
+    @classmethod
+    def from_turn(cls, turn: TurnInfo) -> FleetTurnContext:
+        return cls(
+            turn=turn,
+            max_ship_id_bound=compute_max_ship_id_bound(turn),
+        )

--- a/packages/api/api/analytics/scores/export_snapshot.py
+++ b/packages/api/api/analytics/scores/export_snapshot.py
@@ -123,6 +123,24 @@ def _cached_stream_admission(
     return CachedCompleteRowAdmission(event=cached)
 
 
+def gather_scores_materialization_probe_snapshot(
+    services: ScoresExportContext,
+    scope: ExportScope,
+    turn: TurnInfo,
+) -> ScoresInferenceSnapshot:
+    """Lightweight scores snapshot for fleet materialization provenance (no export context)."""
+    persisted_row = _load_persisted_row(services, scope)
+    stream_scope = scores_inference_stream_scope(scope)
+    pause_status = services.scheduler.global_pause_status(stream_scope)
+    return ScoresInferenceSnapshot(
+        persisted_row=persisted_row,
+        stream_admission=_cached_stream_admission(services, scope),
+        ensure_sync_admission=None,
+        scheduler_run=_scheduler_row_run(services, scope),
+        globally_paused=bool(pause_status.get("paused")),
+    )
+
+
 def gather_scores_ensure_probe_snapshot(
     ctx: AnalyticQueryContext,
     services: ScoresExportContext,

--- a/packages/api/api/analytics/scores/export_snapshot.py
+++ b/packages/api/api/analytics/scores/export_snapshot.py
@@ -123,21 +123,46 @@ def _cached_stream_admission(
     return CachedCompleteRowAdmission(event=cached)
 
 
+def _gather_scores_probe_snapshot(
+    services: ScoresExportContext,
+    scope: ExportScope,
+    turn: TurnInfo | None,
+    *,
+    ensure_sync_admission: ImmediateRowAdmission | None,
+) -> ScoresInferenceSnapshot:
+    """Shared probe gather: cached stream admission only, no live inference."""
+    persisted_row = _load_persisted_row(services, scope)
+    if turn is None:
+        return ScoresInferenceSnapshot(
+            persisted_row=persisted_row,
+            stream_admission=None,
+            ensure_sync_admission=ensure_sync_admission,
+            scheduler_run=None,
+            globally_paused=False,
+        )
+
+    stream_scope = scores_inference_stream_scope(scope)
+    pause_status = services.scheduler.global_pause_status(stream_scope)
+    return ScoresInferenceSnapshot(
+        persisted_row=persisted_row,
+        stream_admission=_cached_stream_admission(services, scope),
+        ensure_sync_admission=ensure_sync_admission,
+        scheduler_run=_scheduler_row_run(services, scope),
+        globally_paused=bool(pause_status.get("paused")),
+    )
+
+
 def gather_scores_materialization_probe_snapshot(
     services: ScoresExportContext,
     scope: ExportScope,
     turn: TurnInfo,
 ) -> ScoresInferenceSnapshot:
     """Lightweight scores snapshot for fleet materialization provenance (no export context)."""
-    persisted_row = _load_persisted_row(services, scope)
-    stream_scope = scores_inference_stream_scope(scope)
-    pause_status = services.scheduler.global_pause_status(stream_scope)
-    return ScoresInferenceSnapshot(
-        persisted_row=persisted_row,
-        stream_admission=_cached_stream_admission(services, scope),
+    return _gather_scores_probe_snapshot(
+        services,
+        scope,
+        turn,
         ensure_sync_admission=None,
-        scheduler_run=_scheduler_row_run(services, scope),
-        globally_paused=bool(pause_status.get("paused")),
     )
 
 
@@ -148,24 +173,11 @@ def gather_scores_ensure_probe_snapshot(
     turn: TurnInfo | None,
 ) -> ScoresInferenceSnapshot:
     """Lightweight snapshot for export probe walks: persistence and scheduler lookups only."""
-    persisted_row = _load_persisted_row(services, scope)
-    if turn is None:
-        return ScoresInferenceSnapshot(
-            persisted_row=persisted_row,
-            stream_admission=None,
-            ensure_sync_admission=_ensure_sync_admission_from_context(ctx, scope),
-            scheduler_run=None,
-            globally_paused=False,
-        )
-
-    stream_scope = scores_inference_stream_scope(scope)
-    pause_status = services.scheduler.global_pause_status(stream_scope)
-    return ScoresInferenceSnapshot(
-        persisted_row=persisted_row,
-        stream_admission=_cached_stream_admission(services, scope),
+    return _gather_scores_probe_snapshot(
+        services,
+        scope,
+        turn,
         ensure_sync_admission=_ensure_sync_admission_from_context(ctx, scope),
-        scheduler_run=_scheduler_row_run(services, scope),
-        globally_paused=bool(pause_status.get("paused")),
     )
 
 

--- a/packages/api/tests/test_fleet_materialization_provenance.py
+++ b/packages/api/tests/test_fleet_materialization_provenance.py
@@ -1,0 +1,244 @@
+"""Integration tests for per-player fleet materialization provenance (F7.2)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from api.analytics.fleet.chain import (
+    ensure_fleet_baseline,
+    get_or_materialize_fleet_ledger_for_player,
+    get_or_materialize_fleet_snapshot,
+)
+from api.analytics.fleet.held_solutions import FleetInferenceMaterialization, FleetInferenceSupport
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.analytics.scores.export_services import ScoresExportContext
+from api.analytics.turn_roster import iter_turn_players
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+from api.serialization.turn import turn_info_from_json
+from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+from api.storage.memory_asset import MemoryAssetBackend
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as f:
+        backend.put("games/628580/info", json.load(f))
+    with open(ASSETS_DIR / "turn_sample.json") as f:
+        turn_rst = json.load(f)
+        backend.put("games/628580/1/turns/111", turn_rst)
+        turn_110 = copy.deepcopy(turn_rst)
+        turn_110["settings"]["turn"] = 110
+        turn_110["game"]["turn"] = 110
+        backend.put("games/628580/1/turns/110", turn_110)
+    return backend
+
+
+@pytest.fixture
+def persistence(memory_backend):
+    return FleetSnapshotPersistenceService(memory_backend)
+
+
+@pytest.fixture
+def load_turn(memory_backend):
+    def _load(turn_number: int):
+        key = f"games/628580/1/turns/{turn_number}"
+        try:
+            data = memory_backend.get(key)
+        except Exception:
+            return None
+        if data is None:
+            return None
+        return turn_info_from_json(data)
+
+    return _load
+
+
+def test_partial_scores_closure_persists_non_final_provenance(persistence, load_turn):
+    """Incomplete scores@N leaves turnEvidenceAtN false; ledger is not ensure-final."""
+    turn = load_turn(111)
+    assert turn is not None
+    player_id = turn.scores[0].ownerid
+    inference_persistence = InferenceRowPersistenceService(persistence._storage)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    inference_materialization = FleetInferenceMaterialization(
+        inference=FleetInferenceSupport(scores_services=scores_services),
+        load_turn=load_turn,
+    )
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_id,
+        turn,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+
+    loaded = persistence.get_ledger(628580, 1, 111, player_id)
+    assert loaded is not None
+    assert loaded.provenance.turn_evidence_at_n is False
+    assert loaded.provenance.prior_ledger_at_n_minus_1 is False
+    assert loaded.provenance.is_final is False
+    assert persistence.has_ledger(628580, 1, 111, player_id) is True
+    assert persistence.has_final_ledger(628580, 1, 111, player_id) is False
+
+
+def test_complete_scores_closure_persists_final_provenance_when_prior_final(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """When scores@N and fleet@(N-1) legs are closed, provenance is final."""
+    from dataclasses import replace
+
+    turn_one_data = copy.deepcopy(memory_backend.get("games/628580/1/turns/110"))
+    assert isinstance(turn_one_data, dict)
+    turn_one_data["settings"]["turn"] = 1
+    turn_one_data["game"]["turn"] = 1
+    memory_backend.put("games/628580/1/turns/1", turn_one_data)
+    turn_one = turn_info_from_json(memory_backend.get("games/628580/1/turns/1"))
+
+    turn_two_data = copy.deepcopy(turn_one_data)
+    turn_two_data["settings"]["turn"] = 2
+    turn_two_data["game"]["turn"] = 2
+    memory_backend.put("games/628580/1/turns/2", turn_two_data)
+    turn_two = turn_info_from_json(memory_backend.get("games/628580/1/turns/2"))
+
+    player_id = turn_one.scores[0].ownerid
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    inference_materialization = FleetInferenceMaterialization(
+        inference=FleetInferenceSupport(scores_services=scores_services),
+        load_turn=load_turn,
+    )
+
+    def load_turn_one_two(turn_number: int):
+        if turn_number in (1, 2):
+            return turn_info_from_json(memory_backend.get(f"games/628580/1/turns/{turn_number}"))
+        return load_turn(turn_number)
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_id,
+        turn_one,
+        load_turn=load_turn_one_two,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=inference_materialization.inference,
+            load_turn=load_turn_one_two,
+        ),
+    )
+    prior = persistence.get_ledger(628580, 1, 1, player_id)
+    assert prior is not None
+    assert prior.provenance.is_final is True
+
+    turn_two = replace(
+        turn_two,
+        scores=[
+            replace(
+                score,
+                turn=2,
+                ownerid=player_id,
+                shipchange=1,
+                freighterchange=0,
+            )
+            for score in turn_two.scores
+            if score.ownerid == player_id
+        ],
+    )
+    inference_persistence.put_row(
+        628580,
+        1,
+        2,
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="done",
+            solution_count=1,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_id,
+        turn_two,
+        load_turn=load_turn_one_two,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=inference_materialization.inference,
+            load_turn=load_turn_one_two,
+        ),
+    )
+    loaded = persistence.get_ledger(628580, 1, 2, player_id)
+    assert loaded is not None
+    assert loaded.provenance.turn_evidence_at_n is True
+    assert loaded.provenance.prior_ledger_at_n_minus_1 is True
+    assert loaded.provenance.is_final is True
+    assert persistence.has_final_ledger(628580, 1, 2, player_id) is True
+
+
+def test_turn_context_computes_id_bound_once_per_turn(load_turn):
+    turn = load_turn(111)
+    assert turn is not None
+    context = FleetTurnContext.from_turn(turn)
+    assert context.max_ship_id_bound is not None
+
+
+def test_gap_fill_persists_per_player_ledgers_with_provenance(persistence, load_turn):
+    turn = load_turn(111)
+    assert turn is not None
+
+    get_or_materialize_fleet_snapshot(
+        persistence,
+        628580,
+        1,
+        turn,
+        load_turn=load_turn,
+    )
+
+    player_ids = persistence.list_ledger_player_ids(628580, 1, 111)
+    assert len(player_ids) == len(list(iter_turn_players(turn)))
+    for player_id in player_ids:
+        loaded = persistence.get_ledger(628580, 1, 111, player_id)
+        assert loaded is not None
+        assert loaded.provenance is not None
+
+
+def test_gap_fill_persists_intermediate_turn_per_player(persistence, load_turn):
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    turn = load_turn(111)
+    assert turn is not None
+    player_id = turn.scores[0].ownerid
+
+    persistence.put_snapshot(
+        628580,
+        1,
+        110,
+        ensure_fleet_baseline(628580, 1, turn_110),
+    )
+
+    get_or_materialize_fleet_snapshot(
+        persistence,
+        628580,
+        1,
+        turn,
+        load_turn=load_turn,
+    )
+
+    intermediate = persistence.get_ledger(628580, 1, 111, player_id)
+    assert intermediate is not None
+    assert persistence.get_ledger(628580, 1, 110, player_id) is not None

--- a/packages/api/tests/test_fleet_materialization_provenance.py
+++ b/packages/api/tests/test_fleet_materialization_provenance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from api.analytics.fleet.chain import (
@@ -190,11 +191,33 @@ def test_complete_scores_closure_persists_final_provenance_when_prior_final(
     assert persistence.has_final_ledger(628580, 1, 2, player_id) is True
 
 
-def test_turn_context_computes_id_bound_once_per_turn(load_turn):
+def test_turn_context_includes_max_ship_id_bound(load_turn):
     turn = load_turn(111)
     assert turn is not None
     context = FleetTurnContext.from_turn(turn)
     assert context.max_ship_id_bound is not None
+
+
+def test_snapshot_gap_fill_reuses_turn_context_across_players(persistence, load_turn):
+    turn = load_turn(111)
+    assert turn is not None
+    player_count = len(list(iter_turn_players(turn)))
+    assert player_count > 1
+
+    with patch(
+        "api.analytics.fleet.chain.FleetTurnContext.from_turn",
+        wraps=FleetTurnContext.from_turn,
+    ) as from_turn_mock:
+        get_or_materialize_fleet_snapshot(
+            persistence,
+            628580,
+            1,
+            turn,
+            load_turn=load_turn,
+        )
+
+    # Turns 110 and 111 are gap-filled once each, shared across roster players.
+    assert from_turn_mock.call_count == 2
 
 
 def test_gap_fill_persists_per_player_ledgers_with_provenance(persistence, load_turn):

--- a/packages/api/tests/test_fleet_materialization_provenance_policy.py
+++ b/packages/api/tests/test_fleet_materialization_provenance_policy.py
@@ -1,0 +1,75 @@
+"""Unit tests for fleet materialization provenance policy edges."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from api.analytics.fleet.materialization_provenance import (
+    resolve_fleet_materialization_provenance,
+)
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetMaterializationProvenance,
+    PersistedFleetLedger,
+)
+
+
+def _turn_context() -> FleetTurnContext:
+    turn = MagicMock()
+    turn.scores = []
+    return FleetTurnContext(turn=turn, max_ship_id_bound=100)
+
+
+def _resolve(**overrides):
+    defaults = {
+        "materialize_turn": 2,
+        "prior_persisted": None,
+        "turn_context": _turn_context(),
+        "player_id": 8,
+        "game_id": 628580,
+        "perspective": 1,
+        "load_turn": lambda turn_number: MagicMock() if turn_number == 2 else None,
+        "inference_materialization": MagicMock(),
+    }
+    defaults.update(overrides)
+    return resolve_fleet_materialization_provenance(**defaults)
+
+
+def test_non_final_prior_ledger_does_not_close_prior_leg():
+    """Non-final provenance at N-1 leaves prior_ledger_at_n_minus_1 false."""
+    prior_persisted = PersistedFleetLedger(
+        ledger=FleetAcquisitionLedger(player_id=8),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=False,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    assert prior_persisted.provenance.is_final is False
+
+    with patch(
+        "api.analytics.fleet.materialization_provenance._scores_ensure_satisfied_for_player",
+        return_value=True,
+    ):
+        provenance = _resolve(prior_persisted=prior_persisted)
+
+    assert provenance.prior_ledger_at_n_minus_1 is False
+    assert provenance.turn_evidence_at_n is True
+
+
+def test_turn_one_prior_ledger_baseline_leg_is_true():
+    provenance = _resolve(materialize_turn=1)
+
+    assert provenance.prior_ledger_at_n_minus_1 is True
+
+
+def test_missing_inference_materialization_closes_turn_evidence_at_turn_gt_one():
+    provenance = _resolve(materialize_turn=2, inference_materialization=None)
+
+    assert provenance.turn_evidence_at_n is False
+
+
+def test_missing_rst_at_materialize_turn_closes_turn_evidence():
+    provenance = _resolve(load_turn=lambda _turn_number: None)
+
+    assert provenance.turn_evidence_at_n is False

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -548,17 +548,16 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
     assert turn_112 is not None
     sync = threading.Barrier(2)
     put_generations: list[int] = []
-    original_put_snapshot = persistence.put_snapshot
+    original_put_ledger = persistence.put_ledger
 
-    def hooked_put_snapshot(*args, **kwargs):
-        snapshot = original_put_snapshot(*args, **kwargs)
+    def hooked_put_ledger(*args, **kwargs):
+        original_put_ledger(*args, **kwargs)
         put_generations.append(persistence.invalidation_generation(628580, 1))
         if len(put_generations) == 1:
             sync.wait()
             sync.wait()
-        return snapshot
 
-    persistence.put_snapshot = hooked_put_snapshot  # type: ignore[method-assign]
+    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
 
     gap_fill_error: BaseException | None = None
     snapshot: FleetTurnSnapshot | None = None
@@ -605,16 +604,17 @@ def test_gap_fill_does_not_persist_torn_tail_after_mid_chain_invalidation(persis
     attempt_puts: list[list[int]] = []
     current_attempt_puts: list[int] = []
     mid_chain_intercepted = False
-    original_put_snapshot = persistence.put_snapshot
+    original_put_ledger = persistence.put_ledger
 
-    def hooked_put_snapshot(
+    def hooked_put_ledger(
         game_id: int,
         perspective: int,
         turn_number: int,
-        snapshot: FleetTurnSnapshot,
+        player_id: int,
+        persisted,
     ) -> None:
         nonlocal mid_chain_intercepted
-        original_put_snapshot(game_id, perspective, turn_number, snapshot)
+        original_put_ledger(game_id, perspective, turn_number, player_id, persisted)
         current_attempt_puts.append(turn_number)
         if turn_number == 111 and not mid_chain_intercepted:
             mid_chain_intercepted = True
@@ -626,7 +626,7 @@ def test_gap_fill_does_not_persist_torn_tail_after_mid_chain_invalidation(persis
             current_attempt_puts.clear()
             sync.wait()
 
-    persistence.put_snapshot = hooked_put_snapshot  # type: ignore[method-assign]
+    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
 
     gap_fill_error: BaseException | None = None
     snapshot: FleetTurnSnapshot | None = None
@@ -664,18 +664,19 @@ def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, lo
 
     turn_111 = load_turn(111)
     assert turn_111 is not None
-    original_put_snapshot = persistence.put_snapshot
+    original_put_ledger = persistence.put_ledger
 
-    def put_snapshot_that_invalidates(
+    def put_ledger_that_invalidates(
         game_id: int,
         perspective: int,
         turn_number: int,
-        snapshot: FleetTurnSnapshot,
+        player_id: int,
+        persisted,
     ) -> None:
-        original_put_snapshot(game_id, perspective, turn_number, snapshot)
+        original_put_ledger(game_id, perspective, turn_number, player_id, persisted)
         persistence.invalidate_for_turn_write(game_id, perspective, turn_number)
 
-    persistence.put_snapshot = put_snapshot_that_invalidates  # type: ignore[method-assign]
+    persistence.put_ledger = put_ledger_that_invalidates  # type: ignore[method-assign]
 
     with patch("api.analytics.fleet.chain.GAP_FILL_MAX_RETRIES", 3):
         with pytest.raises(ConflictError, match="exceeded 3 invalidation retries"):


### PR DESCRIPTION
## Summary

- Refactor fleet gap-fill to materialize one player at a time: advance prior ledger, apply turn-N evidence, refine from scores, persist with honest provenance flags (`turnEvidenceAtN`, `priorLedgerAtNMinus1`).
- Add shared `FleetTurnContext` (RST-derived inputs computed once per shell turn) and per-player ingest/refine entry points.
- Add `materialization_provenance` module and integration + unit tests for partial vs complete scores closure.

## Test plan

- [x] `make test` (full suite)
- [x] `test_fleet_materialization_provenance.py` -- partial/complete provenance, turn-context caching, per-player persistence
- [x] `test_fleet_materialization_provenance_policy.py` -- policy edge unit tests
- [x] `test_fleet_persistence.py` -- concurrency hooks updated for `put_ledger`

Closes #165


Made with [Cursor](https://cursor.com)