### PR TITLE
Fleet F7.3: ensure/probe provenance gates and compute short-circuit fix

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -223,6 +223,25 @@ def _snapshot_has_all_roster_players(snapshot: FleetTurnSnapshot, turn: TurnInfo
     return roster_ids <= present_ids
 
 
+def _snapshot_is_provenance_final_for_all_roster_players(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    turn: TurnInfo,
+) -> bool:
+    """True when every roster player has an ensure-final ledger at this turn."""
+    for player_id in _roster_player_ids(turn):
+        if not persistence.has_final_ledger(game_id, perspective, turn_number, player_id):
+            return False
+    return True
+
+
+def _is_fleet_ledger_cache_hit(persisted: PersistedFleetLedger) -> bool:
+    """Return whether a cached per-player ledger may short-circuit gap-fill."""
+    return persisted.provenance.is_final
+
+
 def _materialize_and_persist_player_turn(
     coherence: _GapFillCoherence,
     *,
@@ -276,7 +295,7 @@ def _materialize_fleet_ledger_chain_for_player(
     turn_number = turn.settings.turn
 
     existing = persistence.get_ledger(game_id, perspective, turn_number, player_id)
-    if existing is not None:
+    if existing is not None and _is_fleet_ledger_cache_hit(existing):
         return existing
 
     loaded_turns: dict[int, TurnInfo | None] = {}
@@ -453,7 +472,7 @@ def get_or_materialize_fleet_ledger_for_player(
     """Return a cached ledger or materialize turn T for one player."""
     turn_number = turn.settings.turn
     cached = persistence.get_ledger(game_id, perspective, turn_number, player_id)
-    if cached is not None:
+    if cached is not None and _is_fleet_ledger_cache_hit(cached):
         return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):
@@ -483,7 +502,9 @@ def get_or_materialize_fleet_ledger_for_player(
                 turn_number,
                 player_id,
             )
-            if cached_after_invalidation is not None:
+            if cached_after_invalidation is not None and _is_fleet_ledger_cache_hit(
+                cached_after_invalidation
+            ):
                 return cached_after_invalidation
             if attempt + 1 >= GAP_FILL_MAX_RETRIES:
                 break
@@ -495,7 +516,7 @@ def get_or_materialize_fleet_ledger_for_player(
         turn_number,
         player_id,
     )
-    if cached_after_retries is not None:
+    if cached_after_retries is not None and _is_fleet_ledger_cache_hit(cached_after_retries):
         return cached_after_retries
 
     raise ConflictError(
@@ -518,7 +539,14 @@ def get_or_materialize_fleet_snapshot(
     turn_number = turn.settings.turn
     cached = persistence.get_snapshot(game_id, perspective, turn_number)
     if cached is not None and _snapshot_has_all_roster_players(cached, turn):
-        return cached
+        if _snapshot_is_provenance_final_for_all_roster_players(
+            persistence,
+            game_id,
+            perspective,
+            turn_number,
+            turn,
+        ):
+            return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):
         coherence = _GapFillCoherence(
@@ -543,8 +571,16 @@ def get_or_materialize_fleet_snapshot(
                 perspective,
                 turn_number,
             )
-            if cached_after_invalidation is not None and _snapshot_has_all_roster_players(
-                cached_after_invalidation, turn
+            if (
+                cached_after_invalidation is not None
+                and _snapshot_has_all_roster_players(cached_after_invalidation, turn)
+                and _snapshot_is_provenance_final_for_all_roster_players(
+                    persistence,
+                    game_id,
+                    perspective,
+                    turn_number,
+                    turn,
+                )
             ):
                 return cached_after_invalidation
             if attempt + 1 >= GAP_FILL_MAX_RETRIES:
@@ -552,9 +588,16 @@ def get_or_materialize_fleet_snapshot(
             continue
 
     cached_after_retries = persistence.get_snapshot(game_id, perspective, turn_number)
-    if cached_after_retries is not None and _snapshot_has_all_roster_players(
-        cached_after_retries,
-        turn,
+    if (
+        cached_after_retries is not None
+        and _snapshot_has_all_roster_players(cached_after_retries, turn)
+        and _snapshot_is_provenance_final_for_all_roster_players(
+            persistence,
+            game_id,
+            perspective,
+            turn_number,
+            turn,
+        )
     ):
         return cached_after_retries
 

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -560,9 +560,7 @@ def get_or_materialize_fleet_snapshot(
     """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
     turn_number = turn.settings.turn
     cached = persistence.get_snapshot(game_id, perspective, turn_number)
-    if _is_fleet_snapshot_cache_hit(
-        persistence, game_id, perspective, turn_number, turn, cached
-    ):
+    if _is_fleet_snapshot_cache_hit(persistence, game_id, perspective, turn_number, turn, cached):
         return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -242,6 +242,28 @@ def _is_fleet_ledger_cache_hit(persisted: PersistedFleetLedger) -> bool:
     return persisted.provenance.is_final
 
 
+def _is_fleet_snapshot_cache_hit(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    turn: TurnInfo,
+    snapshot: FleetTurnSnapshot | None,
+) -> bool:
+    """Return whether a cached turn snapshot may short-circuit gap-fill."""
+    return (
+        snapshot is not None
+        and _snapshot_has_all_roster_players(snapshot, turn)
+        and _snapshot_is_provenance_final_for_all_roster_players(
+            persistence,
+            game_id,
+            perspective,
+            turn_number,
+            turn,
+        )
+    )
+
+
 def _materialize_and_persist_player_turn(
     coherence: _GapFillCoherence,
     *,
@@ -538,15 +560,10 @@ def get_or_materialize_fleet_snapshot(
     """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
     turn_number = turn.settings.turn
     cached = persistence.get_snapshot(game_id, perspective, turn_number)
-    if cached is not None and _snapshot_has_all_roster_players(cached, turn):
-        if _snapshot_is_provenance_final_for_all_roster_players(
-            persistence,
-            game_id,
-            perspective,
-            turn_number,
-            turn,
-        ):
-            return cached
+    if _is_fleet_snapshot_cache_hit(
+        persistence, game_id, perspective, turn_number, turn, cached
+    ):
+        return cached
 
     for attempt in range(GAP_FILL_MAX_RETRIES):
         coherence = _GapFillCoherence(
@@ -571,16 +588,13 @@ def get_or_materialize_fleet_snapshot(
                 perspective,
                 turn_number,
             )
-            if (
-                cached_after_invalidation is not None
-                and _snapshot_has_all_roster_players(cached_after_invalidation, turn)
-                and _snapshot_is_provenance_final_for_all_roster_players(
-                    persistence,
-                    game_id,
-                    perspective,
-                    turn_number,
-                    turn,
-                )
+            if _is_fleet_snapshot_cache_hit(
+                persistence,
+                game_id,
+                perspective,
+                turn_number,
+                turn,
+                cached_after_invalidation,
             ):
                 return cached_after_invalidation
             if attempt + 1 >= GAP_FILL_MAX_RETRIES:
@@ -588,16 +602,8 @@ def get_or_materialize_fleet_snapshot(
             continue
 
     cached_after_retries = persistence.get_snapshot(game_id, perspective, turn_number)
-    if (
-        cached_after_retries is not None
-        and _snapshot_has_all_roster_players(cached_after_retries, turn)
-        and _snapshot_is_provenance_final_for_all_roster_players(
-            persistence,
-            game_id,
-            perspective,
-            turn_number,
-            turn,
-        )
+    if _is_fleet_snapshot_cache_hit(
+        persistence, game_id, perspective, turn_number, turn, cached_after_retries
     ):
         return cached_after_retries
 

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -57,17 +57,31 @@ def _fleet_snapshot_for_scope(
     return ctx.export_snapshot_for(ANALYTIC_ID, scope, gather)
 
 
-def is_fleet_export_persisted(ctx: AnalyticQueryContext, scope: ExportScope) -> bool:
+def is_fleet_export_ensure_satisfied(ctx: AnalyticQueryContext, scope: ExportScope) -> bool:
+    """Probe/ensure hook: final only when per-player provenance is (true, true)."""
+    if scope.player_id is None:
+        return True
+
     services = resolve_fleet_services(ctx)
-    return services.persistence.has_snapshot(
+    if ctx.load_turn(scope.turn) is None:
+        return True
+
+    return services.persistence.has_final_ledger(
         services.game_id,
         services.perspective,
         scope.turn,
+        scope.player_id,
     )
 
 
+def is_fleet_export_persisted(ctx: AnalyticQueryContext, scope: ExportScope) -> bool:
+    if scope.player_id is None:
+        return False
+    return is_fleet_export_ensure_satisfied(ctx, scope)
+
+
 def ensure_fleet_export(ctx: AnalyticQueryContext, scope: ExportScope) -> bool:
-    if is_fleet_export_persisted(ctx, scope):
+    if is_fleet_export_ensure_satisfied(ctx, scope):
         return True
 
     turn = ctx.load_turn(scope.turn)
@@ -76,7 +90,7 @@ def ensure_fleet_export(ctx: AnalyticQueryContext, scope: ExportScope) -> bool:
 
     _fleet_snapshot_for_scope(ctx, scope, turn=turn)
     ctx.invalidate_export_scope_cache(ANALYTIC_ID, scope)
-    return is_fleet_export_persisted(ctx, scope)
+    return is_fleet_export_ensure_satisfied(ctx, scope)
 
 
 def _scores_search_status_for_scope(
@@ -146,4 +160,5 @@ EXPORT_CATALOG = AnalyticExportCatalog(
     ensure_export=ensure_fleet_export,
     materialize_export_tree=materialize_fleet_export_tree,
     is_persisted=is_fleet_export_persisted,
+    is_ensure_satisfied=is_fleet_export_ensure_satisfied,
 )

--- a/packages/api/tests/test_fleet_export_provenance_gates.py
+++ b/packages/api/tests/test_fleet_export_provenance_gates.py
@@ -1,0 +1,277 @@
+"""F7.3: fleet export ensure/probe provenance gates and compute short-circuit."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+from api.analytics.export_dependency_walk import walk_dependency_tree
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.chain import (
+    _materialize_fleet_ledger_chain_for_player,
+    get_or_materialize_fleet_snapshot,
+)
+from api.analytics.fleet.exports import EXPORT_CATALOG
+from api.analytics.fleet.types import (
+    FleetAcquisitionLedger,
+    FleetMaterializationProvenance,
+    PersistedFleetLedger,
+)
+from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+from tests.export_chain_test_fixtures import GAME_ID, export_chain_query_context
+from tests.fleet_exports_helpers import materialize_fleet_tree
+from tests.scores_exports_helpers import (
+    ensure_missing_step,
+    first_player_id,
+    perspective,
+    put_persisted_row,
+)
+
+
+def _partial_persisted_ledger(player_id: int) -> PersistedFleetLedger:
+    return PersistedFleetLedger(
+        ledger=FleetAcquisitionLedger(player_id=player_id),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=False,
+        ),
+    )
+
+
+def _turn_chain_through(sample_turn, *, through_turn: int):
+    chain = {}
+    for turn_number in range(1, through_turn + 1):
+        chain[turn_number] = replace(
+            sample_turn,
+            settings=replace(sample_turn.settings, turn=turn_number),
+            game=replace(sample_turn.game, turn=turn_number),
+        )
+    return chain
+
+
+def test_partial_fleet_ledger_is_not_ensure_satisfied(sample_turn, persistence):
+    player_id = first_player_id(sample_turn)
+    turn_number = 8
+    stored_turns = _turn_chain_through(sample_turn, through_turn=turn_number)
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    fleet_services.persistence.put_ledger(
+        GAME_ID,
+        perspective(sample_turn),
+        turn_number,
+        player_id,
+        _partial_persisted_ledger(player_id),
+    )
+
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        turn=turn_number,
+        player_id=player_id,
+    )
+
+    assert EXPORT_CATALOG.is_persisted(ctx, scope) is False
+    assert EXPORT_CATALOG.is_ensure_satisfied is not None
+    assert EXPORT_CATALOG.is_ensure_satisfied(ctx, scope) is False
+
+
+def test_probe_fleet_at_8_lists_missing_scores_5_6_7_with_partial_ledgers(
+    sample_turn,
+    persistence,
+):
+    """628580-style gap: partial fleet@8 with no scores rows for turns 5-7."""
+    player_id = first_player_id(sample_turn)
+    turn_number = 8
+    stored_turns = _turn_chain_through(sample_turn, through_turn=turn_number)
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    fleet_services.persistence.put_ledger(
+        GAME_ID,
+        perspective(sample_turn),
+        turn_number,
+        player_id,
+        _partial_persisted_ledger(player_id),
+    )
+    put_persisted_row(
+        persistence,
+        stored_turns[3],
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="seed",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+
+    probe = ctx.probe("fleet", {"turn": turn_number, "player_id": player_id})
+    assert probe.status == "ok"
+
+    missing_scores_turns = sorted(
+        step.turn
+        for step in probe.missing_steps
+        if step.analytic_id == "scores" and step.player_id == player_id
+    )
+    assert {5, 6, 7}.issubset(missing_scores_turns)
+
+    walk = walk_dependency_tree(
+        ctx,
+        "fleet",
+        ExportScope(
+            game_id=GAME_ID,
+            perspective=perspective(sample_turn),
+            turn=turn_number,
+            player_id=player_id,
+        ),
+        visiting=set(),
+    )
+    walk_scores_turns = sorted(
+        step.turn
+        for step in walk.missing_steps
+        if step.analytic_id == "scores" and step.player_id == player_id
+    )
+    assert {5, 6, 7}.issubset(walk_scores_turns)
+    fleet_step = ensure_missing_step(
+        probe,
+        analytic_id="fleet",
+        turn=turn_number,
+        player_id=player_id,
+    )
+    assert fleet_step.status == "not_persisted"
+
+
+def test_get_or_materialize_fleet_snapshot_does_not_short_circuit_on_partial_cache(
+    sample_turn,
+    persistence,
+):
+    player_id = first_player_id(sample_turn)
+    turn_number = 8
+    stored_turns = _turn_chain_through(sample_turn, through_turn=turn_number)
+    turn = stored_turns[turn_number]
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    fleet_services.persistence.put_ledger(
+        GAME_ID,
+        perspective(sample_turn),
+        turn_number,
+        player_id,
+        _partial_persisted_ledger(player_id),
+    )
+
+    with patch(
+        "api.analytics.fleet.chain._materialize_fleet_snapshot_chain",
+        side_effect=AssertionError("must not gap-fill when only partial cache exists"),
+    ):
+        with pytest.raises(AssertionError, match="must not gap-fill"):
+            get_or_materialize_fleet_snapshot(
+                fleet_services.persistence,
+                GAME_ID,
+                perspective(sample_turn),
+                turn,
+                load_turn=ctx.load_turn,
+                inference_materialization=fleet_services.inference_materialization,
+            )
+
+
+def test_get_or_materialize_fleet_ledger_rechains_when_cached_partial(
+    sample_turn,
+    persistence,
+):
+    player_id = first_player_id(sample_turn)
+    turn_number = 8
+    stored_turns = _turn_chain_through(sample_turn, through_turn=turn_number)
+    turn = stored_turns[turn_number]
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    fleet_services.persistence.put_ledger(
+        GAME_ID,
+        perspective(sample_turn),
+        turn_number,
+        player_id,
+        _partial_persisted_ledger(player_id),
+    )
+
+    materialize_calls = 0
+    original = _materialize_fleet_ledger_chain_for_player
+
+    def counting_materialize(*args, **kwargs):
+        nonlocal materialize_calls
+        materialize_calls += 1
+        return original(*args, **kwargs)
+
+    with patch(
+        "api.analytics.fleet.chain._materialize_fleet_ledger_chain_for_player",
+        side_effect=counting_materialize,
+    ):
+        get_or_materialize_fleet_snapshot(
+            fleet_services.persistence,
+            GAME_ID,
+            perspective(sample_turn),
+            turn,
+            load_turn=ctx.load_turn,
+            inference_materialization=fleet_services.inference_materialization,
+        )
+
+    assert materialize_calls >= 1
+    loaded = fleet_services.persistence.get_ledger(
+        GAME_ID,
+        perspective(sample_turn),
+        turn_number,
+        player_id,
+    )
+    assert loaded is not None
+    assert loaded.provenance.is_final is False
+
+
+def test_ensure_fleet_export_succeeds_when_provenance_final(sample_turn, persistence):
+    player_id = first_player_id(sample_turn)
+    turn_number = sample_turn.settings.turn
+    ctx = export_chain_query_context(
+        sample_turn,
+        persistence=persistence,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    put_persisted_row(
+        persistence,
+        sample_turn,
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="seed",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        turn=turn_number,
+        player_id=player_id,
+    )
+
+    assert EXPORT_CATALOG.ensure_export(ctx, scope) is True
+    assert EXPORT_CATALOG.is_ensure_satisfied(ctx, scope) is True
+
+    tree, _ = materialize_fleet_tree(ctx, player_id)
+    assert tree["meta"]["hostTurn"] == turn_number

--- a/packages/api/tests/test_fleet_exports.py
+++ b/packages/api/tests/test_fleet_exports.py
@@ -310,10 +310,11 @@ def test_ensure_fleet_export_materializes_snapshot_when_missing(sample_turn, per
 
     EXPORT_CATALOG.ensure_export(ctx, scope)
 
-    assert fleet_services.persistence.has_snapshot(
+    assert fleet_services.persistence.has_final_ledger(
         GAME_ID,
         perspective(sample_turn),
         turn_number,
+        player_id,
     )
 
 

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -19,8 +19,10 @@ from api.analytics.fleet.serialization import fleet_turn_snapshot_to_json
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
     FleetFieldKnown,
+    FleetMaterializationProvenance,
     FleetShipRecord,
     FleetTurnSnapshot,
+    PersistedFleetLedger,
 )
 from api.errors import ConflictError, NotFoundError, ValidationError
 from api.serialization.turn import turn_info_from_json
@@ -692,18 +694,43 @@ def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, lo
     assert persistence.invalidation_generation(628580, 1) == 3
 
 
+def _put_provenance_final_snapshot(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    turn,
+) -> FleetTurnSnapshot:
+    baseline = ensure_fleet_baseline(game_id, perspective, turn)
+    for ledger in baseline.players:
+        persistence.put_ledger(
+            game_id,
+            perspective,
+            turn.settings.turn,
+            ledger.player_id,
+            PersistedFleetLedger(
+                ledger=ledger,
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+    snapshot = persistence.get_snapshot(game_id, perspective, turn.settings.turn)
+    assert snapshot is not None
+    return snapshot
+
+
 def test_gap_fill_returns_cached_snapshot_when_peer_finished_during_retries(persistence, load_turn):
     """After invalidation retries, return a peer-written snapshot instead of ConflictError."""
     from api.analytics.fleet.chain import _FleetSnapshotInvalidated
 
     turn_110 = load_turn(110)
     assert turn_110 is not None
-    persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
 
     turn_111 = load_turn(111)
     assert turn_111 is not None
-    winner = ensure_fleet_baseline(628580, 1, turn_111)
-    persistence.put_snapshot(628580, 1, 111, winner)
+    winner = _put_provenance_final_snapshot(persistence, 628580, 1, turn_111)
 
     with patch(
         "api.analytics.fleet.chain._materialize_fleet_snapshot_chain",


### PR DESCRIPTION
## Summary

- Gate fleet export `is_ensure_satisfied` / `is_persisted` on per-player provenance `(true, true)` via `has_final_ledger`, and wire the hook on `EXPORT_CATALOG`.
- Stop fleet compute gap-fill from short-circuiting on partial cached ledgers or snapshots; only provenance-final cache hits skip materialization.
- Add F7.3 probe/ensure/walk tests for 628580-style partial `fleet@8` gaps (missing `scores@5/6/7`), and extract `_is_fleet_snapshot_cache_hit` so all snapshot short-circuit paths share one policy check.

Closes #166.

## Test plan

- [x] `cd packages/api && uv run pytest tests/test_fleet_export_provenance_gates.py tests/test_fleet_exports.py tests/test_fleet_persistence.py`
- [ ] `make test_api` (full API suite)


Made with [Cursor](https://cursor.com)