### PR TITLE
Fleet F7.4: per-player fleet invalidation on scores evidence (#167)

### DIFF
--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -269,16 +269,19 @@ class FleetSnapshotPersistenceService:
         turn_number: int,
     ) -> set[int]:
         """Drop fleet snapshots at turns >= turn_number for one perspective."""
-        cleared: set[int] = set()
-        for stored_turn in self._stored_turn_numbers(game_id, perspective):
-            if stored_turn < turn_number:
-                continue
+
+        def invalidate_turn(stored_turn: int) -> bool:
             if not self._document_exists(game_id, perspective, stored_turn):
-                continue
+                return False
             self.delete_snapshot(game_id, perspective, stored_turn)
-            cleared.add(stored_turn)
-        self._bump_invalidation_generation(game_id, perspective)
-        return cleared
+            return True
+
+        return self._invalidate_stored_turns_from(
+            game_id,
+            perspective,
+            turn_number,
+            invalidate_turn,
+        )
 
     def invalidate_player_ledgers_from_turn(
         self,
@@ -288,18 +291,37 @@ class FleetSnapshotPersistenceService:
         player_id: int,
     ) -> set[int]:
         """Drop one player's fleet ledgers at turns >= turn_number for one perspective."""
+
+        def invalidate_turn(stored_turn: int) -> bool:
+            document = self._load_document(game_id, perspective, stored_turn)
+            if document is None:
+                return False
+            ledgers = self._ledgers_object(document)
+            if str(player_id) not in ledgers:
+                return False
+            self._delete_ledger_entry(game_id, perspective, stored_turn, player_id)
+            return True
+
+        return self._invalidate_stored_turns_from(
+            game_id,
+            perspective,
+            turn_number,
+            invalidate_turn,
+        )
+
+    def _invalidate_stored_turns_from(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        invalidate_turn: Callable[[int], bool],
+    ) -> set[int]:
         cleared: set[int] = set()
         for stored_turn in self._stored_turn_numbers(game_id, perspective):
             if stored_turn < turn_number:
                 continue
-            document = self._load_document(game_id, perspective, stored_turn)
-            if document is None:
-                continue
-            ledgers = self._ledgers_object(document)
-            if str(player_id) not in ledgers:
-                continue
-            self._delete_ledger_entry(game_id, perspective, stored_turn, player_id)
-            cleared.add(stored_turn)
+            if invalidate_turn(stored_turn):
+                cleared.add(stored_turn)
         self._bump_invalidation_generation(game_id, perspective)
         return cleared
 

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -40,17 +40,16 @@ class FleetSnapshotPersistenceService:
     **fleet acquisition ledger** plus **fleet materialization provenance** and
     ``materializationVersion``.
 
-    Scores-invalidation coupling (F2.x): when scores inference rows are cleared
-    for host turn *H*, fleet snapshots at turns ``>= H`` for the same perspective
-    must be re-materialized so build evidence and reconciliation stay aligned.
-    ``InferenceInvalidationService.on_inference_evidence_updated`` performs that
-    invalidation when inference rows are persisted or held solutions stream in.
-    Fleet turn-document invalidation (``invalidate_for_turn_write``) is independent
-    of scores pair-aware invalidation (turn *T* and *T-1*); both hooks run from
+    Scores-invalidation coupling (F2.x): when scores inference evidence updates
+    for player P at host turn *H*, ``InferenceInvalidationService`` drops P's
+    ledgers at fleet turns ``>= H`` via ``invalidate_player_ledgers_from_turn``.
+    Turn document replace at *T* clears all players via
+    ``invalidate_for_turn_write``. Scores pair-aware invalidation (turn *T* and
+    *T-1*) is independent of fleet invalidation; both scores hooks run from
     ``on_turn_stored`` today.
 
     **Invalidation generation:** Each ``(game_id, perspective)`` pair has a
-    monotonic counter bumped on every ``invalidate_for_turn_write`` call. Gap-fill
+    monotonic counter bumped on every fleet invalidation call. Gap-fill
     in ``get_or_materialize_fleet_snapshot`` records the generation at chain start
     and aborts (then retries from a fresh anchor) when the counter advances during
     multi-turn materialization. Invalidation does not block on gap-fill; concurrent
@@ -277,6 +276,29 @@ class FleetSnapshotPersistenceService:
             if not self._document_exists(game_id, perspective, stored_turn):
                 continue
             self.delete_snapshot(game_id, perspective, stored_turn)
+            cleared.add(stored_turn)
+        self._bump_invalidation_generation(game_id, perspective)
+        return cleared
+
+    def invalidate_player_ledgers_from_turn(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_id: int,
+    ) -> set[int]:
+        """Drop one player's fleet ledgers at turns >= turn_number for one perspective."""
+        cleared: set[int] = set()
+        for stored_turn in self._stored_turn_numbers(game_id, perspective):
+            if stored_turn < turn_number:
+                continue
+            document = self._load_document(game_id, perspective, stored_turn)
+            if document is None:
+                continue
+            ledgers = self._ledgers_object(document)
+            if str(player_id) not in ledgers:
+                continue
+            self._delete_ledger_entry(game_id, perspective, stored_turn, player_id)
             cleared.add(stored_turn)
         self._bump_invalidation_generation(game_id, perspective)
         return cleared

--- a/packages/api/api/services/inference_invalidation_service.py
+++ b/packages/api/api/services/inference_invalidation_service.py
@@ -53,15 +53,16 @@ class InferenceInvalidationService:
         game_id: int,
         perspective: int,
         host_turn: int,
-        _player_id: int,
+        player_id: int,
     ) -> set[int]:
-        """Drop fleet snapshots at turns >= host_turn after scores inference evidence changes."""
+        """Drop one player's fleet ledgers at turns >= host_turn after scores evidence changes."""
         if self._fleet_persistence is None:
             return set()
-        return self._fleet_persistence.invalidate_for_turn_write(
+        return self._fleet_persistence.invalidate_player_ledgers_from_turn(
             game_id,
             perspective,
             host_turn,
+            player_id,
         )
 
     def wire_fleet_invalidation_to_persistence(self) -> None:

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -316,6 +316,76 @@ def test_invalidate_for_turn_write_drops_snapshots_at_and_after_turn(persistence
     assert persistence.get_snapshot(628580, 1, 112) is None
 
 
+def test_invalidate_player_ledgers_from_turn_drops_only_target_player(persistence):
+    player_8 = FleetAcquisitionLedger(player_id=8)
+    player_3 = FleetAcquisitionLedger(player_id=3)
+    for turn_number in (110, 111, 112):
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            8,
+            PersistedFleetLedger(ledger=player_8),
+        )
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            3,
+            PersistedFleetLedger(ledger=player_3),
+        )
+    assert persistence.invalidation_generation(628580, 1) == 0
+    cleared = persistence.invalidate_player_ledgers_from_turn(628580, 1, 111, 8)
+    assert cleared == {111, 112}
+    assert persistence.invalidation_generation(628580, 1) == 1
+    assert persistence.get_ledger(628580, 1, 110, 8) is not None
+    assert persistence.get_ledger(628580, 1, 110, 3) is not None
+    assert persistence.get_ledger(628580, 1, 111, 8) is None
+    assert persistence.get_ledger(628580, 1, 112, 8) is None
+    assert persistence.get_ledger(628580, 1, 111, 3) is not None
+    assert persistence.get_ledger(628580, 1, 112, 3) is not None
+
+
+def test_inference_evidence_updated_preserves_other_players_ledgers(memory_backend):
+    fleet_persistence, inference_persistence, _, _ = _wired_fleet_inference_services(memory_backend)
+    player_8 = FleetAcquisitionLedger(player_id=8)
+    player_3 = FleetAcquisitionLedger(player_id=3)
+    for turn_number in (111, 112):
+        fleet_persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            8,
+            PersistedFleetLedger(ledger=player_8),
+        )
+        fleet_persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            3,
+            PersistedFleetLedger(ledger=player_3),
+        )
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+    inference_persistence.put_row(
+        628580,
+        1,
+        111,
+        8,
+        PersistedInferenceRow(
+            status="exact",
+            summary="updated",
+            solution_count=1,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+    assert fleet_persistence.get_ledger(628580, 1, 111, 8) is None
+    assert fleet_persistence.get_ledger(628580, 1, 112, 8) is None
+    assert fleet_persistence.get_ledger(628580, 1, 111, 3) is not None
+    assert fleet_persistence.get_ledger(628580, 1, 112, 3) is not None
+
+
 def test_turn_store_invalidates_fleet_snapshots(memory_backend):
     _, turns, _, _, _ = build_service_stack(memory_backend)
     persistence = FleetSnapshotPersistenceService(memory_backend)
@@ -477,7 +547,13 @@ def test_inference_row_persisted_invalidates_cached_fleet_for_refinement(
             ],
         ),
     )
-    assert fleet_persistence.get_snapshot(628580, 1, 111) is None
+    assert fleet_persistence.get_ledger(628580, 1, 111, 8) is None
+    other_player_ids = [
+        player_id
+        for player_id in fleet_persistence.list_ledger_player_ids(628580, 1, 111)
+        if player_id != 8
+    ]
+    assert other_player_ids
 
     rematerialized = get_or_materialize_fleet_snapshot(
         fleet_persistence,
@@ -534,7 +610,7 @@ def test_held_solutions_scheduler_callback_invalidates_cached_fleet_snapshot(
     assert scheduler._on_held_solutions_updated is not None
     scheduler._on_held_solutions_updated(scheduled.session)
 
-    assert fleet_persistence.get_snapshot(628580, 1, turn_number) is None
+    assert fleet_persistence.get_ledger(628580, 1, turn_number, player_id) is None
 
 
 def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memory_backend):


### PR DESCRIPTION
## Summary

- When scores inference evidence updates for player P at host turn H, invalidate only P's fleet ledgers at turns `>= H` (same perspective) instead of wiping the whole turn document for all players.
- Turn document replace at T continues to clear all players via perspective-wide `invalidate_for_turn_write`.
- Extract `_invalidate_stored_turns_from` so perspective-wide and per-player invalidation share one turn-scan loop and generation bump.

Closes #167.

## Test plan

- [x] `uv run pytest packages/api/tests/test_fleet_persistence.py` (25 passed)
- [x] `make test` (full suite)
- [x] `test_invalidate_player_ledgers_from_turn_drops_only_target_player` -- P cleared, Q preserved
- [x] `test_inference_evidence_updated_preserves_other_players_ledgers` -- scores row persist wired path
- [x] `test_turn_store_invalidates_fleet_snapshots` -- turn reload still clears all players
- [x] Invalidation generation still bumps on fleet invalidation (gap-fill abort semantics preserved)


Made with [Cursor](https://cursor.com)