### PR TITLE
Fleet F7.5: fleet table NDJSON stream (Core + BFF)

### DIFF
--- a/packages/api/api/analytics/fleet/__init__.py
+++ b/packages/api/api/analytics/fleet/__init__.py
@@ -42,6 +42,30 @@ def _load_fleet_export_catalog():
     return EXPORT_CATALOG
 
 
+def iter_fleet_table_stream(
+    turn: TurnInfo,
+    player_ids: tuple[int, ...],
+    *,
+    game_id: int,
+    perspective: int,
+    fleet_services,
+    persistence,
+    scheduler=None,
+):
+    """Yield NDJSON wire events for fleet table materialization on one stream."""
+    from api.analytics.fleet.fleet_table_stream_rows import iter_fleet_table_stream_events
+
+    yield from iter_fleet_table_stream_events(
+        turn,
+        player_ids,
+        game_id=game_id,
+        perspective=perspective,
+        fleet_services=fleet_services,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+
+
 REGISTRATION = TurnAnalyticRegistration(
     catalog_entry=catalog_entry(ANALYTIC_ID),
     compute=compute_fleet,

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -1,0 +1,171 @@
+"""Per-player fleet table stream session and background materialization job."""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+import uuid
+from dataclasses import dataclass, field
+
+from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
+from api.analytics.fleet.compute_services import FleetComputeServices
+from api.analytics.fleet.serialization import (
+    fleet_acquisition_ledger_to_json,
+    fleet_ship_record_to_json,
+)
+from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord, PersistedFleetLedger
+from api.analytics.turn_roster import iter_turn_players
+from api.errors import PlanetsConsoleError
+from api.models.game import TurnInfo
+from api.transport.fleet_table_stream import (
+    fleet_complete_event,
+    fleet_error_event,
+    fleet_ledger_updated_event,
+    fleet_provenance_event,
+    fleet_record_refined_event,
+)
+
+
+class FleetPlayerCancelToken:
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+
+@dataclass
+class FleetPlayerStreamSession:
+    player_id: int
+    turn: TurnInfo
+    game_id: int
+    perspective: int
+    run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    cancel_token: FleetPlayerCancelToken = field(default_factory=FleetPlayerCancelToken)
+    event_queue: queue.Queue[dict[str, object]] = field(default_factory=queue.Queue)
+
+
+@dataclass
+class ScheduledFleetPlayer:
+    player_id: int
+    session: FleetPlayerStreamSession
+
+
+def _records_by_id(ledger: FleetAcquisitionLedger | None) -> dict[str, FleetShipRecord]:
+    if ledger is None:
+        return {}
+    return {record.record_id: record for record in ledger.records}
+
+
+def _record_refined(before: FleetShipRecord, after: FleetShipRecord) -> bool:
+    before_wire = fleet_ship_record_to_json(before)
+    after_wire = fleet_ship_record_to_json(after)
+    return json.dumps(before_wire, sort_keys=True) != json.dumps(after_wire, sort_keys=True)
+
+
+def _wire_provenance(persisted: PersistedFleetLedger) -> dict[str, object]:
+    return fleet_provenance_event(
+        turn_evidence_at_n=persisted.provenance.turn_evidence_at_n,
+        prior_ledger_at_n_minus_1=persisted.provenance.prior_ledger_at_n_minus_1,
+        is_final=persisted.provenance.is_final,
+    )
+
+
+def wire_cached_player_events(persisted: PersistedFleetLedger) -> tuple[dict[str, object], ...]:
+    """Replay terminal stream events for an ensure-final cached ledger."""
+    return (
+        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_json(persisted.ledger)),
+        _wire_provenance(persisted),
+        fleet_complete_event(
+            is_final=True,
+            summary="Fleet ledger loaded from cache.",
+        ),
+    )
+
+
+def wire_materialized_player_events(
+    *,
+    before: FleetAcquisitionLedger | None,
+    persisted: PersistedFleetLedger,
+) -> tuple[dict[str, object], ...]:
+    """Build wire events after materialization completes for one player."""
+    before_records = _records_by_id(before)
+    after_records = _records_by_id(persisted.ledger)
+    events: list[dict[str, object]] = []
+    for record_id, record in after_records.items():
+        prior = before_records.get(record_id)
+        if prior is not None and _record_refined(prior, record):
+            events.append(fleet_record_refined_event(record=fleet_ship_record_to_json(record)))
+    events.append(
+        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_json(persisted.ledger))
+    )
+    events.append(_wire_provenance(persisted))
+    summary = (
+        "Fleet ledger materialization complete."
+        if persisted.provenance.is_final
+        else "Fleet ledger materialized with open provenance legs."
+    )
+    events.append(
+        fleet_complete_event(
+            is_final=persisted.provenance.is_final,
+            summary=summary,
+        )
+    )
+    return tuple(events)
+
+
+def run_fleet_player_materialization_job(
+    session: FleetPlayerStreamSession,
+    *,
+    fleet_services: FleetComputeServices,
+    persistence,
+) -> None:
+    """Materialize one player's fleet ledger and enqueue stream wire events."""
+    if session.cancel_token.is_cancelled():
+        return
+
+    player_id = session.player_id
+    turn = session.turn
+    roster_ids = {player.id for player in iter_turn_players(turn)}
+    if player_id not in roster_ids:
+        session.event_queue.put(
+            fleet_error_event(f"Player {player_id} is not on turn {turn.settings.turn} roster")
+        )
+        return
+
+    turn_number = turn.settings.turn
+    before_persisted = persistence.get_ledger(
+        fleet_services.game_id,
+        fleet_services.perspective,
+        turn_number,
+        player_id,
+    )
+    before_ledger = before_persisted.ledger if before_persisted is not None else None
+
+    try:
+        persisted = get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            fleet_services.game_id,
+            fleet_services.perspective,
+            player_id,
+            turn,
+            load_turn=fleet_services.load_turn,
+            inference_materialization=fleet_services.inference_materialization,
+        )
+    except PlanetsConsoleError as exc:
+        detail = str(exc) or "Fleet ledger materialization failed"
+        session.event_queue.put(fleet_error_event(detail))
+        return
+    except Exception:
+        session.event_queue.put(fleet_error_event("Fleet ledger materialization failed"))
+        return
+
+    if session.cancel_token.is_cancelled():
+        return
+
+    for event in wire_materialized_player_events(before=before_ledger, persisted=persisted):
+        session.event_queue.put(event)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
@@ -1,0 +1,146 @@
+"""Lifecycle controller for one fleet table NDJSON stream."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+
+from api.analytics.fleet.compute_services import FleetComputeServices
+from api.analytics.fleet.fleet_table_player_run import ScheduledFleetPlayer
+from api.analytics.fleet.fleet_table_stream_registry import (
+    attach_fleet_table_stream,
+    detach_fleet_table_stream,
+)
+from api.analytics.fleet.fleet_table_stream_rows import (
+    PlayerAdmissionDispatch,
+    resolve_player_stream_admission,
+    schedule_fleet_player_run,
+    tag_fleet_table_stream_event,
+)
+from api.analytics.fleet.fleet_table_stream_scheduler import FleetTableStreamScheduler
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.models.game import TurnInfo
+
+
+@dataclass
+class FleetTableStreamController:
+    scope: FleetTableStreamScope
+    stream_token: str
+    turn: TurnInfo
+    player_ids: tuple[int, ...]
+    scheduler: FleetTableStreamScheduler
+    fleet_services: FleetComputeServices
+    persistence: FleetSnapshotPersistenceService
+    scheduled_players: dict[int, ScheduledFleetPlayer] = field(default_factory=dict)
+    pending_wire_events: list[dict[str, object]] = field(default_factory=list)
+    finished_run_ids: set[str] = field(default_factory=set)
+    stream_lock: threading.Lock = field(default_factory=threading.Lock)
+    wake_multiplex: threading.Event = field(default_factory=threading.Event)
+
+    def drain_pending_wire_events(self) -> list[dict[str, object]]:
+        with self.stream_lock:
+            pending = self.pending_wire_events
+            self.pending_wire_events = []
+            return pending
+
+    def current_scheduled_players(self) -> tuple[ScheduledFleetPlayer, ...]:
+        with self.stream_lock:
+            return tuple(self.scheduled_players.values())
+
+    def register_scheduled_player(self, player_id: int, row: ScheduledFleetPlayer) -> None:
+        with self.stream_lock:
+            self.scheduled_players[player_id] = row
+
+    def _dispatch_player_admission(
+        self,
+        player_id: int,
+        admission,
+    ) -> PlayerAdmissionDispatch:
+        from api.analytics.fleet.fleet_table_stream_rows import CachedCompletePlayerAdmission
+
+        if isinstance(admission, CachedCompletePlayerAdmission):
+            return PlayerAdmissionDispatch(
+                wire_events=tuple(
+                    tag_fleet_table_stream_event(event, player_id=player_id)
+                    for event in admission.events
+                ),
+            )
+        scheduled = schedule_fleet_player_run(
+            self.scheduler,
+            turn=self.turn,
+            player_id=player_id,
+            game_id=self.fleet_services.game_id,
+            perspective=self.fleet_services.perspective,
+            fleet_services=self.fleet_services,
+            persistence=self.persistence,
+            stream_token=self.stream_token,
+        )
+        if scheduled is None:
+            return PlayerAdmissionDispatch(schedule_failed=True)
+        return PlayerAdmissionDispatch(scheduled_player=scheduled)
+
+    def _register_admitted_schedule(self, player_id: int, admission) -> bool:
+        dispatch = self._dispatch_player_admission(player_id, admission)
+        if dispatch.schedule_failed:
+            return False
+        if dispatch.wire_events:
+            self.pending_wire_events.extend(dispatch.wire_events)
+        if dispatch.scheduled_player is not None:
+            self.scheduled_players[player_id] = dispatch.scheduled_player
+            self.finished_run_ids.discard(dispatch.scheduled_player.session.run_id)
+        return True
+
+    def reschedule_player(self, player_id: int) -> bool:
+        with self.stream_lock:
+            old_row = self.scheduled_players.get(player_id)
+            if old_row is not None:
+                self.scheduler.cancel_player_run(old_row.session.run_id)
+                self.finished_run_ids.discard(old_row.session.run_id)
+            self.scheduled_players.pop(player_id, None)
+            admission = resolve_player_stream_admission(
+                self.persistence,
+                game_id=self.fleet_services.game_id,
+                perspective=self.fleet_services.perspective,
+                turn_number=self.turn.settings.turn,
+                player_id=player_id,
+            )
+            if not self._register_admitted_schedule(player_id, admission):
+                return False
+        self.wake_multiplex.set()
+        return True
+
+    def reschedule_all_players(self, *, force_schedule: bool = False) -> bool:
+        with self.stream_lock:
+            for player_id in self.player_ids:
+                old_row = self.scheduled_players.get(player_id)
+                if old_row is not None:
+                    self.scheduler.cancel_player_run(old_row.session.run_id)
+            self.finished_run_ids.clear()
+            self.scheduled_players.clear()
+            for player_id in self.player_ids:
+                admission = resolve_player_stream_admission(
+                    self.persistence,
+                    game_id=self.fleet_services.game_id,
+                    perspective=self.fleet_services.perspective,
+                    turn_number=self.turn.settings.turn,
+                    player_id=player_id,
+                    force_schedule=force_schedule,
+                )
+                if not self._register_admitted_schedule(player_id, admission):
+                    return False
+        self.wake_multiplex.set()
+        return True
+
+    def attach(self) -> None:
+        attach_fleet_table_stream(self)
+
+    def detach(self) -> None:
+        detach_fleet_table_stream(self.stream_token)
+
+    def end_stream(self, scheduler: FleetTableStreamScheduler) -> None:
+        scheduler.end_fleet_table_stream(
+            self.scope,
+            tuple(row.session for row in self.current_scheduled_players()),
+            stream_token=self.stream_token,
+        )

--- a/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
@@ -12,7 +12,9 @@ from api.analytics.fleet.fleet_table_stream_registry import (
     detach_fleet_table_stream,
 )
 from api.analytics.fleet.fleet_table_stream_rows import (
+    CachedCompletePlayerAdmission,
     PlayerAdmissionDispatch,
+    PlayerStreamAdmission,
     resolve_player_stream_admission,
     schedule_fleet_player_run,
     tag_fleet_table_stream_event,
@@ -52,13 +54,11 @@ class FleetTableStreamController:
         with self.stream_lock:
             self.scheduled_players[player_id] = row
 
-    def _dispatch_player_admission(
+    def dispatch_player_admission(
         self,
         player_id: int,
-        admission,
+        admission: PlayerStreamAdmission,
     ) -> PlayerAdmissionDispatch:
-        from api.analytics.fleet.fleet_table_stream_rows import CachedCompletePlayerAdmission
-
         if isinstance(admission, CachedCompletePlayerAdmission):
             return PlayerAdmissionDispatch(
                 wire_events=tuple(
@@ -81,7 +81,7 @@ class FleetTableStreamController:
         return PlayerAdmissionDispatch(scheduled_player=scheduled)
 
     def _register_admitted_schedule(self, player_id: int, admission) -> bool:
-        dispatch = self._dispatch_player_admission(player_id, admission)
+        dispatch = self.dispatch_player_admission(player_id, admission)
         if dispatch.schedule_failed:
             return False
         if dispatch.wire_events:

--- a/packages/api/api/analytics/fleet/fleet_table_stream_registry.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_registry.py
@@ -1,0 +1,57 @@
+"""Registry for active fleet table NDJSON streams (in-place reschedule)."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+
+if TYPE_CHECKING:
+    from api.analytics.fleet.fleet_table_stream_controller import FleetTableStreamController
+
+_registry_lock = threading.Lock()
+_active_controllers: dict[FleetTableStreamScope, FleetTableStreamController] = {}
+
+
+def attach_fleet_table_stream(controller: FleetTableStreamController) -> None:
+    with _registry_lock:
+        _active_controllers[controller.scope] = controller
+
+
+def detach_fleet_table_stream(stream_token: str) -> None:
+    with _registry_lock:
+        for scope, controller in list(_active_controllers.items()):
+            if controller.stream_token == stream_token:
+                del _active_controllers[scope]
+                return
+
+
+def controller_for_scope(scope: FleetTableStreamScope) -> FleetTableStreamController | None:
+    with _registry_lock:
+        return _active_controllers.get(scope)
+
+
+def reschedule_fleet_table_player(scope: FleetTableStreamScope, player_id: int) -> bool:
+    """Cancel and reschedule one player on the open fleet table stream for ``scope``."""
+    controller = controller_for_scope(scope)
+    if controller is None:
+        return False
+    return controller.reschedule_player(player_id)
+
+
+def reschedule_all_fleet_table_players(
+    scope: FleetTableStreamScope,
+    *,
+    force_schedule: bool = False,
+) -> bool:
+    """Cancel and reschedule every player on the open fleet table stream for ``scope``."""
+    controller = controller_for_scope(scope)
+    if controller is None:
+        return False
+    return controller.reschedule_all_players(force_schedule=force_schedule)
+
+
+def reset_fleet_table_stream_registry_for_tests() -> None:
+    with _registry_lock:
+        _active_controllers.clear()

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -1,0 +1,336 @@
+"""Fleet table NDJSON stream helpers: player scheduling, multiplexing, and lifecycle."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Literal
+
+from api.analytics.fleet.compute_services import FleetComputeServices
+from api.analytics.fleet.fleet_table_player_run import (
+    FleetPlayerStreamSession,
+    ScheduledFleetPlayer,
+    run_fleet_player_materialization_job,
+    wire_cached_player_events,
+)
+from api.analytics.fleet.fleet_table_stream_scheduler import (
+    FleetTableStreamScheduler,
+    TableStreamScopeAlreadyActive,
+    get_fleet_table_stream_scheduler,
+)
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.models.game import TurnInfo
+from api.transport.fleet_table_stream import (
+    TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    fleet_error_event,
+)
+
+_MULTiplexWaitSeconds = 0.05
+
+
+@dataclass(frozen=True)
+class ImmediatePlayerAdmission:
+    kind: Literal["immediate"] = "immediate"
+    events: tuple[dict[str, object], ...] = ()
+
+
+@dataclass(frozen=True)
+class CachedCompletePlayerAdmission:
+    kind: Literal["cached"] = "cached"
+    events: tuple[dict[str, object], ...] = ()
+
+
+@dataclass(frozen=True)
+class SchedulePlayerAdmission:
+    kind: Literal["schedule"] = "schedule"
+
+
+PlayerStreamAdmission = (
+    ImmediatePlayerAdmission | CachedCompletePlayerAdmission | SchedulePlayerAdmission
+)
+
+
+@dataclass(frozen=True)
+class PlayerAdmissionDispatch:
+    wire_events: tuple[dict[str, object], ...] = ()
+    scheduled_player: ScheduledFleetPlayer | None = None
+    schedule_failed: bool = False
+
+
+def tag_fleet_table_stream_event(
+    event: dict[str, object],
+    *,
+    player_id: int,
+) -> dict[str, object]:
+    if "playerId" in event:
+        return event
+    return {**event, "playerId": player_id}
+
+
+def resolve_player_stream_admission(
+    persistence: FleetSnapshotPersistenceService,
+    *,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_id: int,
+    force_schedule: bool = False,
+) -> PlayerStreamAdmission:
+    """Decide whether a fleet table player is cached-complete or needs scheduling."""
+    if not force_schedule:
+        persisted = persistence.get_ledger(game_id, perspective, turn_number, player_id)
+        if persisted is not None and persisted.provenance.is_final:
+            return CachedCompletePlayerAdmission(events=wire_cached_player_events(persisted))
+    return SchedulePlayerAdmission()
+
+
+def schedule_fleet_player_run(
+    scheduler: FleetTableStreamScheduler,
+    *,
+    turn: TurnInfo,
+    player_id: int,
+    game_id: int,
+    perspective: int,
+    fleet_services: FleetComputeServices,
+    persistence: FleetSnapshotPersistenceService,
+    stream_token: str | None = None,
+) -> ScheduledFleetPlayer | None:
+    session = FleetPlayerStreamSession(
+        player_id=player_id,
+        turn=turn,
+        game_id=game_id,
+        perspective=perspective,
+    )
+
+    def materialize(active_session: FleetPlayerStreamSession) -> None:
+        run_fleet_player_materialization_job(
+            active_session,
+            fleet_services=fleet_services,
+            persistence=persistence,
+        )
+
+    scheduler.enqueue_player_run(
+        session,
+        materialize,
+        stream_token=stream_token,
+    )
+    if stream_token is not None and not scheduler.owns_table_stream(stream_token):
+        return None
+    active_session = scheduler.row_run_for_player(
+        FleetTableStreamScope(
+            game_id=game_id,
+            perspective=perspective,
+            turn_number=turn.settings.turn,
+        ),
+        player_id,
+    )
+    if active_session is None:
+        return None
+    return ScheduledFleetPlayer(player_id=player_id, session=active_session)
+
+
+def drain_available_multiplex_events(
+    players: tuple[ScheduledFleetPlayer, ...],
+    *,
+    tag_player_id: bool,
+    finished_run_ids: set[str],
+) -> Iterator[dict[str, object]]:
+    """Yield any events already queued without blocking."""
+    for row in players:
+        if row.session.run_id in finished_run_ids:
+            continue
+        while True:
+            try:
+                event = row.session.event_queue.get_nowait()
+            except queue.Empty:
+                break
+            if tag_player_id:
+                event = tag_fleet_table_stream_event(event, player_id=row.player_id)
+            if event.get("type") in ("complete", "error"):
+                finished_run_ids.add(row.session.run_id)
+            yield event
+
+
+def iter_multiplexed_fleet_table_events(
+    players: tuple[ScheduledFleetPlayer, ...],
+    *,
+    tag_player_id: bool,
+    finished_run_ids: set[str] | None = None,
+    is_stream_active: Callable[[], bool] | None = None,
+    player_provider: Callable[[], tuple[ScheduledFleetPlayer, ...]] | None = None,
+    pending_events_provider: Callable[[], list[dict[str, object]]] | None = None,
+    wake_event: threading.Event | None = None,
+) -> Iterator[dict[str, object]]:
+    """Round-robin blocking reads across player event queues until players finish."""
+    finished = finished_run_ids if finished_run_ids is not None else set()
+    cursor = 0
+
+    def active_players() -> tuple[ScheduledFleetPlayer, ...]:
+        if player_provider is not None:
+            return player_provider()
+        return players
+
+    def refresh_pending_run_ids() -> set[str]:
+        return {
+            row.session.run_id for row in active_players() if row.session.run_id not in finished
+        }
+
+    pending_run_ids = refresh_pending_run_ids()
+
+    while pending_run_ids or (is_stream_active is not None and is_stream_active()):
+        if not pending_run_ids and not (is_stream_active is not None and is_stream_active()):
+            return
+        if pending_events_provider is not None:
+            for event in pending_events_provider():
+                yield event
+        if not pending_run_ids:
+            if wake_event is not None:
+                wake_event.wait(timeout=_MULTiplexWaitSeconds)
+                if wake_event.is_set():
+                    wake_event.clear()
+                pending_run_ids = refresh_pending_run_ids()
+            continue
+        active_rows = list(active_players())
+        if not active_rows:
+            continue
+        row = active_rows[cursor % len(active_rows)]
+        cursor += 1
+        if row.session.run_id not in pending_run_ids:
+            continue
+        try:
+            event = row.session.event_queue.get(timeout=_MULTiplexWaitSeconds)
+        except queue.Empty:
+            if wake_event is not None and wake_event.is_set():
+                wake_event.clear()
+                pending_run_ids = refresh_pending_run_ids()
+            continue
+        if tag_player_id:
+            event = tag_fleet_table_stream_event(event, player_id=row.player_id)
+        if event.get("type") in ("complete", "error"):
+            pending_run_ids.discard(row.session.run_id)
+            finished.add(row.session.run_id)
+        yield event
+
+
+def cleanup_fleet_table_stream_sessions(
+    scheduler: FleetTableStreamScheduler,
+    scope: FleetTableStreamScope,
+    sessions: tuple[FleetPlayerStreamSession, ...],
+    *,
+    stream_token: str,
+) -> None:
+    if sessions:
+        scheduler.end_fleet_table_stream(scope, sessions, stream_token=stream_token)
+
+
+def iter_fleet_table_stream_events(
+    turn: TurnInfo,
+    player_ids: tuple[int, ...],
+    *,
+    game_id: int,
+    perspective: int,
+    fleet_services: FleetComputeServices,
+    persistence: FleetSnapshotPersistenceService,
+    scheduler: FleetTableStreamScheduler | None = None,
+) -> Iterator[dict[str, object]]:
+    """Yield tagged fleet table events for all requested players on one NDJSON stream."""
+    from api.analytics.fleet.fleet_table_stream_controller import FleetTableStreamController
+
+    turn_number = turn.settings.turn
+    stream_scope = FleetTableStreamScope(
+        game_id=game_id,
+        perspective=perspective,
+        turn_number=turn_number,
+    )
+    scheduler = scheduler or get_fleet_table_stream_scheduler()
+    try:
+        stream_token = scheduler.begin_scope(stream_scope)
+    except TableStreamScopeAlreadyActive:
+        yield fleet_error_event(TABLE_STREAM_ALREADY_ACTIVE_DETAIL)
+        return
+
+    controller = FleetTableStreamController(
+        scope=stream_scope,
+        stream_token=stream_token,
+        turn=turn,
+        player_ids=player_ids,
+        scheduler=scheduler,
+        fleet_services=fleet_services,
+        persistence=persistence,
+    )
+    controller.attach()
+
+    def dispatch_player_admission(
+        player_id: int,
+        admission: PlayerStreamAdmission,
+    ) -> PlayerAdmissionDispatch:
+        if isinstance(admission, CachedCompletePlayerAdmission):
+            return PlayerAdmissionDispatch(
+                wire_events=tuple(
+                    tag_fleet_table_stream_event(event, player_id=player_id)
+                    for event in admission.events
+                ),
+            )
+        scheduled = schedule_fleet_player_run(
+            scheduler,
+            turn=turn,
+            player_id=player_id,
+            game_id=game_id,
+            perspective=perspective,
+            fleet_services=fleet_services,
+            persistence=persistence,
+            stream_token=stream_token,
+        )
+        if scheduled is None:
+            return PlayerAdmissionDispatch(schedule_failed=True)
+        return PlayerAdmissionDispatch(scheduled_player=scheduled)
+
+    try:
+        for player_id in player_ids:
+            if not scheduler.owns_table_stream(stream_token):
+                return
+
+            admission = resolve_player_stream_admission(
+                persistence,
+                game_id=game_id,
+                perspective=perspective,
+                turn_number=turn_number,
+                player_id=player_id,
+            )
+            dispatch = dispatch_player_admission(player_id, admission)
+            if dispatch.schedule_failed:
+                return
+
+            yield from dispatch.wire_events
+
+            if dispatch.scheduled_player is not None:
+                controller.register_scheduled_player(player_id, dispatch.scheduled_player)
+                yield from drain_available_multiplex_events(
+                    controller.current_scheduled_players(),
+                    tag_player_id=True,
+                    finished_run_ids=controller.finished_run_ids,
+                )
+
+        if player_ids and controller.current_scheduled_players():
+            try:
+                yield from iter_multiplexed_fleet_table_events(
+                    controller.current_scheduled_players(),
+                    tag_player_id=True,
+                    finished_run_ids=controller.finished_run_ids,
+                    is_stream_active=lambda: scheduler.owns_table_stream(stream_token),
+                    player_provider=controller.current_scheduled_players,
+                    pending_events_provider=controller.drain_pending_wire_events,
+                    wake_event=controller.wake_multiplex,
+                )
+            finally:
+                cleanup_fleet_table_stream_sessions(
+                    scheduler,
+                    stream_scope,
+                    tuple(row.session for row in controller.current_scheduled_players()),
+                    stream_token=stream_token,
+                )
+    finally:
+        controller.detach()

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -268,31 +268,6 @@ def iter_fleet_table_stream_events(
     )
     controller.attach()
 
-    def dispatch_player_admission(
-        player_id: int,
-        admission: PlayerStreamAdmission,
-    ) -> PlayerAdmissionDispatch:
-        if isinstance(admission, CachedCompletePlayerAdmission):
-            return PlayerAdmissionDispatch(
-                wire_events=tuple(
-                    tag_fleet_table_stream_event(event, player_id=player_id)
-                    for event in admission.events
-                ),
-            )
-        scheduled = schedule_fleet_player_run(
-            scheduler,
-            turn=turn,
-            player_id=player_id,
-            game_id=game_id,
-            perspective=perspective,
-            fleet_services=fleet_services,
-            persistence=persistence,
-            stream_token=stream_token,
-        )
-        if scheduled is None:
-            return PlayerAdmissionDispatch(schedule_failed=True)
-        return PlayerAdmissionDispatch(scheduled_player=scheduled)
-
     try:
         for player_id in player_ids:
             if not scheduler.owns_table_stream(stream_token):
@@ -305,7 +280,7 @@ def iter_fleet_table_stream_events(
                 turn_number=turn_number,
                 player_id=player_id,
             )
-            dispatch = dispatch_player_admission(player_id, admission)
+            dispatch = controller.dispatch_player_admission(player_id, admission)
             if dispatch.schedule_failed:
                 return
 

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -180,8 +180,13 @@ def iter_multiplexed_fleet_table_events(
 
     pending_run_ids = refresh_pending_run_ids()
 
-    while pending_run_ids or (is_stream_active is not None and is_stream_active()):
-        if not pending_run_ids and not (is_stream_active is not None and is_stream_active()):
+    def should_continue() -> bool:
+        if is_stream_active is not None:
+            return is_stream_active()
+        return bool(pending_run_ids)
+
+    while should_continue():
+        if is_stream_active is not None and not is_stream_active():
             return
         if pending_events_provider is not None:
             for event in pending_events_provider():
@@ -314,7 +319,7 @@ def iter_fleet_table_stream_events(
                     finished_run_ids=controller.finished_run_ids,
                 )
 
-        if player_ids and controller.current_scheduled_players():
+        if player_ids:
             try:
                 yield from iter_multiplexed_fleet_table_events(
                     controller.current_scheduled_players(),

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -1,0 +1,184 @@
+"""Process-wide scheduler for fleet table stream per-player materialization jobs."""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from api.analytics.fleet.fleet_table_player_run import (
+    FleetPlayerStreamSession,
+)
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.errors import PlanetsConsoleError
+
+_DEFAULT_WORKER_COUNT = 4
+_DEQUEUE_WAIT_SECONDS = 0.25
+
+
+class TableStreamScopeAlreadyActive(PlanetsConsoleError):
+    """Another NDJSON fleet table stream already owns this turn scope."""
+
+
+@dataclass(frozen=True)
+class FleetPlayerJob:
+    session: FleetPlayerStreamSession
+    materialize: Callable[[FleetPlayerStreamSession], None]
+
+
+class FleetTableStreamScheduler:
+    """Fair scheduler: one materialization job per player on a table stream."""
+
+    def __init__(self, worker_count: int = _DEFAULT_WORKER_COUNT) -> None:
+        self._work_queue: deque[FleetPlayerJob] = deque()
+        self._runs: dict[str, FleetPlayerStreamSession] = {}
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._worker_count = worker_count
+        self._workers: list[threading.Thread] = []
+        self._shutdown = False
+        self._active_scope: FleetTableStreamScope | None = None
+        self._has_active_table_stream = False
+        self._active_table_stream_token: str | None = None
+        for _ in range(worker_count):
+            thread = threading.Thread(target=self._worker_loop, daemon=True)
+            thread.start()
+            self._workers.append(thread)
+
+    def begin_scope(self, scope: FleetTableStreamScope) -> str:
+        with self._condition:
+            if self._active_scope == scope and self._has_active_table_stream:
+                raise TableStreamScopeAlreadyActive()
+            if self._active_scope != scope:
+                self._invalidate_retained_state_locked()
+                self._active_scope = scope
+            stream_token = str(uuid.uuid4())
+            self._has_active_table_stream = True
+            self._active_table_stream_token = stream_token
+            return stream_token
+
+    def owns_table_stream(self, stream_token: str) -> bool:
+        with self._condition:
+            return self._active_table_stream_token == stream_token
+
+    def active_scope_matches(self, scope: FleetTableStreamScope) -> bool:
+        with self._condition:
+            return self._active_scope == scope
+
+    def row_run_for_player(
+        self,
+        scope: FleetTableStreamScope,
+        player_id: int,
+    ) -> FleetPlayerStreamSession | None:
+        with self._condition:
+            for session in self._runs.values():
+                if (
+                    session.game_id == scope.game_id
+                    and session.perspective == scope.perspective
+                    and session.turn.settings.turn == scope.turn_number
+                    and session.player_id == player_id
+                ):
+                    return session
+            return None
+
+    def enqueue_player_run(
+        self,
+        session: FleetPlayerStreamSession,
+        materialize: Callable[[FleetPlayerStreamSession], None],
+        *,
+        stream_token: str | None = None,
+    ) -> FleetPlayerStreamSession | None:
+        with self._condition:
+            if stream_token is not None and self._active_table_stream_token != stream_token:
+                return None
+            for existing in self._runs.values():
+                if existing.player_id == session.player_id:
+                    return existing
+            self._runs[session.run_id] = session
+            self._work_queue.append(FleetPlayerJob(session=session, materialize=materialize))
+            self._condition.notify()
+            return session
+
+    def cancel_player_run(self, run_id: str) -> None:
+        with self._condition:
+            session = self._runs.get(run_id)
+            if session is not None:
+                session.cancel_token.cancel()
+            self._work_queue = deque(
+                job for job in self._work_queue if job.session.run_id != run_id
+            )
+            self._runs.pop(run_id, None)
+            self._condition.notify_all()
+
+    def end_fleet_table_stream(
+        self,
+        scope: FleetTableStreamScope,
+        sessions: tuple[FleetPlayerStreamSession, ...],
+        *,
+        stream_token: str,
+    ) -> None:
+        with self._condition:
+            owns_scope = self._active_table_stream_token == stream_token
+            for session in sessions:
+                session.cancel_token.cancel()
+                self._work_queue = deque(
+                    job for job in self._work_queue if job.session.run_id != session.run_id
+                )
+                self._runs.pop(session.run_id, None)
+            if owns_scope and self._active_scope == scope:
+                self._has_active_table_stream = False
+                self._active_table_stream_token = None
+            self._condition.notify_all()
+
+    def _invalidate_retained_state_locked(self) -> None:
+        for session in self._runs.values():
+            session.cancel_token.cancel()
+        self._runs.clear()
+        self._work_queue.clear()
+
+    def _worker_loop(self) -> None:
+        while True:
+            with self._condition:
+                while not self._shutdown and not self._work_queue:
+                    self._condition.wait(timeout=_DEQUEUE_WAIT_SECONDS)
+                if self._shutdown:
+                    return
+                job = self._work_queue.popleft()
+            if job.session.cancel_token.is_cancelled():
+                continue
+            try:
+                job.materialize(job.session)
+            except Exception:
+                continue
+
+
+_process_scheduler: FleetTableStreamScheduler | None = None
+_process_scheduler_lock = threading.Lock()
+
+
+def _configured_worker_count() -> int:
+    raw = os.environ.get("FLEET_TABLE_STREAM_SCHEDULER_WORKERS")
+    if raw is not None:
+        return max(1, int(raw))
+    return _DEFAULT_WORKER_COUNT
+
+
+def get_fleet_table_stream_scheduler() -> FleetTableStreamScheduler:
+    global _process_scheduler
+    with _process_scheduler_lock:
+        if _process_scheduler is None:
+            _process_scheduler = FleetTableStreamScheduler(worker_count=_configured_worker_count())
+        return _process_scheduler
+
+
+def reset_fleet_table_stream_scheduler_for_tests() -> None:
+    global _process_scheduler
+    with _process_scheduler_lock:
+        if _process_scheduler is not None:
+            _process_scheduler._shutdown = True
+            with _process_scheduler._condition:
+                _process_scheduler._condition.notify_all()
+        _process_scheduler = FleetTableStreamScheduler(worker_count=0)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scope.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scope.py
@@ -1,0 +1,12 @@
+"""Scope key for a multiplexed fleet table NDJSON stream on one turn snapshot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, order=True)
+class FleetTableStreamScope:
+    game_id: int
+    perspective: int
+    turn_number: int

--- a/packages/api/api/routers/games.py
+++ b/packages/api/api/routers/games.py
@@ -28,6 +28,7 @@ from api.transport.connections_options import (
     WARP_SPEED_QUERY,
     FlareConnectionMode,
 )
+from api.transport.fleet_table_stream import stream_fleet_table_ndjson
 from api.transport.game_info_update import GameInfoUpdateRequest, RefreshGameInfoParams
 from api.transport.inference_hull_catalog import InferenceHullCatalogMaskUpdateRequest
 from api.transport.inference_stream import stream_inference_ndjson
@@ -146,6 +147,33 @@ def get_scores_table_inference_stream(
     return StreamingResponse(
         stream_inference_ndjson(
             lambda: analytics.iter_scores_table_inference_stream(
+                game_id,
+                perspective,
+                turn_number,
+                parsed_player_ids,
+            )
+        ),
+        media_type="application/x-ndjson",
+    )
+
+
+@router.get("/{game_id}/{perspective}/turns/{turn_number}/analytics/fleet/table-stream")
+def get_fleet_table_stream(
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    player_ids: str = Query(
+        ...,
+        alias="playerIds",
+        description="Comma-separated fleet player ids",
+    ),
+    analytics: TurnAnalyticService = Depends(get_turn_analytic_service),
+) -> StreamingResponse:
+    """Stream fleet table materialization for requested players (NDJSON)."""
+    parsed_player_ids = tuple(int(part.strip()) for part in player_ids.split(",") if part.strip())
+    return StreamingResponse(
+        stream_fleet_table_ndjson(
+            lambda: analytics.iter_fleet_table_stream(
                 game_id,
                 perspective,
                 turn_number,

--- a/packages/api/api/services/inference_invalidation_service.py
+++ b/packages/api/api/services/inference_invalidation_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from api.analytics.fleet.fleet_table_stream_registry import reschedule_fleet_table_player
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
@@ -58,12 +60,22 @@ class InferenceInvalidationService:
         """Drop one player's fleet ledgers at turns >= host_turn after scores evidence changes."""
         if self._fleet_persistence is None:
             return set()
-        return self._fleet_persistence.invalidate_player_ledgers_from_turn(
+        cleared_turns = self._fleet_persistence.invalidate_player_ledgers_from_turn(
             game_id,
             perspective,
             host_turn,
             player_id,
         )
+        for fleet_turn in cleared_turns:
+            reschedule_fleet_table_player(
+                FleetTableStreamScope(
+                    game_id=game_id,
+                    perspective=perspective,
+                    turn_number=fleet_turn,
+                ),
+                player_id,
+            )
+        return cleared_turns
 
     def wire_fleet_invalidation_to_persistence(self) -> None:
         """Register fleet snapshot invalidation on inference row persistence writes."""

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -257,6 +257,31 @@ class TurnAnalyticService:
             scheduler=self._inference_scheduler_instance(),
         )
 
+    def iter_fleet_table_stream(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_ids: tuple[int, ...],
+    ):
+        from api.analytics.fleet import iter_fleet_table_stream
+        from api.analytics.fleet.fleet_table_stream_scheduler import (
+            get_fleet_table_stream_scheduler,
+        )
+
+        turn = self._turns.get_turn_info(game_id, perspective, turn_number)
+        export_services = self._turn_export_services(game_id, perspective)
+        fleet_services = export_services[FLEET_ANALYTIC_ID]
+        return iter_fleet_table_stream(
+            turn,
+            player_ids,
+            game_id=game_id,
+            perspective=perspective,
+            fleet_services=fleet_services,
+            persistence=self._fleet_persistence,
+            scheduler=get_fleet_table_stream_scheduler(),
+        )
+
     def _inference_scheduler_instance(self) -> InferenceRowScheduler:
         if self._inference_scheduler is not None:
             return self._inference_scheduler

--- a/packages/api/api/storage/__init__.py
+++ b/packages/api/api/storage/__init__.py
@@ -51,6 +51,12 @@ def clear_backend_cache() -> None:
     """Clear the cached backend (for tests after config change)."""
     global _backend_cache
     _backend_cache = None
+    from api.analytics.fleet.fleet_table_stream_registry import (
+        reset_fleet_table_stream_registry_for_tests,
+    )
+    from api.analytics.fleet.fleet_table_stream_scheduler import (
+        reset_fleet_table_stream_scheduler_for_tests,
+    )
     from api.analytics.military_score_inference.inference_scheduler import (
         reset_inference_row_scheduler_for_tests,
     )
@@ -60,3 +66,5 @@ def clear_backend_cache() -> None:
 
     reset_inference_row_scheduler_for_tests()
     reset_inference_table_stream_registry_for_tests()
+    reset_fleet_table_stream_scheduler_for_tests()
+    reset_fleet_table_stream_registry_for_tests()

--- a/packages/api/api/transport/fleet_table_stream.py
+++ b/packages/api/api/transport/fleet_table_stream.py
@@ -1,0 +1,72 @@
+"""NDJSON wire events and line encoding for fleet table materialization streams."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterator
+from typing import TypeAlias
+
+from api.errors import PlanetsConsoleError
+
+logger = logging.getLogger(__name__)
+
+_FLEET_TABLE_STREAM_UNEXPECTED_ERROR_DETAIL = "Internal server error"
+
+TABLE_STREAM_ALREADY_ACTIVE_DETAIL = "A fleet table stream is already active for this scope."
+
+
+def fleet_ledger_updated_event(*, ledger: dict[str, object]) -> dict[str, object]:
+    return {"type": "ledger_updated", "ledger": ledger}
+
+
+def fleet_record_refined_event(*, record: dict[str, object]) -> dict[str, object]:
+    return {"type": "record_refined", "record": record}
+
+
+def fleet_provenance_event(
+    *,
+    turn_evidence_at_n: bool,
+    prior_ledger_at_n_minus_1: bool,
+    is_final: bool,
+) -> dict[str, object]:
+    return {
+        "type": "provenance",
+        "turnEvidenceAtN": turn_evidence_at_n,
+        "priorLedgerAtNMinus1": prior_ledger_at_n_minus_1,
+        "isFinal": is_final,
+    }
+
+
+def fleet_complete_event(*, is_final: bool, summary: str) -> dict[str, object]:
+    return {"type": "complete", "isFinal": is_final, "summary": summary}
+
+
+def fleet_error_event(detail: str) -> dict[str, object]:
+    return {"type": "error", "detail": detail}
+
+
+FleetTableStreamItem: TypeAlias = dict[str, object]
+
+
+def iter_fleet_table_ndjson_lines(iterator: Iterator[FleetTableStreamItem]) -> Iterator[str]:
+    for item in iterator:
+        yield json.dumps(item) + "\n"
+
+
+def _fleet_table_stream_error_detail(exc: BaseException) -> str:
+    if isinstance(exc, PlanetsConsoleError):
+        return str(exc) or _FLEET_TABLE_STREAM_UNEXPECTED_ERROR_DETAIL
+    return _FLEET_TABLE_STREAM_UNEXPECTED_ERROR_DETAIL
+
+
+def stream_fleet_table_ndjson(
+    stream_iterator: Callable[[], Iterator[FleetTableStreamItem]],
+) -> Iterator[str]:
+    """Run a fleet table event iterator and yield NDJSON lines."""
+    try:
+        yield from iter_fleet_table_ndjson_lines(stream_iterator())
+    except Exception as exc:
+        if not isinstance(exc, PlanetsConsoleError):
+            logger.exception("Fleet table NDJSON stream failed")
+        yield json.dumps(fleet_error_event(_fleet_table_stream_error_detail(exc))) + "\n"

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -51,7 +51,21 @@ def _events_for_players(
         persistence=resolved_services.persistence,
         scheduler=scheduler,
     )
-    return list(stream)
+    events: list[dict[str, object]] = []
+    expected_players = set(player_ids)
+    finished_players: set[int] = set()
+    try:
+        for event in stream:
+            events.append(event)
+            if event.get("type") in ("complete", "error") and isinstance(
+                event.get("playerId"), int
+            ):
+                finished_players.add(event["playerId"])
+            if finished_players == expected_players:
+                break
+    finally:
+        stream.close()
+    return events
 
 
 def test_fleet_table_stream_reconnect_returns_conflict_while_active(sample_turn):

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -1,0 +1,327 @@
+"""Tests for the multiplexed fleet table NDJSON stream."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.fleet_table_stream_rows import (
+    ScheduledFleetPlayer,
+    drain_available_multiplex_events,
+    iter_fleet_table_stream_events,
+    schedule_fleet_player_run,
+    tag_fleet_table_stream_event,
+)
+from api.analytics.fleet.fleet_table_stream_scheduler import (
+    FleetTableStreamScheduler,
+    reset_fleet_table_stream_scheduler_for_tests,
+)
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.serialization import (
+    fleet_acquisition_ledger_to_json,
+)
+from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+from api.transport.fleet_table_stream import (
+    TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+    fleet_complete_event,
+    stream_fleet_table_ndjson,
+)
+
+
+def _events_for_players(
+    sample_turn,
+    player_ids: tuple[int, ...],
+    *,
+    scheduler: FleetTableStreamScheduler | None = None,
+    services=None,
+) -> list[dict[str, object]]:
+    resolved_services = services or build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    stream = iter_fleet_table_stream_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        fleet_services=resolved_services,
+        persistence=resolved_services.persistence,
+        scheduler=scheduler,
+    )
+    return list(stream)
+
+
+def test_fleet_table_stream_reconnect_returns_conflict_while_active(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scope = FleetTableStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    stream_token = scheduler.begin_scope(scope)
+    try:
+        services = build_ephemeral_fleet_compute_services(
+            sample_turn,
+            game_id=628580,
+            perspective=1,
+        )
+        replacement = iter_fleet_table_stream_events(
+            sample_turn,
+            (sample_turn.scores[0].ownerid,),
+            game_id=628580,
+            perspective=1,
+            fleet_services=services,
+            persistence=services.persistence,
+            scheduler=scheduler,
+        )
+        assert next(replacement) == {
+            "type": "error",
+            "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+        }
+        replacement.close()
+    finally:
+        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+
+
+def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scope = FleetTableStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    stream_token = scheduler.begin_scope(scope)
+    try:
+        services = build_ephemeral_fleet_compute_services(
+            sample_turn,
+            game_id=628580,
+            perspective=1,
+        )
+
+        def replacement_loader():
+            yield from iter_fleet_table_stream_events(
+                sample_turn,
+                (sample_turn.scores[0].ownerid,),
+                game_id=628580,
+                perspective=1,
+                fleet_services=services,
+                persistence=services.persistence,
+                scheduler=scheduler,
+            )
+
+        lines = list(stream_fleet_table_ndjson(replacement_loader))
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == {
+            "type": "error",
+            "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
+        }
+    finally:
+        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+
+
+def test_cached_final_ledger_replays_terminal_events_without_scheduling(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    final_persisted = PersistedFleetLedger(
+        ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    services.persistence.put_ledger(
+        628580,
+        1,
+        sample_turn.settings.turn,
+        player_id,
+        final_persisted,
+    )
+
+    events = _events_for_players(
+        sample_turn,
+        (player_id,),
+        scheduler=scheduler,
+        services=services,
+    )
+    types = [event["type"] for event in events]
+    assert types == ["ledger_updated", "provenance", "complete"]
+    assert events[0]["playerId"] == player_id
+    assert events[0]["ledger"] == fleet_acquisition_ledger_to_json(final_persisted.ledger)
+    assert events[1]["isFinal"] is True
+    assert events[2]["isFinal"] is True
+    assert scheduler._runs == {}
+
+
+def test_multi_player_stream_emits_tagged_terminal_events(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    for player_id in player_ids:
+        services.persistence.put_ledger(
+            628580,
+            1,
+            sample_turn.settings.turn,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+    events = _events_for_players(
+        sample_turn,
+        player_ids,
+        scheduler=scheduler,
+        services=services,
+    )
+    complete_player_ids = {
+        event["playerId"]
+        for event in events
+        if event.get("type") == "complete" and isinstance(event.get("playerId"), int)
+    }
+    assert complete_player_ids == set(player_ids)
+
+
+def test_player_event_ordering_provenance_before_complete(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    services.persistence.put_ledger(
+        628580,
+        1,
+        sample_turn.settings.turn,
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+    )
+    events = _events_for_players(
+        sample_turn,
+        (player_id,),
+        scheduler=scheduler,
+        services=services,
+    )
+    player_events = [event for event in events if event.get("playerId") == player_id]
+    provenance_index = next(
+        index for index, event in enumerate(player_events) if event["type"] == "provenance"
+    )
+    complete_index = next(
+        index for index, event in enumerate(player_events) if event["type"] == "complete"
+    )
+    assert provenance_index < complete_index
+
+
+def test_schedule_dedupes_in_flight_player_runs(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    scope = FleetTableStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    stream_token = scheduler.begin_scope(scope)
+    try:
+        first = schedule_fleet_player_run(
+            scheduler,
+            turn=sample_turn,
+            player_id=player_id,
+            game_id=628580,
+            perspective=1,
+            fleet_services=services,
+            persistence=services.persistence,
+            stream_token=stream_token,
+        )
+        second = schedule_fleet_player_run(
+            scheduler,
+            turn=sample_turn,
+            player_id=player_id,
+            game_id=628580,
+            perspective=1,
+            fleet_services=services,
+            persistence=services.persistence,
+            stream_token=stream_token,
+        )
+        assert first is not None
+        assert second is not None
+        assert first.session.run_id == second.session.run_id
+        assert len(scheduler._runs) == 1
+        assert len(scheduler._work_queue) == 1
+    finally:
+        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+
+
+def test_tag_fleet_table_stream_event_adds_player_id():
+    tagged = tag_fleet_table_stream_event(
+        fleet_complete_event(is_final=True, summary="done"),
+        player_id=3,
+    )
+    assert tagged["playerId"] == 3
+
+
+def test_drain_available_multiplex_events_returns_queued_events_without_blocking():
+    from api.analytics.fleet.fleet_table_player_run import FleetPlayerStreamSession
+
+    session = FleetPlayerStreamSession(
+        player_id=8,
+        turn=None,  # type: ignore[arg-type]
+        game_id=628580,
+        perspective=1,
+    )
+    session.event_queue.put(fleet_complete_event(is_final=True, summary="ok"))
+    row = ScheduledFleetPlayer(player_id=8, session=session)
+    finished: set[str] = set()
+    events = list(
+        drain_available_multiplex_events(
+            (row,),
+            tag_player_id=True,
+            finished_run_ids=finished,
+        )
+    )
+    assert len(events) == 1
+    assert events[0]["playerId"] == 8
+
+
+@pytest.mark.slow
+def test_concurrent_multi_player_materialization_completes(sample_turn):
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=2)
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:3])
+    events = _events_for_players(sample_turn, player_ids, scheduler=scheduler)
+    assert {
+        event["playerId"]
+        for event in events
+        if event.get("type") == "complete" and isinstance(event.get("playerId"), int)
+    } == set(player_ids)

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -124,7 +124,7 @@ def test_all_cached_replay_keeps_stream_open_for_evidence_invalidation_integrati
     monkeypatch,
     memory_backend,
 ):
-    """After every player replays from cache, evidence invalidation reschedules on the open stream."""
+    """All-cached replay: evidence invalidation reschedules on the open stream."""
     reset_fleet_table_stream_registry_for_tests()
     scheduler = _install_workerless_scheduler(monkeypatch)
     player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -1,0 +1,281 @@
+"""Integration tests for fleet table stream invalidation and in-place reschedule."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.fleet_table_stream_registry import (
+    controller_for_scope,
+    reset_fleet_table_stream_registry_for_tests,
+)
+from api.analytics.fleet.fleet_table_stream_rows import iter_fleet_table_stream_events
+from api.analytics.fleet.fleet_table_stream_scheduler import (
+    FleetTableStreamScheduler,
+    reset_fleet_table_stream_scheduler_for_tests,
+)
+from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+from api.services.inference_invalidation_service import InferenceInvalidationService
+from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+from api.storage.memory_asset import MemoryAssetBackend
+from api.transport.fleet_table_stream import fleet_complete_event
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as handle:
+        backend.put("games/628580/info", json.load(handle))
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        backend.put("games/628580/1/turns/111", json.load(handle))
+    return backend
+
+
+def _install_workerless_scheduler(monkeypatch: pytest.MonkeyPatch) -> FleetTableStreamScheduler:
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=0)
+
+    def _get_scheduler() -> FleetTableStreamScheduler:
+        return scheduler
+
+    monkeypatch.setattr(
+        "api.analytics.fleet.fleet_table_stream_rows.get_fleet_table_stream_scheduler",
+        _get_scheduler,
+    )
+    return scheduler
+
+
+def _stream_scope(sample_turn) -> FleetTableStreamScope:
+    return FleetTableStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+
+
+def _end_open_fleet_table_stream(
+    scope: FleetTableStreamScope,
+    scheduler: FleetTableStreamScheduler,
+) -> None:
+    controller = controller_for_scope(scope)
+    if controller is not None:
+        controller.end_stream(scheduler)
+
+
+def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_seconds: float = 2.0,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met before timeout")
+
+
+def _run_ids_for_players(
+    scheduler: FleetTableStreamScheduler,
+    player_ids: tuple[int, ...],
+) -> dict[int, str]:
+    mapping: dict[int, str] = {}
+    for session in scheduler._runs.values():
+        if session.player_id in player_ids:
+            mapping[session.player_id] = session.run_id
+    return mapping
+
+
+def _seed_cached_ledgers(
+    persistence: FleetSnapshotPersistenceService,
+    sample_turn,
+    *,
+    turn_number: int,
+    player_ids: tuple[int, ...],
+) -> None:
+    for player_id in player_ids:
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+
+
+def test_all_cached_replay_keeps_stream_open_for_evidence_invalidation_integration(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+):
+    """After every player replays from cache, evidence invalidation reschedules on the open stream."""
+    reset_fleet_table_stream_registry_for_tests()
+    scheduler = _install_workerless_scheduler(monkeypatch)
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    turn_number = sample_turn.settings.turn
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    fleet_persistence = services.persistence
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        fleet_persistence=fleet_persistence,
+    )
+    _seed_cached_ledgers(
+        fleet_persistence,
+        sample_turn,
+        turn_number=turn_number,
+        player_ids=player_ids,
+    )
+
+    stream = iter_fleet_table_stream_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        fleet_services=services,
+        persistence=fleet_persistence,
+        scheduler=scheduler,
+    )
+    events: list[dict[str, object]] = []
+    stream_closed = threading.Event()
+    scope = _stream_scope(sample_turn)
+
+    def consume_stream() -> None:
+        try:
+            for event in stream:
+                events.append(event)
+        finally:
+            stream.close()
+            stream_closed.set()
+
+    thread = threading.Thread(target=consume_stream, daemon=True)
+    thread.start()
+
+    _wait_until(
+        lambda: sum(1 for event in events if event.get("type") == "complete") >= len(player_ids)
+    )
+    assert len(scheduler._runs) == 0
+    assert not stream_closed.is_set()
+    assert controller_for_scope(scope) is not None
+
+    target_player_id, other_player_id = player_ids
+    invalidation.on_inference_evidence_updated(628580, 1, turn_number, target_player_id)
+
+    _wait_until(lambda: target_player_id in _run_ids_for_players(scheduler, player_ids))
+    assert other_player_id not in _run_ids_for_players(scheduler, (other_player_id,))
+    assert fleet_persistence.get_ledger(628580, 1, turn_number, target_player_id) is None
+
+    rescheduled_run = scheduler._runs[_run_ids_for_players(scheduler, player_ids)[target_player_id]]
+    rescheduled_run.event_queue.put(
+        fleet_complete_event(
+            is_final=True,
+            summary="after evidence invalidation on cached row",
+        )
+    )
+
+    _wait_until(
+        lambda: any(
+            event.get("type") == "complete"
+            and event.get("playerId") == target_player_id
+            and event.get("summary") == "after evidence invalidation on cached row"
+            for event in events
+        )
+    )
+    cached_other_events = [
+        event
+        for event in events
+        if event.get("type") == "complete"
+        and event.get("playerId") == other_player_id
+        and event.get("summary") == "Fleet ledger loaded from cache."
+    ]
+    assert len(cached_other_events) == 1
+
+    _end_open_fleet_table_stream(scope, scheduler)
+    thread.join(timeout=2.0)
+
+
+def test_evidence_invalidation_reschedules_player_on_open_stream_integration(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+):
+    """Integration: invalidation while iter_fleet_table_stream_events multiplex is active."""
+    reset_fleet_table_stream_registry_for_tests()
+    scheduler = _install_workerless_scheduler(monkeypatch)
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    turn_number = sample_turn.settings.turn
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    fleet_persistence = services.persistence
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        fleet_persistence=fleet_persistence,
+    )
+    _seed_cached_ledgers(
+        fleet_persistence,
+        sample_turn,
+        turn_number=turn_number,
+        player_ids=player_ids,
+    )
+
+    stream = iter_fleet_table_stream_events(
+        sample_turn,
+        player_ids,
+        game_id=628580,
+        perspective=1,
+        fleet_services=services,
+        persistence=fleet_persistence,
+        scheduler=scheduler,
+    )
+
+    def consume_stream() -> None:
+        try:
+            for _event in stream:
+                pass
+        finally:
+            stream.close()
+
+    thread = threading.Thread(target=consume_stream, daemon=True)
+    thread.start()
+    _wait_until(
+        lambda: controller_for_scope(_stream_scope(sample_turn)) is not None
+        and len(scheduler._runs) == 0
+    )
+
+    target_player_id, other_player_id = player_ids
+    before = _run_ids_for_players(scheduler, player_ids)
+    assert before == {}
+
+    invalidation.on_inference_evidence_updated(628580, 1, turn_number, target_player_id)
+
+    _wait_until(lambda: target_player_id in _run_ids_for_players(scheduler, player_ids))
+    after = _run_ids_for_players(scheduler, player_ids)
+    assert other_player_id not in after
+    assert fleet_persistence.get_ledger(628580, 1, turn_number, target_player_id) is None
+
+    _end_open_fleet_table_stream(_stream_scope(sample_turn), scheduler)
+    thread.join(timeout=2.0)

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -262,8 +262,10 @@ def test_evidence_invalidation_reschedules_player_on_open_stream_integration(
     thread = threading.Thread(target=consume_stream, daemon=True)
     thread.start()
     _wait_until(
-        lambda: controller_for_scope(_stream_scope(sample_turn)) is not None
-        and len(scheduler._runs) == 0
+        lambda: (
+            controller_for_scope(_stream_scope(sample_turn)) is not None
+            and len(scheduler._runs) == 0
+        )
     )
 
     target_player_id, other_player_id = player_ids

--- a/packages/bff/bff/app.py
+++ b/packages/bff/bff/app.py
@@ -9,6 +9,13 @@ from bff.config import get_config
 from bff.errors import BFFError, BFFValidationError, make_http_exception_handler
 from bff.routers import analytics, diagnostics, games, shell
 from bff.strip_bff_prefix import StripBffPrefixWhenRootApp
+from bff.transport.fleet_table_stream_responses import (
+    FleetTableStreamCompleteEvent,
+    FleetTableStreamErrorEvent,
+    FleetTableStreamLedgerUpdatedEvent,
+    FleetTableStreamProvenanceEvent,
+    FleetTableStreamRecordRefinedEvent,
+)
 from bff.transport.game_responses import (
     LoadAllProgressUpdate,
     LoadAllStreamCompleteEvent,
@@ -57,6 +64,11 @@ def build_openapi_schema() -> dict:
         InferenceStreamProgressEvent,
         InferenceStreamCompleteEvent,
         InferenceStreamErrorEvent,
+        FleetTableStreamLedgerUpdatedEvent,
+        FleetTableStreamRecordRefinedEvent,
+        FleetTableStreamProvenanceEvent,
+        FleetTableStreamCompleteEvent,
+        FleetTableStreamErrorEvent,
     ):
         _merge_model_json_schema(openapi_schema, model)
     app.openapi_schema = openapi_schema

--- a/packages/bff/bff/core_client.py
+++ b/packages/bff/bff/core_client.py
@@ -253,6 +253,20 @@ class CoreClient:
             player_ids,
         )
 
+    def iter_fleet_table_stream(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        player_ids: tuple[int, ...],
+    ):
+        yield from self._analytics.iter_fleet_table_stream(
+            game_id,
+            perspective,
+            turn_number,
+            player_ids,
+        )
+
     def get_inference_hull_catalog_mask(
         self,
         game_id: int,

--- a/packages/bff/bff/routers/analytics.py
+++ b/packages/bff/bff/routers/analytics.py
@@ -31,10 +31,11 @@ from bff.diagnostics_dep import (
     optional_request_root,
     with_timed_child,
 )
-from bff.routers import scores_inference
+from bff.routers import fleet_table_stream, scores_inference
 
 router = APIRouter()
 router.include_router(scores_inference.router, prefix="/scores")
+router.include_router(fleet_table_stream.router, prefix="/fleet")
 
 
 def _turn_analytics_from_core(

--- a/packages/bff/bff/routers/fleet_table_stream.py
+++ b/packages/bff/bff/routers/fleet_table_stream.py
@@ -1,0 +1,40 @@
+"""Fleet table NDJSON stream BFF route."""
+
+from api.transport.fleet_table_stream import stream_fleet_table_ndjson
+from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
+
+from bff.core_client import get_core_client
+
+router = APIRouter()
+
+
+@router.get(
+    "/table-stream",
+    responses={
+        200: {
+            "description": "NDJSON stream of tagged fleet table materialization events.",
+            "content": {"application/x-ndjson": {}},
+        }
+    },
+)
+def get_fleet_table_stream(
+    game_id: int = Query(..., alias="gameId"),
+    turn: int = Query(..., ge=1),
+    perspective: int = Query(..., ge=0),
+    player_ids: str = Query(..., alias="playerIds"),
+):
+    """Stream fleet table materialization for requested players on one NDJSON connection."""
+    parsed_player_ids = tuple(int(part.strip()) for part in player_ids.split(",") if part.strip())
+    core = get_core_client()
+    return StreamingResponse(
+        stream_fleet_table_ndjson(
+            lambda: core.iter_fleet_table_stream(
+                game_id,
+                perspective,
+                turn,
+                parsed_player_ids,
+            )
+        ),
+        media_type="application/x-ndjson",
+    )

--- a/packages/bff/bff/transport/fleet_table_stream_responses.py
+++ b/packages/bff/bff/transport/fleet_table_stream_responses.py
@@ -1,0 +1,49 @@
+"""BFF OpenAPI models for fleet table NDJSON stream events."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class FleetTableStreamLedgerUpdatedEvent(BaseModel):
+    type: Literal["ledger_updated"]
+    playerId: int | None = None
+    ledger: dict[str, Any]
+
+
+class FleetTableStreamRecordRefinedEvent(BaseModel):
+    type: Literal["record_refined"]
+    playerId: int | None = None
+    record: dict[str, Any]
+
+
+class FleetTableStreamProvenanceEvent(BaseModel):
+    type: Literal["provenance"]
+    playerId: int | None = None
+    turnEvidenceAtN: bool
+    priorLedgerAtNMinus1: bool
+    isFinal: bool
+
+
+class FleetTableStreamCompleteEvent(BaseModel):
+    type: Literal["complete"]
+    playerId: int | None = None
+    isFinal: bool
+    summary: str
+
+
+class FleetTableStreamErrorEvent(BaseModel):
+    type: Literal["error"]
+    playerId: int | None = None
+    detail: str
+
+
+__all__ = [
+    "FleetTableStreamCompleteEvent",
+    "FleetTableStreamErrorEvent",
+    "FleetTableStreamLedgerUpdatedEvent",
+    "FleetTableStreamProvenanceEvent",
+    "FleetTableStreamRecordRefinedEvent",
+]

--- a/packages/frontend/src/api/fleetTableStreamEventSchema.ts
+++ b/packages/frontend/src/api/fleetTableStreamEventSchema.ts
@@ -1,0 +1,75 @@
+/**
+ * Fleet table NDJSON stream: runtime validation and TypeScript types.
+ */
+
+import { z } from 'zod'
+import {
+  fleetCountDiscrepancySchema,
+  fleetTableRecordSchema,
+} from '../analytics/fleet/fleetTableWireSchema'
+
+const fleetTableStreamPlayerScopeSchema = z.object({
+  playerId: z.number().int().optional(),
+})
+
+const fleetTableStreamLedgerSchema = z.object({
+  playerId: z.number().int(),
+  playerName: z.string(),
+  records: z.array(fleetTableRecordSchema),
+  discrepancy: fleetCountDiscrepancySchema.optional(),
+})
+
+export const fleetTableStreamLedgerUpdatedEventSchema =
+  fleetTableStreamPlayerScopeSchema.extend({
+    type: z.literal('ledger_updated'),
+    ledger: fleetTableStreamLedgerSchema,
+  })
+
+export const fleetTableStreamRecordRefinedEventSchema =
+  fleetTableStreamPlayerScopeSchema.extend({
+    type: z.literal('record_refined'),
+    record: fleetTableRecordSchema,
+  })
+
+export const fleetTableStreamProvenanceEventSchema =
+  fleetTableStreamPlayerScopeSchema.extend({
+    type: z.literal('provenance'),
+    turnEvidenceAtN: z.boolean(),
+    priorLedgerAtNMinus1: z.boolean(),
+    isFinal: z.boolean(),
+  })
+
+export const fleetTableStreamCompleteEventSchema = fleetTableStreamPlayerScopeSchema.extend({
+  type: z.literal('complete'),
+  isFinal: z.boolean(),
+  summary: z.string(),
+})
+
+export const fleetTableStreamErrorEventSchema = fleetTableStreamPlayerScopeSchema.extend({
+  type: z.literal('error'),
+  detail: z.string(),
+})
+
+export const fleetTableStreamEventSchema = z.discriminatedUnion('type', [
+  fleetTableStreamLedgerUpdatedEventSchema,
+  fleetTableStreamRecordRefinedEventSchema,
+  fleetTableStreamProvenanceEventSchema,
+  fleetTableStreamCompleteEventSchema,
+  fleetTableStreamErrorEventSchema,
+])
+
+export type FleetTableStreamEvent = z.infer<typeof fleetTableStreamEventSchema>
+
+export function formatFleetTableStreamValidationError(error: z.ZodError): string {
+  const issue = error.issues[0]
+  if (!issue) {
+    return 'Fleet table stream event has an invalid shape.'
+  }
+  if (issue.code === 'invalid_union_discriminator') {
+    return 'Fleet table stream returned unknown event type.'
+  }
+  if (issue.path.includes('detail')) {
+    return 'Fleet table stream error event has an invalid shape.'
+  }
+  return 'Fleet table stream event has an invalid shape.'
+}

--- a/packages/frontend/src/api/parseFleetTableStreamEvent.test.ts
+++ b/packages/frontend/src/api/parseFleetTableStreamEvent.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { parseFleetTableStreamEvent } from './parseFleetTableStreamEvent'
+
+describe('parseFleetTableStreamEvent', () => {
+  it('parses ledger_updated with player scope', () => {
+    const event = parseFleetTableStreamEvent(
+      JSON.stringify({
+        type: 'ledger_updated',
+        playerId: 8,
+        ledger: {
+          playerId: 8,
+          playerName: 'dougp314',
+          records: [],
+        },
+      })
+    )
+    expect(event).toEqual({
+      type: 'ledger_updated',
+      playerId: 8,
+      ledger: {
+        playerId: 8,
+        playerName: 'dougp314',
+        records: [],
+      },
+    })
+  })
+
+  it('parses provenance and complete terminal events', () => {
+    const provenance = parseFleetTableStreamEvent(
+      JSON.stringify({
+        type: 'provenance',
+        playerId: 6,
+        turnEvidenceAtN: true,
+        priorLedgerAtNMinus1: false,
+        isFinal: false,
+      })
+    )
+    expect(provenance?.type).toBe('provenance')
+
+    const complete = parseFleetTableStreamEvent(
+      JSON.stringify({
+        type: 'complete',
+        playerId: 6,
+        isFinal: false,
+        summary: 'Fleet ledger materialized with open provenance legs.',
+      })
+    )
+    expect(complete?.type).toBe('complete')
+  })
+
+  it('rejects unknown event types', () => {
+    expect(() => parseFleetTableStreamEvent(JSON.stringify({ type: 'unknown' }))).toThrow(
+      'Fleet table stream returned unknown event type.'
+    )
+  })
+})

--- a/packages/frontend/src/api/parseFleetTableStreamEvent.ts
+++ b/packages/frontend/src/api/parseFleetTableStreamEvent.ts
@@ -1,0 +1,25 @@
+import {
+  fleetTableStreamEventSchema,
+  formatFleetTableStreamValidationError,
+  type FleetTableStreamEvent,
+} from './fleetTableStreamEventSchema'
+
+export type { FleetTableStreamEvent }
+
+export function parseFleetTableStreamEvent(line: string): FleetTableStreamEvent | null {
+  const trimmed = line.trim()
+  if (!trimmed) {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    throw new Error('Fleet table stream returned invalid JSON.')
+  }
+  const result = fleetTableStreamEventSchema.safeParse(parsed)
+  if (!result.success) {
+    throw new Error(formatFleetTableStreamValidationError(result.error))
+  }
+  return result.data
+}

--- a/packages/frontend/src/api/schema-analytics.ts
+++ b/packages/frontend/src/api/schema-analytics.ts
@@ -120,6 +120,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/analytics/fleet/table-stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Fleet Table Stream
+         * @description Stream fleet table materialization for requested players on one NDJSON connection.
+         */
+        get: operations["get_fleet_table_stream_analytics_fleet_table_stream_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/analytics": {
         parameters: {
             query?: never;
@@ -524,6 +544,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_fleet_table_stream_analytics_fleet_table_stream_get: {
+        parameters: {
+            query: {
+                gameId: number;
+                turn: number;
+                perspective: number;
+                playerIds: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description NDJSON stream of tagged fleet table materialization events. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "application/x-ndjson": unknown;
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary

- Add fleet table NDJSON stream end-to-end: Core controller/registry/scheduler, per-player materialization jobs, wire events (`ledger_updated`, `record_refined`, `provenance`, `complete`, `error`), and invalidation-driven in-place reschedule on open streams.
- Expose Core `GET .../analytics/fleet/table-stream` and BFF `/analytics/fleet/table-stream`; add OpenAPI models and frontend Zod parser module for F7.6.
- Mirror scores stream lifecycle: stream stays open after all-cached replay, admission dispatch centralized on the controller, integration tests for multi-player connect, dedup, ordering, and evidence invalidation.

Closes #168

## Test plan

- [x] `make test_api` (1067 passed)
- [ ] `make test_bff` / `make test_frontend` in CI
- [ ] Manual: connect BFF fleet table stream with multiple `playerIds`, confirm tagged terminal events per player
- [ ] Manual: open stream with all cached-final ledgers, trigger scores evidence invalidation, confirm target player reschedules without reconnect

## Follow-up

- #175 tracks extracting shared table-stream session framework (scores + fleet), including scope teardown on all connect exit paths.


Made with [Cursor](https://cursor.com)