### PR TITLE
Defer fleet snapshot notifications until gap-fill chains complete

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -55,6 +55,7 @@ class _GapFillCoherence:
             turn_number,
             player_id,
             persisted,
+            snapshot_complete_roster=None,
         )
         self._assert_unchanged()
 
@@ -215,6 +216,60 @@ def _first_stored_rst_turn(
 
 def _roster_player_ids(turn: TurnInfo) -> list[int]:
     return [player.id for player in iter_turn_players(turn)]
+
+
+def _complete_snapshot_turn_numbers(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    through_turn: int,
+    load_turn: Callable[[int], TurnInfo | None],
+) -> frozenset[int]:
+    """Return fleet turn numbers through ``through_turn`` with ensure-final snapshots."""
+    complete: set[int] = set()
+    for turn_number in range(1, through_turn + 1):
+        turn_info = load_turn(turn_number)
+        if turn_info is None:
+            continue
+        snapshot = persistence.get_snapshot(game_id, perspective, turn_number)
+        if _is_fleet_snapshot_cache_hit(
+            persistence,
+            game_id,
+            perspective,
+            turn_number,
+            turn_info,
+            snapshot,
+        ):
+            complete.add(turn_number)
+    return frozenset(complete)
+
+
+def _emit_deferred_fleet_snapshot_notifications(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    *,
+    complete_before: frozenset[int],
+    through_turn: int,
+    load_turn: Callable[[int], TurnInfo | None],
+) -> None:
+    """Notify scores consumers after gap-fill; never mid-chain.
+
+    Interim correctness policy before fleet gap-fill coordinator (#161): each
+    ``get_or_materialize_*`` call emits ``on_snapshot_persisted`` once per turn
+    that became ensure-final during that call, after the chain succeeds.
+    """
+    if persistence.on_snapshot_persisted is None:
+        return
+    complete_after = _complete_snapshot_turn_numbers(
+        persistence,
+        game_id,
+        perspective,
+        through_turn,
+        load_turn,
+    )
+    for fleet_turn in sorted(complete_after - complete_before):
+        persistence.on_snapshot_persisted(game_id, perspective, fleet_turn)
 
 
 def _snapshot_has_all_roster_players(snapshot: FleetTurnSnapshot, turn: TurnInfo) -> bool:
@@ -497,6 +552,14 @@ def get_or_materialize_fleet_ledger_for_player(
     if cached is not None and _is_fleet_ledger_cache_hit(cached):
         return cached
 
+    complete_before = _complete_snapshot_turn_numbers(
+        persistence,
+        game_id,
+        perspective,
+        turn_number,
+        load_turn,
+    )
+
     for attempt in range(GAP_FILL_MAX_RETRIES):
         coherence = _GapFillCoherence(
             persistence,
@@ -506,7 +569,7 @@ def get_or_materialize_fleet_ledger_for_player(
         )
         turn_context_cache: dict[int, FleetTurnContext] = {}
         try:
-            return _materialize_fleet_ledger_chain_for_player(
+            persisted = _materialize_fleet_ledger_chain_for_player(
                 persistence,
                 game_id,
                 perspective,
@@ -517,6 +580,15 @@ def get_or_materialize_fleet_ledger_for_player(
                 coherence=coherence,
                 turn_context_cache=turn_context_cache,
             )
+            _emit_deferred_fleet_snapshot_notifications(
+                persistence,
+                game_id,
+                perspective,
+                complete_before=complete_before,
+                through_turn=turn_number,
+                load_turn=load_turn,
+            )
+            return persisted
         except _FleetSnapshotInvalidated:
             cached_after_invalidation = persistence.get_ledger(
                 game_id,
@@ -563,6 +635,14 @@ def get_or_materialize_fleet_snapshot(
     if _is_fleet_snapshot_cache_hit(persistence, game_id, perspective, turn_number, turn, cached):
         return cached
 
+    complete_before = _complete_snapshot_turn_numbers(
+        persistence,
+        game_id,
+        perspective,
+        turn_number,
+        load_turn,
+    )
+
     for attempt in range(GAP_FILL_MAX_RETRIES):
         coherence = _GapFillCoherence(
             persistence,
@@ -571,7 +651,7 @@ def get_or_materialize_fleet_snapshot(
             persistence.invalidation_generation(game_id, perspective),
         )
         try:
-            return _materialize_fleet_snapshot_chain(
+            snapshot = _materialize_fleet_snapshot_chain(
                 persistence,
                 game_id,
                 perspective,
@@ -580,6 +660,15 @@ def get_or_materialize_fleet_snapshot(
                 inference_materialization=inference_materialization,
                 coherence=coherence,
             )
+            _emit_deferred_fleet_snapshot_notifications(
+                persistence,
+                game_id,
+                perspective,
+                complete_before=complete_before,
+                through_turn=turn_number,
+                load_turn=load_turn,
+            )
+            return snapshot
         except _FleetSnapshotInvalidated:
             cached_after_invalidation = persistence.get_snapshot(
                 game_id,

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -11,8 +11,11 @@ from dataclasses import dataclass, field
 from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
 from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.serialization import (
-    fleet_acquisition_ledger_to_json,
     fleet_ship_record_to_json,
+)
+from api.analytics.fleet.table_wire import (
+    fleet_acquisition_ledger_to_table_wire,
+    fleet_ship_record_to_table_wire,
 )
 from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord, PersistedFleetLedger
 from api.analytics.turn_roster import iter_turn_players
@@ -78,7 +81,7 @@ def _wire_provenance(persisted: PersistedFleetLedger) -> dict[str, object]:
 def wire_cached_player_events(persisted: PersistedFleetLedger) -> tuple[dict[str, object], ...]:
     """Replay terminal stream events for an ensure-final cached ledger."""
     return (
-        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_json(persisted.ledger)),
+        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_table_wire(persisted.ledger)),
         _wire_provenance(persisted),
         fleet_complete_event(
             is_final=True,
@@ -99,9 +102,11 @@ def wire_materialized_player_events(
     for record_id, record in after_records.items():
         prior = before_records.get(record_id)
         if prior is not None and _record_refined(prior, record):
-            events.append(fleet_record_refined_event(record=fleet_ship_record_to_json(record)))
+            events.append(
+                fleet_record_refined_event(record=fleet_ship_record_to_table_wire(record))
+            )
     events.append(
-        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_json(persisted.ledger))
+        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_table_wire(persisted.ledger))
     )
     events.append(_wire_provenance(persisted))
     summary = (

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -104,6 +104,8 @@ class FleetSnapshotPersistenceService:
         turn_number: int,
         player_id: int,
         persisted: PersistedFleetLedger,
+        *,
+        snapshot_complete_roster: frozenset[int] | None = None,
     ) -> None:
         if persisted.ledger.player_id != player_id:
             raise ValidationError(
@@ -119,8 +121,12 @@ class FleetSnapshotPersistenceService:
         ledgers = self._ledgers_object(document)
         ledgers[str(player_id)] = persisted_fleet_ledger_to_json(to_store)
         self._write_document(game_id, perspective, turn_number, document)
-        if self._on_snapshot_persisted is not None:
-            self._on_snapshot_persisted(game_id, perspective, turn_number)
+        self._notify_snapshot_persisted_if_complete(
+            game_id,
+            perspective,
+            turn_number,
+            snapshot_complete_roster=snapshot_complete_roster,
+        )
 
     def has_ledger(
         self,
@@ -235,8 +241,55 @@ class FleetSnapshotPersistenceService:
             turn_number,
             fleet_turn_snapshot_to_json(snapshot),
         )
-        if self._on_snapshot_persisted is not None:
+        self._notify_snapshot_persisted_if_complete(
+            game_id,
+            perspective,
+            turn_number,
+            snapshot_complete_roster=None,
+            force=True,
+        )
+
+    def _notify_snapshot_persisted_if_complete(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        *,
+        snapshot_complete_roster: frozenset[int] | None,
+        force: bool = False,
+    ) -> None:
+        if self._on_snapshot_persisted is None:
+            return
+        if force:
             self._on_snapshot_persisted(game_id, perspective, turn_number)
+            return
+        if snapshot_complete_roster is None:
+            return
+        if not self._roster_has_final_ledgers(
+            game_id,
+            perspective,
+            turn_number,
+            snapshot_complete_roster,
+        ):
+            return
+        self._on_snapshot_persisted(game_id, perspective, turn_number)
+
+    def _roster_has_final_ledgers(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+        roster_player_ids: frozenset[int],
+    ) -> bool:
+        for roster_player_id in roster_player_ids:
+            if not self.has_final_ledger(
+                game_id,
+                perspective,
+                turn_number,
+                roster_player_id,
+            ):
+                return False
+        return True
 
     @property
     def on_snapshot_persisted(self) -> OnSnapshotPersistedCallback | None:

--- a/packages/api/api/analytics/fleet/table_wire.py
+++ b/packages/api/api/analytics/fleet/table_wire.py
@@ -1,0 +1,55 @@
+"""SPA fleet table wire shaping shared by the BFF table route and NDJSON stream."""
+
+from __future__ import annotations
+
+from api.analytics.fleet.serialization import (
+    fleet_acquisition_ledger_to_json,
+    fleet_ship_record_to_json,
+)
+from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord
+
+
+def fleet_ship_record_to_table_wire(record: FleetShipRecord) -> dict[str, object]:
+    """Shape one ship record for the SPA table wire (no evidence events)."""
+    return fleet_ship_record_to_table_wire_json(fleet_ship_record_to_json(record))
+
+
+def fleet_ship_record_to_table_wire_json(record: dict[str, object]) -> dict[str, object]:
+    """Shape one core ship record dict for the SPA table wire (no evidence events)."""
+    shaped: dict[str, object] = {
+        "recordId": record.get("recordId"),
+        "disposition": record.get("disposition", "active"),
+    }
+    if "qualifiers" in record:
+        shaped["qualifiers"] = record["qualifiers"]
+    if "fields" in record:
+        shaped["fields"] = record["fields"]
+    if "buildOptionSets" in record:
+        shaped["buildOptionSets"] = record["buildOptionSets"]
+    if "displayDefaultOptionSetIndex" in record:
+        shaped["displayDefaultOptionSetIndex"] = record["displayDefaultOptionSetIndex"]
+    if "lastSeen" in record:
+        shaped["lastSeen"] = record["lastSeen"]
+    return shaped
+
+
+def fleet_acquisition_ledger_to_table_wire(ledger: FleetAcquisitionLedger) -> dict[str, object]:
+    """Shape one player ledger for the SPA table wire."""
+    return fleet_acquisition_ledger_to_table_wire_json(fleet_acquisition_ledger_to_json(ledger))
+
+
+def fleet_acquisition_ledger_to_table_wire_json(player: dict[str, object]) -> dict[str, object]:
+    """Shape one core player ledger dict for the SPA table wire."""
+    shaped: dict[str, object] = {
+        "playerId": player.get("playerId"),
+        "playerName": player.get("playerName", ""),
+        "records": [
+            fleet_ship_record_to_table_wire_json(record)
+            for record in player.get("records", [])
+            if isinstance(record, dict)
+        ],
+    }
+    discrepancy = player.get("discrepancy")
+    if discrepancy is not None:
+        shaped["discrepancy"] = discrepancy
+    return shaped

--- a/packages/api/api/analytics/fleet/table_wire.py
+++ b/packages/api/api/analytics/fleet/table_wire.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from api.analytics.fleet.serialization import (
-    fleet_acquisition_ledger_to_json,
-    fleet_ship_record_to_json,
-)
-from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord
+from typing import TYPE_CHECKING
 
-
-def fleet_ship_record_to_table_wire(record: FleetShipRecord) -> dict[str, object]:
-    """Shape one ship record for the SPA table wire (no evidence events)."""
-    return fleet_ship_record_to_table_wire_json(fleet_ship_record_to_json(record))
+if TYPE_CHECKING:
+    from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord
 
 
 def fleet_ship_record_to_table_wire_json(record: dict[str, object]) -> dict[str, object]:
@@ -33,8 +27,17 @@ def fleet_ship_record_to_table_wire_json(record: dict[str, object]) -> dict[str,
     return shaped
 
 
+def fleet_ship_record_to_table_wire(record: FleetShipRecord) -> dict[str, object]:
+    """Shape one ship record for the SPA table wire (no evidence events)."""
+    from api.analytics.fleet.serialization import fleet_ship_record_to_json
+
+    return fleet_ship_record_to_table_wire_json(fleet_ship_record_to_json(record))
+
+
 def fleet_acquisition_ledger_to_table_wire(ledger: FleetAcquisitionLedger) -> dict[str, object]:
     """Shape one player ledger for the SPA table wire."""
+    from api.analytics.fleet.serialization import fleet_acquisition_ledger_to_json
+
     return fleet_acquisition_ledger_to_table_wire_json(fleet_acquisition_ledger_to_json(ledger))
 
 

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -259,3 +259,45 @@ def test_delete_ledger_removes_one_player_entry(persistence, sample_ledger):
 
     assert persistence.get_ledger(628580, 1, 111, 8) is None
     assert persistence.get_ledger(628580, 1, 111, 3) is not None
+
+
+def test_put_ledger_notifies_snapshot_persisted_only_when_roster_is_final(persistence):
+    callback_turns: list[int] = []
+
+    def on_snapshot_persisted(_game_id: int, _perspective: int, turn_number: int) -> None:
+        callback_turns.append(turn_number)
+
+    persistence.on_snapshot_persisted = on_snapshot_persisted
+    roster = frozenset({3, 8})
+    final = PersistedFleetLedger(
+        ledger=FleetAcquisitionLedger(player_id=3, player_name="other"),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    persistence.put_ledger(
+        628580,
+        1,
+        111,
+        3,
+        final,
+        snapshot_complete_roster=roster,
+    )
+    assert callback_turns == []
+
+    persistence.put_ledger(
+        628580,
+        1,
+        111,
+        8,
+        PersistedFleetLedger(
+            ledger=FleetAcquisitionLedger(player_id=8, player_name="koshling"),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+        snapshot_complete_roster=roster,
+    )
+    assert callback_turns == [111]

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -750,8 +750,16 @@ def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, lo
         turn_number: int,
         player_id: int,
         persisted,
+        **kwargs,
     ) -> None:
-        original_put_ledger(game_id, perspective, turn_number, player_id, persisted)
+        original_put_ledger(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+            persisted,
+            **kwargs,
+        )
         persistence.invalidate_for_turn_write(game_id, perspective, turn_number)
 
     persistence.put_ledger = put_ledger_that_invalidates  # type: ignore[method-assign]
@@ -794,6 +802,48 @@ def _put_provenance_final_snapshot(
     snapshot = persistence.get_snapshot(game_id, perspective, turn.settings.turn)
     assert snapshot is not None
     return snapshot
+
+
+def _inference_materialization_for_fleet(memory_backend, load_turn):
+    from api.analytics.fleet.held_solutions import (
+        FleetInferenceMaterialization,
+        FleetInferenceSupport,
+    )
+    from api.analytics.scores.export_services import ScoresExportContext
+
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    return (
+        inference_persistence,
+        FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(scores_services=scores_services),
+            load_turn=load_turn,
+        ),
+    )
+
+
+def _seed_scores_rows_for_all_players(
+    inference_persistence: InferenceRowPersistenceService,
+    turn,
+) -> None:
+    from api.analytics.military_score_inference.solver import STATUS_EXACT
+    from api.analytics.turn_roster import iter_turn_players
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+    for player in iter_turn_players(turn):
+        inference_persistence.put_row(
+            628580,
+            1,
+            turn.settings.turn,
+            player.id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary=f"cached-{player.id}",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+        )
 
 
 def test_gap_fill_returns_cached_snapshot_when_peer_finished_during_retries(persistence, load_turn):
@@ -915,3 +965,96 @@ def test_stale_chain_anchor_skipped_during_gap_fill(persistence, load_turn, memo
     assert rematerialized_110 is not None
     assert rematerialized_110.materialization_version == FLEET_MATERIALIZATION_VERSION
     assert all(record.record_id != "stale-rec" for record in rematerialized_110.players[0].records)
+
+
+def test_gap_fill_defers_snapshot_notify_until_chain_completes(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """Per-player put_ledger during gap-fill must not notify; flush runs after the chain."""
+    from api.analytics.turn_roster import iter_turn_players
+
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+
+    inference_persistence, inference_materialization = _inference_materialization_for_fleet(
+        memory_backend,
+        load_turn,
+    )
+    _seed_scores_rows_for_all_players(inference_persistence, turn_111)
+
+    callback_turns: list[int] = []
+    persistence.on_snapshot_persisted = lambda _g, _p, turn_number: callback_turns.append(
+        turn_number
+    )
+
+    put_ledger_calls = 0
+    original_put_ledger = persistence.put_ledger
+
+    def counting_put_ledger(*args, **kwargs):
+        nonlocal put_ledger_calls
+        put_ledger_calls += 1
+        return original_put_ledger(*args, **kwargs)
+
+    persistence.put_ledger = counting_put_ledger  # type: ignore[method-assign]
+
+    snapshot = get_or_materialize_fleet_snapshot(
+        persistence,
+        628580,
+        1,
+        turn_111,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+
+    assert snapshot.turn == 111
+    roster_size = len(list(iter_turn_players(turn_111)))
+    assert roster_size > 1
+    assert put_ledger_calls >= roster_size
+    assert callback_turns == [111]
+
+
+def test_gap_fill_emits_deferred_scores_invalidation_after_chain_completes(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """After gap-fill, newly complete fleet@(T-1) invalidates scores@T (not mid-chain)."""
+    from api.analytics.turn_roster import iter_turn_players
+
+    inference_persistence, inference_materialization = _inference_materialization_for_fleet(
+        memory_backend,
+        load_turn,
+    )
+    invalidation = InferenceInvalidationService(
+        inference_persistence,
+        fleet_persistence=persistence,
+    )
+    invalidation.wire_scores_invalidation_to_fleet_persistence()
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+    _seed_scores_rows_for_all_players(inference_persistence, turn_111)
+    _seed_scores_rows_for_all_players(inference_persistence, turn_112)
+
+    snapshot = get_or_materialize_fleet_snapshot(
+        persistence,
+        628580,
+        1,
+        turn_112,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+
+    assert snapshot.turn == 112
+    for player in iter_turn_players(turn_112):
+        assert inference_persistence.get_row(628580, 1, 112, player.id) is None

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -690,9 +690,17 @@ def test_gap_fill_does_not_persist_torn_tail_after_mid_chain_invalidation(persis
         turn_number: int,
         player_id: int,
         persisted,
+        **kwargs,
     ) -> None:
         nonlocal mid_chain_intercepted
-        original_put_ledger(game_id, perspective, turn_number, player_id, persisted)
+        original_put_ledger(
+            game_id,
+            perspective,
+            turn_number,
+            player_id,
+            persisted,
+            **kwargs,
+        )
         current_attempt_puts.append(turn_number)
         if turn_number == 111 and not mid_chain_intercepted:
             mid_chain_intercepted = True

--- a/packages/api/tests/test_fleet_table_wire.py
+++ b/packages/api/tests/test_fleet_table_wire.py
@@ -1,0 +1,60 @@
+"""Tests for SPA fleet table wire shaping."""
+
+from __future__ import annotations
+
+from api.analytics.fleet.chain import ensure_fleet_baseline
+from api.analytics.fleet.fleet_table_player_run import wire_cached_player_events
+from api.analytics.fleet.serialization import fleet_ship_record_to_json
+from api.analytics.fleet.table_wire import (
+    fleet_acquisition_ledger_to_table_wire,
+    fleet_ship_record_to_table_wire,
+)
+from api.analytics.fleet.types import (
+    FleetMaterializationProvenance,
+    FleetShipRecord,
+    PersistedFleetLedger,
+)
+
+
+def test_table_wire_record_omits_evidence_events():
+    record = FleetShipRecord(
+        record_id="rec-1",
+        disposition="active",
+        events=(),
+    )
+    core_record = fleet_ship_record_to_json(record)
+    assert core_record["events"] == []
+
+    table_record = fleet_ship_record_to_table_wire(record)
+    assert "events" not in table_record
+    assert table_record["recordId"] == "rec-1"
+
+
+def test_table_wire_ledger_matches_bff_player_shape(sample_turn):
+    baseline = ensure_fleet_baseline(628580, 1, sample_turn)
+    ledger = baseline.players[0]
+    table_wire = fleet_acquisition_ledger_to_table_wire(ledger)
+    assert table_wire["playerId"] == ledger.player_id
+    assert len(table_wire["records"]) == len(ledger.records)
+    for record in table_wire["records"]:
+        assert "events" not in record
+
+
+def test_cached_stream_events_use_table_wire(sample_turn):
+    baseline = ensure_fleet_baseline(628580, 1, sample_turn)
+    ledger = baseline.players[0]
+    persisted = PersistedFleetLedger(
+        ledger=ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    events = wire_cached_player_events(persisted)
+    ledger_event = events[0]
+    assert ledger_event["type"] == "ledger_updated"
+    ledger_wire = ledger_event["ledger"]
+    assert isinstance(ledger_wire, dict)
+    for record in ledger_wire.get("records", []):
+        assert isinstance(record, dict)
+        assert "events" not in record

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -89,11 +89,19 @@ def _install_scheduler(
     return scheduler
 
 
-def test_on_fleet_snapshot_persisted_only_clears_host_turn_document(
+def test_on_fleet_snapshot_persisted_clears_scores_host_turn_document(
     memory_backend,
     persistence,
 ):
-    """Persisting fleet@(N-1) invalidates scores@N only, not scores@(N-1)."""
+    """Persisting fleet@(N-1) always drops scores@N cache; reschedule needs an open stream."""
+    from unittest.mock import MagicMock
+
+    from api.analytics.military_score_inference.inference_stream_scope import InferenceStreamScope
+    from api.analytics.military_score_inference.inference_table_stream_registry import (
+        attach_inference_table_stream,
+        reset_inference_table_stream_registry_for_tests,
+    )
+
     fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
     scheduler = InferenceRowScheduler(worker_count=0)
     invalidation = InferenceInvalidationService(
@@ -118,6 +126,23 @@ def test_on_fleet_snapshot_persisted_only_clears_host_turn_document(
 
     assert persistence.get_row(game_id, persp, 111, player_id) is None
     assert persistence.get_row(game_id, persp, 110, player_id) is not None
+
+    persistence.put_row(game_id, persp, 111, player_id, row)
+
+    try:
+        scope = InferenceStreamScope(game_id=game_id, perspective=persp, turn_number=111)
+        controller = MagicMock()
+        controller.scope = scope
+        controller.player_ids = (player_id,)
+        controller.reschedule_all_rows = MagicMock(return_value=True)
+        attach_inference_table_stream(controller)
+
+        invalidation.on_fleet_snapshot_persisted(game_id, persp, fleet_turn=110)
+
+        assert persistence.get_row(game_id, persp, 111, player_id) is None
+        controller.reschedule_all_rows.assert_called_once()
+    finally:
+        reset_inference_table_stream_registry_for_tests()
 
 
 def _fleet_overlay_from_diagnostics(diagnostics: object) -> dict[str, object]:

--- a/packages/bff/bff/analytics/fleet.py
+++ b/packages/bff/bff/analytics/fleet.py
@@ -1,6 +1,7 @@
 """BFF Fleet analytic handlers."""
 
 from api.analytics.catalog import catalog_entry
+from api.analytics.fleet.table_wire import fleet_acquisition_ledger_to_table_wire_json
 from api.diagnostics import Diagnostics
 from api.models.game import TurnInfo
 
@@ -15,39 +16,8 @@ from bff.analytics.models import (
 ANALYTIC_ID = "fleet"
 
 
-def _shape_table_record(record: dict[str, object]) -> dict[str, object]:
-    """Shape one core fleet ship record for the SPA table wire (no evidence events)."""
-    shaped: dict[str, object] = {
-        "recordId": record.get("recordId"),
-        "disposition": record.get("disposition", "active"),
-    }
-    if "qualifiers" in record:
-        shaped["qualifiers"] = record["qualifiers"]
-    if "fields" in record:
-        shaped["fields"] = record["fields"]
-    if "buildOptionSets" in record:
-        shaped["buildOptionSets"] = record["buildOptionSets"]
-    if "displayDefaultOptionSetIndex" in record:
-        shaped["displayDefaultOptionSetIndex"] = record["displayDefaultOptionSetIndex"]
-    if "lastSeen" in record:
-        shaped["lastSeen"] = record["lastSeen"]
-    return shaped
-
-
 def _shape_table_player(player: dict[str, object]) -> dict[str, object]:
-    shaped: dict[str, object] = {
-        "playerId": player.get("playerId"),
-        "playerName": player.get("playerName", ""),
-        "records": [
-            _shape_table_record(record)
-            for record in player.get("records", [])
-            if isinstance(record, dict)
-        ],
-    }
-    discrepancy = player.get("discrepancy")
-    if discrepancy is not None:
-        shaped["discrepancy"] = discrepancy
-    return shaped
+    return fleet_acquisition_ledger_to_table_wire_json(player)
 
 
 def component_catalog_wire(turn: TurnInfo) -> dict[str, dict[str, str]]:

--- a/packages/frontend/src/analytics/fleet/useFleetTableQuery.test.tsx
+++ b/packages/frontend/src/analytics/fleet/useFleetTableQuery.test.tsx
@@ -60,4 +60,35 @@ describe('useFleetTableQuery', () => {
       expect(fetchAnalyticTable).toHaveBeenCalledTimes(1)
     })
   })
+
+  it('refetches after scores inference revision when the initial load returned 409', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    vi.mocked(fetchAnalyticTable)
+      .mockRejectedValueOnce(new Error('409 — GET /bff/analytics/fleet/table'))
+      .mockResolvedValueOnce({
+        analyticId: 'fleet',
+      } as unknown as TableDataResponse)
+
+    const { result } = renderHook(
+      ({ activeScope, enabled }) => useFleetTableQuery(activeScope, enabled),
+      {
+        wrapper: createWrapper(client),
+        initialProps: { activeScope: scope, enabled: true },
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+      expect(fetchAnalyticTable).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      bumpScoresInferenceRevision(scope)
+    })
+
+    await waitFor(() => {
+      expect(fetchAnalyticTable).toHaveBeenCalledTimes(2)
+      expect(result.current.isSuccess).toBe(true)
+    })
+  })
 })

--- a/packages/frontend/src/analytics/fleet/useFleetTableQuery.ts
+++ b/packages/frontend/src/analytics/fleet/useFleetTableQuery.ts
@@ -1,15 +1,59 @@
 import { useQuery } from '@tanstack/react-query'
+import { useEffect, useRef } from 'react'
 import { fetchAnalyticTable } from '../../api/bff'
 import type { AnalyticShellScope } from '../../api/bff'
+import { errorDetailFromUnknown, parseHttpStatusFromErrorMessage } from '../../lib/queryRetry'
+import { useScoresInferenceRevision } from '../../stores/scoresInferenceRevision'
 import { fleetTableQueryKey } from './fleetTableQueryKey'
+
+const FLEET_CONFLICT_REFETCH_DEBOUNCE_MS = 300
+
+function isFleetGapFillConflictError(error: unknown): boolean {
+  return parseHttpStatusFromErrorMessage(errorDetailFromUnknown(error)) === 409
+}
 
 export function useFleetTableQuery(
   analyticScope: AnalyticShellScope | null,
   fetchEnabled: boolean
 ) {
-  return useQuery({
+  const inferenceRevision = useScoresInferenceRevision(analyticScope)
+  const previousInferenceRevisionRef = useRef(inferenceRevision)
+
+  const query = useQuery({
     queryKey: fleetTableQueryKey(analyticScope),
     queryFn: () => fetchAnalyticTable('fleet', analyticScope!),
     enabled: fetchEnabled && analyticScope != null,
   })
+
+  useEffect(() => {
+    if (!fetchEnabled || analyticScope == null) {
+      previousInferenceRevisionRef.current = inferenceRevision
+      return
+    }
+    if (inferenceRevision === previousInferenceRevisionRef.current) {
+      return
+    }
+    previousInferenceRevisionRef.current = inferenceRevision
+    if (!query.isError || !isFleetGapFillConflictError(query.error) || query.isFetching) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      void query.refetch()
+    }, FLEET_CONFLICT_REFETCH_DEBOUNCE_MS)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [
+    analyticScope,
+    fetchEnabled,
+    inferenceRevision,
+    query.error,
+    query.isError,
+    query.isFetching,
+    query.refetch,
+  ])
+
+  return query
 }

--- a/packages/frontend/src/api/parseFleetTableStreamEvent.test.ts
+++ b/packages/frontend/src/api/parseFleetTableStreamEvent.test.ts
@@ -22,6 +22,71 @@ describe('parseFleetTableStreamEvent', () => {
     expect(event?.type).toBe('ledger_updated')
   })
 
+  it('parses ledger_updated events with core evidence events stripped on the wire', () => {
+    const event = parseFleetTableStreamEvent(
+      JSON.stringify({
+        type: 'ledger_updated',
+        playerId: 8,
+        ledger: {
+          playerId: 8,
+          playerName: 'Alice',
+          records: [
+            {
+              recordId: 'rec-1',
+              disposition: 'active',
+              qualifiers: {},
+              fields: {
+                shipId: { kind: 'bounded', operator: 'lte', value: 100 },
+                hull: { kind: 'unknown' },
+                engine: { kind: 'unknown' },
+                beams: { kind: 'unknown' },
+                launchers: { kind: 'unknown' },
+                builtTurn: { kind: 'unknown' },
+                location: { kind: 'unknown' },
+              },
+              buildOptionSets: [],
+            },
+          ],
+        },
+      })
+    )
+
+    expect(event?.type).toBe('ledger_updated')
+  })
+
+  it('rejects ledger_updated records that still carry core-only evidence events', () => {
+    expect(() =>
+      parseFleetTableStreamEvent(
+        JSON.stringify({
+          type: 'ledger_updated',
+          playerId: 8,
+          ledger: {
+            playerId: 8,
+            playerName: 'Alice',
+            records: [
+              {
+                recordId: 'rec-1',
+                disposition: 'active',
+                qualifiers: {},
+                fields: {
+                  shipId: { kind: 'bounded', operator: 'lte', value: 100 },
+                  hull: { kind: 'unknown' },
+                  engine: { kind: 'unknown' },
+                  beams: { kind: 'unknown' },
+                  launchers: { kind: 'unknown' },
+                  builtTurn: { kind: 'unknown' },
+                  location: { kind: 'unknown' },
+                },
+                buildOptionSets: [],
+                events: [{ kind: 'scoreboard_ingest', turn: 4 }],
+              },
+            ],
+          },
+        })
+      )
+    ).toThrow(/invalid shape/i)
+  })
+
   it('rejects unknown event types', () => {
     expect(() =>
       parseFleetTableStreamEvent(JSON.stringify({ type: 'unknown', playerId: 8 }))


### PR DESCRIPTION
## Summary

- Gap-fill `put_ledger` no longer fires `on_snapshot_persisted` mid-chain; notifications flush once per newly ensure-final turn after the chain succeeds (`_emit_deferred_fleet_snapshot_notifications`)
- `put_ledger` only notifies when an explicit roster is final; `put_snapshot` still forces notify
- Fleet table refetches on scores inference revision bump when the REST query is stuck in 409

Interim correctness bridge before [#161](https://github.com/SteveDraper/Planets-Console/issues/161) (fleet gap-fill coordinator). Fixes the scores↔fleet feedback loop where mid-chain `fleet@(N-1)` persistence invalidated `scores@N`, rescheduled inference, bumped fleet invalidation, and left fleet callers on `ConflictError`.

## Test plan

- [x] `uv run pytest` targeted fleet persistence / ledger / prior-turn warm tests
- [x] `npm test -- --run useFleetTableQuery.test.tsx`
- [x] `make lint`
- [ ] Manual: game 628580 / perspective 2 / turn 8 -- scoreboard reschedules when fleet@7 lands; fleet recovers from 409 after scoreboard settles


Made with [Cursor](https://cursor.com)