### PR TITLE
Player-scoped fleet gap-fill and export ensure materialization (#179)

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -277,6 +277,23 @@ def _find_gap_start_turn(
     return target_turn + 1
 
 
+def _find_gap_start_turn_for_player(
+    persistence: FleetSnapshotPersistenceService,
+    game_id: int,
+    perspective: int,
+    player_id: int,
+    target_turn: int,
+    load_turn: Callable[[int], TurnInfo | None],
+) -> int:
+    """Return the first turn in ``1..target_turn`` lacking ensure-final ledger for P."""
+    for turn_number in range(1, target_turn + 1):
+        if load_turn(turn_number) is None:
+            continue
+        if not persistence.has_final_ledger(game_id, perspective, turn_number, player_id):
+            return turn_number
+    return target_turn + 1
+
+
 def _snapshot_has_all_roster_players(snapshot: FleetTurnSnapshot, turn: TurnInfo) -> bool:
     roster_ids = set(_roster_player_ids(turn))
     present_ids = {ledger.player_id for ledger in snapshot.players}
@@ -594,8 +611,7 @@ def get_or_materialize_fleet_ledger_for_player(
     """Return a cached ledger or materialize turn T for one player."""
     from api.analytics.fleet.gap_fill_coordinator import coordinator_for
 
-    return coordinator_for(persistence, game_id, perspective).materialize_ledger_for_player(
-        player_id,
+    return coordinator_for(persistence, game_id, perspective, player_id).materialize_ledger(
         turn,
         load_turn=load_turn,
         inference_materialization=inference_materialization,
@@ -613,12 +629,36 @@ def get_or_materialize_fleet_snapshot(
     inference_materialization: FleetInferenceMaterialization | None = None,
     query_context: AnalyticQueryContext | None = None,
 ) -> FleetTurnSnapshot:
-    """Return a cached snapshot or materialize turn T from T-1 plus turn-T delta."""
-    from api.analytics.fleet.gap_fill_coordinator import coordinator_for
-
-    return coordinator_for(persistence, game_id, perspective).materialize_snapshot(
+    """Return a cached snapshot or fan out per-player materialization for turn T."""
+    turn_number = turn.settings.turn
+    cached = persistence.get_snapshot(game_id, perspective, turn_number)
+    if _is_fleet_snapshot_cache_hit(
+        persistence,
+        game_id,
+        perspective,
+        turn_number,
         turn,
-        load_turn=load_turn,
-        inference_materialization=inference_materialization,
-        query_context=query_context,
-    )
+        cached,
+    ):
+        assert cached is not None
+        return cached
+
+    for player_id in _roster_player_ids(turn):
+        get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            game_id,
+            perspective,
+            player_id,
+            turn,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+        )
+
+    snapshot = persistence.get_snapshot(game_id, perspective, turn_number)
+    if snapshot is None or not _snapshot_has_all_roster_players(snapshot, turn):
+        raise ConflictError(
+            f"fleet snapshot gap-fill produced incomplete document "
+            f"for game {game_id} perspective {perspective} turn {turn_number}"
+        )
+    return snapshot

--- a/packages/api/api/analytics/fleet/constants.py
+++ b/packages/api/api/analytics/fleet/constants.py
@@ -10,6 +10,10 @@ GAP_FILL_MAX_RETRIES = 10
 # Max seconds a waiter blocks on an in-flight coordinated gap-fill before surfacing error.
 GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC = 300
 
+# Brief settle window so concurrent same-player requests can raise target_turn
+# before the leader invokes the materialize chain.
+GAP_FILL_TARGET_TURN_COLLECT_SEC = 0.05
+
 # Persisted fleet turn snapshot materialization semantics. Bump conservatively when
 # materialization output would change for the same stored RST + scores inputs
 # (chain/gap-fill rules, inferred acquisition ingest, observation-inference merge).

--- a/packages/api/api/analytics/fleet/constants.py
+++ b/packages/api/api/analytics/fleet/constants.py
@@ -10,8 +10,9 @@ GAP_FILL_MAX_RETRIES = 10
 # Max seconds a waiter blocks on an in-flight coordinated gap-fill before surfacing error.
 GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC = 300
 
-# Brief settle window so concurrent same-player requests can raise target_turn
-# before the leader invokes the materialize chain.
+# Quiet period after the last target_turn bump before the leader starts unwind.
+# Waiters notify via threading.Condition; this bounds how long the leader waits
+# for late joiners that raise target_turn.
 GAP_FILL_TARGET_TURN_COLLECT_SEC = 0.05
 
 # Persisted fleet turn snapshot materialization semantics. Bump conservatively when

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -8,7 +8,10 @@ from api.analytics.export_context import AnalyticQueryContext
 from api.analytics.export_types import EnsureDependency, ExportScope, PathPrefixScopeRule
 from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.meta_wire import build_export_meta_branch
-from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+from api.analytics.fleet.chain import (
+    get_or_materialize_fleet_ledger_for_player,
+    get_or_materialize_fleet_snapshot,
+)
 from api.analytics.fleet.composition_export import build_fleet_composition_branch
 from api.analytics.fleet.compute_services import resolve_fleet_services
 from api.analytics.fleet.constants import ANALYTIC_ID
@@ -45,6 +48,24 @@ def _fleet_snapshot_for_scope(
         raise ValidationError(f"Turn {scope.turn} is not stored")
 
     def gather() -> FleetTurnSnapshot:
+        if scope.player_id is not None:
+            persisted = get_or_materialize_fleet_ledger_for_player(
+                services.persistence,
+                services.game_id,
+                services.perspective,
+                scope.player_id,
+                resolved_turn,
+                load_turn=services.load_turn,
+                inference_materialization=services.inference_materialization,
+                query_context=ctx,
+            )
+            return FleetTurnSnapshot(
+                analytic_id=ANALYTIC_ID,
+                game_id=services.game_id,
+                perspective=services.perspective,
+                turn=scope.turn,
+                players=[persisted.ledger],
+            )
         return get_or_materialize_fleet_snapshot(
             services.persistence,
             services.game_id,

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -24,6 +25,7 @@ from api.analytics.fleet.constants import (
     ANALYTIC_ID,
     GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC,
     GAP_FILL_MAX_RETRIES,
+    GAP_FILL_TARGET_TURN_COLLECT_SEC,
 )
 from api.analytics.fleet.exports import ensure_fleet_export
 from api.analytics.fleet.gap_fill_deferred_notifications import (
@@ -132,10 +134,24 @@ class FleetGapFillCoordinator:
         with self._lock:
             self._reap_abandoned_inflight_locked()
             if self._inflight is not None and self._inflight.event.is_set():
-                self._inflight = None
+                if (
+                    self._inflight.generation != generation
+                    or turn_number <= self._inflight.target_turn
+                ):
+                    self._inflight = None
             if self._inflight is not None and self._inflight.generation == generation:
-                self._inflight.target_turn = max(self._inflight.target_turn, turn_number)
                 inflight = self._inflight
+                extended = turn_number > inflight.target_turn
+                inflight.target_turn = max(inflight.target_turn, turn_number)
+                if (
+                    inflight.event.is_set()
+                    and inflight.error is None
+                    and extended
+                ):
+                    inflight.event.clear()
+                    inflight.result_ledger = None
+                    inflight.leader_thread = threading.current_thread()
+                    is_leader = True
             else:
                 inflight = _InflightMaterialization(
                     target_turn=turn_number,
@@ -167,9 +183,6 @@ class FleetGapFillCoordinator:
             raise
         finally:
             inflight.event.set()
-            with self._lock:
-                if self._inflight is inflight:
-                    self._inflight = None
 
         if inflight.error is not None:
             raise inflight.error
@@ -184,6 +197,25 @@ class FleetGapFillCoordinator:
             return
         self._inflight = None
         inflight.event.set()
+
+    def _collect_target_turn_extensions(
+        self,
+        inflight: _InflightMaterialization,
+    ) -> None:
+        """Wait until concurrent waiters stop raising ``target_turn``."""
+        settle_deadline = time.monotonic() + GAP_FILL_TARGET_TURN_COLLECT_SEC
+        last_target = inflight.target_turn
+        while True:
+            if time.monotonic() >= settle_deadline:
+                return
+            with self._lock:
+                if self._inflight is not inflight:
+                    return
+                current_target = inflight.target_turn
+            if current_target > last_target:
+                last_target = current_target
+                settle_deadline = time.monotonic() + GAP_FILL_TARGET_TURN_COLLECT_SEC
+            threading.Event().wait(0.001)
 
     def _wait_for_inflight(
         self,
@@ -276,6 +308,7 @@ class FleetGapFillCoordinator:
         )
 
         while True:
+            self._collect_target_turn_extensions(inflight)
             target_turn = inflight.target_turn
             if complete_before is None:
                 complete_before = complete_snapshot_turn_numbers(

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -69,7 +69,8 @@ class _InflightJoin:
 class _InflightSlot:
     """Singleflight slot: join an inflight cycle or start a new leader unwind."""
 
-    def __init__(self) -> None:
+    def __init__(self, inflight_condition: threading.Condition) -> None:
+        self._inflight_condition = inflight_condition
         self._inflight: _InflightMaterialization | None = None
 
     @property
@@ -121,7 +122,10 @@ class _InflightSlot:
         turn_number: int,
     ) -> _InflightJoin:
         extended = turn_number > inflight.target_turn
+        previous_target = inflight.target_turn
         inflight.target_turn = max(inflight.target_turn, turn_number)
+        if inflight.target_turn > previous_target:
+            self._inflight_condition.notify_all()
         if inflight.event.is_set() and inflight.error is None and extended:
             inflight.event.clear()
             inflight.result_ledger = None
@@ -164,8 +168,8 @@ class FleetGapFillCoordinator:
         self._game_id = game_id
         self._perspective = perspective
         self._player_id = player_id
-        self._lock = threading.Lock()
-        self._inflight_slot = _InflightSlot()
+        self._inflight_condition = threading.Condition()
+        self._inflight_slot = _InflightSlot(self._inflight_condition)
 
     @property
     def epoch(self) -> int:
@@ -219,7 +223,7 @@ class FleetGapFillCoordinator:
         query_context: AnalyticQueryContext | None,
     ) -> PersistedFleetLedger:
         turn_number = turn.settings.turn
-        with self._lock:
+        with self._inflight_condition:
             join = self._inflight_slot.join(
                 turn_number,
                 self.epoch,
@@ -255,20 +259,31 @@ class FleetGapFillCoordinator:
         self,
         inflight: _InflightMaterialization,
     ) -> None:
-        """Wait until concurrent waiters stop raising ``target_turn``."""
+        """Wait until concurrent waiters stop raising ``target_turn``.
+
+        Waiters bump ``target_turn`` under ``_inflight_condition`` and notify the
+        leader; the leader waits here (without holding the lock through unwind)
+        until ``target_turn`` is unchanged for ``GAP_FILL_TARGET_TURN_COLLECT_SEC``.
+        """
         settle_deadline = time.monotonic() + GAP_FILL_TARGET_TURN_COLLECT_SEC
         last_target = inflight.target_turn
-        while True:
-            if time.monotonic() >= settle_deadline:
-                return
-            with self._lock:
+        with self._inflight_condition:
+            while True:
+                now = time.monotonic()
+                if now >= settle_deadline:
+                    return
                 if self._inflight_slot.inflight is not inflight:
                     return
+
                 current_target = inflight.target_turn
-            if current_target > last_target:
-                last_target = current_target
-                settle_deadline = time.monotonic() + GAP_FILL_TARGET_TURN_COLLECT_SEC
-            threading.Event().wait(0.001)
+                if current_target > last_target:
+                    last_target = current_target
+                    settle_deadline = now + GAP_FILL_TARGET_TURN_COLLECT_SEC
+
+                remaining = settle_deadline - now
+                if remaining <= 0:
+                    return
+                self._inflight_condition.wait(timeout=remaining)
 
     def _wait_for_inflight(
         self,

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -533,6 +533,7 @@ class FleetGapFillCoordinator:
     ) -> bool:
         """Return True when every gap turn has ensure-final ledger for this player."""
         player_id = self._player_id
+        all_gap_turns_final = True
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
             if turn_info is None:
@@ -572,8 +573,8 @@ class FleetGapFillCoordinator:
                 materialize_turn,
                 player_id,
             ):
-                return False
-        return True
+                all_gap_turns_final = False
+        return all_gap_turns_final
 
 
 _registry_lock = threading.Lock()

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -143,11 +143,7 @@ class FleetGapFillCoordinator:
                 inflight = self._inflight
                 extended = turn_number > inflight.target_turn
                 inflight.target_turn = max(inflight.target_turn, turn_number)
-                if (
-                    inflight.event.is_set()
-                    and inflight.error is None
-                    and extended
-                ):
+                if inflight.event.is_set() and inflight.error is None and extended:
                     inflight.event.clear()
                     inflight.result_ledger = None
                     inflight.leader_thread = threading.current_thread()

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -10,12 +10,11 @@ from typing import TYPE_CHECKING
 from api.analytics.export_context import AnalyticQueryContext, make_analytic_query_context
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
-    _find_gap_start_turn,
+    _find_gap_start_turn_for_player,
     _FleetSnapshotInvalidated,
     _GapFillCoherence,
     _is_fleet_ledger_cache_hit,
-    _is_fleet_snapshot_cache_hit,
-    _materialize_fleet_snapshot_chain,
+    _materialize_fleet_ledger_chain_for_player,
     _run_materialize_on_active_coherence,
     active_gap_fill_coherence,
     gap_fill_coherence_scope,
@@ -33,16 +32,15 @@ from api.analytics.fleet.gap_fill_deferred_notifications import (
 )
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import FleetTurnSnapshot, PersistedFleetLedger
+from api.analytics.fleet.types import PersistedFleetLedger
 from api.analytics.options import TurnAnalyticsOptions
-from api.analytics.turn_roster import iter_turn_players
 from api.errors import ConflictError, FleetMaterializationTimeoutError, NotFoundError
 from api.models.game import TurnInfo
 
 if TYPE_CHECKING:
     pass
 
-_CoordinatorKey = tuple[int, int, int]
+_CoordinatorKey = tuple[int, int, int, int]
 
 
 @dataclass
@@ -53,25 +51,25 @@ class _InflightMaterialization:
     inference_materialization: FleetInferenceMaterialization | None
     query_context: AnalyticQueryContext | None
     event: threading.Event = field(default_factory=threading.Event)
-    result_snapshot: FleetTurnSnapshot | None = None
     result_ledger: PersistedFleetLedger | None = None
-    result_player_id: int | None = None
     error: BaseException | None = None
     leader_thread: threading.Thread | None = None
 
 
 class FleetGapFillCoordinator:
-    """At most one active gap-fill unwind per ``(persistence, game_id, perspective)``."""
+    """At most one active gap-fill unwind per ``(persistence, game_id, perspective, player_id)``."""
 
     def __init__(
         self,
         persistence: FleetSnapshotPersistenceService,
         game_id: int,
         perspective: int,
+        player_id: int,
     ) -> None:
         self._persistence = persistence
         self._game_id = game_id
         self._perspective = perspective
+        self._player_id = player_id
         self._lock = threading.Lock()
         self._inflight: _InflightMaterialization | None = None
 
@@ -80,48 +78,8 @@ class FleetGapFillCoordinator:
         """Current invalidation generation for this perspective scope."""
         return self._persistence.invalidation_generation(self._game_id, self._perspective)
 
-    def materialize_snapshot(
+    def materialize_ledger(
         self,
-        turn: TurnInfo,
-        *,
-        load_turn: Callable[[int], TurnInfo | None],
-        inference_materialization: FleetInferenceMaterialization | None = None,
-        query_context: AnalyticQueryContext | None = None,
-    ) -> FleetTurnSnapshot:
-        turn_number = turn.settings.turn
-        cached = self._persistence.get_snapshot(self._game_id, self._perspective, turn_number)
-        if _is_fleet_snapshot_cache_hit(
-            self._persistence,
-            self._game_id,
-            self._perspective,
-            turn_number,
-            turn,
-            cached,
-        ):
-            return cached
-
-        if active_gap_fill_coherence() is not None:
-            return _run_materialize_on_active_coherence(
-                self._persistence,
-                self._game_id,
-                self._perspective,
-                turn,
-                load_turn=load_turn,
-                inference_materialization=inference_materialization,
-                materialize_player_id=None,
-            )
-
-        return self._coordinate(
-            turn,
-            load_turn=load_turn,
-            inference_materialization=inference_materialization,
-            query_context=query_context,
-            materialize_player_id=None,
-        )
-
-    def materialize_ledger_for_player(
-        self,
-        player_id: int,
         turn: TurnInfo,
         *,
         load_turn: Callable[[int], TurnInfo | None],
@@ -133,28 +91,29 @@ class FleetGapFillCoordinator:
             self._game_id,
             self._perspective,
             turn_number,
-            player_id,
+            self._player_id,
         )
         if cached is not None and _is_fleet_ledger_cache_hit(cached):
             return cached
 
         if active_gap_fill_coherence() is not None:
-            return _run_materialize_on_active_coherence(
+            result = _run_materialize_on_active_coherence(
                 self._persistence,
                 self._game_id,
                 self._perspective,
                 turn,
                 load_turn=load_turn,
                 inference_materialization=inference_materialization,
-                materialize_player_id=player_id,
+                materialize_player_id=self._player_id,
             )
+            assert isinstance(result, PersistedFleetLedger)
+            return result
 
         return self._coordinate(
             turn,
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
-            materialize_player_id=player_id,
         )
 
     def _coordinate(
@@ -164,8 +123,7 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
-        materialize_player_id: int | None,
-    ) -> FleetTurnSnapshot | PersistedFleetLedger:
+    ) -> PersistedFleetLedger:
         turn_number = turn.settings.turn
         generation = self.epoch
         inflight: _InflightMaterialization | None
@@ -192,14 +150,8 @@ class FleetGapFillCoordinator:
 
         if not is_leader:
             assert inflight is not None
-            self._wait_for_inflight(inflight, turn_number, turn, load_turn, materialize_player_id)
-            return self._result_for_request(
-                inflight,
-                turn_number,
-                turn,
-                load_turn,
-                materialize_player_id,
-            )
+            self._wait_for_inflight(inflight, turn_number)
+            return self._result_for_request(inflight, turn_number, turn)
 
         assert inflight is not None
         try:
@@ -209,7 +161,6 @@ class FleetGapFillCoordinator:
                 load_turn=load_turn,
                 inference_materialization=inference_materialization,
                 query_context=query_context,
-                materialize_player_id=materialize_player_id,
             )
         except BaseException as exc:
             inflight.error = exc
@@ -222,13 +173,7 @@ class FleetGapFillCoordinator:
 
         if inflight.error is not None:
             raise inflight.error
-        return self._result_for_request(
-            inflight,
-            turn_number,
-            turn,
-            load_turn,
-            materialize_player_id,
-        )
+        return self._result_for_request(inflight, turn_number, turn)
 
     def _reap_abandoned_inflight_locked(self) -> None:
         inflight = self._inflight
@@ -244,37 +189,31 @@ class FleetGapFillCoordinator:
         self,
         inflight: _InflightMaterialization,
         turn_number: int,
-        turn: TurnInfo,
-        load_turn: Callable[[int], TurnInfo | None],
-        materialize_player_id: int | None,
     ) -> None:
         if not inflight.event.wait(timeout=GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC):
             raise FleetMaterializationTimeoutError(
                 "fleet gap-fill for game "
-                f"{self._game_id} perspective {self._perspective} turn {turn_number} "
+                f"{self._game_id} perspective {self._perspective} "
+                f"player {self._player_id} turn {turn_number} "
                 f"did not complete within {GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC}s"
             )
         if inflight.error is not None:
             return
-        if materialize_player_id is None:
-            cached = self._persistence.get_snapshot(self._game_id, self._perspective, turn_number)
-            if cached is not None:
-                return
-        else:
-            cached = self._persistence.get_ledger(
-                self._game_id,
-                self._perspective,
-                turn_number,
-                materialize_player_id,
-            )
-            if cached is not None:
-                return
+        cached = self._persistence.get_ledger(
+            self._game_id,
+            self._perspective,
+            turn_number,
+            self._player_id,
+        )
+        if cached is not None:
+            return
         if inflight.generation != self.epoch:
             return
         raise FleetMaterializationTimeoutError(
             "fleet gap-fill waiter for game "
-            f"{self._game_id} perspective {self._perspective} turn {turn_number} "
-            "completed without satisfying the requested snapshot"
+            f"{self._game_id} perspective {self._perspective} "
+            f"player {self._player_id} turn {turn_number} "
+            "completed without satisfying the requested ledger"
         )
 
     def _result_for_request(
@@ -282,63 +221,34 @@ class FleetGapFillCoordinator:
         inflight: _InflightMaterialization,
         turn_number: int,
         turn: TurnInfo,
-        load_turn: Callable[[int], TurnInfo | None],
-        materialize_player_id: int | None,
-    ) -> FleetTurnSnapshot | PersistedFleetLedger:
+    ) -> PersistedFleetLedger:
         if inflight.error is not None:
             raise inflight.error
-        if materialize_player_id is None:
-            if inflight.result_snapshot is not None:
-                return inflight.result_snapshot
-            cached = self._persistence.get_snapshot(self._game_id, self._perspective, turn_number)
-            if _is_fleet_snapshot_cache_hit(
-                self._persistence,
-                self._game_id,
-                self._perspective,
-                turn_number,
-                turn,
-                cached,
-            ):
-                assert cached is not None
-                return cached
-        else:
-            if (
-                inflight.result_ledger is not None
-                and inflight.result_player_id == materialize_player_id
-            ):
-                return inflight.result_ledger
-            cached = self._persistence.get_ledger(
-                self._game_id,
-                self._perspective,
-                turn_number,
-                materialize_player_id,
-            )
-            if cached is not None and _is_fleet_ledger_cache_hit(cached):
-                return cached
+        if inflight.result_ledger is not None:
+            return inflight.result_ledger
+        cached = self._persistence.get_ledger(
+            self._game_id,
+            self._perspective,
+            turn_number,
+            self._player_id,
+        )
+        if cached is not None and _is_fleet_ledger_cache_hit(cached):
+            return cached
 
         if inflight.generation != self.epoch:
-            return self._retry_after_epoch_bump(inflight, turn, materialize_player_id)
+            return self._retry_after_epoch_bump(inflight, turn)
 
         raise ConflictError(
             f"fleet gap-fill for game {self._game_id} perspective {self._perspective} "
-            f"turn {turn_number} completed without a cache hit"
+            f"player {self._player_id} turn {turn_number} completed without a cache hit"
         )
 
     def _retry_after_epoch_bump(
         self,
         inflight: _InflightMaterialization,
         turn: TurnInfo,
-        materialize_player_id: int | None,
-    ) -> FleetTurnSnapshot | PersistedFleetLedger:
-        if materialize_player_id is None:
-            return self.materialize_snapshot(
-                turn,
-                load_turn=inflight.load_turn,
-                inference_materialization=inflight.inference_materialization,
-                query_context=inflight.query_context,
-            )
-        return self.materialize_ledger_for_player(
-            materialize_player_id,
+    ) -> PersistedFleetLedger:
+        return self.materialize_ledger(
             turn,
             load_turn=inflight.load_turn,
             inference_materialization=inflight.inference_materialization,
@@ -353,7 +263,6 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
-        materialize_player_id: int | None,
     ) -> None:
         complete_before: frozenset[int] | None = None
         query_ctx = _resolve_query_context(
@@ -390,10 +299,11 @@ class FleetGapFillCoordinator:
                 )
                 try:
                     with gap_fill_coherence_scope(coherence):
-                        gap_start = _find_gap_start_turn(
+                        gap_start = _find_gap_start_turn_for_player(
                             self._persistence,
                             self._game_id,
                             self._perspective,
+                            self._player_id,
                             current_target,
                             load_turn,
                         )
@@ -403,7 +313,7 @@ class FleetGapFillCoordinator:
                                     "fleet gap-fill requires query context when "
                                     "inference materialization is configured for "
                                     f"game {self._game_id} perspective "
-                                    f"{self._perspective}"
+                                    f"{self._perspective} player {self._player_id}"
                                 )
 
                             materialized_via_export = False
@@ -428,61 +338,48 @@ class FleetGapFillCoordinator:
                                         raise NotFoundError(
                                             f"fleet gap-fill requires stored turn "
                                             f"{current_target} for game {self._game_id} "
-                                            f"perspective {self._perspective}"
+                                            f"perspective {self._perspective} "
+                                            f"player {self._player_id}"
                                         )
-                                _materialize_fleet_snapshot_chain(
+                                from api.analytics.fleet.turn_context import FleetTurnContext
+
+                                turn_context_cache: dict[int, FleetTurnContext] = {}
+                                _materialize_fleet_ledger_chain_for_player(
                                     self._persistence,
                                     self._game_id,
                                     self._perspective,
+                                    self._player_id,
                                     target_turn_info,
                                     load_turn=load_turn,
                                     inference_materialization=inference_materialization,
                                     coherence=coherence,
+                                    turn_context_cache=turn_context_cache,
                                 )
                     materialized_target = current_target
                     break
                 except _FleetSnapshotInvalidated:
-                    if materialize_player_id is None:
-                        cached = self._persistence.get_snapshot(
-                            self._game_id,
-                            self._perspective,
-                            current_target,
-                        )
-                        target_turn_info = load_turn(current_target) or turn
-                        if _is_fleet_snapshot_cache_hit(
-                            self._persistence,
-                            self._game_id,
-                            self._perspective,
-                            current_target,
-                            target_turn_info,
-                            cached,
-                        ):
-                            assert cached is not None
-                            inflight.result_snapshot = cached
-                            return
-                    else:
-                        cached = self._persistence.get_ledger(
-                            self._game_id,
-                            self._perspective,
-                            current_target,
-                            materialize_player_id,
-                        )
-                        if cached is not None and _is_fleet_ledger_cache_hit(cached):
-                            inflight.result_ledger = cached
-                            inflight.result_player_id = materialize_player_id
-                            return
+                    cached = self._persistence.get_ledger(
+                        self._game_id,
+                        self._perspective,
+                        current_target,
+                        self._player_id,
+                    )
+                    if cached is not None and _is_fleet_ledger_cache_hit(cached):
+                        inflight.result_ledger = cached
+                        return
                     if attempt + 1 >= GAP_FILL_MAX_RETRIES:
                         raise ConflictError(
                             f"fleet gap-fill for game {self._game_id} "
-                            f"perspective {self._perspective} turn {inflight.target_turn} "
+                            f"perspective {self._perspective} "
+                            f"player {self._player_id} turn {inflight.target_turn} "
                             f"exceeded {GAP_FILL_MAX_RETRIES} invalidation retries"
                         ) from None
                     continue
             if materialized_target is None:
                 raise ConflictError(
                     f"fleet gap-fill for game {self._game_id} perspective {self._perspective} "
-                    f"turn {inflight.target_turn} exceeded {GAP_FILL_MAX_RETRIES} "
-                    "invalidation retries"
+                    f"player {self._player_id} turn {inflight.target_turn} exceeded "
+                    f"{GAP_FILL_MAX_RETRIES} invalidation retries"
                 )
 
             if inflight.target_turn > materialized_target:
@@ -499,52 +396,29 @@ class FleetGapFillCoordinator:
             )
 
             final_target = materialized_target
-            if materialize_player_id is None:
-                target_turn_info = load_turn(final_target)
-                if target_turn_info is None:
-                    if final_target == turn.settings.turn:
-                        target_turn_info = turn
-                    else:
-                        raise NotFoundError(
-                            f"fleet gap-fill requires stored turn {final_target} "
-                            f"for game {self._game_id} perspective {self._perspective}"
-                        )
-                snapshot = self._persistence.get_snapshot(
-                    self._game_id,
-                    self._perspective,
-                    final_target,
-                )
-                if snapshot is None:
-                    raise ConflictError(
-                        f"fleet snapshot gap-fill produced no document "
+            target_turn_info = load_turn(final_target)
+            if target_turn_info is None:
+                if final_target == turn.settings.turn:
+                    target_turn_info = turn
+                else:
+                    raise NotFoundError(
+                        f"fleet gap-fill requires stored turn {final_target} "
                         f"for game {self._game_id} perspective {self._perspective} "
-                        f"turn {final_target}"
+                        f"player {self._player_id}"
                     )
-                inflight.result_snapshot = snapshot
-            else:
-                target_turn_info = load_turn(final_target)
-                if target_turn_info is None:
-                    if final_target == turn.settings.turn:
-                        target_turn_info = turn
-                    else:
-                        raise NotFoundError(
-                            f"fleet gap-fill requires stored turn {final_target} "
-                            f"for game {self._game_id} perspective {self._perspective}"
-                        )
-                persisted = self._persistence.get_ledger(
-                    self._game_id,
-                    self._perspective,
-                    final_target,
-                    materialize_player_id,
+            persisted = self._persistence.get_ledger(
+                self._game_id,
+                self._perspective,
+                final_target,
+                self._player_id,
+            )
+            if persisted is None:
+                raise ConflictError(
+                    f"fleet ledger gap-fill produced no ledger "
+                    f"for game {self._game_id} perspective {self._perspective} "
+                    f"player {self._player_id} turn {final_target}"
                 )
-                if persisted is None:
-                    raise ConflictError(
-                        f"fleet ledger gap-fill produced no ledger "
-                        f"for game {self._game_id} perspective {self._perspective} "
-                        f"player {materialize_player_id} turn {final_target}"
-                    )
-                inflight.result_ledger = persisted
-                inflight.result_player_id = materialize_player_id
+            inflight.result_ledger = persisted
             return
 
     def _forward_unwind_via_export_ensure(
@@ -556,45 +430,41 @@ class FleetGapFillCoordinator:
         *,
         inference_materialization: FleetInferenceMaterialization | None,
     ) -> bool:
-        """Return True when every gap turn has a persisted snapshot after export ensure."""
+        """Return True when every gap turn has ensure-final ledger for this player."""
         from api.analytics.fleet.chain import _run_materialize_on_active_coherence
 
+        player_id = self._player_id
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
             if turn_info is None:
                 raise NotFoundError(
                     f"fleet forward unwind requires stored turn {materialize_turn} "
-                    f"for game {self._game_id} perspective {self._perspective}"
+                    f"for game {self._game_id} perspective {self._perspective} "
+                    f"player {player_id}"
                 )
-            for player in iter_turn_players(turn_info):
-                scope = ExportScope(
-                    game_id=self._game_id,
-                    perspective=self._perspective,
-                    turn=materialize_turn,
-                    player_id=player.id,
-                )
-                ensure_fleet_export(query_ctx, scope)
+            scope = ExportScope(
+                game_id=self._game_id,
+                perspective=self._perspective,
+                turn=materialize_turn,
+                player_id=player_id,
+            )
+            ensure_fleet_export(query_ctx, scope)
 
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
             if turn_info is None:
                 raise NotFoundError(
                     f"fleet forward unwind requires stored turn {materialize_turn} "
-                    f"for game {self._game_id} perspective {self._perspective}"
+                    f"for game {self._game_id} perspective {self._perspective} "
+                    f"player {player_id}"
                 )
-            snapshot = self._persistence.get_snapshot(
+            persisted = self._persistence.get_ledger(
                 self._game_id,
                 self._perspective,
                 materialize_turn,
+                player_id,
             )
-            if _is_fleet_snapshot_cache_hit(
-                self._persistence,
-                self._game_id,
-                self._perspective,
-                materialize_turn,
-                turn_info,
-                snapshot,
-            ):
+            if persisted is not None and _is_fleet_ledger_cache_hit(persisted):
                 continue
             _run_materialize_on_active_coherence(
                 self._persistence,
@@ -603,17 +473,15 @@ class FleetGapFillCoordinator:
                 turn_info,
                 load_turn=load_turn,
                 inference_materialization=inference_materialization,
-                materialize_player_id=None,
+                materialize_player_id=player_id,
             )
 
         for materialize_turn in range(gap_start, target_turn + 1):
-            if (
-                self._persistence.get_snapshot(
-                    self._game_id,
-                    self._perspective,
-                    materialize_turn,
-                )
-                is None
+            if not self._persistence.has_final_ledger(
+                self._game_id,
+                self._perspective,
+                materialize_turn,
+                player_id,
             ):
                 return False
         return True
@@ -627,12 +495,18 @@ def coordinator_for(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
     perspective: int,
+    player_id: int,
 ) -> FleetGapFillCoordinator:
-    key = (id(persistence), game_id, perspective)
+    key = (id(persistence), game_id, perspective, player_id)
     with _registry_lock:
         coordinator = _coordinators.get(key)
         if coordinator is None:
-            coordinator = FleetGapFillCoordinator(persistence, game_id, perspective)
+            coordinator = FleetGapFillCoordinator(
+                persistence,
+                game_id,
+                perspective,
+                player_id,
+            )
             _coordinators[key] = coordinator
         return coordinator
 

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -58,6 +58,98 @@ class _InflightMaterialization:
     leader_thread: threading.Thread | None = None
 
 
+@dataclass(frozen=True)
+class _InflightJoin:
+    """Whether the caller should lead gap-fill or wait on an existing inflight cycle."""
+
+    inflight: _InflightMaterialization
+    is_leader: bool
+
+
+class _InflightSlot:
+    """Singleflight slot: join an inflight cycle or start a new leader unwind."""
+
+    def __init__(self) -> None:
+        self._inflight: _InflightMaterialization | None = None
+
+    @property
+    def inflight(self) -> _InflightMaterialization | None:
+        return self._inflight
+
+    def join(
+        self,
+        turn_number: int,
+        generation: int,
+        *,
+        load_turn: Callable[[int], TurnInfo | None],
+        inference_materialization: FleetInferenceMaterialization | None,
+        query_context: AnalyticQueryContext | None,
+    ) -> _InflightJoin:
+        self._reap_abandoned()
+        self._discard_stale_completed(turn_number, generation)
+        existing = self._inflight
+        if existing is not None and existing.generation == generation:
+            return self._join_existing(existing, turn_number)
+        return self._start_new(
+            turn_number,
+            generation,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+        )
+
+    def _reap_abandoned(self) -> None:
+        inflight = self._inflight
+        if inflight is None or inflight.event.is_set():
+            return
+        leader_thread = inflight.leader_thread
+        if leader_thread is not None and leader_thread.is_alive():
+            return
+        self._inflight = None
+        inflight.event.set()
+
+    def _discard_stale_completed(self, turn_number: int, generation: int) -> None:
+        inflight = self._inflight
+        if inflight is None or not inflight.event.is_set():
+            return
+        if inflight.generation != generation or turn_number <= inflight.target_turn:
+            self._inflight = None
+
+    def _join_existing(
+        self,
+        inflight: _InflightMaterialization,
+        turn_number: int,
+    ) -> _InflightJoin:
+        extended = turn_number > inflight.target_turn
+        inflight.target_turn = max(inflight.target_turn, turn_number)
+        if inflight.event.is_set() and inflight.error is None and extended:
+            inflight.event.clear()
+            inflight.result_ledger = None
+            inflight.leader_thread = threading.current_thread()
+            return _InflightJoin(inflight=inflight, is_leader=True)
+        return _InflightJoin(inflight=inflight, is_leader=False)
+
+    def _start_new(
+        self,
+        turn_number: int,
+        generation: int,
+        *,
+        load_turn: Callable[[int], TurnInfo | None],
+        inference_materialization: FleetInferenceMaterialization | None,
+        query_context: AnalyticQueryContext | None,
+    ) -> _InflightJoin:
+        inflight = _InflightMaterialization(
+            target_turn=turn_number,
+            generation=generation,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+            leader_thread=threading.current_thread(),
+        )
+        self._inflight = inflight
+        return _InflightJoin(inflight=inflight, is_leader=True)
+
+
 class FleetGapFillCoordinator:
     """At most one active gap-fill unwind per ``(persistence, game_id, perspective, player_id)``."""
 
@@ -73,7 +165,7 @@ class FleetGapFillCoordinator:
         self._perspective = perspective
         self._player_id = player_id
         self._lock = threading.Lock()
-        self._inflight: _InflightMaterialization | None = None
+        self._inflight_slot = _InflightSlot()
 
     @property
     def epoch(self) -> int:
@@ -127,45 +219,20 @@ class FleetGapFillCoordinator:
         query_context: AnalyticQueryContext | None,
     ) -> PersistedFleetLedger:
         turn_number = turn.settings.turn
-        generation = self.epoch
-        inflight: _InflightMaterialization | None
-        is_leader = False
-
         with self._lock:
-            self._reap_abandoned_inflight_locked()
-            if self._inflight is not None and self._inflight.event.is_set():
-                if (
-                    self._inflight.generation != generation
-                    or turn_number <= self._inflight.target_turn
-                ):
-                    self._inflight = None
-            if self._inflight is not None and self._inflight.generation == generation:
-                inflight = self._inflight
-                extended = turn_number > inflight.target_turn
-                inflight.target_turn = max(inflight.target_turn, turn_number)
-                if inflight.event.is_set() and inflight.error is None and extended:
-                    inflight.event.clear()
-                    inflight.result_ledger = None
-                    inflight.leader_thread = threading.current_thread()
-                    is_leader = True
-            else:
-                inflight = _InflightMaterialization(
-                    target_turn=turn_number,
-                    generation=generation,
-                    load_turn=load_turn,
-                    inference_materialization=inference_materialization,
-                    query_context=query_context,
-                    leader_thread=threading.current_thread(),
-                )
-                self._inflight = inflight
-                is_leader = True
+            join = self._inflight_slot.join(
+                turn_number,
+                self.epoch,
+                load_turn=load_turn,
+                inference_materialization=inference_materialization,
+                query_context=query_context,
+            )
+        inflight = join.inflight
 
-        if not is_leader:
-            assert inflight is not None
+        if not join.is_leader:
             self._wait_for_inflight(inflight, turn_number)
             return self._result_for_request(inflight, turn_number, turn)
 
-        assert inflight is not None
         try:
             self._run_leader_unwind(
                 inflight,
@@ -184,16 +251,6 @@ class FleetGapFillCoordinator:
             raise inflight.error
         return self._result_for_request(inflight, turn_number, turn)
 
-    def _reap_abandoned_inflight_locked(self) -> None:
-        inflight = self._inflight
-        if inflight is None or inflight.event.is_set():
-            return
-        leader_thread = inflight.leader_thread
-        if leader_thread is not None and leader_thread.is_alive():
-            return
-        self._inflight = None
-        inflight.event.set()
-
     def _collect_target_turn_extensions(
         self,
         inflight: _InflightMaterialization,
@@ -205,7 +262,7 @@ class FleetGapFillCoordinator:
             if time.monotonic() >= settle_deadline:
                 return
             with self._lock:
-                if self._inflight is not inflight:
+                if self._inflight_slot.inflight is not inflight:
                     return
                 current_target = inflight.target_turn
             if current_target > last_target:
@@ -460,8 +517,6 @@ class FleetGapFillCoordinator:
         inference_materialization: FleetInferenceMaterialization | None,
     ) -> bool:
         """Return True when every gap turn has ensure-final ledger for this player."""
-        from api.analytics.fleet.chain import _run_materialize_on_active_coherence
-
         player_id = self._player_id
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
@@ -479,33 +534,23 @@ class FleetGapFillCoordinator:
             )
             ensure_fleet_export(query_ctx, scope)
 
-        for materialize_turn in range(gap_start, target_turn + 1):
-            turn_info = load_turn(materialize_turn)
-            if turn_info is None:
-                raise NotFoundError(
-                    f"fleet forward unwind requires stored turn {materialize_turn} "
-                    f"for game {self._game_id} perspective {self._perspective} "
-                    f"player {player_id}"
-                )
             persisted = self._persistence.get_ledger(
                 self._game_id,
                 self._perspective,
                 materialize_turn,
                 player_id,
             )
-            if persisted is not None and _is_fleet_ledger_cache_hit(persisted):
-                continue
-            _run_materialize_on_active_coherence(
-                self._persistence,
-                self._game_id,
-                self._perspective,
-                turn_info,
-                load_turn=load_turn,
-                inference_materialization=inference_materialization,
-                materialize_player_id=player_id,
-            )
+            if persisted is None or not _is_fleet_ledger_cache_hit(persisted):
+                _run_materialize_on_active_coherence(
+                    self._persistence,
+                    self._game_id,
+                    self._perspective,
+                    turn_info,
+                    load_turn=load_turn,
+                    inference_materialization=inference_materialization,
+                    materialize_player_id=player_id,
+                )
 
-        for materialize_turn in range(gap_start, target_turn + 1):
             if not self._persistence.has_final_ledger(
                 self._game_id,
                 self._perspective,

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -152,9 +152,33 @@ def _load_prior_turn_fleet_snapshot(
         if not ensure_fleet_export(ctx, scope):
             return None
 
-    if not persistence.has_snapshot(scope.game_id, scope.perspective, scope.turn):
+    if scope.player_id is None:
+        if not persistence.has_snapshot(scope.game_id, scope.perspective, scope.turn):
+            return None
+        return persistence.get_snapshot(scope.game_id, scope.perspective, scope.turn)
+
+    if not persistence.has_ledger(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        scope.player_id,
+    ):
         return None
-    return persistence.get_snapshot(scope.game_id, scope.perspective, scope.turn)
+    persisted = persistence.get_ledger(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        scope.player_id,
+    )
+    if persisted is None:
+        return None
+    return FleetTurnSnapshot(
+        analytic_id=FLEET_ANALYTIC_ID,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        players=[persisted.ledger],
+    )
 
 
 def _overlay_from_snapshot(
@@ -231,10 +255,11 @@ def schedule_background_prior_turn_fleet_warm(
     turn: TurnInfo,
     load_turn: Callable[[int], TurnInfo | None],
     export_services: Mapping[str, object] | None,
+    player_ids: tuple[int, ...],
 ) -> None:
-    """Kick off non-blocking materialization of fleet@(host_turn - 1) for table streams."""
+    """Kick off non-blocking per-player materialization of fleet@(host_turn - 1)."""
     host_turn = turn.settings.turn
-    if host_turn <= 1:
+    if host_turn <= 1 or not player_ids:
         return
 
     fleet_services = _resolve_fleet_services(
@@ -249,11 +274,15 @@ def schedule_background_prior_turn_fleet_warm(
     if prior_turn_info is None:
         return
 
-    if fleet_services.persistence.has_snapshot(
-        fleet_services.game_id,
-        fleet_services.perspective,
-        prior_turn,
-    ):
+    persistence = fleet_services.persistence
+    game_id = fleet_services.game_id
+    perspective = fleet_services.perspective
+    players_needing_warm = tuple(
+        player_id
+        for player_id in player_ids
+        if not persistence.has_final_ledger(game_id, perspective, prior_turn, player_id)
+    )
+    if not players_needing_warm:
         return
 
     query_context = make_analytic_query_context(
@@ -263,35 +292,39 @@ def schedule_background_prior_turn_fleet_warm(
         export_services=export_services,
     )
 
-    def warm_prior_turn_fleet() -> None:
-        from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+    def warm_prior_turn_fleet_for_player(player_id: int) -> None:
+        from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
         from api.errors import ConflictError, FleetMaterializationTimeoutError
 
-        persistence = fleet_services.persistence
-        game_id = fleet_services.game_id
-        perspective = fleet_services.perspective
-
-        def prior_turn_snapshot_available() -> bool:
-            return persistence.has_snapshot(game_id, perspective, prior_turn)
+        def prior_turn_ledger_available() -> bool:
+            return persistence.has_final_ledger(game_id, perspective, prior_turn, player_id)
 
         try:
-            get_or_materialize_fleet_snapshot(
+            get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 game_id,
                 perspective,
+                player_id,
                 prior_turn_info,
                 load_turn=fleet_services.load_turn,
                 inference_materialization=fleet_services.inference_materialization,
                 query_context=query_context,
             )
         except ConflictError, FleetMaterializationTimeoutError, OSError, ValueError, KeyError:
-            if prior_turn_snapshot_available():
+            if prior_turn_ledger_available():
                 return
             logger.warning(
-                "Background prior-turn fleet warm failed for game %s perspective %s turn %s",
+                "Background prior-turn fleet warm failed for game %s perspective %s "
+                "player %s turn %s",
                 game_id,
                 perspective,
+                player_id,
                 prior_turn,
             )
 
-    threading.Thread(target=warm_prior_turn_fleet, daemon=True).start()
+    for player_id in players_needing_warm:
+        threading.Thread(
+            target=warm_prior_turn_fleet_for_player,
+            args=(player_id,),
+            daemon=True,
+        ).start()

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -228,6 +228,7 @@ class TurnAnalyticService:
             turn=turn,
             load_turn=load_turn,
             export_services=export_services,
+            player_ids=player_ids,
         )
 
         def resolve_fleet_torp_resolution_for_player(

--- a/packages/api/tests/test_fleet_export_provenance_gates.py
+++ b/packages/api/tests/test_fleet_export_provenance_gates.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import replace
 from unittest.mock import patch
 
-import pytest
 from api.analytics.export_dependency_walk import walk_dependency_tree
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
@@ -14,7 +13,6 @@ from api.analytics.fleet.chain import (
     get_or_materialize_fleet_ledger_for_player,
     get_or_materialize_fleet_snapshot,
 )
-from api.analytics.turn_roster import iter_turn_players
 from api.analytics.fleet.exports import EXPORT_CATALOG
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -22,6 +20,7 @@ from api.analytics.fleet.types import (
     PersistedFleetLedger,
 )
 from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.analytics.turn_roster import iter_turn_players
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 
 from tests.export_chain_test_fixtures import GAME_ID, export_chain_query_context

--- a/packages/api/tests/test_fleet_export_provenance_gates.py
+++ b/packages/api/tests/test_fleet_export_provenance_gates.py
@@ -9,9 +9,12 @@ import pytest
 from api.analytics.export_dependency_walk import walk_dependency_tree
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
+    _is_fleet_snapshot_cache_hit,
     _materialize_fleet_ledger_chain_for_player,
+    get_or_materialize_fleet_ledger_for_player,
     get_or_materialize_fleet_snapshot,
 )
+from api.analytics.turn_roster import iter_turn_players
 from api.analytics.fleet.exports import EXPORT_CATALOG
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -174,24 +177,47 @@ def test_get_or_materialize_fleet_snapshot_does_not_short_circuit_on_partial_cac
         _partial_persisted_ledger(player_id),
     )
 
+    perspective_id = perspective(sample_turn)
+    roster_ids = {player.id for player in iter_turn_players(turn)}
+    cached_snapshot = fleet_services.persistence.get_snapshot(
+        GAME_ID,
+        perspective_id,
+        turn_number,
+    )
+    assert (
+        _is_fleet_snapshot_cache_hit(
+            fleet_services.persistence,
+            GAME_ID,
+            perspective_id,
+            turn_number,
+            turn,
+            cached_snapshot,
+        )
+        is False
+    )
+
+    ledger_calls: list[int] = []
+    original_ledger_materialize = get_or_materialize_fleet_ledger_for_player
+
+    def counting_ledger_materialize(*args, **kwargs):
+        ledger_calls.append(kwargs.get("player_id", args[3]))
+        return original_ledger_materialize(*args, **kwargs)
+
     with patch(
-        "api.analytics.fleet.chain._is_fleet_snapshot_cache_hit",
-        return_value=False,
-    ) as cache_hit_mock:
+        "api.analytics.fleet.chain.get_or_materialize_fleet_ledger_for_player",
+        side_effect=counting_ledger_materialize,
+    ):
         snapshot = get_or_materialize_fleet_snapshot(
             fleet_services.persistence,
             GAME_ID,
-            perspective(sample_turn),
+            perspective_id,
             turn,
             load_turn=ctx.load_turn,
             inference_materialization=fleet_services.inference_materialization,
         )
 
-    from api.analytics.turn_roster import iter_turn_players
-
-    cache_hit_mock.assert_called()
+    assert set(ledger_calls) == roster_ids
     assert snapshot is not None
-    roster_ids = {player.id for player in iter_turn_players(turn)}
     assert roster_ids <= {ledger.player_id for ledger in snapshot.players}
 
 

--- a/packages/api/tests/test_fleet_export_provenance_gates.py
+++ b/packages/api/tests/test_fleet_export_provenance_gates.py
@@ -175,18 +175,24 @@ def test_get_or_materialize_fleet_snapshot_does_not_short_circuit_on_partial_cac
     )
 
     with patch(
-        "api.analytics.fleet.chain._materialize_fleet_snapshot_chain",
-        side_effect=AssertionError("must not gap-fill when only partial cache exists"),
-    ):
-        with pytest.raises(AssertionError, match="must not gap-fill"):
-            get_or_materialize_fleet_snapshot(
-                fleet_services.persistence,
-                GAME_ID,
-                perspective(sample_turn),
-                turn,
-                load_turn=ctx.load_turn,
-                inference_materialization=fleet_services.inference_materialization,
-            )
+        "api.analytics.fleet.chain._is_fleet_snapshot_cache_hit",
+        return_value=False,
+    ) as cache_hit_mock:
+        snapshot = get_or_materialize_fleet_snapshot(
+            fleet_services.persistence,
+            GAME_ID,
+            perspective(sample_turn),
+            turn,
+            load_turn=ctx.load_turn,
+            inference_materialization=fleet_services.inference_materialization,
+        )
+
+    from api.analytics.turn_roster import iter_turn_players
+
+    cache_hit_mock.assert_called()
+    assert snapshot is not None
+    roster_ids = {player.id for player in iter_turn_players(turn)}
+    assert roster_ids <= {ledger.player_id for ledger in snapshot.players}
 
 
 def test_get_or_materialize_fleet_ledger_rechains_when_cached_partial(

--- a/packages/api/tests/test_fleet_materialization_provenance.py
+++ b/packages/api/tests/test_fleet_materialization_provenance.py
@@ -216,8 +216,8 @@ def test_snapshot_gap_fill_reuses_turn_context_across_players(persistence, load_
             load_turn=load_turn,
         )
 
-    # Turns 110 and 111 are gap-filled once each, shared across roster players.
-    assert from_turn_mock.call_count == 2
+    # Each player gap-fills with its own chain; turn context is built per turn per chain.
+    assert from_turn_mock.call_count == 2 * player_count
 
 
 def test_gap_fill_persists_per_player_ledgers_with_provenance(persistence, load_turn):

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -886,7 +886,7 @@ def test_gap_fill_returns_cached_snapshot_when_peer_finished_during_retries(pers
     winner = _put_provenance_final_snapshot(persistence, 628580, 1, turn_111)
 
     with patch(
-        "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_snapshot_chain",
+        "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
         side_effect=_FleetSnapshotInvalidated,
     ):
         result = get_or_materialize_fleet_snapshot(

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -83,6 +83,100 @@ def _roster_ids(turn) -> list[int]:
     return [player.id for player in iter_turn_players(turn)]
 
 
+def _ensure_fleet_export_gap_fill_context(
+    sample_turn,
+    memory_backend,
+    *,
+    turn_number: int = 8,
+):
+    """Export-ensure context with per-player prerequisites through T-1 (one-turn gap at T)."""
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
+    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+
+    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
+
+    player_id = first_player_id(sample_turn)
+    other_player_id = sample_turn.scores[1].ownerid
+    host_turn = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=turn_number),
+        game=replace(sample_turn.game, turn=turn_number),
+    )
+    stored_turns = turn_chain_through(host_turn)
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
+    persp = perspective(sample_turn)
+    final_provenance = FleetMaterializationProvenance(
+        turn_evidence_at_n=True,
+        prior_ledger_at_n_minus_1=True,
+    )
+
+    for prior_turn in range(1, turn_number):
+        prior_turn_info = stored_turns[prior_turn]
+        put_persisted_row(
+            inference_persistence,
+            prior_turn_info,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seed",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+        )
+        fleet_persistence.put_ledger(
+            GAME_ID,
+            persp,
+            prior_turn,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(
+                    GAME_ID,
+                    persp,
+                    prior_turn_info,
+                    player_id,
+                ),
+                provenance=final_provenance,
+            ),
+        )
+
+    put_persisted_row(
+        inference_persistence,
+        host_turn,
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="seed",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+
+    ctx = export_chain_query_context(
+        host_turn,
+        persistence=inference_persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    ctx.export_services["fleet"] = FleetComputeServices(
+        persistence=fleet_persistence,
+        game_id=GAME_ID,
+        perspective=persp,
+        load_turn=stored_turns.get,
+        inference_materialization=fleet_services.inference_materialization,
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=persp,
+        turn=turn_number,
+        player_id=player_id,
+    )
+    return ctx, scope, player_id, other_player_id, fleet_persistence
+
+
 def test_single_player_gap_fill_does_not_materialize_other_players(persistence, load_turn):
     turn_109 = load_turn(109)
     turn_112 = load_turn(112)
@@ -108,30 +202,8 @@ def test_single_player_gap_fill_does_not_materialize_other_players(persistence, 
 
 
 def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
-    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
-    from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
-
-    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
-
-    player_id = first_player_id(sample_turn)
-    other_player_id = sample_turn.scores[1].ownerid
-    inference_persistence = InferenceRowPersistenceService(memory_backend)
-    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
-    ctx = export_chain_query_context(sample_turn, persistence=inference_persistence)
-    fleet_services = ctx.export_services["fleet"]
-    ctx.export_services["fleet"] = FleetComputeServices(
-        persistence=fleet_persistence,
-        game_id=GAME_ID,
-        perspective=perspective(sample_turn),
-        load_turn=lambda turn_number: turn_chain_through(sample_turn).get(turn_number),
-        inference_materialization=fleet_services.inference_materialization,
-    )
-    scope = ExportScope(
-        game_id=GAME_ID,
-        perspective=perspective(sample_turn),
-        turn=sample_turn.settings.turn,
-        player_id=player_id,
+    ctx, scope, player_id, other_player_id, fleet_persistence = (
+        _ensure_fleet_export_gap_fill_context(sample_turn, memory_backend)
     )
     ledger_calls: list[int] = []
     original = get_or_materialize_fleet_ledger_for_player
@@ -144,11 +216,26 @@ def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
         "api.analytics.fleet.exports.get_or_materialize_fleet_ledger_for_player",
         side_effect=tracking_ledger,
     ):
-        ensure_fleet_export(ctx, scope)
+        assert ensure_fleet_export(ctx, scope) is True
 
     assert ledger_calls
-    assert all(call_player_id == player_id for call_player_id in ledger_calls)
+    assert set(ledger_calls) == {player_id}
+    assert len(ledger_calls) <= 2, (
+        f"expected at most two ledger materializations for one-turn gap; got {ledger_calls}"
+    )
     assert other_player_id not in ledger_calls
+    assert fleet_persistence.has_final_ledger(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        player_id,
+    )
+    assert not fleet_persistence.has_ledger(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        other_player_id,
+    )
 
 
 def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
@@ -240,29 +327,9 @@ def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
 
 
 def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_turn, memory_backend):
-    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
-    from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
-
-    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
-
-    player_id = first_player_id(sample_turn)
-    inference_persistence = InferenceRowPersistenceService(memory_backend)
-    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
-    ctx = export_chain_query_context(sample_turn, persistence=inference_persistence)
-    fleet_services = ctx.export_services["fleet"]
-    ctx.export_services["fleet"] = FleetComputeServices(
-        persistence=fleet_persistence,
-        game_id=GAME_ID,
-        perspective=perspective(sample_turn),
-        load_turn=lambda turn_number: turn_chain_through(sample_turn).get(turn_number),
-        inference_materialization=fleet_services.inference_materialization,
-    )
-    scope = ExportScope(
-        game_id=GAME_ID,
-        perspective=perspective(sample_turn),
-        turn=sample_turn.settings.turn,
-        player_id=player_id,
+    ctx, scope, player_id, _, fleet_persistence = _ensure_fleet_export_gap_fill_context(
+        sample_turn,
+        memory_backend,
     )
 
     def forbid_snapshot(*_args, **_kwargs):
@@ -272,7 +339,14 @@ def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_tu
         "api.analytics.fleet.exports.get_or_materialize_fleet_snapshot",
         side_effect=forbid_snapshot,
     ):
-        ensure_fleet_export(ctx, scope)
+        assert ensure_fleet_export(ctx, scope) is True
+
+    assert fleet_persistence.has_final_ledger(
+        scope.game_id,
+        scope.perspective,
+        scope.turn,
+        player_id,
+    )
 
 
 def test_per_player_cache_hit_does_not_require_roster_complete(persistence, load_turn):

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -14,13 +14,18 @@ from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
 from api.analytics.fleet.exports import ensure_fleet_export
 from api.analytics.fleet.gap_fill_coordinator import coordinator_for, reset_coordinators
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.analytics.turn_roster import iter_turn_players
 from api.errors import FleetMaterializationTimeoutError
+from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.serialization.turn import turn_info_from_json
 from api.storage.memory_asset import MemoryAssetBackend
 
 from tests.export_chain_test_fixtures import export_chain_query_context
-from tests.test_fleet_persistence import _put_provenance_final_snapshot
+from tests.test_fleet_persistence import (
+    _inference_materialization_for_fleet,
+    _put_provenance_final_snapshot,
+)
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
@@ -207,6 +212,81 @@ def test_per_player_cache_hit_does_not_require_roster_complete(persistence, load
     )
 
     assert not persistence.has_ledger(628580, 1, 111, roster[1])
+
+
+def test_per_player_prior_turn_materializes_while_other_scores_inference_in_progress(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """Incident regression (game 628580 turn 8): fleet 409 while scores stream active.
+
+    Per-player materialization of fleet@(T-1) for one player must succeed without
+    requiring all-roster snapshot finality when other players' scores@T inference is
+    still in progress. Would raise ConflictError under perspective-batch coordinator
+    behavior that waited for full-roster ensure-final before one-player access.
+    """
+    turn_110 = load_turn(110)
+    turn_111 = load_turn(111)
+    turn_112 = load_turn(112)
+    assert turn_110 is not None and turn_111 is not None and turn_112 is not None
+    roster = _roster_ids(turn_112)
+    assert len(roster) > 1
+    player_p, player_q = roster[0], roster[1]
+
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+
+    inference_persistence, inference_materialization = _inference_materialization_for_fleet(
+        memory_backend,
+        load_turn,
+    )
+    inference_persistence.put_row(
+        628580,
+        1,
+        112,
+        player_p,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="done-for-p",
+            solution_count=1,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+    inference_persistence.put_row(
+        628580,
+        1,
+        112,
+        player_q,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="still-running",
+            solution_count=0,
+            is_complete=False,
+            solutions=[],
+        ),
+    )
+
+    assert persistence.get_snapshot(628580, 1, 111) is None
+    assert not persistence.has_ledger(628580, 1, 111, player_p)
+    assert not persistence.has_ledger(628580, 1, 111, player_q)
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_p,
+        turn_111,
+        load_turn=load_turn,
+        inference_materialization=inference_materialization,
+    )
+
+    assert persistence.has_ledger(628580, 1, 111, player_p)
+    assert not persistence.has_ledger(628580, 1, 111, player_q)
+    snapshot_111 = persistence.get_snapshot(628580, 1, 111)
+    assert snapshot_111 is None or player_q not in {
+        ledger.player_id for ledger in snapshot_111.players
+    }
 
 
 def test_per_player_gap_start_independent(persistence, load_turn):

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -678,3 +678,263 @@ def test_coordinator_waiter_timeout_per_player(persistence, load_turn):
 
     assert any(isinstance(error, FleetMaterializationTimeoutError) for error in errors)
     assert persistence.has_ledger(628580, 1, 112, player_q)
+
+
+def test_forward_unwind_scores_before_fleet_per_player(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """Gap M..N for one player: scores@t,P is ensured before fleet@t,P at each gap turn."""
+    from api.analytics.export_context import AnalyticQueryContext
+
+    turn_109 = load_turn(109)
+    turn_111 = load_turn(111)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
+    player_p = _roster_ids(turn_112)[0]
+
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    _, inference_materialization = _inference_materialization_for_fleet(
+        memory_backend,
+        load_turn,
+    )
+
+    ensure_events: list[tuple[str, int, int | None]] = []
+    fleet_exports = __import__(
+        "api.analytics.fleet.exports",
+        fromlist=["ensure_fleet_export"],
+    )
+    original_fleet_ensure = fleet_exports.ensure_fleet_export
+
+    def tracking_ensure_declared_dependencies(self, analytic_id, scope):
+        walk_outcome = self._walk_export_dependencies(
+            analytic_id,
+            scope,
+            catch_ensure_cycle=False,
+        )
+        from api.analytics.export_dependency_walk import DependencyWalkResult
+
+        if not isinstance(walk_outcome, DependencyWalkResult):
+            return walk_outcome
+        for dependency_id, dependency_scope, catalog in walk_outcome.pending_ensure:
+            if dependency_id == analytic_id and dependency_scope == scope:
+                break
+            if catalog.ensure_export is None:
+                continue
+            ensure_events.append(
+                (dependency_id, dependency_scope.turn, dependency_scope.player_id),
+            )
+            catalog.ensure_export(self, dependency_scope)
+        return None
+
+    def tracking_fleet_ensure(query_ctx, scope):
+        result = original_fleet_ensure(query_ctx, scope)
+        ensure_events.append(("fleet", scope.turn, scope.player_id))
+        return result
+
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator.ensure_fleet_export",
+            side_effect=tracking_fleet_ensure,
+        ),
+        patch.object(
+            AnalyticQueryContext,
+            "ensure_declared_dependencies",
+            tracking_ensure_declared_dependencies,
+        ),
+    ):
+        get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            628580,
+            1,
+            player_p,
+            turn_112,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+        )
+
+    assert ensure_events
+    assert all(player_id == player_p for _, _, player_id in ensure_events), (
+        f"ensure calls must be scoped to player {player_p}; events={ensure_events}"
+    )
+
+    fleet_turns = [
+        turn for analytic_id, turn, _player_id in ensure_events if analytic_id == "fleet"
+    ]
+    assert fleet_turns
+    gap_turns = range(min(fleet_turns), max(fleet_turns) + 1)
+    for event_index, (analytic_id, turn, player_id) in enumerate(ensure_events):
+        if analytic_id != "fleet" or turn not in gap_turns:
+            continue
+        prior_scores = [
+            index
+            for index, (dependency_id, dependency_turn, dependency_player_id) in enumerate(
+                ensure_events[:event_index],
+            )
+            if dependency_id == "scores"
+            and dependency_turn == turn
+            and dependency_player_id == player_id
+        ]
+        assert prior_scores, (
+            f"expected scores ensure before fleet ensure at turn {turn} "
+            f"for player {player_id}; events={ensure_events}"
+        )
+
+
+def test_invalidation_mid_chain_same_player_waiters_retry_once(persistence, load_turn):
+    """P invalidation aborts P's chain and waiters retry; Q's in-flight chain is unaffected."""
+    from api.analytics.fleet.types import PersistedFleetLedger
+
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    roster = _roster_ids(turn_112)
+    assert len(roster) > 1
+    player_p, player_q = roster[0], roster[1]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    leader_mid_chain = threading.Event()
+    p_waiter_joined = threading.Event()
+    q_started = threading.Event()
+    release_leader = threading.Event()
+    original_put_ledger = persistence.put_ledger
+    mid_chain_puts = 0
+
+    def hooked_put_ledger(*args, **kwargs):
+        nonlocal mid_chain_puts
+        turn_number = args[2]
+        player_id = args[3]
+        original_put_ledger(*args, **kwargs)
+        if player_id == player_p and turn_number == 111 and mid_chain_puts == 0:
+            mid_chain_puts += 1
+            leader_mid_chain.set()
+            assert release_leader.wait(timeout=5)
+
+    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
+
+    coordinator_p = coordinator_for(persistence, 628580, 1, player_p)
+    coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
+    original_chain = __import__(
+        "api.analytics.fleet.gap_fill_coordinator",
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
+    original_run_leader_p = coordinator_p._run_leader_unwind
+
+    p_materialize_calls = 0
+    q_materialize_calls = 0
+    leader_unwind_calls = 0
+
+    def counting_chain(*args, **kwargs):
+        nonlocal p_materialize_calls, q_materialize_calls
+        materialize_player_id = args[3]
+        if materialize_player_id == player_p:
+            p_materialize_calls += 1
+        elif materialize_player_id == player_q:
+            q_materialize_calls += 1
+        return original_chain(*args, **kwargs)
+
+    def counting_run_leader_p(
+        inflight,
+        turn,
+        *,
+        load_turn,
+        inference_materialization,
+        query_context,
+    ):
+        nonlocal leader_unwind_calls
+        leader_unwind_calls += 1
+        return original_run_leader_p(
+            inflight,
+            turn,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+        )
+
+    p_leader_result: PersistedFleetLedger | None = None
+    p_waiter_result: PersistedFleetLedger | None = None
+    errors: list[BaseException] = []
+
+    def run_p_leader() -> None:
+        nonlocal p_leader_result
+        try:
+            p_leader_result = get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def run_p_waiter() -> None:
+        nonlocal p_waiter_result
+        assert leader_mid_chain.wait(timeout=5)
+        p_waiter_joined.set()
+        try:
+            p_waiter_result = get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def run_q() -> None:
+        q_started.set()
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_q,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
+            side_effect=counting_chain,
+        ),
+        patch.object(coordinator_p, "_run_leader_unwind", side_effect=counting_run_leader_p),
+    ):
+        p_leader_thread = threading.Thread(target=run_p_leader)
+        p_waiter_thread = threading.Thread(target=run_p_waiter)
+        q_thread = threading.Thread(target=run_q)
+        p_leader_thread.start()
+        p_waiter_thread.start()
+        assert leader_mid_chain.wait(timeout=5)
+        assert p_waiter_joined.wait(timeout=5)
+        q_thread.start()
+        assert q_started.wait(timeout=5)
+        persistence.invalidate_player_ledgers_from_turn(628580, 1, 111, player_p)
+        release_leader.set()
+        p_leader_thread.join(timeout=30)
+        p_waiter_thread.join(timeout=30)
+        q_thread.join(timeout=30)
+
+    assert not errors
+    assert p_leader_result is not None
+    assert p_waiter_result is not None
+    assert p_leader_result.ledger.player_id == player_p
+    assert p_waiter_result.ledger.player_id == player_p
+    assert persistence.get_ledger(628580, 1, 112, player_p) is not None
+    assert persistence.get_ledger(628580, 1, 112, player_q) is not None
+    assert leader_unwind_calls == 1, f"expected one P leader unwind, got {leader_unwind_calls}"
+    assert p_materialize_calls <= 2, (
+        f"expected at most one P invalidation retry, got {p_materialize_calls}"
+    )
+    assert q_materialize_calls == 1, (
+        f"expected one Q materialization chain, got {q_materialize_calls}"
+    )
+    assert coordinator_p is not coordinator_q

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -231,9 +231,7 @@ def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
         )
 
     assert result.status == "ok"
-    target_ensure_calls = [
-        call for call in fleet_ensure_calls if call == (turn_number, player_id)
-    ]
+    target_ensure_calls = [call for call in fleet_ensure_calls if call == (turn_number, player_id)]
     assert len(target_ensure_calls) == 2
     target_materialize_calls = [
         call for call in materialize_calls if call == (turn_number, player_id)

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import copy
 import json
 import threading
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from api.analytics.export_types import ExportScope
-from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
-from api.analytics.fleet.exports import ensure_fleet_export
+from api.analytics.fleet.chain import (
+    _materialize_fleet_ledger_chain_for_player,
+    get_or_materialize_fleet_ledger_for_player,
+)
+from api.analytics.fleet.compute_services import turn_chain_through
+from api.analytics.fleet.exports import EXPORT_CATALOG, ensure_fleet_export
 from api.analytics.fleet.gap_fill_coordinator import coordinator_for, reset_coordinators
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.military_score_inference.solver import STATUS_EXACT
@@ -19,9 +24,11 @@ from api.analytics.turn_roster import iter_turn_players
 from api.errors import FleetMaterializationTimeoutError
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.serialization.turn import turn_info_from_json
+from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.storage.memory_asset import MemoryAssetBackend
 
 from tests.export_chain_test_fixtures import export_chain_query_context
+from tests.scores_exports_helpers import first_player_id, put_persisted_row
 from tests.test_fleet_persistence import (
     _inference_materialization_for_fleet,
     _put_provenance_final_snapshot,
@@ -142,6 +149,96 @@ def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
     assert ledger_calls
     assert all(call_player_id == player_id for call_player_id in ledger_calls)
     assert other_player_id not in ledger_calls
+
+
+def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
+    """Dependency walk and forward unwind both ensure fleet@T,P once; materialize once."""
+    player_id = first_player_id(sample_turn)
+    turn_number = 8
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    host_turn = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=turn_number),
+        game=replace(sample_turn.game, turn=turn_number),
+    )
+    stored_turns = turn_chain_through(host_turn)
+    ctx = export_chain_query_context(
+        host_turn,
+        persistence=inference_persistence,
+        stored_turns=stored_turns,
+        seed_fleet_prerequisites_for=player_id,
+    )
+    put_persisted_row(
+        inference_persistence,
+        host_turn,
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="seed",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+
+    fleet_ensure_calls: list[tuple[int, int | None]] = []
+    materialize_calls: list[tuple[int, int]] = []
+    original_ensure = ensure_fleet_export
+    original_materialize = _materialize_fleet_ledger_chain_for_player
+
+    def tracking_ensure(query_ctx, scope):
+        fleet_ensure_calls.append((scope.turn, scope.player_id))
+        return original_ensure(query_ctx, scope)
+
+    def counting_materialize(
+        persistence_service,
+        game_id,
+        perspective_id,
+        materialize_player_id,
+        turn,
+        **kwargs,
+    ):
+        materialize_calls.append((turn.settings.turn, materialize_player_id))
+        return original_materialize(
+            persistence_service,
+            game_id,
+            perspective_id,
+            materialize_player_id,
+            turn,
+            **kwargs,
+        )
+
+    ctx.export_registry = {
+        **ctx.export_registry,
+        "fleet": replace(EXPORT_CATALOG, ensure_export=tracking_ensure),
+    }
+
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator.ensure_fleet_export",
+            side_effect=tracking_ensure,
+        ),
+        patch(
+            "api.analytics.fleet.chain._materialize_fleet_ledger_chain_for_player",
+            side_effect=counting_materialize,
+        ),
+    ):
+        result = ctx.query(
+            "fleet",
+            ["$.players"],
+            {"turn": turn_number, "player_id": player_id},
+            force_inline_ensure=True,
+        )
+
+    assert result.status == "ok"
+    target_ensure_calls = [
+        call for call in fleet_ensure_calls if call == (turn_number, player_id)
+    ]
+    assert len(target_ensure_calls) == 2
+    target_materialize_calls = [
+        call for call in materialize_calls if call == (turn_number, player_id)
+    ]
+    assert len(target_materialize_calls) == 1
 
 
 def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_turn, memory_backend):

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -1,0 +1,503 @@
+"""Player-scoped fleet gap-fill and export ensure (#179)."""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
+from api.analytics.fleet.exports import ensure_fleet_export
+from api.analytics.fleet.gap_fill_coordinator import coordinator_for, reset_coordinators
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.turn_roster import iter_turn_players
+from api.errors import FleetMaterializationTimeoutError
+from api.serialization.turn import turn_info_from_json
+from api.storage.memory_asset import MemoryAssetBackend
+
+from tests.export_chain_test_fixtures import export_chain_query_context
+from tests.test_fleet_persistence import _put_provenance_final_snapshot
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture(autouse=True)
+def _reset_coordinators():
+    reset_coordinators()
+    yield
+    reset_coordinators()
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as f:
+        backend.put("games/628580/info", json.load(f))
+    with open(ASSETS_DIR / "turn_sample.json") as f:
+        turn_rst = json.load(f)
+        for turn_number in (109, 110, 111, 112):
+            turn_data = copy.deepcopy(turn_rst)
+            turn_data["settings"]["turn"] = turn_number
+            turn_data["game"]["turn"] = turn_number
+            backend.put(f"games/628580/1/turns/{turn_number}", turn_data)
+    return backend
+
+
+@pytest.fixture
+def persistence(memory_backend):
+    return FleetSnapshotPersistenceService(memory_backend)
+
+
+@pytest.fixture
+def load_turn(memory_backend):
+    def _load(turn_number: int):
+        key = f"games/628580/1/turns/{turn_number}"
+        try:
+            data = memory_backend.get(key)
+        except Exception:
+            return None
+        if data is None:
+            return None
+        return turn_info_from_json(data)
+
+    return _load
+
+
+def _roster_ids(turn) -> list[int]:
+    return [player.id for player in iter_turn_players(turn)]
+
+
+def test_single_player_gap_fill_does_not_materialize_other_players(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    roster = _roster_ids(turn_112)
+    assert len(roster) > 1
+    player_p, player_q = roster[0], roster[1]
+
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_p,
+        turn_112,
+        load_turn=load_turn,
+    )
+
+    for turn_number in range(110, 113):
+        assert persistence.has_ledger(628580, 1, turn_number, player_p)
+        assert not persistence.has_ledger(628580, 1, turn_number, player_q)
+
+
+def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
+    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
+    from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+
+    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
+
+    player_id = first_player_id(sample_turn)
+    other_player_id = sample_turn.scores[1].ownerid
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
+    ctx = export_chain_query_context(sample_turn, persistence=inference_persistence)
+    fleet_services = ctx.export_services["fleet"]
+    ctx.export_services["fleet"] = FleetComputeServices(
+        persistence=fleet_persistence,
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        load_turn=lambda turn_number: turn_chain_through(sample_turn).get(turn_number),
+        inference_materialization=fleet_services.inference_materialization,
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        turn=sample_turn.settings.turn,
+        player_id=player_id,
+    )
+    ledger_calls: list[int] = []
+    original = get_or_materialize_fleet_ledger_for_player
+
+    def tracking_ledger(*args, **kwargs):
+        ledger_calls.append(args[3])
+        return original(*args, **kwargs)
+
+    with patch(
+        "api.analytics.fleet.exports.get_or_materialize_fleet_ledger_for_player",
+        side_effect=tracking_ledger,
+    ):
+        ensure_fleet_export(ctx, scope)
+
+    assert ledger_calls
+    assert all(call_player_id == player_id for call_player_id in ledger_calls)
+    assert other_player_id not in ledger_calls
+
+
+def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_turn, memory_backend):
+    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
+    from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+
+    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
+
+    player_id = first_player_id(sample_turn)
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
+    ctx = export_chain_query_context(sample_turn, persistence=inference_persistence)
+    fleet_services = ctx.export_services["fleet"]
+    ctx.export_services["fleet"] = FleetComputeServices(
+        persistence=fleet_persistence,
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        load_turn=lambda turn_number: turn_chain_through(sample_turn).get(turn_number),
+        inference_materialization=fleet_services.inference_materialization,
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=perspective(sample_turn),
+        turn=sample_turn.settings.turn,
+        player_id=player_id,
+    )
+
+    def forbid_snapshot(*_args, **_kwargs):
+        raise AssertionError("ensure_fleet_export must not call get_or_materialize_fleet_snapshot")
+
+    with patch(
+        "api.analytics.fleet.exports.get_or_materialize_fleet_snapshot",
+        side_effect=forbid_snapshot,
+    ):
+        ensure_fleet_export(ctx, scope)
+
+
+def test_per_player_cache_hit_does_not_require_roster_complete(persistence, load_turn):
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+
+    turn = load_turn(111)
+    assert turn is not None
+    roster = _roster_ids(turn)
+    player_p = roster[0]
+    persistence.put_ledger(
+        628580,
+        1,
+        111,
+        player_p,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, turn, player_p),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+    )
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_p,
+        turn,
+        load_turn=load_turn,
+    )
+
+    assert not persistence.has_ledger(628580, 1, 111, roster[1])
+
+
+def test_per_player_gap_start_independent(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_110 = load_turn(110)
+    turn_111 = load_turn(111)
+    assert turn_109 is not None and turn_110 is not None and turn_111 is not None
+    roster = _roster_ids(turn_111)
+    player_p, player_q = roster[0], roster[1]
+
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+
+    get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        628580,
+        1,
+        player_p,
+        turn_111,
+        load_turn=load_turn,
+    )
+
+    assert persistence.has_ledger(628580, 1, 111, player_p)
+    assert not persistence.has_ledger(628580, 1, 111, player_q)
+
+
+def test_compute_fleet_fan_out_materializes_all_players_explicitly(persistence, load_turn):
+    from api.analytics.compute_context import invoke_analytic_compute
+    from api.analytics.fleet import compute_fleet
+    from api.analytics.fleet.compute_services import FleetComputeServices
+
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    roster_size = len(_roster_ids(turn_112))
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    fleet_services = FleetComputeServices(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        load_turn=load_turn,
+        inference_materialization=None,
+    )
+
+    ledger_calls = 0
+    original = get_or_materialize_fleet_ledger_for_player
+
+    def counting_ledger(*args, **kwargs):
+        nonlocal ledger_calls
+        ledger_calls += 1
+        return original(*args, **kwargs)
+
+    with patch(
+        "api.analytics.fleet.chain.get_or_materialize_fleet_ledger_for_player",
+        side_effect=counting_ledger,
+    ):
+        invoke_analytic_compute(
+            compute_fleet,
+            turn_112,
+            export_services={"fleet": fleet_services},
+        )
+
+    assert ledger_calls == roster_size
+
+
+def test_coordinator_two_threads_same_player_share_one_chain(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_111 = load_turn(111)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
+    player_id = _roster_ids(turn_112)[0]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    materialize_calls = 0
+    original_chain = __import__(
+        "api.analytics.fleet.gap_fill_coordinator",
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
+
+    def counting_chain(*args, **kwargs):
+        nonlocal materialize_calls
+        materialize_calls += 1
+        return original_chain(*args, **kwargs)
+
+    results: list[object] = []
+
+    def materialize_to(turn):
+        results.append(
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_id,
+                turn,
+                load_turn=load_turn,
+            ),
+        )
+
+    with patch(
+        "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
+        side_effect=counting_chain,
+    ):
+        leader = threading.Thread(target=materialize_to, args=(turn_111,))
+        waiter = threading.Thread(target=materialize_to, args=(turn_112,))
+        leader.start()
+        waiter.start()
+        leader.join(timeout=30)
+        waiter.join(timeout=30)
+
+    assert len(results) == 2
+    assert materialize_calls == 1
+
+
+def test_coordinator_same_player_waiters_satisfy_to_max_turn(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_111 = load_turn(111)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
+    player_id = _roster_ids(turn_112)[0]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    leader_ready = threading.Event()
+    release_leader = threading.Event()
+    coordinator = coordinator_for(persistence, 628580, 1, player_id)
+    original_run_leader = coordinator._run_leader_unwind
+
+    def gated_run_leader(inflight, turn, **kwargs):
+        leader_ready.set()
+        assert release_leader.wait(timeout=5)
+        return original_run_leader(inflight, turn, **kwargs)
+
+    with patch.object(coordinator, "_run_leader_unwind", side_effect=gated_run_leader):
+        leader = threading.Thread(
+            target=lambda: get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_id,
+                turn_111,
+                load_turn=load_turn,
+            ),
+        )
+        waiter = threading.Thread(
+            target=lambda: get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_id,
+                turn_112,
+                load_turn=load_turn,
+            ),
+        )
+        leader.start()
+        assert leader_ready.wait(timeout=5)
+        waiter.start()
+        release_leader.set()
+        leader.join(timeout=30)
+        waiter.join(timeout=30)
+
+    assert persistence.has_ledger(628580, 1, 111, player_id)
+    assert persistence.has_ledger(628580, 1, 112, player_id)
+
+
+def test_coordinator_different_players_separate_dedupe_keys(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    roster = _roster_ids(turn_112)
+    player_p, player_q = roster[0], roster[1]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    coordinator_p = coordinator_for(persistence, 628580, 1, player_p)
+    coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
+    assert coordinator_p is not coordinator_q
+
+    leader_p_ready = threading.Event()
+    release_p = threading.Event()
+    original_p_unwind = coordinator_p._run_leader_unwind
+
+    def gated_p_unwind(inflight, turn, **kwargs):
+        leader_p_ready.set()
+        assert release_p.wait(timeout=5)
+        return original_p_unwind(inflight, turn, **kwargs)
+
+    q_started = threading.Event()
+
+    def materialize_q() -> None:
+        q_started.set()
+        get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            628580,
+            1,
+            player_q,
+            turn_112,
+            load_turn=load_turn,
+        )
+
+    with patch.object(coordinator_p, "_run_leader_unwind", side_effect=gated_p_unwind):
+        thread_p = threading.Thread(
+            target=lambda: get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            ),
+        )
+        thread_q = threading.Thread(target=materialize_q)
+        thread_p.start()
+        assert leader_p_ready.wait(timeout=5)
+        thread_q.start()
+        assert q_started.wait(timeout=5)
+        release_p.set()
+        thread_p.join(timeout=30)
+        thread_q.join(timeout=30)
+
+    assert persistence.has_ledger(628580, 1, 112, player_p)
+    assert persistence.has_ledger(628580, 1, 112, player_q)
+
+
+def test_coordinator_waiter_timeout_per_player(persistence, load_turn):
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    player_p, player_q = _roster_ids(turn_112)[:2]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    started = threading.Event()
+    release = threading.Event()
+    original_unwind = coordinator_for(persistence, 628580, 1, player_p)._run_leader_unwind
+
+    def blocking_unwind(*args, **kwargs):
+        started.set()
+        assert release.wait(timeout=5)
+        return original_unwind(*args, **kwargs)
+
+    errors: list[BaseException] = []
+
+    def wait_for_p() -> None:
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator.GAP_FILL_MATERIALIZE_WAIT_TIMEOUT_SEC",
+            0.2,
+        ),
+        patch.object(
+            coordinator_for(persistence, 628580, 1, player_p),
+            "_run_leader_unwind",
+            side_effect=blocking_unwind,
+        ),
+    ):
+        leader = threading.Thread(
+            target=lambda: get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            ),
+        )
+        waiter = threading.Thread(target=wait_for_p)
+        leader.start()
+        assert started.wait(timeout=5)
+        waiter.start()
+        waiter.join(timeout=5)
+        release.set()
+        leader.join(timeout=5)
+
+        # Player Q is unaffected by player P's timeout.
+        get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            628580,
+            1,
+            player_q,
+            turn_112,
+            load_turn=load_turn,
+        )
+
+    assert any(isinstance(error, FleetMaterializationTimeoutError) for error in errors)
+    assert persistence.has_ledger(628580, 1, 112, player_q)

--- a/packages/api/tests/test_gap_fill_coordinator.py
+++ b/packages/api/tests/test_gap_fill_coordinator.py
@@ -9,10 +9,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+from api.analytics.fleet.chain import (
+    get_or_materialize_fleet_ledger_for_player,
+    get_or_materialize_fleet_snapshot,
+)
 from api.analytics.fleet.gap_fill_coordinator import coordinator_for, reset_coordinators
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import FleetTurnSnapshot
+from api.analytics.fleet.types import PersistedFleetLedger
+from api.analytics.turn_roster import iter_turn_players
 from api.errors import ConflictError, FleetMaterializationTimeoutError
 from api.serialization.turn import turn_info_from_json
 from api.storage.memory_asset import MemoryAssetBackend
@@ -63,6 +67,10 @@ def load_turn(memory_backend):
     return _load
 
 
+def _first_player_id(turn) -> int:
+    return next(iter_turn_players(turn)).id
+
+
 def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence, load_turn):
     from api.analytics.fleet.chain import ensure_fleet_baseline
 
@@ -73,12 +81,13 @@ def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence
     turn_111 = load_turn(111)
     turn_112 = load_turn(112)
     assert turn_111 is not None and turn_112 is not None
+    player_id = _first_player_id(turn_111)
 
     materialize_calls = 0
     original_chain = __import__(
         "api.analytics.fleet.gap_fill_coordinator",
-        fromlist=["_materialize_fleet_snapshot_chain"],
-    )._materialize_fleet_snapshot_chain
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
 
     def counting_chain(*args, **kwargs):
         nonlocal materialize_calls
@@ -92,10 +101,11 @@ def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence
         turn = load_turn(turn_number)
         assert turn is not None
         try:
-            results[turn_number] = get_or_materialize_fleet_snapshot(
+            results[turn_number] = get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn,
                 load_turn=load_turn,
             )
@@ -104,7 +114,7 @@ def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence
 
     leader_ready = threading.Event()
     release_leader = threading.Event()
-    coordinator = coordinator_for(persistence, 628580, 1)
+    coordinator = coordinator_for(persistence, 628580, 1, player_id)
     original_run_leader = coordinator._run_leader_unwind
 
     def gated_run_leader(
@@ -114,7 +124,6 @@ def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence
         load_turn,
         inference_materialization,
         query_context,
-        materialize_player_id,
     ):
         leader_ready.set()
         assert release_leader.wait(timeout=5)
@@ -124,12 +133,11 @@ def test_coordinator_singleflight_satisfies_concurrent_turn_requests(persistence
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
-            materialize_player_id=materialize_player_id,
         )
 
     with (
         patch(
-            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_snapshot_chain",
+            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
             side_effect=counting_chain,
         ),
         patch.object(coordinator, "_run_leader_unwind", side_effect=gated_run_leader),
@@ -157,6 +165,7 @@ def test_coordinator_waiter_times_out_when_leader_never_finishes(persistence, lo
     persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
     turn_112 = load_turn(112)
     assert turn_112 is not None
+    player_id = _first_player_id(turn_112)
 
     started = threading.Event()
     release_leader = threading.Event()
@@ -165,6 +174,7 @@ def test_coordinator_waiter_times_out_when_leader_never_finishes(persistence, lo
         persistence,
         628580,
         1,
+        player_id,
     )._run_leader_unwind
 
     def blocking_unwind(*args, **kwargs):
@@ -174,12 +184,13 @@ def test_coordinator_waiter_times_out_when_leader_never_finishes(persistence, lo
 
     errors: list[BaseException] = []
 
-    def wait_for_snapshot() -> None:
+    def wait_for_ledger() -> None:
         try:
-            get_or_materialize_fleet_snapshot(
+            get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             )
@@ -192,21 +203,22 @@ def test_coordinator_waiter_times_out_when_leader_never_finishes(persistence, lo
             0.2,
         ),
         patch.object(
-            coordinator_for(persistence, 628580, 1),
+            coordinator_for(persistence, 628580, 1, player_id),
             "_run_leader_unwind",
             side_effect=blocking_unwind,
         ),
     ):
         leader = threading.Thread(
-            target=lambda: get_or_materialize_fleet_snapshot(
+            target=lambda: get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             ),
         )
-        waiter = threading.Thread(target=wait_for_snapshot)
+        waiter = threading.Thread(target=wait_for_ledger)
         leader.start()
         assert started.wait(timeout=5)
         waiter.start()
@@ -440,11 +452,20 @@ def test_gap_fill_with_inference_never_uses_legacy_chain_path(
         load_turn,
     )
 
-    with patch(
-        "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_snapshot_chain",
-        side_effect=AssertionError(
-            "legacy chain path must not run when inference materialization is set",
-        ),
+    from api.analytics.fleet.gap_fill_coordinator import FleetGapFillCoordinator
+
+    original_forward_unwind = FleetGapFillCoordinator._forward_unwind_via_export_ensure
+    forward_unwind_calls = 0
+
+    def tracking_forward_unwind(self, *args, **kwargs):
+        nonlocal forward_unwind_calls
+        forward_unwind_calls += 1
+        return original_forward_unwind(self, *args, **kwargs)
+
+    with patch.object(
+        FleetGapFillCoordinator,
+        "_forward_unwind_via_export_ensure",
+        tracking_forward_unwind,
     ):
         get_or_materialize_fleet_snapshot(
             persistence,
@@ -454,6 +475,8 @@ def test_gap_fill_with_inference_never_uses_legacy_chain_path(
             load_turn=load_turn,
             inference_materialization=inference_materialization,
         )
+
+    assert forward_unwind_calls >= 1
 
 
 def test_gap_fill_with_inference_fails_when_query_context_unresolved(
@@ -505,6 +528,7 @@ def test_coordinator_waiter_retries_with_leader_after_epoch_bump(persistence, lo
 
     turn_112 = load_turn(112)
     assert turn_112 is not None
+    player_id = _first_player_id(turn_112)
 
     leader_mid_chain = threading.Event()
     waiter_joined = threading.Event()
@@ -523,17 +547,18 @@ def test_coordinator_waiter_retries_with_leader_after_epoch_bump(persistence, lo
 
     persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
 
-    leader_result: FleetTurnSnapshot | None = None
-    waiter_result: FleetTurnSnapshot | None = None
+    leader_result: PersistedFleetLedger | None = None
+    waiter_result: PersistedFleetLedger | None = None
     errors: list[BaseException] = []
 
     def run_leader() -> None:
         nonlocal leader_result
         try:
-            leader_result = get_or_materialize_fleet_snapshot(
+            leader_result = get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             )
@@ -545,10 +570,11 @@ def test_coordinator_waiter_retries_with_leader_after_epoch_bump(persistence, lo
         assert leader_mid_chain.wait(timeout=5)
         waiter_joined.set()
         try:
-            waiter_result = get_or_materialize_fleet_snapshot(
+            waiter_result = get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             )
@@ -568,9 +594,9 @@ def test_coordinator_waiter_retries_with_leader_after_epoch_bump(persistence, lo
     assert not errors
     assert leader_result is not None
     assert waiter_result is not None
-    assert leader_result.turn == 112
-    assert waiter_result.turn == 112
-    assert persistence.get_snapshot(628580, 1, 112) is not None
+    assert leader_result.ledger.player_id == player_id
+    assert waiter_result.ledger.player_id == player_id
+    assert persistence.get_ledger(628580, 1, 112, player_id) is not None
 
 
 def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
@@ -586,6 +612,7 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
 
     turn_112 = load_turn(112)
     assert turn_112 is not None
+    player_id = _first_player_id(turn_112)
 
     leader_mid_chain = threading.Event()
     waiter_joined = threading.Event()
@@ -604,11 +631,11 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
 
     persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
 
-    coordinator = coordinator_for(persistence, 628580, 1)
+    coordinator = coordinator_for(persistence, 628580, 1, player_id)
     original_chain = __import__(
         "api.analytics.fleet.gap_fill_coordinator",
-        fromlist=["_materialize_fleet_snapshot_chain"],
-    )._materialize_fleet_snapshot_chain
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
     original_run_leader = coordinator._run_leader_unwind
 
     materialize_calls = 0
@@ -626,7 +653,6 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
         load_turn,
         inference_materialization,
         query_context,
-        materialize_player_id,
     ):
         nonlocal leader_unwind_calls
         leader_unwind_calls += 1
@@ -636,20 +662,20 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
-            materialize_player_id=materialize_player_id,
         )
 
-    leader_result: FleetTurnSnapshot | None = None
-    waiter_result: FleetTurnSnapshot | None = None
+    leader_result: PersistedFleetLedger | None = None
+    waiter_result: PersistedFleetLedger | None = None
     errors: list[BaseException] = []
 
     def run_leader() -> None:
         nonlocal leader_result
         try:
-            leader_result = get_or_materialize_fleet_snapshot(
+            leader_result = get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             )
@@ -661,10 +687,11 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
         assert leader_mid_chain.wait(timeout=5)
         waiter_joined.set()
         try:
-            waiter_result = get_or_materialize_fleet_snapshot(
+            waiter_result = get_or_materialize_fleet_ledger_for_player(
                 persistence,
                 628580,
                 1,
+                player_id,
                 turn_112,
                 load_turn=load_turn,
             )
@@ -673,7 +700,7 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
 
     with (
         patch(
-            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_snapshot_chain",
+            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
             side_effect=counting_chain,
         ),
         patch.object(coordinator, "_run_leader_unwind", side_effect=counting_run_leader),
@@ -691,9 +718,9 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
     assert not errors
     assert leader_result is not None
     assert waiter_result is not None
-    assert leader_result.turn == 112
-    assert waiter_result.turn == 112
-    assert persistence.get_snapshot(628580, 1, 112) is not None
+    assert leader_result.ledger.player_id == player_id
+    assert waiter_result.ledger.player_id == player_id
+    assert persistence.get_ledger(628580, 1, 112, player_id) is not None
     assert leader_unwind_calls == 1, f"expected one leader unwind, got {leader_unwind_calls}"
     assert materialize_calls <= 2, (
         f"expected at most one invalidation retry on the chain, got {materialize_calls}"

--- a/packages/api/tests/test_gap_fill_coordinator.py
+++ b/packages/api/tests/test_gap_fill_coordinator.py
@@ -439,6 +439,7 @@ def test_gap_fill_with_inference_never_uses_legacy_chain_path(
     from tests.test_fleet_persistence import (
         _inference_materialization_for_fleet,
         _put_provenance_final_snapshot,
+        _seed_scores_rows_for_all_players,
     )
 
     turn_110 = load_turn(110)
@@ -447,10 +448,14 @@ def test_gap_fill_with_inference_never_uses_legacy_chain_path(
 
     turn_112 = load_turn(112)
     assert turn_112 is not None
-    _, inference_materialization = _inference_materialization_for_fleet(
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    inference_persistence, inference_materialization = _inference_materialization_for_fleet(
         memory_backend,
         load_turn,
     )
+    _seed_scores_rows_for_all_players(inference_persistence, turn_111)
+    _seed_scores_rows_for_all_players(inference_persistence, turn_112)
 
     from api.analytics.fleet.gap_fill_coordinator import FleetGapFillCoordinator
 
@@ -462,10 +467,18 @@ def test_gap_fill_with_inference_never_uses_legacy_chain_path(
         forward_unwind_calls += 1
         return original_forward_unwind(self, *args, **kwargs)
 
-    with patch.object(
-        FleetGapFillCoordinator,
-        "_forward_unwind_via_export_ensure",
-        tracking_forward_unwind,
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
+            side_effect=AssertionError(
+                "legacy chain path must not run when inference materialization is set",
+            ),
+        ),
+        patch.object(
+            FleetGapFillCoordinator,
+            "_forward_unwind_via_export_ensure",
+            tracking_forward_unwind,
+        ),
     ):
         get_or_materialize_fleet_snapshot(
             persistence,

--- a/packages/api/tests/test_prior_turn_fleet_stream_warm.py
+++ b/packages/api/tests/test_prior_turn_fleet_stream_warm.py
@@ -171,10 +171,10 @@ def _wait_until(
 
 
 def _run_warm_synchronously(monkeypatch: pytest.MonkeyPatch) -> None:
-    def immediate_thread(*, target, daemon=True):
+    def immediate_thread(*, target, args=(), daemon=True):
         class _ImmediateThread:
             def start(self) -> None:
-                target()
+                target(*args)
 
         return _ImmediateThread()
 
@@ -408,9 +408,15 @@ def test_background_warm_eventually_applies_fleet_overlay(
         turn=host_turn,
         load_turn=ctx.load_turn,
         export_services=ctx.export_services,
+        player_ids=(player_id,),
     )
 
-    assert fleet_persistence.has_snapshot(ctx.game_id, ctx.perspective, prior_turn)
+    assert fleet_persistence.has_final_ledger(
+        ctx.game_id,
+        ctx.perspective,
+        prior_turn,
+        player_id,
+    )
 
     applied = resolve_prior_turn_fleet_torp_overlay(
         turn=host_turn,

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -6,14 +6,19 @@ import logging
 from dataclasses import replace
 
 import pytest
-from api.analytics.fleet.chain import ensure_fleet_baseline, get_or_materialize_fleet_snapshot
+from api.analytics.fleet.chain import (
+    ensure_fleet_baseline_for_player,
+    get_or_materialize_fleet_snapshot,
+)
 from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
     FleetBuildOptionSet,
     FleetFieldUnknown,
+    FleetMaterializationProvenance,
     FleetShipRecord,
     FleetShipRecordFields,
+    PersistedFleetLedger,
 )
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
     resolve_prior_turn_fleet_torp_overlay,
@@ -156,10 +161,10 @@ def test_resolve_prior_turn_overlay_uses_export_services(sample_turn, persistenc
 
 
 def _run_warm_synchronously(monkeypatch: pytest.MonkeyPatch) -> None:
-    def immediate_thread(*, target, daemon=True):
+    def immediate_thread(*, target, args=(), daemon=True):
         class _ImmediateThread:
             def start(self) -> None:
-                target()
+                target(*args)
 
         return _ImmediateThread()
 
@@ -174,6 +179,7 @@ def test_background_warm_swallows_conflict_when_prior_turn_snapshot_exists(
     monkeypatch,
     caplog,
 ):
+    player_id = 8
     host_turn, stored_turns = host_turn_at(sample_turn, HOST_TURN)
     fleet_services = build_ephemeral_fleet_compute_services(
         host_turn,
@@ -182,18 +188,30 @@ def test_background_warm_swallows_conflict_when_prior_turn_snapshot_exists(
     prior_turn = HOST_TURN - 1
     prior_turn_info = fleet_services.load_turn(prior_turn)
     assert prior_turn_info is not None
-    fleet_services.persistence.put_snapshot(
+    fleet_services.persistence.put_ledger(
         fleet_services.game_id,
         fleet_services.perspective,
         prior_turn,
-        ensure_fleet_baseline(fleet_services.game_id, fleet_services.perspective, prior_turn_info),
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(
+                fleet_services.game_id,
+                fleet_services.perspective,
+                prior_turn_info,
+                player_id,
+            ),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
     )
 
     def raise_conflict(*_args, **_kwargs):
         raise ConflictError("fleet snapshot gap-fill exceeded invalidation retries")
 
     monkeypatch.setattr(
-        "api.analytics.fleet.chain.get_or_materialize_fleet_snapshot",
+        "api.analytics.fleet.chain.get_or_materialize_fleet_ledger_for_player",
         raise_conflict,
     )
     _run_warm_synchronously(monkeypatch)
@@ -203,6 +221,7 @@ def test_background_warm_swallows_conflict_when_prior_turn_snapshot_exists(
             turn=host_turn,
             load_turn=fleet_services.load_turn,
             export_services={"fleet": fleet_services},
+            player_ids=(player_id,),
         )
 
     assert "Background prior-turn fleet warm failed" not in caplog.text
@@ -213,6 +232,7 @@ def test_background_warm_logs_warning_on_conflict_without_prior_turn_snapshot(
     monkeypatch,
     caplog,
 ):
+    player_id = sample_turn.scores[0].ownerid
     host_turn, stored_turns = host_turn_at(sample_turn, HOST_TURN)
     fleet_services = build_ephemeral_fleet_compute_services(
         host_turn,
@@ -223,7 +243,7 @@ def test_background_warm_logs_warning_on_conflict_without_prior_turn_snapshot(
         raise ConflictError("fleet snapshot gap-fill exceeded invalidation retries")
 
     monkeypatch.setattr(
-        "api.analytics.fleet.chain.get_or_materialize_fleet_snapshot",
+        "api.analytics.fleet.chain.get_or_materialize_fleet_ledger_for_player",
         raise_conflict,
     )
     _run_warm_synchronously(monkeypatch)
@@ -233,6 +253,7 @@ def test_background_warm_logs_warning_on_conflict_without_prior_turn_snapshot(
             turn=host_turn,
             load_turn=fleet_services.load_turn,
             export_services={"fleet": fleet_services},
+            player_ids=(player_id,),
         )
 
     assert "Background prior-turn fleet warm failed" in caplog.text


### PR DESCRIPTION
## Summary

- Scope fleet gap-fill coordinator dedupe to `(persistence, game_id, perspective, player_id)` so materializing one player no longer unwinds the full roster.
- Route `ensure_fleet_export` and background prior-turn fleet warm through per-player ledger materialization; keep `get_or_materialize_fleet_snapshot` as an explicit N-player fan-out for full-table callers.
- Add comprehensive player-scoped gap-fill, concurrency, and incident-regression tests (game 628580 turn-8 class); fix forward unwind to ensure every gap turn before checking finality so scores inference is scheduled for later turns.

Closes #179.

## Test plan

- [x] `make test_api` (fleet gap-fill, export, coordinator, prior-turn warm suites)
- [ ] Manual: fleet table at turn 8 no longer 409s when only one player's scores inference is in progress on a multi-player roster


Made with [Cursor](https://cursor.com)