### PR TITLE
Per-player fleet gap-fill coordinator invalidation epoch (#183)

### DIFF
--- a/docs/adr/0004-fleet-per-player-persistence-and-ensure-provenance.md
+++ b/docs/adr/0004-fleet-per-player-persistence-and-ensure-provenance.md
@@ -78,7 +78,7 @@ Gap-fill coordinator ([#161](https://github.com/SteveDraper/Planets-Console/issu
 | Turn document replace at *T* | Drop all fleet ledgers at turns `>= T` |
 | Hull mask / recompute (scores) | Existing per-player scores hooks; fleet follows scores row clears for P |
 
-Invalidation generation counter remains per `(gameId, perspective)` unless coordinator work splits epochs per player (implementation detail of [#179](https://github.com/SteveDraper/Planets-Console/issues/179) if needed).
+**Invalidation generation:** A monotonic counter per `(gameId, perspective, playerId)` -- the same grain as the gap-fill coordinator ([#179](https://github.com/SteveDraper/Planets-Console/issues/179)). The counter bumps when that player's fleet ledgers are dropped: per-player scores invalidation for P, stale `materializationVersion` prune on read, or turn document replace clearing P's stored ledgers. Gap-fill coordinators record the generation at chain start and abort multi-turn materialization when the counter advances for that player, then retry from a fresh anchor. Per-player scores invalidation bumps only P; turn document replace bumps every player who had ledgers cleared at affected turns. Invalidation does not block on in-flight gap-fill work.
 
 ### 6. Fleet table NDJSON stream (scores-shaped)
 

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -74,6 +74,7 @@ class _GapFillCoherence:
     persistence: FleetSnapshotPersistenceService
     game_id: int
     perspective: int
+    player_id: int
     generation: int
 
     def put_ledger(
@@ -95,7 +96,11 @@ class _GapFillCoherence:
 
     def _assert_unchanged(self) -> None:
         if (
-            self.persistence.invalidation_generation(self.game_id, self.perspective)
+            self.persistence.invalidation_generation(
+                self.game_id,
+                self.perspective,
+                self.player_id,
+            )
             != self.generation
         ):
             raise _FleetSnapshotInvalidated()
@@ -533,11 +538,18 @@ def _materialize_fleet_snapshot_chain(
     *,
     load_turn: Callable[[int], TurnInfo | None],
     inference_materialization: FleetInferenceMaterialization | None = None,
-    coherence: _GapFillCoherence,
 ) -> FleetTurnSnapshot:
     """Gap-fill fleet ledgers for every roster player through turn T."""
     turn_context_cache: dict[int, FleetTurnContext] = {}
     for player_id in _roster_player_ids(turn):
+        generation = persistence.invalidation_generation(game_id, perspective, player_id)
+        player_coherence = _GapFillCoherence(
+            persistence,
+            game_id,
+            perspective,
+            player_id,
+            generation,
+        )
         _materialize_fleet_ledger_chain_for_player(
             persistence,
             game_id,
@@ -546,7 +558,7 @@ def _materialize_fleet_snapshot_chain(
             turn,
             load_turn=load_turn,
             inference_materialization=inference_materialization,
-            coherence=coherence,
+            coherence=player_coherence,
             turn_context_cache=turn_context_cache,
         )
     snapshot = persistence.get_snapshot(game_id, perspective, turn.settings.turn)
@@ -582,7 +594,6 @@ def _run_materialize_on_active_coherence(
             turn,
             load_turn=load_turn,
             inference_materialization=inference_materialization,
-            coherence=coherence,
         )
     return _materialize_fleet_ledger_chain_for_player(
         persistence,

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -80,7 +80,6 @@ class _GapFillCoherence:
     def put_ledger(
         self,
         turn_number: int,
-        player_id: int,
         persisted: PersistedFleetLedger,
     ) -> None:
         self._assert_unchanged()
@@ -88,7 +87,7 @@ class _GapFillCoherence:
             self.game_id,
             self.perspective,
             turn_number,
-            player_id,
+            self.player_id,
             persisted,
             snapshot_complete_roster=None,
         )
@@ -379,7 +378,7 @@ def _materialize_and_persist_player_turn(
         inference_materialization=inference_materialization,
     )
     persisted = PersistedFleetLedger(ledger=ledger, provenance=provenance)
-    coherence.put_ledger(materialize_turn, player_id, persisted)
+    coherence.put_ledger(materialize_turn, persisted)
     return persisted
 
 

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -173,8 +173,12 @@ class FleetGapFillCoordinator:
 
     @property
     def epoch(self) -> int:
-        """Current invalidation generation for this perspective scope."""
-        return self._persistence.invalidation_generation(self._game_id, self._perspective)
+        """Current invalidation generation for this player scope."""
+        return self._persistence.invalidation_generation(
+            self._game_id,
+            self._perspective,
+            self._player_id,
+        )
 
     def materialize_ledger(
         self,
@@ -396,6 +400,7 @@ class FleetGapFillCoordinator:
                     self._persistence,
                     self._game_id,
                     self._perspective,
+                    self._player_id,
                     generation,
                 )
                 try:

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -55,7 +55,10 @@ class FleetSnapshotPersistenceService:
     Per-player scores invalidation bumps only the target player; turn document replace
     bumps every player who had ledgers dropped at affected turns. Invalidation does not
     block on gap-fill; concurrent invalidation callbacks only bump counters and delete
-    stored snapshots.
+    stored snapshots. ``put_snapshot`` does not bump invalidation generation; per-player
+    counters advance only on read-time stale pruning, legacy document delete, and
+    explicit invalidation methods (``invalidate_for_turn_write``,
+    ``invalidate_player_ledgers_from_turn``).
 
     **Materialization version:** Each persisted ledger entry carries
     ``materializationVersion`` (see ``FLEET_MATERIALIZATION_VERSION``). On read,

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -387,18 +387,6 @@ class FleetSnapshotPersistenceService:
             key = (game_id, perspective, player_id)
             self._invalidation_generation[key] = self._invalidation_generation.get(key, 0) + 1
 
-    def _document_exists(
-        self,
-        game_id: int,
-        perspective: int,
-        turn_number: int,
-    ) -> bool:
-        try:
-            data = self._storage.get(self.document_key(game_id, perspective, turn_number))
-        except NotFoundError:
-            return False
-        return data is not None
-
     def _read_document_raw(
         self,
         game_id: int,

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -48,12 +48,14 @@ class FleetSnapshotPersistenceService:
     *T-1*) is independent of fleet invalidation; both scores hooks run from
     ``on_turn_stored`` today.
 
-    **Invalidation generation:** Each ``(game_id, perspective)`` pair has a
-    monotonic counter bumped on every fleet invalidation call. Gap-fill
-    in ``get_or_materialize_fleet_snapshot`` records the generation at chain start
-    and aborts (then retries from a fresh anchor) when the counter advances during
-    multi-turn materialization. Invalidation does not block on gap-fill; concurrent
-    invalidation callbacks only bump the counter and delete stored snapshots.
+    **Invalidation generation:** Each ``(game_id, perspective, player_id)`` scope has a
+    monotonic counter bumped when that player's fleet ledgers are invalidated.
+    Gap-fill coordinators record the generation at chain start and abort (then retry
+    from a fresh anchor) when the counter advances during multi-turn materialization.
+    Per-player scores invalidation bumps only the target player; turn document replace
+    bumps every player who had ledgers dropped at affected turns. Invalidation does not
+    block on gap-fill; concurrent invalidation callbacks only bump counters and delete
+    stored snapshots.
 
     **Materialization version:** Each persisted ledger entry carries
     ``materializationVersion`` (see ``FLEET_MATERIALIZATION_VERSION``). On read,
@@ -70,7 +72,7 @@ class FleetSnapshotPersistenceService:
     ) -> None:
         self._storage = storage
         self._on_snapshot_persisted = on_snapshot_persisted
-        self._invalidation_generation: dict[tuple[int, int], int] = {}
+        self._invalidation_generation: dict[tuple[int, int, int], int] = {}
         self._generation_lock = threading.Lock()
 
     @staticmethod
@@ -93,7 +95,7 @@ class FleetSnapshotPersistenceService:
         persisted = persisted_fleet_ledger_from_json(ledger_wire)
         if not is_current_fleet_materialization_version(persisted.materialization_version):
             self._delete_ledger_entry(game_id, perspective, turn_number, player_id)
-            self._bump_invalidation_generation(game_id, perspective)
+            self._bump_invalidation_generation(game_id, perspective, player_id)
             return None
         return persisted
 
@@ -310,10 +312,15 @@ class FleetSnapshotPersistenceService:
         except NotFoundError:
             pass
 
-    def invalidation_generation(self, game_id: int, perspective: int) -> int:
-        """Return the current invalidation generation for one perspective scope."""
+    def invalidation_generation(
+        self,
+        game_id: int,
+        perspective: int,
+        player_id: int,
+    ) -> int:
+        """Return the current invalidation generation for one player scope."""
         with self._generation_lock:
-            return self._invalidation_generation.get((game_id, perspective), 0)
+            return self._invalidation_generation.get((game_id, perspective, player_id), 0)
 
     def invalidate_for_turn_write(
         self,
@@ -323,18 +330,23 @@ class FleetSnapshotPersistenceService:
     ) -> set[int]:
         """Drop fleet snapshots at turns >= turn_number for one perspective."""
 
-        def invalidate_turn(stored_turn: int) -> bool:
-            if not self._document_exists(game_id, perspective, stored_turn):
-                return False
+        cleared: set[int] = set()
+        cleared_player_ids: set[int] = set()
+        for stored_turn in self._stored_turn_numbers(game_id, perspective):
+            if stored_turn < turn_number:
+                continue
+            document = self._read_document_raw(game_id, perspective, stored_turn)
+            if document is None:
+                continue
+            player_ids = self._player_ids_in_document(document)
+            if not player_ids:
+                continue
             self.delete_snapshot(game_id, perspective, stored_turn)
-            return True
-
-        return self._invalidate_stored_turns_from(
-            game_id,
-            perspective,
-            turn_number,
-            invalidate_turn,
-        )
+            cleared.add(stored_turn)
+            cleared_player_ids.update(player_ids)
+        for cleared_player_id in cleared_player_ids:
+            self._bump_invalidation_generation(game_id, perspective, cleared_player_id)
+        return cleared
 
     def invalidate_player_ledgers_from_turn(
         self,
@@ -355,32 +367,24 @@ class FleetSnapshotPersistenceService:
             self._delete_ledger_entry(game_id, perspective, stored_turn, player_id)
             return True
 
-        return self._invalidate_stored_turns_from(
-            game_id,
-            perspective,
-            turn_number,
-            invalidate_turn,
-        )
-
-    def _invalidate_stored_turns_from(
-        self,
-        game_id: int,
-        perspective: int,
-        turn_number: int,
-        invalidate_turn: Callable[[int], bool],
-    ) -> set[int]:
         cleared: set[int] = set()
         for stored_turn in self._stored_turn_numbers(game_id, perspective):
             if stored_turn < turn_number:
                 continue
             if invalidate_turn(stored_turn):
                 cleared.add(stored_turn)
-        self._bump_invalidation_generation(game_id, perspective)
+        if cleared:
+            self._bump_invalidation_generation(game_id, perspective, player_id)
         return cleared
 
-    def _bump_invalidation_generation(self, game_id: int, perspective: int) -> None:
+    def _bump_invalidation_generation(
+        self,
+        game_id: int,
+        perspective: int,
+        player_id: int,
+    ) -> None:
         with self._generation_lock:
-            key = (game_id, perspective)
+            key = (game_id, perspective, player_id)
             self._invalidation_generation[key] = self._invalidation_generation.get(key, 0) + 1
 
     def _document_exists(
@@ -424,8 +428,14 @@ class FleetSnapshotPersistenceService:
             if not is_current_fleet_materialization_version(
                 fleet_materialization_version_from_json(data),
             ):
+                player_ids = self._player_ids_in_document(data)
                 self.delete_snapshot(game_id, perspective, turn_number)
-                self._bump_invalidation_generation(game_id, perspective)
+                for document_player_id in player_ids:
+                    self._bump_invalidation_generation(
+                        game_id,
+                        perspective,
+                        document_player_id,
+                    )
                 return None
             upgraded = upgrade_legacy_fleet_turn_document(data)
             self._write_document(game_id, perspective, turn_number, upgraded)
@@ -519,8 +529,27 @@ class FleetSnapshotPersistenceService:
             self._write_document(game_id, perspective, turn_number, document)
         else:
             self.delete_snapshot(game_id, perspective, turn_number)
-        self._bump_invalidation_generation(game_id, perspective)
+        for stale_player_id in stale_player_ids:
+            self._bump_invalidation_generation(game_id, perspective, stale_player_id)
         return False
+
+    @staticmethod
+    def _player_ids_in_document(document: dict[str, object]) -> list[int]:
+        player_ids: list[int] = []
+        ledgers = document.get(FLEET_LEDGERS_KEY)
+        if isinstance(ledgers, dict):
+            for player_key in ledgers:
+                if player_key.isdigit():
+                    player_ids.append(int(player_key))
+        players = document.get("players")
+        if isinstance(players, list):
+            for player_wire in players:
+                if not isinstance(player_wire, dict):
+                    continue
+                player_id = player_wire.get("playerId")
+                if isinstance(player_id, int):
+                    player_ids.append(player_id)
+        return sorted(set(player_ids))
 
     def _stored_turn_numbers(self, game_id: int, perspective: int) -> list[int]:
         turns_prefix = f"games/{game_id}/{perspective}/turns"

--- a/packages/api/api/analytics/fleet/persistence.py
+++ b/packages/api/api/analytics/fleet/persistence.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 
 from api.analytics.fleet.constants import (
     ANALYTIC_ID,
@@ -335,9 +335,8 @@ class FleetSnapshotPersistenceService:
 
         cleared: set[int] = set()
         cleared_player_ids: set[int] = set()
-        for stored_turn in self._stored_turn_numbers(game_id, perspective):
-            if stored_turn < turn_number:
-                continue
+        for stored_turn in self._iter_stored_turns_from(game_id, perspective, turn_number):
+            # Turn replace deletes whole documents; raw read avoids legacy upgrade side effects.
             document = self._read_document_raw(game_id, perspective, stored_turn)
             if document is None:
                 continue
@@ -361,6 +360,7 @@ class FleetSnapshotPersistenceService:
         """Drop one player's fleet ledgers at turns >= turn_number for one perspective."""
 
         def invalidate_turn(stored_turn: int) -> bool:
+            # Per-player delete may upgrade legacy layout before removing one ledger entry.
             document = self._load_document(game_id, perspective, stored_turn)
             if document is None:
                 return False
@@ -371,9 +371,7 @@ class FleetSnapshotPersistenceService:
             return True
 
         cleared: set[int] = set()
-        for stored_turn in self._stored_turn_numbers(game_id, perspective):
-            if stored_turn < turn_number:
-                continue
+        for stored_turn in self._iter_stored_turns_from(game_id, perspective, turn_number):
             if invalidate_turn(stored_turn):
                 cleared.add(stored_turn)
         if cleared:
@@ -541,6 +539,18 @@ class FleetSnapshotPersistenceService:
                 if isinstance(player_id, int):
                     player_ids.append(player_id)
         return sorted(set(player_ids))
+
+    def _iter_stored_turns_from(
+        self,
+        game_id: int,
+        perspective: int,
+        turn_number: int,
+    ) -> Iterator[int]:
+        """Yield stored fleet turn numbers at or after ``turn_number``."""
+
+        for stored_turn in self._stored_turn_numbers(game_id, perspective):
+            if stored_turn >= turn_number:
+                yield stored_turn
 
     def _stored_turn_numbers(self, game_id: int, perspective: int) -> list[int]:
         turns_prefix = f"games/{game_id}/{perspective}/turns"

--- a/packages/api/tests/export_chain_test_fixtures.py
+++ b/packages/api/tests/export_chain_test_fixtures.py
@@ -9,9 +9,7 @@ from pathlib import Path
 
 from api.analytics.export_context import AnalyticQueryContext, make_analytic_query_context
 from api.analytics.fleet.chain import (
-    _GapFillCoherence,
     _materialize_fleet_snapshot_chain,
-    gap_fill_coherence_scope,
 )
 from api.analytics.fleet.compute_services import (
     FleetComputeServices,
@@ -132,26 +130,14 @@ def seed_fleet_unwind_through(
                     solutions=[],
                 ),
             )
-        generation = fleet_services.persistence.invalidation_generation(
-            ctx.game_id,
-            ctx.perspective,
-        )
-        coherence = _GapFillCoherence(
+        _materialize_fleet_snapshot_chain(
             fleet_services.persistence,
             ctx.game_id,
             ctx.perspective,
-            generation,
+            turn,
+            load_turn=ctx.load_turn,
+            inference_materialization=fleet_services.inference_materialization,
         )
-        with gap_fill_coherence_scope(coherence):
-            _materialize_fleet_snapshot_chain(
-                fleet_services.persistence,
-                ctx.game_id,
-                ctx.perspective,
-                turn,
-                load_turn=ctx.load_turn,
-                inference_materialization=fleet_services.inference_materialization,
-                coherence=coherence,
-            )
 
 
 def seed_storage_analytics_fixture(

--- a/packages/api/tests/fleet_player_scoped_gap_fill_helpers.py
+++ b/packages/api/tests/fleet_player_scoped_gap_fill_helpers.py
@@ -41,9 +41,7 @@ def require_turns(
 ) -> tuple[TurnInfo, ...]:
     turns = tuple(load_turn(turn_number) for turn_number in turn_numbers)
     missing = [
-        turn_number
-        for turn_number, turn in zip(turn_numbers, turns, strict=True)
-        if turn is None
+        turn_number for turn_number, turn in zip(turn_numbers, turns, strict=True) if turn is None
     ]
     assert not missing, f"missing turns: {missing}"
     return turns
@@ -61,7 +59,7 @@ def seed_provenance_snapshot(
     *,
     from_turn: int = 109,
 ) -> TurnInfo:
-    turn, = require_turns(load_turn, from_turn)
+    (turn,) = require_turns(load_turn, from_turn)
     _put_provenance_final_snapshot(persistence, GAME_ID, 1, turn)
     return turn
 

--- a/packages/api/tests/fleet_player_scoped_gap_fill_helpers.py
+++ b/packages/api/tests/fleet_player_scoped_gap_fill_helpers.py
@@ -1,0 +1,192 @@
+"""Shared helpers for player-scoped fleet gap-fill tests."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Any
+
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.military_score_inference.solver import STATUS_EXACT
+from api.analytics.turn_roster import iter_turn_players
+from api.models.game import TurnInfo
+from api.serialization.inference_row_persistence import PersistedInferenceRow
+from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+
+from tests.export_chain_test_fixtures import export_chain_query_context
+from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective, put_persisted_row
+from tests.test_fleet_persistence import _put_provenance_final_snapshot
+
+__all__ = [
+    "ensure_fleet_export_gap_fill_context",
+    "install_mid_chain_put_ledger_gate",
+    "materialize_chain_from_coordinator_module",
+    "require_turns",
+    "roster_ids",
+    "seed_provenance_snapshot",
+    "two_players_from_turn",
+]
+
+
+def roster_ids(turn: TurnInfo) -> list[int]:
+    return [player.id for player in iter_turn_players(turn)]
+
+
+def require_turns(
+    load_turn: Callable[[int], TurnInfo | None],
+    *turn_numbers: int,
+) -> tuple[TurnInfo, ...]:
+    turns = tuple(load_turn(turn_number) for turn_number in turn_numbers)
+    missing = [
+        turn_number
+        for turn_number, turn in zip(turn_numbers, turns, strict=True)
+        if turn is None
+    ]
+    assert not missing, f"missing turns: {missing}"
+    return turns
+
+
+def two_players_from_turn(turn: TurnInfo) -> tuple[int, int]:
+    roster = roster_ids(turn)
+    assert len(roster) > 1
+    return roster[0], roster[1]
+
+
+def seed_provenance_snapshot(
+    persistence: FleetSnapshotPersistenceService,
+    load_turn: Callable[[int], TurnInfo | None],
+    *,
+    from_turn: int = 109,
+) -> TurnInfo:
+    turn, = require_turns(load_turn, from_turn)
+    _put_provenance_final_snapshot(persistence, GAME_ID, 1, turn)
+    return turn
+
+
+def ensure_fleet_export_gap_fill_context(
+    sample_turn,
+    memory_backend,
+    *,
+    turn_number: int = 8,
+):
+    """Export-ensure context with per-player prerequisites through T-1 (one-turn gap at T)."""
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+
+    player_id = first_player_id(sample_turn)
+    other_player_id = sample_turn.scores[1].ownerid
+    host_turn = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=turn_number),
+        game=replace(sample_turn.game, turn=turn_number),
+    )
+    stored_turns = turn_chain_through(host_turn)
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
+    persp = perspective(sample_turn)
+    final_provenance = FleetMaterializationProvenance(
+        turn_evidence_at_n=True,
+        prior_ledger_at_n_minus_1=True,
+    )
+
+    for prior_turn in range(1, turn_number):
+        prior_turn_info = stored_turns[prior_turn]
+        put_persisted_row(
+            inference_persistence,
+            prior_turn_info,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seed",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+        )
+        fleet_persistence.put_ledger(
+            GAME_ID,
+            persp,
+            prior_turn,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(
+                    GAME_ID,
+                    persp,
+                    prior_turn_info,
+                    player_id,
+                ),
+                provenance=final_provenance,
+            ),
+        )
+
+    put_persisted_row(
+        inference_persistence,
+        host_turn,
+        player_id,
+        PersistedInferenceRow(
+            status=STATUS_EXACT,
+            summary="seed",
+            solution_count=0,
+            is_complete=True,
+            solutions=[],
+        ),
+    )
+
+    ctx = export_chain_query_context(
+        host_turn,
+        persistence=inference_persistence,
+        stored_turns=stored_turns,
+    )
+    fleet_services = ctx.export_services["fleet"]
+    ctx.export_services["fleet"] = FleetComputeServices(
+        persistence=fleet_persistence,
+        game_id=GAME_ID,
+        perspective=persp,
+        load_turn=stored_turns.get,
+        inference_materialization=fleet_services.inference_materialization,
+    )
+    scope = ExportScope(
+        game_id=GAME_ID,
+        perspective=persp,
+        turn=turn_number,
+        player_id=player_id,
+    )
+    return ctx, scope, player_id, other_player_id, fleet_persistence
+
+
+def materialize_chain_from_coordinator_module():
+    return __import__(
+        "api.analytics.fleet.gap_fill_coordinator",
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
+
+
+def install_mid_chain_put_ledger_gate(
+    persistence: FleetSnapshotPersistenceService,
+    *,
+    player_id: int,
+    turn_number: int,
+    leader_mid_chain: threading.Event,
+    release_leader: threading.Event,
+) -> None:
+    original_put_ledger = persistence.put_ledger
+    mid_chain_puts = 0
+
+    def hooked_put_ledger(*args: Any, **kwargs: Any) -> None:
+        nonlocal mid_chain_puts
+        hooked_turn_number = args[2]
+        hooked_player_id = args[3]
+        original_put_ledger(*args, **kwargs)
+        if (
+            hooked_player_id == player_id
+            and hooked_turn_number == turn_number
+            and mid_chain_puts == 0
+        ):
+            mid_chain_puts += 1
+            leader_mid_chain.set()
+            assert release_leader.wait(timeout=5)
+
+    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]

--- a/packages/api/tests/test_fleet_ledger_persistence.py
+++ b/packages/api/tests/test_fleet_ledger_persistence.py
@@ -224,11 +224,12 @@ def test_stale_per_ledger_materialization_version_is_deleted_on_read(
     assert isinstance(ledger_wire, dict)
     ledger_wire["materializationVersion"] = FLEET_MATERIALIZATION_VERSION - 1
     memory_backend.put(persistence.document_key(628580, 1, 111), document)
-    generation_before = persistence.invalidation_generation(628580, 1)
+    generation_before = persistence.invalidation_generation(628580, 1, 8)
 
     assert persistence.get_ledger(628580, 1, 111, 8) is None
     assert persistence.has_ledger(628580, 1, 111, 8) is False
-    assert persistence.invalidation_generation(628580, 1) == generation_before + 1
+    assert persistence.invalidation_generation(628580, 1, 8) == generation_before + 1
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
 
 
 def test_list_ledger_player_ids_returns_sorted_ids(persistence, sample_ledger):

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -695,14 +695,16 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
     turn_112 = load_turn(112)
     assert turn_112 is not None
     sync = threading.Barrier(2)
-    put_generations: list[int] = []
+    put_records: list[tuple[int, int]] = []
     original_put_ledger = persistence.put_ledger
 
     def hooked_put_ledger(*args, **kwargs):
         original_put_ledger(*args, **kwargs)
         player_id = args[3]
-        put_generations.append(persistence.invalidation_generation(628580, 1, player_id))
-        if len(put_generations) == 1:
+        put_records.append(
+            (player_id, persistence.invalidation_generation(628580, 1, player_id)),
+        )
+        if len(put_records) == 1:
             sync.wait()
             sync.wait()
 
@@ -734,8 +736,23 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
     assert gap_fill_error is None
     assert snapshot is not None
     assert snapshot.turn == 112
-    assert put_generations[0] == 0
-    assert 1 in put_generations
+    assert put_records[0][1] == 0
+    for player_id in {recorded_player_id for recorded_player_id, _ in put_records}:
+        player_generations = [
+            generation
+            for recorded_player_id, generation in put_records
+            if recorded_player_id == player_id
+        ]
+        if 1 not in player_generations:
+            continue
+        last_generation_zero_index = max(
+            index
+            for index, generation in enumerate(player_generations)
+            if generation == 0
+        )
+        post_invalidation_generations = player_generations[last_generation_zero_index + 1 :]
+        assert post_invalidation_generations
+        assert post_invalidation_generations == [1] * len(post_invalidation_generations)
     assert persistence.get_snapshot(628580, 1, 111) is not None
     assert persistence.get_snapshot(628580, 1, 112) == snapshot
     assert len(snapshot.players[0].records) == 6

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -746,9 +746,7 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
         if 1 not in player_generations:
             continue
         last_generation_zero_index = max(
-            index
-            for index, generation in enumerate(player_generations)
-            if generation == 0
+            index for index, generation in enumerate(player_generations) if generation == 0
         )
         post_invalidation_generations = player_generations[last_generation_zero_index + 1 :]
         assert post_invalidation_generations

--- a/packages/api/tests/test_fleet_persistence.py
+++ b/packages/api/tests/test_fleet_persistence.py
@@ -318,10 +318,10 @@ def test_invalidate_for_turn_write_drops_snapshots_at_and_after_turn(persistence
                 players=[FleetAcquisitionLedger(player_id=8)],
             ),
         )
-    assert persistence.invalidation_generation(628580, 1) == 0
+    assert persistence.invalidation_generation(628580, 1, 8) == 0
     cleared = persistence.invalidate_for_turn_write(628580, 1, 111)
     assert cleared == {111, 112}
-    assert persistence.invalidation_generation(628580, 1) == 1
+    assert persistence.invalidation_generation(628580, 1, 8) == 1
     assert persistence.get_snapshot(628580, 1, 110) is not None
     assert persistence.get_snapshot(628580, 1, 111) is None
     assert persistence.get_snapshot(628580, 1, 112) is None
@@ -345,16 +345,75 @@ def test_invalidate_player_ledgers_from_turn_drops_only_target_player(persistenc
             3,
             PersistedFleetLedger(ledger=player_3),
         )
-    assert persistence.invalidation_generation(628580, 1) == 0
+    assert persistence.invalidation_generation(628580, 1, 8) == 0
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
     cleared = persistence.invalidate_player_ledgers_from_turn(628580, 1, 111, 8)
     assert cleared == {111, 112}
-    assert persistence.invalidation_generation(628580, 1) == 1
+    assert persistence.invalidation_generation(628580, 1, 8) == 1
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
     assert persistence.get_ledger(628580, 1, 110, 8) is not None
     assert persistence.get_ledger(628580, 1, 110, 3) is not None
     assert persistence.get_ledger(628580, 1, 111, 8) is None
     assert persistence.get_ledger(628580, 1, 112, 8) is None
     assert persistence.get_ledger(628580, 1, 111, 3) is not None
     assert persistence.get_ledger(628580, 1, 112, 3) is not None
+
+
+def test_invalidation_bumps_epoch_for_target_player_only(persistence):
+    """invalidate_player_ledgers_from_turn bumps only the target player's generation."""
+    player_8 = FleetAcquisitionLedger(player_id=8)
+    player_3 = FleetAcquisitionLedger(player_id=3)
+    for turn_number in (111, 112):
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            8,
+            PersistedFleetLedger(ledger=player_8),
+        )
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            3,
+            PersistedFleetLedger(ledger=player_3),
+        )
+
+    assert persistence.invalidation_generation(628580, 1, 8) == 0
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
+    persistence.invalidate_player_ledgers_from_turn(628580, 1, 111, 8)
+    assert persistence.invalidation_generation(628580, 1, 8) == 1
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
+
+
+def test_turn_document_replace_bumps_all_player_epochs(persistence):
+    """invalidate_for_turn_write bumps every player who had ledgers at affected turns."""
+    player_8 = FleetAcquisitionLedger(player_id=8)
+    player_3 = FleetAcquisitionLedger(player_id=3)
+    for turn_number in (110, 111, 112):
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            8,
+            PersistedFleetLedger(ledger=player_8),
+        )
+        persistence.put_ledger(
+            628580,
+            1,
+            turn_number,
+            3,
+            PersistedFleetLedger(ledger=player_3),
+        )
+
+    assert persistence.invalidation_generation(628580, 1, 8) == 0
+    assert persistence.invalidation_generation(628580, 1, 3) == 0
+    cleared = persistence.invalidate_for_turn_write(628580, 1, 111)
+    assert cleared == {111, 112}
+    assert persistence.invalidation_generation(628580, 1, 8) == 1
+    assert persistence.invalidation_generation(628580, 1, 3) == 1
+    assert persistence.get_ledger(628580, 1, 110, 8) is not None
+    assert persistence.get_ledger(628580, 1, 110, 3) is not None
 
 
 def test_inference_evidence_updated_preserves_other_players_ledgers(memory_backend):
@@ -641,7 +700,8 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
 
     def hooked_put_ledger(*args, **kwargs):
         original_put_ledger(*args, **kwargs)
-        put_generations.append(persistence.invalidation_generation(628580, 1))
+        player_id = args[3]
+        put_generations.append(persistence.invalidation_generation(628580, 1, player_id))
         if len(put_generations) == 1:
             sync.wait()
             sync.wait()
@@ -675,7 +735,7 @@ def test_gap_fill_aborts_on_concurrent_invalidation(persistence, load_turn, memo
     assert snapshot is not None
     assert snapshot.turn == 112
     assert put_generations[0] == 0
-    assert put_generations[-2:] == [1, 1]
+    assert 1 in put_generations
     assert persistence.get_snapshot(628580, 1, 111) is not None
     assert persistence.get_snapshot(628580, 1, 112) == snapshot
     assert len(snapshot.players[0].records) == 6
@@ -791,6 +851,9 @@ def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, lo
 
     persistence.put_ledger = put_ledger_that_invalidates  # type: ignore[method-assign]
 
+    from api.analytics.turn_roster import iter_turn_players
+
+    first_player_id = next(iter_turn_players(turn_111)).id
     with patch("api.analytics.fleet.gap_fill_coordinator.GAP_FILL_MAX_RETRIES", 3):
         with pytest.raises(ConflictError, match="exceeded 3 invalidation retries"):
             get_or_materialize_fleet_snapshot(
@@ -802,7 +865,7 @@ def test_gap_fill_raises_conflict_after_max_invalidation_retries(persistence, lo
             )
 
     assert persistence.get_snapshot(628580, 1, 111) is None
-    assert persistence.invalidation_generation(628580, 1) == 3
+    assert persistence.invalidation_generation(628580, 1, first_player_id) == 3
 
 
 def _put_provenance_final_snapshot(
@@ -926,11 +989,15 @@ def test_stale_materialization_version_is_deleted_on_read(persistence, load_turn
         persistence.document_key(628580, 1, 111),
         stale_payload,
     )
-    generation_before = persistence.invalidation_generation(628580, 1)
+    first_player_id = snapshot.players[0].player_id
+    generation_before = persistence.invalidation_generation(628580, 1, first_player_id)
 
     assert persistence.get_snapshot(628580, 1, 111) is None
     assert persistence.has_snapshot(628580, 1, 111) is False
-    assert persistence.invalidation_generation(628580, 1) == generation_before + 1
+    for player_ledger in snapshot.players:
+        assert persistence.invalidation_generation(628580, 1, player_ledger.player_id) == (
+            generation_before + 1
+        )
 
 
 def test_missing_materialization_version_is_deleted_on_read(persistence, load_turn, memory_backend):

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -258,7 +258,7 @@ def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_tu
 def test_per_player_cache_hit_does_not_require_roster_complete(persistence, load_turn):
     from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
 
-    turn, = require_turns(load_turn, 111)
+    (turn,) = require_turns(load_turn, 111)
     roster = roster_ids(turn)
     player_p = roster[0]
     persistence.put_ledger(

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -10,17 +10,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
     _materialize_fleet_ledger_chain_for_player,
     get_or_materialize_fleet_ledger_for_player,
 )
-from api.analytics.fleet.compute_services import turn_chain_through
 from api.analytics.fleet.exports import EXPORT_CATALOG, ensure_fleet_export
 from api.analytics.fleet.gap_fill_coordinator import coordinator_for, reset_coordinators
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
 from api.analytics.military_score_inference.solver import STATUS_EXACT
-from api.analytics.turn_roster import iter_turn_players
 from api.errors import FleetMaterializationTimeoutError
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 from api.serialization.turn import turn_info_from_json
@@ -28,10 +26,18 @@ from api.services.inference_row_persistence_service import InferenceRowPersisten
 from api.storage.memory_asset import MemoryAssetBackend
 
 from tests.export_chain_test_fixtures import export_chain_query_context
+from tests.fleet_player_scoped_gap_fill_helpers import (
+    ensure_fleet_export_gap_fill_context,
+    install_mid_chain_put_ledger_gate,
+    materialize_chain_from_coordinator_module,
+    require_turns,
+    roster_ids,
+    seed_provenance_snapshot,
+    two_players_from_turn,
+)
 from tests.scores_exports_helpers import first_player_id, put_persisted_row
 from tests.test_fleet_persistence import (
     _inference_materialization_for_fleet,
-    _put_provenance_final_snapshot,
 )
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
@@ -47,10 +53,10 @@ def _reset_coordinators():
 @pytest.fixture
 def memory_backend():
     backend = MemoryAssetBackend(initial={})
-    with open(ASSETS_DIR / "game_info_sample.json") as f:
-        backend.put("games/628580/info", json.load(f))
-    with open(ASSETS_DIR / "turn_sample.json") as f:
-        turn_rst = json.load(f)
+    with open(ASSETS_DIR / "game_info_sample.json") as handle:
+        backend.put("games/628580/info", json.load(handle))
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        turn_rst = json.load(handle)
         for turn_number in (109, 110, 111, 112):
             turn_data = copy.deepcopy(turn_rst)
             turn_data["settings"]["turn"] = turn_number
@@ -79,113 +85,11 @@ def load_turn(memory_backend):
     return _load
 
 
-def _roster_ids(turn) -> list[int]:
-    return [player.id for player in iter_turn_players(turn)]
-
-
-def _ensure_fleet_export_gap_fill_context(
-    sample_turn,
-    memory_backend,
-    *,
-    turn_number: int = 8,
-):
-    """Export-ensure context with per-player prerequisites through T-1 (one-turn gap at T)."""
-    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
-    from api.analytics.fleet.compute_services import FleetComputeServices, turn_chain_through
-    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
-
-    from tests.scores_exports_helpers import GAME_ID, first_player_id, perspective
-
-    player_id = first_player_id(sample_turn)
-    other_player_id = sample_turn.scores[1].ownerid
-    host_turn = replace(
-        sample_turn,
-        settings=replace(sample_turn.settings, turn=turn_number),
-        game=replace(sample_turn.game, turn=turn_number),
-    )
-    stored_turns = turn_chain_through(host_turn)
-    inference_persistence = InferenceRowPersistenceService(memory_backend)
-    fleet_persistence = FleetSnapshotPersistenceService(memory_backend)
-    persp = perspective(sample_turn)
-    final_provenance = FleetMaterializationProvenance(
-        turn_evidence_at_n=True,
-        prior_ledger_at_n_minus_1=True,
-    )
-
-    for prior_turn in range(1, turn_number):
-        prior_turn_info = stored_turns[prior_turn]
-        put_persisted_row(
-            inference_persistence,
-            prior_turn_info,
-            player_id,
-            PersistedInferenceRow(
-                status=STATUS_EXACT,
-                summary="seed",
-                solution_count=0,
-                is_complete=True,
-                solutions=[],
-            ),
-        )
-        fleet_persistence.put_ledger(
-            GAME_ID,
-            persp,
-            prior_turn,
-            player_id,
-            PersistedFleetLedger(
-                ledger=ensure_fleet_baseline_for_player(
-                    GAME_ID,
-                    persp,
-                    prior_turn_info,
-                    player_id,
-                ),
-                provenance=final_provenance,
-            ),
-        )
-
-    put_persisted_row(
-        inference_persistence,
-        host_turn,
-        player_id,
-        PersistedInferenceRow(
-            status=STATUS_EXACT,
-            summary="seed",
-            solution_count=0,
-            is_complete=True,
-            solutions=[],
-        ),
-    )
-
-    ctx = export_chain_query_context(
-        host_turn,
-        persistence=inference_persistence,
-        stored_turns=stored_turns,
-    )
-    fleet_services = ctx.export_services["fleet"]
-    ctx.export_services["fleet"] = FleetComputeServices(
-        persistence=fleet_persistence,
-        game_id=GAME_ID,
-        perspective=persp,
-        load_turn=stored_turns.get,
-        inference_materialization=fleet_services.inference_materialization,
-    )
-    scope = ExportScope(
-        game_id=GAME_ID,
-        perspective=persp,
-        turn=turn_number,
-        player_id=player_id,
-    )
-    return ctx, scope, player_id, other_player_id, fleet_persistence
-
-
 def test_single_player_gap_fill_does_not_materialize_other_players(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    roster = _roster_ids(turn_112)
-    assert len(roster) > 1
-    player_p, player_q = roster[0], roster[1]
+    _, turn_112 = require_turns(load_turn, 109, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
 
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     get_or_materialize_fleet_ledger_for_player(
         persistence,
@@ -203,7 +107,7 @@ def test_single_player_gap_fill_does_not_materialize_other_players(persistence, 
 
 def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
     ctx, scope, player_id, other_player_id, fleet_persistence = (
-        _ensure_fleet_export_gap_fill_context(sample_turn, memory_backend)
+        ensure_fleet_export_gap_fill_context(sample_turn, memory_backend)
     )
     ledger_calls: list[int] = []
     original = get_or_materialize_fleet_ledger_for_player
@@ -240,6 +144,8 @@ def test_ensure_fleet_export_scoped_to_player_only(sample_turn, memory_backend):
 
 def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
     """Dependency walk and forward unwind both ensure fleet@T,P once; materialize once."""
+    from api.analytics.fleet.compute_services import turn_chain_through
+
     player_id = first_player_id(sample_turn)
     turn_number = 8
     inference_persistence = InferenceRowPersistenceService(memory_backend)
@@ -327,7 +233,7 @@ def test_nested_ensure_dedupes_same_player_node(sample_turn, memory_backend):
 
 
 def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_turn, memory_backend):
-    ctx, scope, player_id, _, fleet_persistence = _ensure_fleet_export_gap_fill_context(
+    ctx, scope, player_id, _, fleet_persistence = ensure_fleet_export_gap_fill_context(
         sample_turn,
         memory_backend,
     )
@@ -351,11 +257,9 @@ def test_ensure_fleet_export_does_not_invoke_full_snapshot_materialize(sample_tu
 
 def test_per_player_cache_hit_does_not_require_roster_complete(persistence, load_turn):
     from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
-    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
 
-    turn = load_turn(111)
-    assert turn is not None
-    roster = _roster_ids(turn)
+    turn, = require_turns(load_turn, 111)
+    roster = roster_ids(turn)
     player_p = roster[0]
     persistence.put_ledger(
         628580,
@@ -395,15 +299,10 @@ def test_per_player_prior_turn_materializes_while_other_scores_inference_in_prog
     still in progress. Would raise ConflictError under perspective-batch coordinator
     behavior that waited for full-roster ensure-final before one-player access.
     """
-    turn_110 = load_turn(110)
-    turn_111 = load_turn(111)
-    turn_112 = load_turn(112)
-    assert turn_110 is not None and turn_111 is not None and turn_112 is not None
-    roster = _roster_ids(turn_112)
-    assert len(roster) > 1
-    player_p, player_q = roster[0], roster[1]
+    turn_110, turn_111, turn_112 = require_turns(load_turn, 110, 111, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
 
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=110)
 
     inference_persistence, inference_materialization = _inference_materialization_for_fleet(
         memory_backend,
@@ -459,15 +358,11 @@ def test_per_player_prior_turn_materializes_while_other_scores_inference_in_prog
 
 
 def test_per_player_gap_start_independent(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_110 = load_turn(110)
-    turn_111 = load_turn(111)
-    assert turn_109 is not None and turn_110 is not None and turn_111 is not None
-    roster = _roster_ids(turn_111)
-    player_p, player_q = roster[0], roster[1]
+    turn_109, turn_110, turn_111 = require_turns(load_turn, 109, 110, 111)
+    player_p, player_q = two_players_from_turn(turn_111)
 
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=110)
 
     get_or_materialize_fleet_ledger_for_player(
         persistence,
@@ -487,11 +382,9 @@ def test_compute_fleet_fan_out_materializes_all_players_explicitly(persistence, 
     from api.analytics.fleet import compute_fleet
     from api.analytics.fleet.compute_services import FleetComputeServices
 
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    roster_size = len(_roster_ids(turn_112))
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_112 = require_turns(load_turn, 109, 112)
+    roster_size = len(roster_ids(turn_112))
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     fleet_services = FleetComputeServices(
         persistence=persistence,
@@ -523,18 +416,12 @@ def test_compute_fleet_fan_out_materializes_all_players_explicitly(persistence, 
 
 
 def test_coordinator_two_threads_same_player_share_one_chain(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_111 = load_turn(111)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
-    player_id = _roster_ids(turn_112)[0]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_111, turn_112 = require_turns(load_turn, 109, 111, 112)
+    player_id = roster_ids(turn_112)[0]
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     materialize_calls = 0
-    original_chain = __import__(
-        "api.analytics.fleet.gap_fill_coordinator",
-        fromlist=["_materialize_fleet_ledger_chain_for_player"],
-    )._materialize_fleet_ledger_chain_for_player
+    original_chain = materialize_chain_from_coordinator_module()
 
     def counting_chain(*args, **kwargs):
         nonlocal materialize_calls
@@ -571,12 +458,9 @@ def test_coordinator_two_threads_same_player_share_one_chain(persistence, load_t
 
 
 def test_coordinator_same_player_waiters_satisfy_to_max_turn(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_111 = load_turn(111)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
-    player_id = _roster_ids(turn_112)[0]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_111, turn_112 = require_turns(load_turn, 109, 111, 112)
+    player_id = roster_ids(turn_112)[0]
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     leader_ready = threading.Event()
     release_leader = threading.Event()
@@ -621,12 +505,9 @@ def test_coordinator_same_player_waiters_satisfy_to_max_turn(persistence, load_t
 
 
 def test_coordinator_different_players_separate_dedupe_keys(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    roster = _roster_ids(turn_112)
-    player_p, player_q = roster[0], roster[1]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_112 = require_turns(load_turn, 109, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     coordinator_p = coordinator_for(persistence, 628580, 1, player_p)
     coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
@@ -679,11 +560,9 @@ def test_coordinator_different_players_separate_dedupe_keys(persistence, load_tu
 
 
 def test_coordinator_waiter_timeout_per_player(persistence, load_turn):
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    player_p, player_q = _roster_ids(turn_112)[:2]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_112 = require_turns(load_turn, 109, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     started = threading.Event()
     release = threading.Event()
@@ -760,13 +639,10 @@ def test_forward_unwind_scores_before_fleet_per_player(
     """Gap M..N for one player: scores@t,P is ensured before fleet@t,P at each gap turn."""
     from api.analytics.export_context import AnalyticQueryContext
 
-    turn_109 = load_turn(109)
-    turn_111 = load_turn(111)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_111 is not None and turn_112 is not None
-    player_p = _roster_ids(turn_112)[0]
+    turn_109, turn_111, turn_112 = require_turns(load_turn, 109, 111, 112)
+    player_p = roster_ids(turn_112)[0]
 
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     _, inference_materialization = _inference_materialization_for_fleet(
         memory_backend,
@@ -857,41 +733,25 @@ def test_forward_unwind_scores_before_fleet_per_player(
 
 def test_invalidation_mid_chain_same_player_waiters_retry_once(persistence, load_turn):
     """P invalidation aborts P's chain and waiters retry; Q's in-flight chain is unaffected."""
-    from api.analytics.fleet.types import PersistedFleetLedger
-
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    roster = _roster_ids(turn_112)
-    assert len(roster) > 1
-    player_p, player_q = roster[0], roster[1]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_112 = require_turns(load_turn, 109, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     leader_mid_chain = threading.Event()
     p_waiter_joined = threading.Event()
     q_started = threading.Event()
     release_leader = threading.Event()
-    original_put_ledger = persistence.put_ledger
-    mid_chain_puts = 0
-
-    def hooked_put_ledger(*args, **kwargs):
-        nonlocal mid_chain_puts
-        turn_number = args[2]
-        player_id = args[3]
-        original_put_ledger(*args, **kwargs)
-        if player_id == player_p and turn_number == 111 and mid_chain_puts == 0:
-            mid_chain_puts += 1
-            leader_mid_chain.set()
-            assert release_leader.wait(timeout=5)
-
-    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
+    install_mid_chain_put_ledger_gate(
+        persistence,
+        player_id=player_p,
+        turn_number=111,
+        leader_mid_chain=leader_mid_chain,
+        release_leader=release_leader,
+    )
 
     coordinator_p = coordinator_for(persistence, 628580, 1, player_p)
     coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
-    original_chain = __import__(
-        "api.analytics.fleet.gap_fill_coordinator",
-        fromlist=["_materialize_fleet_ledger_chain_for_player"],
-    )._materialize_fleet_ledger_chain_for_player
+    original_chain = materialize_chain_from_coordinator_module()
     original_run_leader_p = coordinator_p._run_leader_unwind
 
     p_materialize_calls = 0
@@ -1014,37 +874,23 @@ def test_invalidation_mid_chain_same_player_waiters_retry_once(persistence, load
 
 def test_coordinator_q_unaffected_when_p_epoch_bumps_mid_chain(persistence, load_turn):
     """Q leader does not re-enter materialize chain when only P's epoch bumps."""
-    turn_109 = load_turn(109)
-    turn_112 = load_turn(112)
-    assert turn_109 is not None and turn_112 is not None
-    roster = _roster_ids(turn_112)
-    assert len(roster) > 1
-    player_p, player_q = roster[0], roster[1]
-    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+    turn_109, turn_112 = require_turns(load_turn, 109, 112)
+    player_p, player_q = two_players_from_turn(turn_112)
+    seed_provenance_snapshot(persistence, load_turn, from_turn=109)
 
     leader_mid_chain = threading.Event()
     q_started = threading.Event()
     release_leader = threading.Event()
-    original_put_ledger = persistence.put_ledger
-    mid_chain_puts = 0
-
-    def hooked_put_ledger(*args, **kwargs):
-        nonlocal mid_chain_puts
-        turn_number = args[2]
-        player_id = args[3]
-        original_put_ledger(*args, **kwargs)
-        if player_id == player_p and turn_number == 111 and mid_chain_puts == 0:
-            mid_chain_puts += 1
-            leader_mid_chain.set()
-            assert release_leader.wait(timeout=5)
-
-    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
+    install_mid_chain_put_ledger_gate(
+        persistence,
+        player_id=player_p,
+        turn_number=111,
+        leader_mid_chain=leader_mid_chain,
+        release_leader=release_leader,
+    )
 
     coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
-    original_chain = __import__(
-        "api.analytics.fleet.gap_fill_coordinator",
-        fromlist=["_materialize_fleet_ledger_chain_for_player"],
-    )._materialize_fleet_ledger_chain_for_player
+    original_chain = materialize_chain_from_coordinator_module()
     original_run_leader_q = coordinator_q._run_leader_unwind
 
     q_materialize_calls = 0

--- a/packages/api/tests/test_fleet_player_scoped_gap_fill.py
+++ b/packages/api/tests/test_fleet_player_scoped_gap_fill.py
@@ -1010,3 +1010,127 @@ def test_invalidation_mid_chain_same_player_waiters_retry_once(persistence, load
         f"expected one Q materialization chain, got {q_materialize_calls}"
     )
     assert coordinator_p is not coordinator_q
+
+
+def test_coordinator_q_unaffected_when_p_epoch_bumps_mid_chain(persistence, load_turn):
+    """Q leader does not re-enter materialize chain when only P's epoch bumps."""
+    turn_109 = load_turn(109)
+    turn_112 = load_turn(112)
+    assert turn_109 is not None and turn_112 is not None
+    roster = _roster_ids(turn_112)
+    assert len(roster) > 1
+    player_p, player_q = roster[0], roster[1]
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_109)
+
+    leader_mid_chain = threading.Event()
+    q_started = threading.Event()
+    release_leader = threading.Event()
+    original_put_ledger = persistence.put_ledger
+    mid_chain_puts = 0
+
+    def hooked_put_ledger(*args, **kwargs):
+        nonlocal mid_chain_puts
+        turn_number = args[2]
+        player_id = args[3]
+        original_put_ledger(*args, **kwargs)
+        if player_id == player_p and turn_number == 111 and mid_chain_puts == 0:
+            mid_chain_puts += 1
+            leader_mid_chain.set()
+            assert release_leader.wait(timeout=5)
+
+    persistence.put_ledger = hooked_put_ledger  # type: ignore[method-assign]
+
+    coordinator_q = coordinator_for(persistence, 628580, 1, player_q)
+    original_chain = __import__(
+        "api.analytics.fleet.gap_fill_coordinator",
+        fromlist=["_materialize_fleet_ledger_chain_for_player"],
+    )._materialize_fleet_ledger_chain_for_player
+    original_run_leader_q = coordinator_q._run_leader_unwind
+
+    q_materialize_calls = 0
+    q_leader_unwind_calls = 0
+    q_epoch_at_start: int | None = None
+    errors: list[BaseException] = []
+
+    def counting_chain(*args, **kwargs):
+        nonlocal q_materialize_calls
+        materialize_player_id = args[3]
+        if materialize_player_id == player_q:
+            q_materialize_calls += 1
+        return original_chain(*args, **kwargs)
+
+    def counting_run_leader_q(
+        inflight,
+        turn,
+        *,
+        load_turn,
+        inference_materialization,
+        query_context,
+    ):
+        nonlocal q_leader_unwind_calls, q_epoch_at_start
+        if q_epoch_at_start is None:
+            q_epoch_at_start = coordinator_q.epoch
+        q_leader_unwind_calls += 1
+        return original_run_leader_q(
+            inflight,
+            turn,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+        )
+
+    def run_p_leader() -> None:
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_p,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def run_q() -> None:
+        q_started.set()
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_q,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    with (
+        patch(
+            "api.analytics.fleet.gap_fill_coordinator._materialize_fleet_ledger_chain_for_player",
+            side_effect=counting_chain,
+        ),
+        patch.object(coordinator_q, "_run_leader_unwind", side_effect=counting_run_leader_q),
+    ):
+        p_leader_thread = threading.Thread(target=run_p_leader)
+        p_leader_thread.start()
+        assert leader_mid_chain.wait(timeout=5)
+        q_thread = threading.Thread(target=run_q)
+        q_thread.start()
+        assert q_started.wait(timeout=5)
+        q_epoch_before_invalidation = coordinator_q.epoch
+        persistence.invalidate_player_ledgers_from_turn(628580, 1, 111, player_p)
+        assert coordinator_q.epoch == q_epoch_before_invalidation
+        release_leader.set()
+        p_leader_thread.join(timeout=30)
+        q_thread.join(timeout=30)
+
+    assert not errors
+    assert persistence.get_ledger(628580, 1, 112, player_q) is not None
+    assert q_epoch_at_start is not None
+    assert coordinator_q.epoch == q_epoch_at_start
+    assert q_leader_unwind_calls == 1, f"expected one Q leader unwind, got {q_leader_unwind_calls}"
+    assert q_materialize_calls == 1, (
+        f"expected one Q materialization chain, got {q_materialize_calls}"
+    )


### PR DESCRIPTION
## Summary

- Split fleet invalidation generation from per-perspective to per `(gameId, perspective, playerId)`, matching gap-fill coordinator registry keys.
- Coordinator `epoch` and `_GapFillCoherence` now track the target player only, so invalidating player P no longer aborts in-flight gap-fill work for player Q.
- Bump rules: per-player scores invalidation bumps P only; turn document replace bumps every player who had ledgers cleared at affected turns; stale prune and legacy delete bump affected players individually. `put_snapshot` does not bump generation.
- ADR 0004 section 5 updated to document per-player invalidation generation policy.

Closes #183.

## Test plan

- [x] `make test_api` (1098 passed)
- [x] `test_invalidation_bumps_epoch_for_target_player_only`
- [x] `test_turn_document_replace_bumps_all_player_epochs`
- [x] `test_coordinator_q_unaffected_when_p_epoch_bumps_mid_chain`
- [x] Regression: same-player mid-chain invalidation retry and coordinator concurrency tests


Made with [Cursor](https://cursor.com)