### PR TITLE
Homeworld extraction and epic/standard classification tightening

### DIFF
--- a/assets/analytics/scores/prior_mining_patterns_epic.yaml
+++ b/assets/analytics/scores/prior_mining_patterns_epic.yaml
@@ -1,5 +1,5 @@
 # Inference prior miner discovery config for epic games (#92).
-# Epic: shiplimit >= 500, not campaign, endturn > 30 (GameCategory.from_game_settings).
+# Epic: shiplimit >= 500, not campaign, endturn > 30, exactly 11 players (GameCategory.from_game_info).
 # Authoritative spec: docs/design-military-score-inference-build-priors.md section 10.1
 version: 1
 patterns:

--- a/assets/analytics/scores/prior_weights_asset.template.yaml
+++ b/assets/analytics/scores/prior_weights_asset.template.yaml
@@ -15,7 +15,7 @@
 
 version: 4
 category: __CATEGORY__  # must match filename stem prior_weights_{category}.yaml
-gameCategoryRulesVersion: 2  # bump when GameCategory.from_game_settings() rules change
+gameCategoryRulesVersion: 4  # bump when GameCategory.from_game_settings() rules change
 
 hulls:
   # Inference ship-limit band: tables split on whether the player is before/after ship limit.

--- a/assets/analytics/scores/prior_weights_campaign.yaml
+++ b/assets/analytics/scores/prior_weights_campaign.yaml
@@ -14,7 +14,7 @@
 
 version: 4
 category: campaign  # must match filename stem prior_weights_{category}.yaml
-gameCategoryRulesVersion: 2  # bump when GameCategory.from_game_settings() rules change
+gameCategoryRulesVersion: 4  # bump when GameCategory.from_game_settings() rules change
 
 hulls:
   # Inference ship-limit band: P(hull|category) pseudo-counts keyed by inference hull category.

--- a/assets/analytics/scores/prior_weights_epic.yaml
+++ b/assets/analytics/scores/prior_weights_epic.yaml
@@ -14,7 +14,7 @@
 
 version: 4
 category: epic  # must match filename stem prior_weights_{category}.yaml
-gameCategoryRulesVersion: 2  # bump when GameCategory.from_game_settings() rules change
+gameCategoryRulesVersion: 4  # bump when GameCategory.from_game_settings() rules change
 
 hulls:
   # Inference ship-limit band: P(hull|category) pseudo-counts keyed by inference hull category.

--- a/assets/analytics/scores/prior_weights_standard.yaml
+++ b/assets/analytics/scores/prior_weights_standard.yaml
@@ -14,7 +14,7 @@
 
 version: 4
 category: standard  # must match filename stem prior_weights_{category}.yaml
-gameCategoryRulesVersion: 2  # bump when GameCategory.from_game_settings() rules change
+gameCategoryRulesVersion: 4  # bump when GameCategory.from_game_settings() rules change
 
 hulls:
   # Inference ship-limit band: P(hull|category) pseudo-counts keyed by inference hull category.

--- a/packages/api/api/analytics/military_score_inference/prior_mining/discovery.py
+++ b/packages/api/api/analytics/military_score_inference/prior_mining/discovery.py
@@ -124,7 +124,7 @@ def iter_accepted_games_for_pattern(
                 exc,
             )
             continue
-        resolved = GameCategory.from_game_settings(info.settings)
+        resolved = GameCategory.from_game_info(info)
         if resolved != pattern.game_category:
             counters.category_mismatches += 1
             LOGGER.info(

--- a/packages/api/api/concepts/game_category.py
+++ b/packages/api/api/concepts/game_category.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from api.models.game import GameSettings
+from api.models.game import GameInfo, GameSettings
 
 BLITZ_MAX_ENDTURN = 30
 EPIC_MIN_SHIPLIMIT = 500
+STANDARD_EPIC_PLAYER_COUNT = 11
 
-GAME_CATEGORY_RULES_VERSION = 2
+GAME_CATEGORY_RULES_VERSION = 4
 
 
 class GameCategory(StrEnum):
@@ -17,9 +18,30 @@ class GameCategory(StrEnum):
     BLITZ = "blitz"
     EPIC = "epic"
     STANDARD = "standard"
+    UNKNOWN = "unknown"
 
     @classmethod
-    def from_game_settings(cls, settings: GameSettings) -> GameCategory:
+    def from_game_info(cls, info: GameInfo) -> GameCategory:
+        return cls.from_game_settings(info.settings, player_count=len(info.players))
+
+    @classmethod
+    def from_game_settings(
+        cls,
+        settings: GameSettings,
+        *,
+        player_count: int | None = None,
+    ) -> GameCategory:
+        category = cls._shape_category(settings)
+        if (
+            player_count is not None
+            and category in (cls.EPIC, cls.STANDARD)
+            and player_count != STANDARD_EPIC_PLAYER_COUNT
+        ):
+            return cls.UNKNOWN
+        return category
+
+    @classmethod
+    def _shape_category(cls, settings: GameSettings) -> GameCategory:
         if settings.campaignmode:
             return cls.CAMPAIGN
         if settings.endturn <= BLITZ_MAX_ENDTURN:

--- a/packages/api/tests/fixtures/hand_seeded_prior_weights/prior_weights_standard.yaml
+++ b/packages/api/tests/fixtures/hand_seeded_prior_weights/prior_weights_standard.yaml
@@ -14,7 +14,7 @@
 
 version: 4
 category: standard  # must match filename stem prior_weights_{category}.yaml
-gameCategoryRulesVersion: 2  # bump when GameCategory.from_game_settings() rules change
+gameCategoryRulesVersion: 4  # bump when GameCategory.from_game_settings() rules change
 
 hulls:
   # Inference ship-limit band: P(hull|category) pseudo-counts keyed by inference hull category.

--- a/packages/api/tests/test_game_category.py
+++ b/packages/api/tests/test_game_category.py
@@ -26,3 +26,31 @@ def test_from_game_settings_non_campaign_rules(sample_turn):
         GameCategory.from_game_settings(replace(base, endturn=100, shiplimit=500))
         == GameCategory.EPIC
     )
+
+
+def test_epic_and_standard_require_exactly_eleven_players(sample_turn):
+    base = replace(sample_turn.settings, campaignmode=False, endturn=100)
+    epic_settings = replace(base, shiplimit=500)
+    standard_settings = replace(base, shiplimit=499)
+
+    assert GameCategory.from_game_settings(epic_settings, player_count=11) == GameCategory.EPIC
+    assert GameCategory.from_game_settings(epic_settings, player_count=10) == GameCategory.UNKNOWN
+    assert GameCategory.from_game_settings(epic_settings, player_count=12) == GameCategory.UNKNOWN
+    assert (
+        GameCategory.from_game_settings(standard_settings, player_count=11)
+        == GameCategory.STANDARD
+    )
+    assert (
+        GameCategory.from_game_settings(standard_settings, player_count=8)
+        == GameCategory.UNKNOWN
+    )
+
+
+def test_from_game_settings_without_player_count_keeps_shape_category(sample_turn):
+    settings = replace(
+        sample_turn.settings,
+        campaignmode=False,
+        endturn=100,
+        shiplimit=500,
+    )
+    assert GameCategory.from_game_settings(settings) == GameCategory.EPIC

--- a/packages/api/tests/test_game_category.py
+++ b/packages/api/tests/test_game_category.py
@@ -37,12 +37,10 @@ def test_epic_and_standard_require_exactly_eleven_players(sample_turn):
     assert GameCategory.from_game_settings(epic_settings, player_count=10) == GameCategory.UNKNOWN
     assert GameCategory.from_game_settings(epic_settings, player_count=12) == GameCategory.UNKNOWN
     assert (
-        GameCategory.from_game_settings(standard_settings, player_count=11)
-        == GameCategory.STANDARD
+        GameCategory.from_game_settings(standard_settings, player_count=11) == GameCategory.STANDARD
     )
     assert (
-        GameCategory.from_game_settings(standard_settings, player_count=8)
-        == GameCategory.UNKNOWN
+        GameCategory.from_game_settings(standard_settings, player_count=8) == GameCategory.UNKNOWN
     )
 
 

--- a/packages/api/tests/test_inference_prior_mining_discovery.py
+++ b/packages/api/tests/test_inference_prior_mining_discovery.py
@@ -155,6 +155,43 @@ def test_discover_games_for_pattern_skips_loadinfo_upstream_error():
     assert result.games_attempted == (628580,)
 
 
+def test_discover_games_for_pattern_skips_dogfight_with_fewer_than_eleven_players():
+    planets = MagicMock()
+    planets.games_list.return_value = [
+        {
+            "id": 645527,
+            "difficulty": 2.0,
+            "datecreated": "10/26/2024 9:02:31 AM",
+            "dateended": "6/23/2025 2:53:43 PM",
+        }
+    ]
+    info = json.loads(
+        (Path(__file__).resolve().parent / "fixtures/inference_corpus/628580/info.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    info["players"] = info["players"][:8]
+    planets.load_game_info.return_value = info
+
+    from api.analytics.military_score_inference.prior_mining.patterns import PriorMiningPattern
+
+    pattern = PriorMiningPattern(
+        id="epic-test",
+        game_category=GameCategory.EPIC,
+        max_games=1,
+        min_difficulty=1.0,
+        earliest_date="2024-01-01",
+    )
+    result = discover_games_for_pattern(
+        pattern,
+        planets=planets,
+        contributing_game_ids=frozenset(),
+        pattern_contributed_count=0,
+        max_selections=1,
+    )
+    assert result.games_attempted == ()
+
+
 def test_discover_games_for_pattern_skips_already_contributed():
     planets = MagicMock()
     planets.games_list.return_value = [

--- a/packages/api/tests/test_military_score_inference_prior_weights_asset.py
+++ b/packages/api/tests/test_military_score_inference_prior_weights_asset.py
@@ -29,7 +29,7 @@ def _minimal_prior_weights_document(**overrides: object) -> dict[str, object]:
     document: dict[str, object] = {
         "version": 4,
         "category": "standard",
-        "gameCategoryRulesVersion": 2,
+        "gameCategoryRulesVersion": 4,
         "hulls": {
             "before_ship_limit": {"global": {}},
             "after_ship_limit": {"global": {}},
@@ -216,7 +216,7 @@ def test_component_tables_reject_unknown_hull_category():
             {
                 "version": 4,
                 "category": "standard",
-                "gameCategoryRulesVersion": 2,
+                "gameCategoryRulesVersion": 4,
                 "hulls": {
                     "before_ship_limit": {"global": {}},
                     "after_ship_limit": {"global": {}},
@@ -239,7 +239,7 @@ def test_slotfill_rejects_wildcard_key():
             {
                 "version": 4,
                 "category": "standard",
-                "gameCategoryRulesVersion": 2,
+                "gameCategoryRulesVersion": 4,
                 "hulls": {
                     "before_ship_limit": {"global": {}},
                     "after_ship_limit": {"global": {}},

--- a/scripts/extract_homeworlds.py
+++ b/scripts/extract_homeworlds.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Extract homeworld coordinates from stored games and write a CSV report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[1] / "packages" / "api"
+_api_root_str = str(_API_ROOT)
+if _api_root_str in sys.path:
+    sys.path.remove(_api_root_str)
+sys.path.insert(0, _api_root_str)
+
+_SCRIPTS_ROOT = Path(__file__).resolve().parent
+_scripts_root_str = str(_SCRIPTS_ROOT)
+if _scripts_root_str not in sys.path:
+    sys.path.insert(0, _scripts_root_str)
+
+import typer  # noqa: E402
+from api.concepts.game_category import GameCategory  # noqa: E402
+from homeworld_extraction import (  # noqa: E402
+    extract_homeworlds_by_category,
+    flatten_homeworld_rows,
+    write_homeworld_csv,
+)
+
+app = typer.Typer(
+    add_completion=False,
+    help=(
+        "Scan a file storage root (e.g. .sampler_data or .data), classify games, "
+        "and export turn-1 homeworld coordinates for epic and standard games."
+    ),
+)
+
+
+def _default_storage_root() -> Path:
+    return Path(".data")
+
+
+@app.callback(invoke_without_command=True)
+def run_command(
+    ctx: typer.Context,
+    storage_root: Path = typer.Option(
+        _default_storage_root(),
+        "--storage-root",
+        help="File backend root containing games/{id}/... (default: ./.data).",
+    ),
+    output: Path = typer.Option(
+        ...,
+        "--output",
+        "-o",
+        help="CSV file to write (columns: game_type, game_id, player, x, y).",
+    ),
+) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if not storage_root.is_dir():
+        typer.echo(f"storage root not found: {storage_root}", err=True)
+        raise typer.Exit(code=2)
+
+    grouped = extract_homeworlds_by_category(storage_root)
+    rows = flatten_homeworld_rows(grouped)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", newline="") as handle:
+        write_homeworld_csv(rows, handle)
+
+    epic_count = len(grouped[GameCategory.EPIC])
+    standard_count = len(grouped[GameCategory.STANDARD])
+    typer.echo(
+        f"wrote {len(rows)} homeworld row(s) from "
+        f"{epic_count} epic and {standard_count} standard game(s) to {output}"
+    )
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/homeworld_extraction.py
+++ b/scripts/homeworld_extraction.py
@@ -1,0 +1,253 @@
+"""Extract homeworld coordinates from stored turn-1 perspective snapshots."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+from api.concepts.game_category import GameCategory
+from api.models.game import GameSettings, TurnInfo
+from api.models.planet import Planet
+from api.models.player import Player
+from api.serialization.game import game_info_from_json
+from api.serialization.turn import turn_info_from_json
+from hull_catalog_analysis import discover_game_ids, perspective_slots_for_game
+
+BASELINE_TURN = 1
+DEFAULT_MIN_BASELINE_CLANS = 10_000
+DEFAULT_PREFERRED_TEMP_W = 50
+CRYSTAL_DESERT_PREFERRED_TEMP_W = 100
+CRYSTAL_RACE_ID = 7
+DESERT_WORLDS_ADVANTAGE_ID = 21
+
+TARGET_GAME_CATEGORIES = frozenset({GameCategory.EPIC, GameCategory.STANDARD})
+
+
+@dataclass(frozen=True)
+class HomeworldLocation:
+    player: str
+    x: int
+    y: int
+
+
+@dataclass(frozen=True)
+class GameHomeworlds:
+    game_id: int
+    game_type: GameCategory
+    homeworlds: tuple[HomeworldLocation, ...]
+
+
+@dataclass(frozen=True)
+class HomeworldCsvRow:
+    game_type: str
+    game_id: int
+    player: str
+    x: int
+    y: int
+
+
+def active_advantage_ids(player: Player) -> frozenset[int]:
+    if not player.activeadvantages.strip():
+        return frozenset()
+    return frozenset(
+        int(part) for part in player.activeadvantages.split(",") if part.strip().isdigit()
+    )
+
+
+def preferred_homeworld_temp_w(*, race_id: int, active_advantages: frozenset[int]) -> int:
+    if race_id == CRYSTAL_RACE_ID and DESERT_WORLDS_ADVANTAGE_ID in active_advantages:
+        return CRYSTAL_DESERT_PREFERRED_TEMP_W
+    return DEFAULT_PREFERRED_TEMP_W
+
+
+def starbase_planet_ids(turn: TurnInfo) -> frozenset[int]:
+    return frozenset(starbase.planetid for starbase in turn.starbases)
+
+
+def matches_homeworld_baseline_profile(
+    planet,
+    *,
+    turn: TurnInfo,
+    settings: GameSettings,
+    min_baseline_clans: int = DEFAULT_MIN_BASELINE_CLANS,
+) -> bool:
+    if planet.ownerid != turn.player.id:
+        return False
+    if planet.clans < min_baseline_clans:
+        return False
+    if settings.homeworldhasstarbase and planet.id not in starbase_planet_ids(turn):
+        return False
+    preferred_temp = preferred_homeworld_temp_w(
+        race_id=turn.player.raceid,
+        active_advantages=active_advantage_ids(turn.player),
+    )
+    return planet.temp == preferred_temp
+
+
+def homeworld_planet_for_turn(turn: TurnInfo) -> Planet | None:
+    """Return the homeworld planet for a turn-1 perspective snapshot, if identifiable."""
+    owned_planets = [planet for planet in turn.planets if planet.ownerid == turn.player.id]
+    if not owned_planets:
+        return None
+
+    baseline_matches = [
+        planet
+        for planet in owned_planets
+        if matches_homeworld_baseline_profile(planet, turn=turn, settings=turn.settings)
+    ]
+    if len(baseline_matches) == 1:
+        return baseline_matches[0]
+    if len(baseline_matches) > 1:
+        return max(baseline_matches, key=lambda planet: planet.clans)
+
+    if len(owned_planets) == 1:
+        return owned_planets[0]
+
+    with_starbase = [planet for planet in owned_planets if planet.id in starbase_planet_ids(turn)]
+    if with_starbase:
+        return max(with_starbase, key=lambda planet: planet.clans)
+
+    return max(owned_planets, key=lambda planet: planet.clans)
+
+
+def load_turn_file(
+    storage_root: Path,
+    game_id: int,
+    perspective: int,
+    turn_number: int,
+    *,
+    settings_defaults: dict,
+) -> TurnInfo | None:
+    turn_path = (
+        storage_root / "games" / str(game_id) / str(perspective) / "turns" / f"{turn_number}.json"
+    )
+    if not turn_path.is_file():
+        return None
+    with turn_path.open() as handle:
+        return turn_info_from_json(json.load(handle), settings_defaults=settings_defaults)
+
+
+def load_game_settings_defaults(storage_root: Path, game_id: int) -> dict | None:
+    info_path = storage_root / "games" / str(game_id) / "info.json"
+    if not info_path.is_file():
+        return None
+    with info_path.open() as handle:
+        return json.load(handle)["settings"]
+
+
+def extract_homeworlds_for_game(
+    storage_root: Path,
+    game_id: int,
+) -> GameHomeworlds | None:
+    settings_defaults = load_game_settings_defaults(storage_root, game_id)
+    if settings_defaults is None:
+        return None
+
+    info = game_info_from_json(
+        json.loads((storage_root / "games" / str(game_id) / "info.json").read_text())
+    )
+    game_type = GameCategory.from_game_info(info)
+    if game_type not in TARGET_GAME_CATEGORIES:
+        return None
+
+    homeworlds: list[HomeworldLocation] = []
+    for perspective in perspective_slots_for_game(storage_root, game_id):
+        if perspective < 1:
+            continue
+        turn = load_turn_file(
+            storage_root,
+            game_id,
+            perspective,
+            BASELINE_TURN,
+            settings_defaults=settings_defaults,
+        )
+        if turn is None:
+            continue
+
+        planet = homeworld_planet_for_turn(turn)
+        if planet is None:
+            continue
+
+        homeworlds.append(
+            HomeworldLocation(
+                player=turn.player.username,
+                x=planet.x,
+                y=planet.y,
+            )
+        )
+
+    return GameHomeworlds(
+        game_id=game_id,
+        game_type=game_type,
+        homeworlds=tuple(homeworlds),
+    )
+
+
+def extract_homeworlds_by_category(
+    storage_root: Path,
+    *,
+    game_ids: Iterable[int] | None = None,
+) -> dict[GameCategory, list[GameHomeworlds]]:
+    selected_game_ids = list(game_ids) if game_ids is not None else discover_game_ids(storage_root)
+    grouped: dict[GameCategory, list[GameHomeworlds]] = {
+        GameCategory.EPIC: [],
+        GameCategory.STANDARD: [],
+    }
+
+    for game_id in selected_game_ids:
+        extracted = extract_homeworlds_for_game(storage_root, game_id)
+        if extracted is None:
+            continue
+        grouped[extracted.game_type].append(extracted)
+
+    for game_type in grouped:
+        grouped[game_type].sort(key=lambda item: item.game_id)
+
+    return grouped
+
+
+def homeworld_rows_for_games(games: Iterable[GameHomeworlds]) -> list[HomeworldCsvRow]:
+    rows: list[HomeworldCsvRow] = []
+    for game in games:
+        for homeworld in game.homeworlds:
+            rows.append(
+                HomeworldCsvRow(
+                    game_type=game.game_type.value,
+                    game_id=game.game_id,
+                    player=homeworld.player,
+                    x=homeworld.x,
+                    y=homeworld.y,
+                )
+            )
+    return rows
+
+
+def flatten_homeworld_rows(
+    grouped: dict[GameCategory, list[GameHomeworlds]],
+) -> list[HomeworldCsvRow]:
+    rows: list[HomeworldCsvRow] = []
+    for game_type in (GameCategory.EPIC, GameCategory.STANDARD):
+        rows.extend(homeworld_rows_for_games(grouped.get(game_type, [])))
+    return rows
+
+
+def write_homeworld_csv(rows: Iterable[HomeworldCsvRow], output: TextIO) -> None:
+    writer = csv.DictWriter(
+        output,
+        fieldnames=["game_type", "game_id", "player", "x", "y"],
+    )
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(
+            {
+                "game_type": row.game_type,
+                "game_id": row.game_id,
+                "player": row.player,
+                "x": row.x,
+                "y": row.y,
+            }
+        )

--- a/scripts/tests/test_homeworld_extraction.py
+++ b/scripts/tests/test_homeworld_extraction.py
@@ -1,0 +1,112 @@
+"""Tests for homeworld extraction helpers and script."""
+
+from __future__ import annotations
+
+import csv
+import json
+import shutil
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from api.concepts.game_category import GameCategory
+from api.serialization.turn import turn_info_from_json
+from homeworld_extraction import (
+    BASELINE_TURN,
+    GameHomeworlds,
+    HomeworldLocation,
+    extract_homeworlds_by_category,
+    extract_homeworlds_for_game,
+    flatten_homeworld_rows,
+    homeworld_planet_for_turn,
+    matches_homeworld_baseline_profile,
+    preferred_homeworld_temp_w,
+    write_homeworld_csv,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_ROOT = REPO_ROOT / "packages" / "api" / "tests" / "fixtures" / "inference_corpus"
+DATA_ROOT = REPO_ROOT / ".data"
+
+
+@pytest.fixture
+def fixture_storage_root(tmp_path: Path) -> Path:
+    destination = tmp_path / "games" / "628580"
+    shutil.copytree(FIXTURES_ROOT / "628580", destination)
+    return tmp_path
+
+
+def _load_fixture_turn(*, perspective: int = 1):
+    settings_defaults = json.loads((FIXTURES_ROOT / "628580" / "info.json").read_text())["settings"]
+    turn_path = FIXTURES_ROOT / "628580" / str(perspective) / "turns" / f"{BASELINE_TURN}.json"
+    turn = turn_info_from_json(
+        json.loads(turn_path.read_text()),
+        settings_defaults=settings_defaults,
+    )
+    return turn, settings_defaults
+
+
+def test_preferred_homeworld_temp_w_for_crystal_desert_advantage() -> None:
+    assert preferred_homeworld_temp_w(race_id=7, active_advantages=frozenset({21})) == 100
+    assert preferred_homeworld_temp_w(race_id=7, active_advantages=frozenset()) == 50
+    assert preferred_homeworld_temp_w(race_id=1, active_advantages=frozenset({21})) == 50
+
+
+def test_matches_homeworld_baseline_profile_on_fixture_turn_1() -> None:
+    turn, _ = _load_fixture_turn(perspective=1)
+    owned = next(planet for planet in turn.planets if planet.ownerid == turn.player.id)
+    assert matches_homeworld_baseline_profile(owned, turn=turn, settings=turn.settings)
+
+
+def test_homeworld_planet_for_turn_returns_owned_planet() -> None:
+    turn, _ = _load_fixture_turn(perspective=1)
+    planet = homeworld_planet_for_turn(turn)
+    assert planet is not None
+    assert planet.name == "Lynch"
+    assert planet.x == 1813
+    assert planet.y == 2810
+
+
+def test_extract_homeworlds_for_fixture_game_is_epic(fixture_storage_root: Path) -> None:
+    extracted = extract_homeworlds_for_game(fixture_storage_root, 628580)
+    assert extracted is not None
+    assert extracted.game_type == GameCategory.EPIC
+    assert len(extracted.homeworlds) == 1
+    assert extracted.homeworlds[0].player == "dougp314"
+    assert extracted.homeworlds[0].x == 1813
+    assert extracted.homeworlds[0].y == 2810
+
+
+def test_extract_homeworlds_by_category_skips_campaign_games(fixture_storage_root: Path) -> None:
+    grouped = extract_homeworlds_by_category(fixture_storage_root)
+    assert grouped[GameCategory.EPIC]
+    assert grouped[GameCategory.STANDARD] == []
+    assert all(item.game_id == 628580 for item in grouped[GameCategory.EPIC])
+
+
+def test_write_homeworld_csv_columns() -> None:
+    extracted = GameHomeworlds(
+        game_id=628580,
+        game_type=GameCategory.EPIC,
+        homeworlds=(HomeworldLocation(player="dougp314", x=1813, y=2810),),
+    )
+    buffer = StringIO()
+    write_homeworld_csv(flatten_homeworld_rows({GameCategory.EPIC: [extracted]}), buffer)
+    rows = list(csv.DictReader(StringIO(buffer.getvalue())))
+    assert rows == [
+        {
+            "game_type": "epic",
+            "game_id": "628580",
+            "player": "dougp314",
+            "x": "1813",
+            "y": "2810",
+        }
+    ]
+
+
+@pytest.mark.skipif(not DATA_ROOT.is_dir(), reason="local .data store only")
+def test_extract_homeworlds_for_local_epic_game_has_multiple_players() -> None:
+    extracted = extract_homeworlds_for_game(DATA_ROOT, 628580)
+    assert extracted is not None
+    assert extracted.game_type == GameCategory.EPIC
+    assert len(extracted.homeworlds) >= 10

--- a/scripts/tests/test_visualize_homeworld_distributions.py
+++ b/scripts/tests/test_visualize_homeworld_distributions.py
@@ -1,0 +1,117 @@
+"""Tests for homeworld distribution center resolution."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from visualize_homeworld_distributions import (
+    DEFAULT_UNIVERSE_CENTER,
+    _game_center,
+    _homeworld_bbox_center,
+    _planet_bbox_center,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_ROOT = REPO_ROOT / "packages" / "api" / "tests" / "fixtures" / "inference_corpus"
+DATA_ROOT = REPO_ROOT / ".data"
+
+
+@pytest.fixture
+def fixture_storage_root(tmp_path: Path) -> Path:
+    destination = tmp_path / "games" / "628580"
+    shutil.copytree(FIXTURES_ROOT / "628580", destination)
+    return tmp_path
+
+
+def test_homeworld_bbox_center_returns_midpoint() -> None:
+    center = _homeworld_bbox_center([(1000, 1100), (1200, 900)])
+    assert center == (1100.0, 1000.0)
+
+
+def test_homeworld_bbox_center_returns_none_for_empty_list() -> None:
+    assert _homeworld_bbox_center([]) is None
+
+
+def test_game_center_uses_homeworld_bbox_when_planets_unavailable(
+    fixture_storage_root: Path,
+) -> None:
+    cache: dict[int, tuple[tuple[float, float], str]] = {}
+    homeworlds = [(1813, 2810), (2384, 1296)]
+    center = _game_center(fixture_storage_root, 628580, homeworlds, cache)
+    assert center == (2098.5, 2053.0)
+    assert cache[628580][1] == "homeworld_bbox"
+
+
+def test_game_center_falls_back_to_homeworld_bbox(tmp_path: Path) -> None:
+    cache: dict[int, tuple[tuple[float, float], str]] = {}
+    homeworlds = [(1000, 1100), (1200, 900)]
+    center = _game_center(tmp_path, 999, homeworlds, cache)
+    assert center == (1100.0, 1000.0)
+    assert cache[999][1] == "homeworld_bbox"
+
+
+def test_game_center_falls_back_to_fixed_universe_center(tmp_path: Path) -> None:
+    cache: dict[int, tuple[tuple[float, float], str]] = {}
+    center = _game_center(tmp_path, 999, [], cache)
+    assert center == DEFAULT_UNIVERSE_CENTER
+    assert cache[999][1] == "fixed_2000"
+
+
+@pytest.mark.skipif(not DATA_ROOT.is_dir(), reason="local .data store only")
+def test_planet_bbox_center_near_two_thousand_for_local_epic_game() -> None:
+    center = _planet_bbox_center(DATA_ROOT, 628580)
+    assert center is not None
+    assert abs(center[0] - 2000) < 50
+    assert abs(center[1] - 2000) < 50
+
+
+@pytest.mark.skipif(not DATA_ROOT.is_dir(), reason="local .data store only")
+def test_game_center_prefers_planet_bbox_for_local_epic_game() -> None:
+    cache: dict[int, tuple[tuple[float, float], str]] = {}
+    homeworlds = [(1813, 2810)]
+    center = _game_center(DATA_ROOT, 628580, homeworlds, cache)
+    planet_center = _planet_bbox_center(DATA_ROOT, 628580)
+    assert planet_center is not None
+    assert center == planet_center
+    assert cache[628580][1] == "planet_bbox"
+
+
+def test_planet_bbox_center_unions_planets_across_perspectives(
+    fixture_storage_root: Path,
+    tmp_path: Path,
+) -> None:
+    game_id = 9001
+    source = fixture_storage_root / "games" / "628580"
+    game_dir = tmp_path / "games" / str(game_id)
+    shutil.copytree(source, game_dir)
+
+    turn_one = json.loads((game_dir / "1" / "turns" / "1.json").read_text())
+    turn_two = json.loads(json.dumps(turn_one))
+    template_planet = json.loads(json.dumps(turn_one["planets"][0]))
+    far = json.loads(json.dumps(template_planet))
+    far.update({"id": 9001, "x": 3000, "y": 3000, "name": "Far"})
+    north = json.loads(json.dumps(template_planet))
+    north.update({"id": 9002, "x": 1000, "y": 3000, "name": "North"})
+    turn_two["planets"] = [far, north]
+    turn_two_dir = game_dir / "2" / "turns"
+    turn_two_dir.mkdir(parents=True)
+    turn_two_dir.joinpath("1.json").write_text(json.dumps(turn_two))
+
+    center = _planet_bbox_center(tmp_path, game_id)
+    assert center is not None
+    assert center[0] > 1500
+    assert center[1] > 1500
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / ".sampler_data").is_dir(),
+    reason="local .sampler_data store only",
+)
+def test_planet_bbox_center_uses_full_map_not_single_perspective_fog() -> None:
+    storage_root = REPO_ROOT / ".sampler_data"
+    center = _planet_bbox_center(storage_root, 652072)
+    assert center is not None
+    assert center == (2005.0, 2002.0)

--- a/scripts/visualize_homeworld_distributions.py
+++ b/scripts/visualize_homeworld_distributions.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Compute homeworld distance distributions from sampled_homeworlds.csv."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import typer
+from api.concepts.game_category import STANDARD_EPIC_PLAYER_COUNT, GameCategory
+from api.serialization.game import game_info_from_json
+from api.serialization.turn import turn_info_from_json
+from hull_catalog_analysis import perspective_slots_for_game
+
+app = typer.Typer(
+    add_completion=False,
+    help="Compute clockwise-neighbor and map-center distance distributions per game type.",
+)
+
+DEFAULT_CSV = Path("local/sampled_homeworlds.csv")
+DEFAULT_STORAGE_ROOT = Path(".sampler_data")
+DEFAULT_UNIVERSE_CENTER = (2000.0, 2000.0)
+BASELINE_TURN = 1
+NEIGHBOR_BIN_WIDTH_LY = 10
+CENTER_BIN_WIDTH_LY = 10
+TARGET_GAME_CATEGORIES = frozenset({GameCategory.EPIC, GameCategory.STANDARD})
+
+
+def _resolved_game_type(storage_root: Path, game_id: int) -> GameCategory | None:
+    info_path = storage_root / "games" / str(game_id) / "info.json"
+    if not info_path.is_file():
+        return None
+    info = game_info_from_json(json.loads(info_path.read_text()))
+    game_type = GameCategory.from_game_info(info)
+    if game_type not in TARGET_GAME_CATEGORIES:
+        return None
+    return game_type
+
+
+def _homeworld_bbox_center(homeworlds: list[tuple[int, int]]) -> tuple[float, float] | None:
+    if not homeworlds:
+        return None
+    xs = [x_coord for x_coord, _ in homeworlds]
+    ys = [y_coord for _, y_coord in homeworlds]
+    return ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+
+
+def _planet_bbox_center(
+    storage_root: Path,
+    game_id: int,
+    *,
+    turn_number: int = BASELINE_TURN,
+) -> tuple[float, float] | None:
+    info_path = storage_root / "games" / str(game_id) / "info.json"
+    if not info_path.is_file():
+        return None
+
+    raw = json.loads(info_path.read_text())
+    settings_defaults = raw["settings"]
+    unique_planets: dict[int, tuple[int, int]] = {}
+    for perspective in perspective_slots_for_game(storage_root, game_id):
+        turn_path = (
+            storage_root
+            / "games"
+            / str(game_id)
+            / str(perspective)
+            / "turns"
+            / f"{turn_number}.json"
+        )
+        if not turn_path.is_file():
+            continue
+        turn = turn_info_from_json(
+            json.loads(turn_path.read_text()),
+            settings_defaults=settings_defaults,
+        )
+        for planet in turn.planets:
+            unique_planets[planet.id] = (planet.x, planet.y)
+
+    if len(unique_planets) < 2:
+        return None
+
+    xs = [x_coord for x_coord, _ in unique_planets.values()]
+    ys = [y_coord for _, y_coord in unique_planets.values()]
+    return ((min(xs) + max(xs)) / 2, (min(ys) + max(ys)) / 2)
+
+
+def _game_center(
+    storage_root: Path,
+    game_id: int,
+    homeworlds: list[tuple[int, int]],
+    cache: dict[int, tuple[tuple[float, float], str]],
+) -> tuple[float, float]:
+    if game_id in cache:
+        return cache[game_id][0]
+
+    center = _planet_bbox_center(storage_root, game_id)
+    source = "planet_bbox"
+    if center is None:
+        center = _homeworld_bbox_center(homeworlds)
+        source = "homeworld_bbox"
+    if center is None:
+        center = DEFAULT_UNIVERSE_CENTER
+        source = "fixed_2000"
+
+    cache[game_id] = (center, source)
+    return center
+
+
+def _distance(a: tuple[int, int], b: tuple[int, int]) -> float:
+    return math.hypot(a[0] - b[0], a[1] - b[1])
+
+
+def _clockwise_neighbor_distances(
+    homeworlds: list[tuple[int, int]],
+    *,
+    center_x: float,
+    center_y: float,
+) -> list[float]:
+    if len(homeworlds) < 2:
+        return []
+    ordered = sorted(
+        homeworlds,
+        key=lambda point: math.atan2(point[1] - center_y, point[0] - center_x),
+        reverse=True,
+    )
+    distances: list[float] = []
+    for index, point in enumerate(ordered):
+        neighbor = ordered[(index + 1) % len(ordered)]
+        distances.append(_distance(point, neighbor))
+    return distances
+
+
+def _histogram(
+    values: list[float],
+    *,
+    bin_width: int,
+    max_edge: float,
+) -> tuple[list[str], list[int]]:
+    if not values:
+        return [], []
+    bin_count = max(1, int(math.ceil(max_edge / bin_width)))
+    counts = [0] * bin_count
+    for value in values:
+        index = min(int(value // bin_width), bin_count - 1)
+        counts[index] += 1
+    labels = [f"{index * bin_width}-{(index + 1) * bin_width}" for index in range(bin_count)]
+    return labels, counts
+
+
+def _summary(values: list[float]) -> dict[str, float | int]:
+    ordered = sorted(values)
+    count = len(ordered)
+    if count == 0:
+        return {"n": 0, "mean": 0, "p25": 0, "p50": 0, "p75": 0, "min": 0, "max": 0}
+
+    def percentile(fraction: float) -> float:
+        return ordered[min(count - 1, int(fraction * count))]
+
+    return {
+        "n": count,
+        "mean": round(sum(ordered) / count, 1),
+        "p25": round(percentile(0.25), 1),
+        "p50": round(percentile(0.5), 1),
+        "p75": round(percentile(0.75), 1),
+        "min": round(ordered[0], 1),
+        "max": round(ordered[-1], 1),
+    }
+
+
+def build_distribution_report(
+    *,
+    csv_path: Path,
+    storage_root: Path,
+) -> dict:
+    games: dict[int, list[tuple[int, int]]] = defaultdict(list)
+    with csv_path.open() as handle:
+        for row in csv.DictReader(handle):
+            games[int(row["game_id"])].append((int(row["x"]), int(row["y"])))
+
+    center_cache: dict[int, tuple[tuple[float, float], str]] = {}
+    center_sources: dict[str, int] = defaultdict(int)
+    neighbor_distances: dict[str, list[float]] = defaultdict(list)
+    center_distances: dict[str, list[float]] = defaultdict(list)
+    games_with_neighbor_samples: dict[str, int] = defaultdict(int)
+    games_skipped_by_category: int = 0
+
+    for game_id, homeworlds in games.items():
+        game_type = _resolved_game_type(storage_root, game_id)
+        if game_type is None:
+            games_skipped_by_category += 1
+            continue
+
+        center_x, center_y = _game_center(storage_root, game_id, homeworlds, center_cache)
+        _, center_source = center_cache[game_id]
+        center_sources[center_source] += 1
+        category_key = game_type.value
+
+        for x_coord, y_coord in homeworlds:
+            center_distances[category_key].append(
+                math.hypot(x_coord - center_x, y_coord - center_y)
+            )
+
+        clockwise = _clockwise_neighbor_distances(
+            homeworlds,
+            center_x=center_x,
+            center_y=center_y,
+        )
+        if clockwise:
+            games_with_neighbor_samples[category_key] += 1
+            neighbor_distances[category_key].extend(clockwise)
+
+    neighbor_max = max(
+        max(neighbor_distances["epic"], default=0.0),
+        max(neighbor_distances["standard"], default=0.0),
+    )
+    center_max = max(
+        max(center_distances["epic"], default=0.0),
+        max(center_distances["standard"], default=0.0),
+    )
+
+    neighbor_labels, neighbor_epic = _histogram(
+        neighbor_distances["epic"],
+        bin_width=NEIGHBOR_BIN_WIDTH_LY,
+        max_edge=neighbor_max,
+    )
+    _, neighbor_standard = _histogram(
+        neighbor_distances["standard"],
+        bin_width=NEIGHBOR_BIN_WIDTH_LY,
+        max_edge=neighbor_max,
+    )
+    center_labels, center_epic = _histogram(
+        center_distances["epic"],
+        bin_width=CENTER_BIN_WIDTH_LY,
+        max_edge=center_max,
+    )
+    _, center_standard = _histogram(
+        center_distances["standard"],
+        bin_width=CENTER_BIN_WIDTH_LY,
+        max_edge=center_max,
+    )
+
+    return {
+        "source": str(csv_path),
+        "storage_root": str(storage_root),
+        "method": {
+            "map_center": (
+                "Per game: center of the planet point-cloud bounding box from turn 1, "
+                "unioning unique planets across all stored player perspectives "
+                "(deduped by planet id). Fallback: homeworld-only bbox center, then "
+                f"fixed {DEFAULT_UNIVERSE_CENTER}."
+            ),
+            "clockwise_neighbor": (
+                "Sort homeworlds by angle from the per-game map center (atan2), descending "
+                "(clockwise); Euclidean distance to the next homeworld on the ring."
+            ),
+            "center_distance": (
+                "Euclidean distance from each homeworld to the per-game map center above."
+            ),
+            "games_skipped": (
+                "Games with fewer than 2 homeworld rows omit clockwise-neighbor samples."
+            ),
+            "category_filter": (
+                "Only games classified as epic or standard via GameCategory.from_game_info "
+                f"(shape rules plus exactly {STANDARD_EPIC_PLAYER_COUNT} players) are included."
+            ),
+        },
+        "center_sources": dict(center_sources),
+        "games_skipped_by_category": games_skipped_by_category,
+        "games_with_neighbor_samples": dict(games_with_neighbor_samples),
+        "neighbor_bin_width_ly": NEIGHBOR_BIN_WIDTH_LY,
+        "center_bin_width_ly": CENTER_BIN_WIDTH_LY,
+        "neighbor": {
+            "categories": neighbor_labels,
+            "epic": neighbor_epic,
+            "standard": neighbor_standard,
+            "summary": {
+                game_type: _summary(neighbor_distances[game_type])
+                for game_type in ("epic", "standard")
+            },
+        },
+        "center": {
+            "categories": center_labels,
+            "epic": center_epic,
+            "standard": center_standard,
+            "summary": {
+                game_type: _summary(center_distances[game_type])
+                for game_type in ("epic", "standard")
+            },
+        },
+    }
+
+
+@app.callback(invoke_without_command=True)
+def run_command(
+    ctx: typer.Context,
+    csv_path: Path = typer.Option(
+        DEFAULT_CSV,
+        "--csv",
+        help="Homeworld CSV produced by extract_homeworlds.py.",
+    ),
+    storage_root: Path = typer.Option(
+        DEFAULT_STORAGE_ROOT,
+        "--storage-root",
+        help="File backend root for turn-1 planet snapshots (info.json + turns).",
+    ),
+    output: Path | None = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Write distribution JSON to this file (stdout when omitted).",
+    ),
+) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if not csv_path.is_file():
+        typer.echo(f"CSV not found: {csv_path}", err=True)
+        raise typer.Exit(code=2)
+
+    report = build_distribution_report(csv_path=csv_path, storage_root=storage_root)
+    payload = json.dumps(report, indent=2)
+
+    if output is None:
+        sys.stdout.write(payload)
+        if not payload.endswith("\n"):
+            sys.stdout.write("\n")
+        return
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(payload if payload.endswith("\n") else payload + "\n")
+    typer.echo(f"wrote distribution report to {output}")
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add homeworld extraction CLI and distribution visualization scripts for turn-1 homeworld sampling and neighbor/center distance analysis.
- Tighten `GameCategory`: epic and standard require exactly 11 players via `from_game_info`; non-matching counts resolve to `unknown` instead of blitz.
- Fix map-center calculation to union turn-1 planets across all stored player perspectives (deduped by planet id), avoiding fog-of-war bias.
- Update prior mining discovery to classify games with `from_game_info`; bump `gameCategoryRulesVersion` to 4.

## Test plan
- [x] `make test_api`
- [x] `make test_scripts`
- [x] Re-run `scripts/extract_homeworlds.py` and `scripts/visualize_homeworld_distributions.py` against local sampler data if validating distributions end-to-end


Made with [Cursor](https://cursor.com)