### PR TITLE
Fleet F7.6: progressive gap-fill stream rows (#189)

### DIFF
--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 FleetMaterializationProgressCallback = Callable[
-    [PersistedFleetLedger, FleetAcquisitionLedger | None, int],
+    [PersistedFleetLedger, int],
     None,
 ]
 
@@ -393,7 +393,6 @@ def _emit_gap_fill_leg_progress(
     *,
     on_progress: FleetMaterializationProgressCallback | None,
     coherence: _GapFillCoherence,
-    before_wire_ledger: FleetAcquisitionLedger | None,
     persisted: PersistedFleetLedger,
     materialize_turn: int,
 ) -> FleetAcquisitionLedger:
@@ -401,7 +400,7 @@ def _emit_gap_fill_leg_progress(
     if resolved_progress is None:
         resolved_progress = coherence.on_progress
     if resolved_progress is not None:
-        resolved_progress(persisted, before_wire_ledger, materialize_turn)
+        resolved_progress(persisted, materialize_turn)
     return persisted.ledger
 
 
@@ -486,23 +485,18 @@ def _materialize_fleet_ledger_chain_for_player(
     start_turn = anchor_turn + 1
     current_ledger = anchor_persisted.ledger if anchor_persisted is not None else None
     current_persisted = anchor_persisted
-    wire_before_ledger = (
-        advance_ledger_to_turn(current_ledger, turn) if current_ledger is not None else None
-    )
 
     def emit_leg_progress(
         persisted_leg: PersistedFleetLedger,
         materialize_turn: int,
     ) -> None:
-        nonlocal wire_before_ledger, current_ledger
+        nonlocal current_ledger
         current_ledger = _emit_gap_fill_leg_progress(
             on_progress=on_progress,
             coherence=coherence,
-            before_wire_ledger=wire_before_ledger,
             persisted=persisted_leg,
             materialize_turn=materialize_turn,
         )
-        wire_before_ledger = advance_ledger_to_turn(current_ledger, turn)
 
     if skip_missing_prefix_rst:
         start_turn = first_stored_rst

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -35,6 +35,12 @@ if TYPE_CHECKING:
     from api.analytics.export_context import AnalyticQueryContext
 
 
+FleetMaterializationProgressCallback = Callable[
+    [PersistedFleetLedger, FleetAcquisitionLedger | None, int],
+    None,
+]
+
+
 class _FleetSnapshotInvalidated(Exception):
     """Gap-fill observed a concurrent fleet snapshot invalidation."""
 
@@ -76,6 +82,7 @@ class _GapFillCoherence:
     perspective: int
     player_id: int
     generation: int
+    on_progress: FleetMaterializationProgressCallback | None = None
 
     def put_ledger(
         self,
@@ -382,6 +389,22 @@ def _materialize_and_persist_player_turn(
     return persisted
 
 
+def _emit_gap_fill_leg_progress(
+    *,
+    on_progress: FleetMaterializationProgressCallback | None,
+    coherence: _GapFillCoherence,
+    before_wire_ledger: FleetAcquisitionLedger | None,
+    persisted: PersistedFleetLedger,
+    materialize_turn: int,
+) -> FleetAcquisitionLedger:
+    resolved_progress = on_progress
+    if resolved_progress is None:
+        resolved_progress = coherence.on_progress
+    if resolved_progress is not None:
+        resolved_progress(persisted, before_wire_ledger, materialize_turn)
+    return persisted.ledger
+
+
 def _materialize_fleet_ledger_chain_for_player(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
@@ -393,6 +416,7 @@ def _materialize_fleet_ledger_chain_for_player(
     inference_materialization: FleetInferenceMaterialization | None,
     coherence: _GapFillCoherence,
     turn_context_cache: dict[int, FleetTurnContext],
+    on_progress: FleetMaterializationProgressCallback | None = None,
 ) -> PersistedFleetLedger:
     """Gap-fill one player's fleet ledger from the latest anchor through turn T."""
     turn_number = turn.settings.turn
@@ -462,6 +486,23 @@ def _materialize_fleet_ledger_chain_for_player(
     start_turn = anchor_turn + 1
     current_ledger = anchor_persisted.ledger if anchor_persisted is not None else None
     current_persisted = anchor_persisted
+    wire_before_ledger = (
+        advance_ledger_to_turn(current_ledger, turn) if current_ledger is not None else None
+    )
+
+    def emit_leg_progress(
+        persisted_leg: PersistedFleetLedger,
+        materialize_turn: int,
+    ) -> None:
+        nonlocal wire_before_ledger, current_ledger
+        current_ledger = _emit_gap_fill_leg_progress(
+            on_progress=on_progress,
+            coherence=coherence,
+            before_wire_ledger=wire_before_ledger,
+            persisted=persisted_leg,
+            materialize_turn=materialize_turn,
+        )
+        wire_before_ledger = advance_ledger_to_turn(current_ledger, turn)
 
     if skip_missing_prefix_rst:
         start_turn = first_stored_rst
@@ -497,7 +538,7 @@ def _materialize_fleet_ledger_chain_for_player(
             load_turn=cached_load,
             inference_materialization=resolved_inference_materialization,
         )
-        current_ledger = current_persisted.ledger
+        emit_leg_progress(current_persisted, 1)
         if turn_number == 1:
             return current_persisted
         start_turn = 2
@@ -523,7 +564,7 @@ def _materialize_fleet_ledger_chain_for_player(
             load_turn=cached_load,
             inference_materialization=resolved_inference_materialization,
         )
-        current_ledger = current_persisted.ledger
+        emit_leg_progress(current_persisted, materialize_turn)
 
     assert current_persisted is not None
     return current_persisted
@@ -617,6 +658,7 @@ def get_or_materialize_fleet_ledger_for_player(
     load_turn: Callable[[int], TurnInfo | None],
     inference_materialization: FleetInferenceMaterialization | None = None,
     query_context: AnalyticQueryContext | None = None,
+    on_progress: FleetMaterializationProgressCallback | None = None,
 ) -> PersistedFleetLedger:
     """Return a cached ledger or materialize turn T for one player."""
     from api.analytics.fleet.gap_fill_coordinator import coordinator_for
@@ -626,6 +668,7 @@ def get_or_materialize_fleet_ledger_for_player(
         load_turn=load_turn,
         inference_materialization=inference_materialization,
         query_context=query_context,
+        on_progress=on_progress,
     )
 
 

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -73,6 +73,49 @@ def gap_fill_coherence_scope(coherence: _GapFillCoherence) -> Iterator[None]:
         set_active_gap_fill_coherence(None, token)
 
 
+_active_gap_fill_progress = threading.local()
+
+
+def active_gap_fill_progress_callback() -> FleetMaterializationProgressCallback | None:
+    getter = getattr(_active_gap_fill_progress, "getter", None)
+    if getter is None:
+        return None
+    return getter()
+
+
+def _set_active_gap_fill_progress_getter(
+    getter: Callable[[], FleetMaterializationProgressCallback | None] | None,
+    token: object | None = None,
+) -> object:
+    if token is not None:
+        _active_gap_fill_progress.getter = getter
+        return token
+    previous = getattr(_active_gap_fill_progress, "getter", None)
+    _active_gap_fill_progress.getter = getter
+    return previous
+
+
+@contextmanager
+def gap_fill_progress_scope(
+    callback_getter: Callable[[], FleetMaterializationProgressCallback | None],
+) -> Iterator[None]:
+    token = _set_active_gap_fill_progress_getter(callback_getter)
+    try:
+        yield
+    finally:
+        _set_active_gap_fill_progress_getter(None, token)
+
+
+def emit_gap_fill_leg_progress(
+    persisted: PersistedFleetLedger,
+    materialize_turn: int,
+) -> None:
+    """Notify the active inflight gap-fill callback after one materialized leg."""
+    callback = active_gap_fill_progress_callback()
+    if callback is not None:
+        callback(persisted, materialize_turn)
+
+
 @dataclass
 class _GapFillCoherence:
     """Guard gap-fill puts against concurrent fleet snapshot invalidation."""
@@ -82,7 +125,6 @@ class _GapFillCoherence:
     perspective: int
     player_id: int
     generation: int
-    on_progress: FleetMaterializationProgressCallback | None = None
 
     def put_ledger(
         self,
@@ -389,21 +431,6 @@ def _materialize_and_persist_player_turn(
     return persisted
 
 
-def _emit_gap_fill_leg_progress(
-    *,
-    on_progress: FleetMaterializationProgressCallback | None,
-    coherence: _GapFillCoherence,
-    persisted: PersistedFleetLedger,
-    materialize_turn: int,
-) -> FleetAcquisitionLedger:
-    resolved_progress = on_progress
-    if resolved_progress is None:
-        resolved_progress = coherence.on_progress
-    if resolved_progress is not None:
-        resolved_progress(persisted, materialize_turn)
-    return persisted.ledger
-
-
 def _materialize_fleet_ledger_chain_for_player(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
@@ -415,7 +442,6 @@ def _materialize_fleet_ledger_chain_for_player(
     inference_materialization: FleetInferenceMaterialization | None,
     coherence: _GapFillCoherence,
     turn_context_cache: dict[int, FleetTurnContext],
-    on_progress: FleetMaterializationProgressCallback | None = None,
 ) -> PersistedFleetLedger:
     """Gap-fill one player's fleet ledger from the latest anchor through turn T."""
     turn_number = turn.settings.turn
@@ -491,12 +517,8 @@ def _materialize_fleet_ledger_chain_for_player(
         materialize_turn: int,
     ) -> None:
         nonlocal current_ledger
-        current_ledger = _emit_gap_fill_leg_progress(
-            on_progress=on_progress,
-            coherence=coherence,
-            persisted=persisted_leg,
-            materialize_turn=materialize_turn,
-        )
+        emit_gap_fill_leg_progress(persisted_leg, materialize_turn)
+        current_ledger = persisted_leg.ledger
 
     if skip_missing_prefix_rst:
         start_turn = first_stored_rst

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -201,13 +201,6 @@ class FleetLedgerWireProgressTracker:
         self.emitted_progress = True
         return events
 
-    def on_materialization_leg(
-        self,
-        persisted: PersistedFleetLedger,
-        _materialize_turn: int,
-    ) -> None:
-        self.leg_progress_events(persisted)
-
 
 def run_fleet_player_materialization_job(
     session: FleetPlayerStreamSession,

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -100,7 +100,7 @@ def _initial_wire_before_ledger(
     before_persisted: PersistedFleetLedger | None,
 ) -> FleetAcquisitionLedger | None:
     if before_persisted is not None:
-        return before_persisted.ledger
+        return _host_turn_shaped_ledger(before_persisted, host_turn)
     _anchor_turn, anchor_persisted = _find_chain_anchor_for_player(
         persistence,
         game_id,

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -268,9 +268,6 @@ def run_fleet_player_materialization_job(
         session.event_queue.put(fleet_error_event("Fleet ledger materialization failed"))
         return
 
-    if session.cancel_token.is_cancelled():
-        return
-
     if progress_tracker.emitted_progress:
         session.event_queue.put(wire_materialized_complete_event(persisted))
         return

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -8,7 +8,10 @@ import threading
 import uuid
 from dataclasses import dataclass, field
 
-from api.analytics.fleet.chain import get_or_materialize_fleet_ledger_for_player
+from api.analytics.fleet.chain import (
+    advance_ledger_to_turn,
+    get_or_materialize_fleet_ledger_for_player,
+)
 from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.serialization import (
     fleet_ship_record_to_json,
@@ -78,6 +81,52 @@ def _wire_provenance(persisted: PersistedFleetLedger) -> dict[str, object]:
     )
 
 
+def _host_turn_shaped_ledger(
+    persisted: PersistedFleetLedger,
+    host_turn: TurnInfo,
+) -> FleetAcquisitionLedger:
+    """Shape interim gap-fill ledger for the host-turn fleet table tile."""
+    return advance_ledger_to_turn(persisted.ledger, host_turn)
+
+
+def wire_ledger_progress_events(
+    *,
+    before: FleetAcquisitionLedger | None,
+    persisted: PersistedFleetLedger,
+    host_turn: TurnInfo,
+) -> tuple[dict[str, object], ...]:
+    """Build incremental stream events after one gap-fill leg toward host turn N."""
+    host_shaped = _host_turn_shaped_ledger(persisted, host_turn)
+    before_records = _records_by_id(before)
+    after_records = _records_by_id(host_shaped)
+    events: list[dict[str, object]] = []
+    for record_id, record in after_records.items():
+        prior = before_records.get(record_id)
+        if prior is not None and _record_refined(prior, record):
+            events.append(
+                fleet_record_refined_event(record=fleet_ship_record_to_table_wire(record))
+            )
+    events.append(
+        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_table_wire(host_shaped))
+    )
+    events.append(_wire_provenance(persisted))
+    return tuple(events)
+
+
+def wire_materialized_complete_event(
+    persisted: PersistedFleetLedger,
+) -> dict[str, object]:
+    summary = (
+        "Fleet ledger materialization complete."
+        if persisted.provenance.is_final
+        else "Fleet ledger materialized with open provenance legs."
+    )
+    return fleet_complete_event(
+        is_final=persisted.provenance.is_final,
+        summary=summary,
+    )
+
+
 def wire_cached_player_events(persisted: PersistedFleetLedger) -> tuple[dict[str, object], ...]:
     """Replay terminal stream events for an ensure-final cached ledger."""
     return (
@@ -94,33 +143,17 @@ def wire_materialized_player_events(
     *,
     before: FleetAcquisitionLedger | None,
     persisted: PersistedFleetLedger,
+    host_turn: TurnInfo,
 ) -> tuple[dict[str, object], ...]:
-    """Build wire events after materialization completes for one player."""
-    before_records = _records_by_id(before)
-    after_records = _records_by_id(persisted.ledger)
-    events: list[dict[str, object]] = []
-    for record_id, record in after_records.items():
-        prior = before_records.get(record_id)
-        if prior is not None and _record_refined(prior, record):
-            events.append(
-                fleet_record_refined_event(record=fleet_ship_record_to_table_wire(record))
-            )
-    events.append(
-        fleet_ledger_updated_event(ledger=fleet_acquisition_ledger_to_table_wire(persisted.ledger))
+    """Build terminal wire events after materialization completes for one player."""
+    return (
+        *wire_ledger_progress_events(
+            before=before,
+            persisted=persisted,
+            host_turn=host_turn,
+        ),
+        wire_materialized_complete_event(persisted),
     )
-    events.append(_wire_provenance(persisted))
-    summary = (
-        "Fleet ledger materialization complete."
-        if persisted.provenance.is_final
-        else "Fleet ledger materialized with open provenance legs."
-    )
-    events.append(
-        fleet_complete_event(
-            is_final=persisted.provenance.is_final,
-            summary=summary,
-        )
-    )
-    return tuple(events)
 
 
 def run_fleet_player_materialization_job(
@@ -149,7 +182,27 @@ def run_fleet_player_materialization_job(
         turn_number,
         player_id,
     )
-    before_ledger = before_persisted.ledger if before_persisted is not None else None
+    wire_before: FleetAcquisitionLedger | None = (
+        before_persisted.ledger if before_persisted is not None else None
+    )
+    emitted_progress = False
+
+    def on_progress(
+        persisted_leg: PersistedFleetLedger,
+        prior_wire_ledger: FleetAcquisitionLedger | None,
+        _materialize_turn: int,
+    ) -> None:
+        nonlocal wire_before, emitted_progress
+        if session.cancel_token.is_cancelled():
+            return
+        for event in wire_ledger_progress_events(
+            before=prior_wire_ledger,
+            persisted=persisted_leg,
+            host_turn=turn,
+        ):
+            session.event_queue.put(event)
+        wire_before = _host_turn_shaped_ledger(persisted_leg, turn)
+        emitted_progress = True
 
     try:
         persisted = get_or_materialize_fleet_ledger_for_player(
@@ -160,6 +213,7 @@ def run_fleet_player_materialization_job(
             turn,
             load_turn=fleet_services.load_turn,
             inference_materialization=fleet_services.inference_materialization,
+            on_progress=on_progress,
         )
     except PlanetsConsoleError as exc:
         detail = str(exc) or "Fleet ledger materialization failed"
@@ -172,5 +226,13 @@ def run_fleet_player_materialization_job(
     if session.cancel_token.is_cancelled():
         return
 
-    for event in wire_materialized_player_events(before=before_ledger, persisted=persisted):
+    if emitted_progress:
+        session.event_queue.put(wire_materialized_complete_event(persisted))
+        return
+
+    for event in wire_materialized_player_events(
+        before=wire_before,
+        persisted=persisted,
+        host_turn=turn,
+    ):
         session.event_queue.put(event)

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -9,6 +9,7 @@ import uuid
 from dataclasses import dataclass, field
 
 from api.analytics.fleet.chain import (
+    _find_chain_anchor_for_player,
     advance_ledger_to_turn,
     get_or_materialize_fleet_ledger_for_player,
 )
@@ -89,6 +90,29 @@ def _host_turn_shaped_ledger(
     return advance_ledger_to_turn(persisted.ledger, host_turn)
 
 
+def _initial_wire_before_ledger(
+    *,
+    persistence,
+    game_id: int,
+    perspective: int,
+    player_id: int,
+    host_turn: TurnInfo,
+    before_persisted: PersistedFleetLedger | None,
+) -> FleetAcquisitionLedger | None:
+    if before_persisted is not None:
+        return before_persisted.ledger
+    _anchor_turn, anchor_persisted = _find_chain_anchor_for_player(
+        persistence,
+        game_id,
+        perspective,
+        player_id,
+        host_turn.settings.turn,
+    )
+    if anchor_persisted is None:
+        return None
+    return _host_turn_shaped_ledger(anchor_persisted, host_turn)
+
+
 def wire_ledger_progress_events(
     *,
     before: FleetAcquisitionLedger | None,
@@ -156,6 +180,35 @@ def wire_materialized_player_events(
     )
 
 
+@dataclass
+class FleetLedgerWireProgressTracker:
+    """Own host-turn wire-before state for incremental gap-fill stream events."""
+
+    host_turn: TurnInfo
+    wire_before: FleetAcquisitionLedger | None = None
+    emitted_progress: bool = False
+
+    def leg_progress_events(
+        self,
+        persisted: PersistedFleetLedger,
+    ) -> tuple[dict[str, object], ...]:
+        events = wire_ledger_progress_events(
+            before=self.wire_before,
+            persisted=persisted,
+            host_turn=self.host_turn,
+        )
+        self.wire_before = _host_turn_shaped_ledger(persisted, self.host_turn)
+        self.emitted_progress = True
+        return events
+
+    def on_materialization_leg(
+        self,
+        persisted: PersistedFleetLedger,
+        _materialize_turn: int,
+    ) -> None:
+        self.leg_progress_events(persisted)
+
+
 def run_fleet_player_materialization_job(
     session: FleetPlayerStreamSession,
     *,
@@ -182,27 +235,26 @@ def run_fleet_player_materialization_job(
         turn_number,
         player_id,
     )
-    wire_before: FleetAcquisitionLedger | None = (
-        before_persisted.ledger if before_persisted is not None else None
+    progress_tracker = FleetLedgerWireProgressTracker(
+        host_turn=turn,
+        wire_before=_initial_wire_before_ledger(
+            persistence=persistence,
+            game_id=fleet_services.game_id,
+            perspective=fleet_services.perspective,
+            player_id=player_id,
+            host_turn=turn,
+            before_persisted=before_persisted,
+        ),
     )
-    emitted_progress = False
 
     def on_progress(
         persisted_leg: PersistedFleetLedger,
-        prior_wire_ledger: FleetAcquisitionLedger | None,
         _materialize_turn: int,
     ) -> None:
-        nonlocal wire_before, emitted_progress
         if session.cancel_token.is_cancelled():
             return
-        for event in wire_ledger_progress_events(
-            before=prior_wire_ledger,
-            persisted=persisted_leg,
-            host_turn=turn,
-        ):
+        for event in progress_tracker.leg_progress_events(persisted_leg):
             session.event_queue.put(event)
-        wire_before = _host_turn_shaped_ledger(persisted_leg, turn)
-        emitted_progress = True
 
     try:
         persisted = get_or_materialize_fleet_ledger_for_player(
@@ -226,12 +278,12 @@ def run_fleet_player_materialization_job(
     if session.cancel_token.is_cancelled():
         return
 
-    if emitted_progress:
+    if progress_tracker.emitted_progress:
         session.event_queue.put(wire_materialized_complete_event(persisted))
         return
 
     for event in wire_materialized_player_events(
-        before=wire_before,
+        before=progress_tracker.wire_before,
         persisted=persisted,
         host_turn=turn,
     ):

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -173,10 +173,21 @@ def iter_multiplexed_fleet_table_events(
             return player_provider()
         return players
 
+    def finish_cancelled_run(row: ScheduledFleetPlayer) -> None:
+        if row.session.cancel_token.is_cancelled():
+            pending_run_ids.discard(row.session.run_id)
+            finished.add(row.session.run_id)
+
     def refresh_pending_run_ids() -> set[str]:
-        return {
-            row.session.run_id for row in active_players() if row.session.run_id not in finished
-        }
+        pending: set[str] = set()
+        for row in active_players():
+            if row.session.run_id in finished:
+                continue
+            if row.session.cancel_token.is_cancelled():
+                finished.add(row.session.run_id)
+                continue
+            pending.add(row.session.run_id)
+        return pending
 
     pending_run_ids = refresh_pending_run_ids()
 
@@ -204,6 +215,9 @@ def iter_multiplexed_fleet_table_events(
         row = active_rows[cursor % len(active_rows)]
         cursor += 1
         if row.session.run_id not in pending_run_ids:
+            continue
+        if row.session.cancel_token.is_cancelled():
+            finish_cancelled_run(row)
             continue
         try:
             event = row.session.event_queue.get(timeout=_MULTiplexWaitSeconds)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -14,6 +14,7 @@ from api.analytics.fleet.fleet_table_player_run import (
 )
 from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
 from api.errors import PlanetsConsoleError
+from api.transport.fleet_table_stream import fleet_error_event
 
 _DEFAULT_WORKER_COUNT = 4
 _DEQUEUE_WAIT_SECONDS = 0.25
@@ -51,8 +52,8 @@ class FleetTableStreamScheduler:
     def begin_scope(self, scope: FleetTableStreamScope) -> str:
         with self._condition:
             if self._active_scope == scope and self._has_active_table_stream:
-                raise TableStreamScopeAlreadyActive()
-            if self._active_scope != scope:
+                self._preempt_active_table_stream_locked()
+            elif self._active_scope != scope:
                 self._invalidate_retained_state_locked()
                 self._active_scope = scope
             stream_token = str(uuid.uuid4())
@@ -133,11 +134,17 @@ class FleetTableStreamScheduler:
                 self._active_table_stream_token = None
             self._condition.notify_all()
 
-    def _invalidate_retained_state_locked(self) -> None:
+    def _preempt_active_table_stream_locked(self) -> None:
+        """Cancel in-flight player runs so a reconnect can own this scope."""
         for session in self._runs.values():
             session.cancel_token.cancel()
         self._runs.clear()
         self._work_queue.clear()
+        self._has_active_table_stream = False
+        self._active_table_stream_token = None
+
+    def _invalidate_retained_state_locked(self) -> None:
+        self._preempt_active_table_stream_locked()
 
     def _worker_loop(self) -> None:
         while True:
@@ -152,7 +159,15 @@ class FleetTableStreamScheduler:
             try:
                 job.materialize(job.session)
             except Exception:
+                if job.session.event_queue.empty():
+                    job.session.event_queue.put(
+                        fleet_error_event("Fleet ledger materialization failed")
+                    )
                 continue
+            if job.session.event_queue.empty():
+                job.session.event_queue.put(
+                    fleet_error_event("Fleet ledger materialization ended without stream events")
+                )
 
 
 _process_scheduler: FleetTableStreamScheduler | None = None

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -11,7 +11,6 @@ from api.analytics.export_context import AnalyticQueryContext, make_analytic_que
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
     FleetMaterializationProgressCallback,
-    _find_chain_anchor_for_player,
     _find_gap_start_turn_for_player,
     _FleetSnapshotInvalidated,
     _GapFillCoherence,
@@ -19,7 +18,6 @@ from api.analytics.fleet.chain import (
     _materialize_fleet_ledger_chain_for_player,
     _run_materialize_on_active_coherence,
     active_gap_fill_coherence,
-    advance_ledger_to_turn,
     gap_fill_coherence_scope,
 )
 from api.analytics.fleet.compute_services import FleetComputeServices
@@ -36,7 +34,7 @@ from api.analytics.fleet.gap_fill_deferred_notifications import (
 )
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import FleetAcquisitionLedger, PersistedFleetLedger
+from api.analytics.fleet.types import PersistedFleetLedger
 from api.analytics.options import TurnAnalyticsOptions
 from api.errors import ConflictError, FleetMaterializationTimeoutError, NotFoundError
 from api.models.game import TurnInfo
@@ -57,11 +55,10 @@ def _merge_progress_callback(
 
     def merged(
         persisted: PersistedFleetLedger,
-        wire_before_ledger: FleetAcquisitionLedger | None,
         materialize_turn: int,
     ) -> None:
-        existing(persisted, wire_before_ledger, materialize_turn)
-        incoming(persisted, wire_before_ledger, materialize_turn)
+        existing(persisted, materialize_turn)
+        incoming(persisted, materialize_turn)
 
     return merged
 
@@ -582,17 +579,6 @@ class FleetGapFillCoordinator:
         """Return True when every gap turn has ensure-final ledger for this player."""
         player_id = self._player_id
         all_gap_turns_final = True
-        wire_before_ledger = None
-        if host_turn is not None:
-            _anchor_turn, anchor_persisted = _find_chain_anchor_for_player(
-                self._persistence,
-                self._game_id,
-                self._perspective,
-                player_id,
-                target_turn,
-            )
-            if anchor_persisted is not None:
-                wire_before_ledger = advance_ledger_to_turn(anchor_persisted.ledger, host_turn)
 
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
@@ -634,8 +620,7 @@ class FleetGapFillCoordinator:
                 player_id,
             )
             if persisted is not None and on_progress is not None and host_turn is not None:
-                on_progress(persisted, wire_before_ledger, materialize_turn)
-                wire_before_ledger = advance_ledger_to_turn(persisted.ledger, host_turn)
+                on_progress(persisted, materialize_turn)
 
             if not self._persistence.has_final_ledger(
                 self._game_id,

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -6,11 +6,12 @@ import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
 
 from api.analytics.export_context import AnalyticQueryContext, make_analytic_query_context
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.chain import (
+    FleetMaterializationProgressCallback,
+    _find_chain_anchor_for_player,
     _find_gap_start_turn_for_player,
     _FleetSnapshotInvalidated,
     _GapFillCoherence,
@@ -18,6 +19,7 @@ from api.analytics.fleet.chain import (
     _materialize_fleet_ledger_chain_for_player,
     _run_materialize_on_active_coherence,
     active_gap_fill_coherence,
+    advance_ledger_to_turn,
     gap_fill_coherence_scope,
 )
 from api.analytics.fleet.compute_services import FleetComputeServices
@@ -39,9 +41,6 @@ from api.analytics.options import TurnAnalyticsOptions
 from api.errors import ConflictError, FleetMaterializationTimeoutError, NotFoundError
 from api.models.game import TurnInfo
 
-if TYPE_CHECKING:
-    pass
-
 _CoordinatorKey = tuple[int, int, int, int]
 
 
@@ -52,6 +51,7 @@ class _InflightMaterialization:
     load_turn: Callable[[int], TurnInfo | None]
     inference_materialization: FleetInferenceMaterialization | None
     query_context: AnalyticQueryContext | None
+    on_progress: FleetMaterializationProgressCallback | None = None
     event: threading.Event = field(default_factory=threading.Event)
     result_ledger: PersistedFleetLedger | None = None
     error: BaseException | None = None
@@ -85,6 +85,7 @@ class _InflightSlot:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
+        on_progress: FleetMaterializationProgressCallback | None = None,
     ) -> _InflightJoin:
         self._reap_abandoned()
         self._discard_stale_completed(turn_number, generation)
@@ -97,6 +98,7 @@ class _InflightSlot:
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
+            on_progress=on_progress,
         )
 
     def _reap_abandoned(self) -> None:
@@ -141,6 +143,7 @@ class _InflightSlot:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
+        on_progress: FleetMaterializationProgressCallback | None = None,
     ) -> _InflightJoin:
         inflight = _InflightMaterialization(
             target_turn=turn_number,
@@ -148,6 +151,7 @@ class _InflightSlot:
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
+            on_progress=on_progress,
             leader_thread=threading.current_thread(),
         )
         self._inflight = inflight
@@ -187,6 +191,7 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None = None,
         query_context: AnalyticQueryContext | None = None,
+        on_progress: FleetMaterializationProgressCallback | None = None,
     ) -> PersistedFleetLedger:
         turn_number = turn.settings.turn
         cached = self._persistence.get_ledger(
@@ -216,6 +221,7 @@ class FleetGapFillCoordinator:
             load_turn=load_turn,
             inference_materialization=inference_materialization,
             query_context=query_context,
+            on_progress=on_progress,
         )
 
     def _coordinate(
@@ -225,6 +231,7 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
+        on_progress: FleetMaterializationProgressCallback | None,
     ) -> PersistedFleetLedger:
         turn_number = turn.settings.turn
         with self._inflight_condition:
@@ -234,6 +241,7 @@ class FleetGapFillCoordinator:
                 load_turn=load_turn,
                 inference_materialization=inference_materialization,
                 query_context=query_context,
+                on_progress=on_progress,
             )
         inflight = join.inflight
 
@@ -403,6 +411,7 @@ class FleetGapFillCoordinator:
                     self._perspective,
                     self._player_id,
                     generation,
+                    on_progress=inflight.on_progress,
                 )
                 try:
                     with gap_fill_coherence_scope(coherence):
@@ -434,6 +443,8 @@ class FleetGapFillCoordinator:
                                     current_target,
                                     load_turn,
                                     inference_materialization=inference_materialization,
+                                    on_progress=inflight.on_progress,
+                                    host_turn=turn,
                                 )
 
                             if not materialized_via_export:
@@ -461,6 +472,7 @@ class FleetGapFillCoordinator:
                                     inference_materialization=inference_materialization,
                                     coherence=coherence,
                                     turn_context_cache=turn_context_cache,
+                                    on_progress=inflight.on_progress,
                                 )
                     materialized_target = current_target
                     break
@@ -537,10 +549,24 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         *,
         inference_materialization: FleetInferenceMaterialization | None,
+        on_progress: FleetMaterializationProgressCallback | None = None,
+        host_turn: TurnInfo | None = None,
     ) -> bool:
         """Return True when every gap turn has ensure-final ledger for this player."""
         player_id = self._player_id
         all_gap_turns_final = True
+        wire_before_ledger = None
+        if host_turn is not None:
+            _anchor_turn, anchor_persisted = _find_chain_anchor_for_player(
+                self._persistence,
+                self._game_id,
+                self._perspective,
+                player_id,
+                target_turn,
+            )
+            if anchor_persisted is not None:
+                wire_before_ledger = advance_ledger_to_turn(anchor_persisted.ledger, host_turn)
+
         for materialize_turn in range(gap_start, target_turn + 1):
             turn_info = load_turn(materialize_turn)
             if turn_info is None:
@@ -573,6 +599,16 @@ class FleetGapFillCoordinator:
                     inference_materialization=inference_materialization,
                     materialize_player_id=player_id,
                 )
+
+            persisted = self._persistence.get_ledger(
+                self._game_id,
+                self._perspective,
+                materialize_turn,
+                player_id,
+            )
+            if persisted is not None and on_progress is not None and host_turn is not None:
+                on_progress(persisted, wire_before_ledger, materialize_turn)
+                wire_before_ledger = advance_ledger_to_turn(persisted.ledger, host_turn)
 
             if not self._persistence.has_final_ledger(
                 self._game_id,

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -18,7 +18,9 @@ from api.analytics.fleet.chain import (
     _materialize_fleet_ledger_chain_for_player,
     _run_materialize_on_active_coherence,
     active_gap_fill_coherence,
+    emit_gap_fill_leg_progress,
     gap_fill_coherence_scope,
+    gap_fill_progress_scope,
 )
 from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.constants import (
@@ -400,6 +402,24 @@ class FleetGapFillCoordinator:
         inference_materialization: FleetInferenceMaterialization | None,
         query_context: AnalyticQueryContext | None,
     ) -> None:
+        with gap_fill_progress_scope(lambda: inflight.on_progress):
+            self._run_leader_unwind_body(
+                inflight,
+                turn,
+                load_turn=load_turn,
+                inference_materialization=inference_materialization,
+                query_context=query_context,
+            )
+
+    def _run_leader_unwind_body(
+        self,
+        inflight: _InflightMaterialization,
+        turn: TurnInfo,
+        *,
+        load_turn: Callable[[int], TurnInfo | None],
+        inference_materialization: FleetInferenceMaterialization | None,
+        query_context: AnalyticQueryContext | None,
+    ) -> None:
         complete_before: frozenset[int] | None = None
         query_ctx = _resolve_query_context(
             self._persistence,
@@ -435,7 +455,6 @@ class FleetGapFillCoordinator:
                     self._perspective,
                     self._player_id,
                     generation,
-                    on_progress=inflight.on_progress,
                 )
                 try:
                     with gap_fill_coherence_scope(coherence):
@@ -467,8 +486,6 @@ class FleetGapFillCoordinator:
                                     current_target,
                                     load_turn,
                                     inference_materialization=inference_materialization,
-                                    on_progress=inflight.on_progress,
-                                    host_turn=turn,
                                 )
 
                             if not materialized_via_export:
@@ -496,7 +513,6 @@ class FleetGapFillCoordinator:
                                     inference_materialization=inference_materialization,
                                     coherence=coherence,
                                     turn_context_cache=turn_context_cache,
-                                    on_progress=inflight.on_progress,
                                 )
                     materialized_target = current_target
                     break
@@ -573,8 +589,6 @@ class FleetGapFillCoordinator:
         load_turn: Callable[[int], TurnInfo | None],
         *,
         inference_materialization: FleetInferenceMaterialization | None,
-        on_progress: FleetMaterializationProgressCallback | None = None,
-        host_turn: TurnInfo | None = None,
     ) -> bool:
         """Return True when every gap turn has ensure-final ledger for this player."""
         player_id = self._player_id
@@ -619,8 +633,8 @@ class FleetGapFillCoordinator:
                 materialize_turn,
                 player_id,
             )
-            if persisted is not None and on_progress is not None and host_turn is not None:
-                on_progress(persisted, materialize_turn)
+            if persisted is not None:
+                emit_gap_fill_leg_progress(persisted, materialize_turn)
 
             if not self._persistence.has_final_ledger(
                 self._game_id,

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -36,12 +36,34 @@ from api.analytics.fleet.gap_fill_deferred_notifications import (
 )
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
-from api.analytics.fleet.types import PersistedFleetLedger
+from api.analytics.fleet.types import FleetAcquisitionLedger, PersistedFleetLedger
 from api.analytics.options import TurnAnalyticsOptions
 from api.errors import ConflictError, FleetMaterializationTimeoutError, NotFoundError
 from api.models.game import TurnInfo
 
 _CoordinatorKey = tuple[int, int, int, int]
+
+
+def _merge_progress_callback(
+    existing: FleetMaterializationProgressCallback | None,
+    incoming: FleetMaterializationProgressCallback | None,
+) -> FleetMaterializationProgressCallback | None:
+    if incoming is None:
+        return existing
+    if existing is None:
+        return incoming
+    if existing is incoming:
+        return existing
+
+    def merged(
+        persisted: PersistedFleetLedger,
+        wire_before_ledger: FleetAcquisitionLedger | None,
+        materialize_turn: int,
+    ) -> None:
+        existing(persisted, wire_before_ledger, materialize_turn)
+        incoming(persisted, wire_before_ledger, materialize_turn)
+
+    return merged
 
 
 @dataclass
@@ -91,7 +113,7 @@ class _InflightSlot:
         self._discard_stale_completed(turn_number, generation)
         existing = self._inflight
         if existing is not None and existing.generation == generation:
-            return self._join_existing(existing, turn_number)
+            return self._join_existing(existing, turn_number, on_progress=on_progress)
         return self._start_new(
             turn_number,
             generation,
@@ -122,7 +144,11 @@ class _InflightSlot:
         self,
         inflight: _InflightMaterialization,
         turn_number: int,
+        *,
+        on_progress: FleetMaterializationProgressCallback | None = None,
     ) -> _InflightJoin:
+        if on_progress is not None:
+            inflight.on_progress = _merge_progress_callback(inflight.on_progress, on_progress)
         extended = turn_number > inflight.target_turn
         previous_target = inflight.target_turn
         inflight.target_turn = max(inflight.target_turn, turn_number)
@@ -365,6 +391,7 @@ class FleetGapFillCoordinator:
             load_turn=inflight.load_turn,
             inference_materialization=inflight.inference_materialization,
             query_context=inflight.query_context,
+            on_progress=inflight.on_progress,
         )
 
     def _run_leader_unwind(

--- a/packages/api/api/analytics/fleet/gap_fill_coordinator.py
+++ b/packages/api/api/analytics/fleet/gap_fill_coordinator.py
@@ -616,6 +616,7 @@ class FleetGapFillCoordinator:
                 materialize_turn,
                 player_id,
             )
+            materialized_via_chain = False
             if persisted is None or not _is_fleet_ledger_cache_hit(persisted):
                 _run_materialize_on_active_coherence(
                     self._persistence,
@@ -626,6 +627,7 @@ class FleetGapFillCoordinator:
                     inference_materialization=inference_materialization,
                     materialize_player_id=player_id,
                 )
+                materialized_via_chain = True
 
             persisted = self._persistence.get_ledger(
                 self._game_id,
@@ -633,7 +635,7 @@ class FleetGapFillCoordinator:
                 materialize_turn,
                 player_id,
             )
-            if persisted is not None:
+            if persisted is not None and not materialized_via_chain:
                 emit_gap_fill_leg_progress(persisted, materialize_turn)
 
             if not self._persistence.has_final_ledger(

--- a/packages/api/api/analytics/military_score_inference/inference_scheduler.py
+++ b/packages/api/api/analytics/military_score_inference/inference_scheduler.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 
 from api.analytics.military_score_inference.inference_row_runner import (
     InferenceTierJobCallbacks,
-    build_stopped_row_complete,
     run_inference_tier_job,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -397,17 +396,22 @@ class InferenceRowScheduler:
             )
         )
 
-    def _finalize_row_run(self, session: InferenceRowStreamSession) -> None:
+    def _try_claim_run_for_finalize(self, session: InferenceRowStreamSession) -> bool:
         with self._condition:
+            if session.cancel_token.is_cancelled():
+                return False
             run = self._runs.pop(session.run_id, None)
-            if run is not None:
-                run.clear_held()
+            if run is None:
+                return False
+            run.clear_held()
+            return True
 
     def _emit_row_complete(self, session: InferenceRowStreamSession, event: RowComplete) -> None:
-        session.event_queue.put(event)
-        self._finalize_row_run(session)
+        if not self._try_claim_run_for_finalize(session):
+            return
         if self._on_row_complete is not None:
             self._on_row_complete(session, event)
+        session.event_queue.put(event)
 
     def cancel_row_run(self, run_id: str) -> None:
         """Cancel one row run and purge its queued tier jobs."""
@@ -451,10 +455,9 @@ class InferenceRowScheduler:
         if outcome.row_complete is not None:
             self._emit_row_complete(session, outcome.row_complete)
             return
-        if session.cancel_token.is_cancelled():
-            self._emit_row_complete(session, build_stopped_row_complete(run))
-            return
         with self._condition:
+            if session.cancel_token.is_cancelled():
+                return
             active_run = self._runs.get(session.run_id)
             if active_run is None:
                 return

--- a/packages/api/api/analytics/military_score_inference/inference_scheduler.py
+++ b/packages/api/api/analytics/military_score_inference/inference_scheduler.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 
 from api.analytics.military_score_inference.inference_row_runner import (
     InferenceTierJobCallbacks,
+    build_stopped_row_complete,
     run_inference_tier_job,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -87,8 +88,8 @@ class InferenceRowScheduler:
     def begin_scope(self, scope: InferenceStreamScope) -> str:
         with self._condition:
             if self._active_scope == scope and self._has_active_table_stream:
-                raise TableStreamScopeAlreadyActive()
-            if self._active_scope != scope:
+                self._preempt_active_table_stream_locked()
+            elif self._active_scope != scope:
                 self._invalidate_retained_state_locked()
                 self._active_scope = scope
             stream_token = str(uuid.uuid4())
@@ -295,7 +296,8 @@ class InferenceRowScheduler:
             job = self._work_queue.popleft()
             self._get_or_create_run(job.session).hold_job(job)
 
-    def _invalidate_retained_state_locked(self) -> None:
+    def _preempt_active_table_stream_locked(self) -> None:
+        """Cancel in-flight row runs so a reconnect can own this scope."""
         self._has_active_table_stream = False
         self._active_table_stream_token = None
         self._globally_paused = False
@@ -305,6 +307,9 @@ class InferenceRowScheduler:
         while self._work_queue:
             job = self._work_queue.popleft()
             job.session.cancel_token.cancel()
+
+    def _invalidate_retained_state_locked(self) -> None:
+        self._preempt_active_table_stream_locked()
 
     def _broadcast_global_pause_locked(self, *, paused: bool) -> None:
         event = GlobalPauseChanged(paused=paused)
@@ -392,22 +397,17 @@ class InferenceRowScheduler:
             )
         )
 
-    def _try_claim_run_for_finalize(self, session: InferenceRowStreamSession) -> bool:
+    def _finalize_row_run(self, session: InferenceRowStreamSession) -> None:
         with self._condition:
-            if session.cancel_token.is_cancelled():
-                return False
             run = self._runs.pop(session.run_id, None)
-            if run is None:
-                return False
-            run.clear_held()
-            return True
+            if run is not None:
+                run.clear_held()
 
     def _emit_row_complete(self, session: InferenceRowStreamSession, event: RowComplete) -> None:
-        if not self._try_claim_run_for_finalize(session):
-            return
+        session.event_queue.put(event)
+        self._finalize_row_run(session)
         if self._on_row_complete is not None:
             self._on_row_complete(session, event)
-        session.event_queue.put(event)
 
     def cancel_row_run(self, run_id: str) -> None:
         """Cancel one row run and purge its queued tier jobs."""
@@ -451,9 +451,10 @@ class InferenceRowScheduler:
         if outcome.row_complete is not None:
             self._emit_row_complete(session, outcome.row_complete)
             return
+        if session.cancel_token.is_cancelled():
+            self._emit_row_complete(session, build_stopped_row_complete(run))
+            return
         with self._condition:
-            if session.cancel_token.is_cancelled():
-                return
             active_run = self._runs.get(session.run_id)
             if active_run is None:
                 return

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -282,10 +282,21 @@ def iter_multiplexed_inference_events(
             return session_provider()
         return sessions
 
+    def finish_cancelled_run(row: ScheduledInferenceRow) -> None:
+        if row.session.cancel_token.is_cancelled():
+            pending_run_ids.discard(row.session.run_id)
+            finished.add(row.session.run_id)
+
     def refresh_pending_run_ids() -> set[str]:
-        return {
-            row.session.run_id for row in active_sessions() if row.session.run_id not in finished
-        }
+        pending: set[str] = set()
+        for row in active_sessions():
+            if row.session.run_id in finished:
+                continue
+            if row.session.cancel_token.is_cancelled():
+                finished.add(row.session.run_id)
+                continue
+            pending.add(row.session.run_id)
+        return pending
 
     pending_run_ids = refresh_pending_run_ids()
     cursor = 0
@@ -314,6 +325,9 @@ def iter_multiplexed_inference_events(
         row = active_rows[cursor % len(active_rows)]
         cursor += 1
         if row.session.run_id not in pending_run_ids:
+            continue
+        if row.session.cancel_token.is_cancelled():
+            finish_cancelled_run(row)
             continue
         try:
             domain_event = row.session.event_queue.get(timeout=_MULTiplexWaitSeconds)

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -181,7 +181,7 @@ def test_fleet_table_stream_early_close_releases_scope_for_reconnect(sample_turn
         second.close()
 
 
-def test_fleet_table_stream_reconnect_returns_conflict_while_active(sample_turn):
+def test_fleet_table_stream_reconnect_preempts_active_scope(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
     scheduler = FleetTableStreamScheduler(worker_count=0)
     scope = FleetTableStreamScope(
@@ -189,29 +189,14 @@ def test_fleet_table_stream_reconnect_returns_conflict_while_active(sample_turn)
         perspective=1,
         turn_number=sample_turn.settings.turn,
     )
-    stream_token = scheduler.begin_scope(scope)
-    try:
-        services = build_ephemeral_fleet_compute_services(
-            sample_turn,
-            game_id=628580,
-            perspective=1,
-        )
-        replacement = iter_fleet_table_stream_events(
-            sample_turn,
-            (sample_turn.scores[0].ownerid,),
-            game_id=628580,
-            perspective=1,
-            fleet_services=services,
-            persistence=services.persistence,
-            scheduler=scheduler,
-        )
-        assert next(replacement) == {
-            "type": "error",
-            "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-        }
-        replacement.close()
-    finally:
-        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+    first_token = scheduler.begin_scope(scope)
+    second_token = scheduler.begin_scope(scope)
+
+    assert second_token != first_token
+    assert not scheduler.owns_table_stream(first_token)
+    assert scheduler.owns_table_stream(second_token)
+
+    scheduler.end_fleet_table_stream(scope, (), stream_token=second_token)
 
 
 def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
@@ -222,33 +207,48 @@ def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
         perspective=1,
         turn_number=sample_turn.settings.turn,
     )
-    stream_token = scheduler.begin_scope(scope)
-    try:
-        services = build_ephemeral_fleet_compute_services(
+    first_token = scheduler.begin_scope(scope)
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    services.persistence.put_ledger(
+        628580,
+        1,
+        sample_turn.settings.turn,
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+    )
+
+    def replacement_loader():
+        yield from iter_fleet_table_stream_events(
             sample_turn,
+            (player_id,),
             game_id=628580,
             perspective=1,
+            fleet_services=services,
+            persistence=services.persistence,
+            scheduler=scheduler,
         )
 
-        def replacement_loader():
-            yield from iter_fleet_table_stream_events(
-                sample_turn,
-                (sample_turn.scores[0].ownerid,),
-                game_id=628580,
-                perspective=1,
-                fleet_services=services,
-                persistence=services.persistence,
-                scheduler=scheduler,
-            )
+    lines: list[str] = []
+    for line in stream_fleet_table_ndjson(replacement_loader):
+        lines.append(line)
+        payload = json.loads(line)
+        if payload.get("type") == "complete":
+            break
 
-        lines = list(stream_fleet_table_ndjson(replacement_loader))
-        assert len(lines) == 1
-        assert json.loads(lines[0]) == {
-            "type": "error",
-            "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-        }
-    finally:
-        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+    assert lines
+    assert json.loads(lines[0]).get("detail") != TABLE_STREAM_ALREADY_ACTIVE_DETAIL
+    assert not scheduler.owns_table_stream(first_token)
 
 
 def test_cached_final_ledger_replays_terminal_events_without_scheduling(sample_turn):
@@ -552,6 +552,73 @@ def test_drain_available_multiplex_events_returns_queued_events_without_blocking
     )
     assert len(events) == 1
     assert events[0]["playerId"] == 8
+
+
+def test_materialization_job_emits_complete_after_progress_when_session_cancelled(
+    persistence,
+    load_turn,
+):
+    """A cancelled session still receives complete after successful gap-fill."""
+    from unittest.mock import patch
+
+    from api.analytics.fleet.chain import ensure_fleet_baseline, ensure_fleet_baseline_for_player
+    from api.analytics.fleet.compute_services import FleetComputeServices
+    from api.analytics.fleet.fleet_table_player_run import (
+        FleetPlayerStreamSession,
+        run_fleet_player_materialization_job,
+    )
+    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    player_id = turn_112.scores[0].ownerid
+
+    session = FleetPlayerStreamSession(
+        player_id=player_id,
+        turn=turn_112,
+        game_id=628580,
+        perspective=1,
+    )
+    services = FleetComputeServices(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        load_turn=load_turn,
+    )
+    final_persisted = PersistedFleetLedger(
+        ledger=ensure_fleet_baseline_for_player(628580, 1, turn_112, player_id),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+
+    def materialize_with_cancel(*args, on_progress=None, **kwargs):
+        if on_progress is not None:
+            on_progress(final_persisted, 112)
+        session.cancel_token.cancel()
+        return final_persisted
+
+    with patch(
+        "api.analytics.fleet.fleet_table_player_run.get_or_materialize_fleet_ledger_for_player",
+        side_effect=materialize_with_cancel,
+    ):
+        run_fleet_player_materialization_job(
+            session,
+            fleet_services=services,
+            persistence=persistence,
+        )
+
+    events: list[dict[str, object]] = []
+    while not session.event_queue.empty():
+        events.append(session.event_queue.get_nowait())
+
+    assert [event.get("type") for event in events if event.get("type") == "ledger_updated"]
+    assert events[-1]["type"] == "complete"
 
 
 @pytest.mark.slow

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import copy
 import json
+from pathlib import Path
 
 import pytest
-from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
-from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.chain import ensure_fleet_baseline, ensure_fleet_baseline_for_player
+from api.analytics.fleet.compute_services import (
+    FleetComputeServices,
+    build_ephemeral_fleet_compute_services,
+)
+from api.analytics.fleet.fleet_table_player_run import wire_ledger_progress_events
 from api.analytics.fleet.fleet_table_stream_rows import (
     ScheduledFleetPlayer,
     drain_available_multiplex_events,
@@ -19,15 +25,69 @@ from api.analytics.fleet.fleet_table_stream_scheduler import (
     reset_fleet_table_stream_scheduler_for_tests,
 )
 from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.gap_fill_coordinator import reset_coordinators
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.serialization import (
     fleet_acquisition_ledger_to_json,
 )
 from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+from api.analytics.turn_roster import iter_turn_players
+from api.serialization.turn import turn_info_from_json
+from api.storage.memory_asset import MemoryAssetBackend
 from api.transport.fleet_table_stream import (
     TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
     fleet_complete_event,
     stream_fleet_table_ndjson,
 )
+
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture(autouse=True)
+def _reset_fleet_gap_fill_coordinators():
+    reset_coordinators()
+    yield
+    reset_coordinators()
+
+
+@pytest.fixture
+def memory_backend():
+    backend = MemoryAssetBackend(initial={})
+    with open(ASSETS_DIR / "game_info_sample.json") as handle:
+        backend.put("games/628580/info", json.load(handle))
+    with open(ASSETS_DIR / "turn_sample.json") as handle:
+        turn_rst = json.load(handle)
+        backend.put("games/628580/1/turns/111", turn_rst)
+        turn_110 = copy.deepcopy(turn_rst)
+        turn_110["settings"]["turn"] = 110
+        turn_110["game"]["turn"] = 110
+        backend.put("games/628580/1/turns/110", turn_110)
+        turn_112 = copy.deepcopy(turn_rst)
+        turn_112["settings"]["turn"] = 112
+        turn_112["game"]["turn"] = 112
+        backend.put("games/628580/1/turns/112", turn_112)
+    return backend
+
+
+@pytest.fixture
+def persistence(memory_backend):
+    return FleetSnapshotPersistenceService(memory_backend)
+
+
+@pytest.fixture
+def load_turn(memory_backend):
+    def _load(turn_number: int):
+        key = f"games/628580/1/turns/{turn_number}"
+        try:
+            data = memory_backend.get(key)
+        except Exception:
+            return None
+        if data is None:
+            return None
+        return turn_info_from_json(data)
+
+    return _load
 
 
 def _events_for_players(
@@ -228,6 +288,89 @@ def test_cached_final_ledger_replays_terminal_events_without_scheduling(sample_t
     assert scheduler._runs == {}
 
 
+def test_gap_fill_stream_emits_incremental_ledger_updates_before_complete(
+    persistence,
+    load_turn,
+):
+    """Gap-fill M..N emits ledger_updated after each leg, then complete."""
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    player_id = turn_112.scores[0].ownerid
+
+    persistence.put_snapshot(
+        628580,
+        1,
+        110,
+        ensure_fleet_baseline(628580, 1, turn_110),
+    )
+
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler(worker_count=1)
+    services = FleetComputeServices(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        load_turn=load_turn,
+    )
+
+    events = _events_for_players(
+        turn_112,
+        (player_id,),
+        scheduler=scheduler,
+        services=services,
+    )
+    player_events = [event for event in events if event.get("playerId") == player_id]
+    ledger_updates = [
+        event for event in player_events if event.get("type") == "ledger_updated"
+    ]
+    complete_events = [event for event in player_events if event.get("type") == "complete"]
+
+    assert len(ledger_updates) >= 2
+    assert len(complete_events) == 1
+    assert complete_events[0]["type"] == "complete"
+    first_records = ledger_updates[0]["ledger"]["records"]
+    assert isinstance(first_records, list)
+    assert len(first_records) > 0
+    complete_index = player_events.index(complete_events[0])
+    assert all(
+        player_events.index(event) < complete_index
+        for event in ledger_updates
+    )
+
+
+def test_wire_ledger_progress_events_use_host_turn_roster_names(sample_turn):
+    from dataclasses import replace
+
+    turn_111 = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=111),
+        game=replace(sample_turn.game, turn=111),
+    )
+    player_id = turn_111.scores[0].ownerid
+    baseline = ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id)
+    persisted = PersistedFleetLedger(
+        ledger=baseline,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=False,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+
+    events = wire_ledger_progress_events(
+        before=None,
+        persisted=persisted,
+        host_turn=turn_111,
+    )
+
+    ledger_event = next(event for event in events if event["type"] == "ledger_updated")
+    expected_name = next(
+        player.username for player in iter_turn_players(turn_111) if player.id == player_id
+    )
+    assert ledger_event["ledger"]["playerName"] == expected_name
+
+
 def test_multi_player_stream_emits_tagged_terminal_events(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
     scheduler = FleetTableStreamScheduler(worker_count=0)
@@ -383,7 +526,7 @@ def test_drain_available_multiplex_events_returns_queued_events_without_blocking
 def test_concurrent_multi_player_materialization_completes(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
     scheduler = FleetTableStreamScheduler(worker_count=2)
-    player_ids = tuple(row.ownerid for row in sample_turn.scores[:3])
+    player_ids = tuple(player.id for player in list(iter_turn_players(sample_turn))[:3])
     events = _events_for_players(sample_turn, player_ids, scheduler=scheduler)
     assert {
         event["playerId"]

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -40,7 +40,6 @@ from api.transport.fleet_table_stream import (
     stream_fleet_table_ndjson,
 )
 
-
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
 
@@ -322,9 +321,7 @@ def test_gap_fill_stream_emits_incremental_ledger_updates_before_complete(
         services=services,
     )
     player_events = [event for event in events if event.get("playerId") == player_id]
-    ledger_updates = [
-        event for event in player_events if event.get("type") == "ledger_updated"
-    ]
+    ledger_updates = [event for event in player_events if event.get("type") == "ledger_updated"]
     complete_events = [event for event in player_events if event.get("type") == "complete"]
 
     assert len(ledger_updates) >= 2
@@ -334,10 +331,7 @@ def test_gap_fill_stream_emits_incremental_ledger_updates_before_complete(
     assert isinstance(first_records, list)
     assert len(first_records) > 0
     complete_index = player_events.index(complete_events[0])
-    assert all(
-        player_events.index(event) < complete_index
-        for event in ledger_updates
-    )
+    assert all(player_events.index(event) < complete_index for event in ledger_updates)
 
 
 def test_wire_ledger_progress_events_use_host_turn_roster_names(sample_turn):

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -12,7 +12,10 @@ from api.analytics.fleet.compute_services import (
     FleetComputeServices,
     build_ephemeral_fleet_compute_services,
 )
-from api.analytics.fleet.fleet_table_player_run import wire_ledger_progress_events
+from api.analytics.fleet.fleet_table_player_run import (
+    _initial_wire_before_ledger,
+    wire_ledger_progress_events,
+)
 from api.analytics.fleet.fleet_table_stream_rows import (
     ScheduledFleetPlayer,
     drain_available_multiplex_events,
@@ -363,6 +366,41 @@ def test_wire_ledger_progress_events_use_host_turn_roster_names(sample_turn):
         player.username for player in iter_turn_players(turn_111) if player.id == player_id
     )
     assert ledger_event["ledger"]["playerName"] == expected_name
+
+
+def test_initial_wire_before_ledger_shapes_cached_host_turn(sample_turn, persistence):
+    from dataclasses import replace
+
+    turn_111 = replace(
+        sample_turn,
+        settings=replace(sample_turn.settings, turn=111),
+        game=replace(sample_turn.game, turn=111),
+    )
+    player_id = turn_111.scores[0].ownerid
+    baseline = ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id)
+    stale_ledger = replace(baseline, player_name="stale-name")
+    before_persisted = PersistedFleetLedger(
+        ledger=stale_ledger,
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+
+    result = _initial_wire_before_ledger(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        player_id=player_id,
+        host_turn=turn_111,
+        before_persisted=before_persisted,
+    )
+
+    expected_name = next(
+        player.username for player in iter_turn_players(turn_111) if player.id == player_id
+    )
+    assert result is not None
+    assert result.player_name == expected_name
 
 
 def test_multi_player_stream_emits_tagged_terminal_events(sample_turn):

--- a/packages/api/tests/test_gap_fill_coordinator.py
+++ b/packages/api/tests/test_gap_fill_coordinator.py
@@ -333,6 +333,64 @@ def test_forward_unwind_calls_ensure_fleet_export_per_gap_turn(
         )
 
 
+def test_forward_unwind_emits_once_per_leg_when_chain_materializes(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    """Export unwind must not double-emit leg progress when chain materializes."""
+    from api.analytics.fleet.chain import emit_gap_fill_leg_progress
+
+    from tests.test_fleet_persistence import (
+        _inference_materialization_for_fleet,
+        _put_provenance_final_snapshot,
+        _seed_scores_rows_for_all_players,
+    )
+
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    _put_provenance_final_snapshot(persistence, 628580, 1, turn_110)
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    player_id = _first_player_id(turn_112)
+    inference_persistence, inference_materialization = _inference_materialization_for_fleet(
+        memory_backend,
+        load_turn,
+    )
+    _seed_scores_rows_for_all_players(inference_persistence, turn_111)
+    _seed_scores_rows_for_all_players(inference_persistence, turn_112)
+
+    emitted_turns: list[int] = []
+    original_emit = emit_gap_fill_leg_progress
+
+    def tracking_emit(persisted: PersistedFleetLedger, materialize_turn: int) -> None:
+        emitted_turns.append(materialize_turn)
+        original_emit(persisted, materialize_turn)
+
+    with patch(
+        "api.analytics.fleet.chain.emit_gap_fill_leg_progress",
+        side_effect=tracking_emit,
+    ):
+        get_or_materialize_fleet_ledger_for_player(
+            persistence,
+            628580,
+            1,
+            player_id,
+            turn_112,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+        )
+
+    gap_turns = {turn for turn in emitted_turns if 111 <= turn <= 112}
+    assert gap_turns, f"expected gap leg progress emissions, got {emitted_turns}"
+    assert len(emitted_turns) == len(set(emitted_turns)), (
+        f"duplicate leg progress emissions: {emitted_turns}"
+    )
+
+
 def test_gap_fill_forward_unwind_refines_intermediate_turn_build_option_sets(
     persistence,
     load_turn,

--- a/packages/api/tests/test_gap_fill_coordinator.py
+++ b/packages/api/tests/test_gap_fill_coordinator.py
@@ -738,3 +738,97 @@ def test_coordinator_invalidation_mid_chain_with_waiters_does_not_storm(
     assert materialize_calls <= 2, (
         f"expected at most one invalidation retry on the chain, got {materialize_calls}"
     )
+
+
+def test_joiner_on_progress_receives_incremental_events_during_inflight_gap_fill(
+    persistence,
+    load_turn,
+):
+    """Joiner with on_progress receives leg events while waiting on inflight gap-fill."""
+    from api.analytics.fleet.chain import ensure_fleet_baseline
+
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    persistence.put_snapshot(628580, 1, 110, ensure_fleet_baseline(628580, 1, turn_110))
+
+    turn_112 = load_turn(112)
+    assert turn_112 is not None
+    player_id = _first_player_id(turn_112)
+
+    leader_ready = threading.Event()
+    release_leader = threading.Event()
+    progress_turns: list[int] = []
+    progress_lock = threading.Lock()
+    errors: list[BaseException] = []
+
+    coordinator = coordinator_for(persistence, 628580, 1, player_id)
+    original_run_leader = coordinator._run_leader_unwind
+
+    def gated_run_leader(
+        inflight,
+        turn,
+        *,
+        load_turn,
+        inference_materialization,
+        query_context,
+    ):
+        leader_ready.set()
+        assert release_leader.wait(timeout=5)
+        return original_run_leader(
+            inflight,
+            turn,
+            load_turn=load_turn,
+            inference_materialization=inference_materialization,
+            query_context=query_context,
+        )
+
+    def joiner_on_progress(
+        _persisted: PersistedFleetLedger,
+        _wire_before,
+        materialize_turn: int,
+    ) -> None:
+        with progress_lock:
+            progress_turns.append(materialize_turn)
+
+    def run_leader() -> None:
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_id,
+                turn_112,
+                load_turn=load_turn,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    def run_joiner() -> None:
+        try:
+            get_or_materialize_fleet_ledger_for_player(
+                persistence,
+                628580,
+                1,
+                player_id,
+                turn_112,
+                load_turn=load_turn,
+                on_progress=joiner_on_progress,
+            )
+        except BaseException as exc:
+            errors.append(exc)
+
+    with patch.object(coordinator, "_run_leader_unwind", side_effect=gated_run_leader):
+        leader_thread = threading.Thread(target=run_leader)
+        joiner_thread = threading.Thread(target=run_joiner)
+        leader_thread.start()
+        assert leader_ready.wait(timeout=5)
+        joiner_thread.start()
+        release_leader.set()
+        leader_thread.join(timeout=30)
+        joiner_thread.join(timeout=30)
+
+    assert not errors
+    assert len(progress_turns) >= 2
+    assert progress_turns == sorted(progress_turns)
+    assert min(progress_turns) <= 111
+    assert max(progress_turns) >= 112

--- a/packages/api/tests/test_gap_fill_coordinator.py
+++ b/packages/api/tests/test_gap_fill_coordinator.py
@@ -784,7 +784,6 @@ def test_joiner_on_progress_receives_incremental_events_during_inflight_gap_fill
 
     def joiner_on_progress(
         _persisted: PersistedFleetLedger,
-        _wire_before,
         materialize_turn: int,
     ) -> None:
         with progress_lock:

--- a/packages/api/tests/test_inference_scheduler_global_pause.py
+++ b/packages/api/tests/test_inference_scheduler_global_pause.py
@@ -5,7 +5,6 @@ from api.analytics.military_score_inference.actions import ActionCatalog
 from api.analytics.military_score_inference.analytic import build_inference_observation
 from api.analytics.military_score_inference.inference_scheduler import (
     InferenceRowScheduler,
-    TableStreamScopeAlreadyActive,
     reset_inference_row_scheduler_for_tests,
 )
 from api.analytics.military_score_inference.inference_stream_domain_events import (
@@ -148,7 +147,7 @@ def test_new_scope_invalidates_retained_pause_state(sample_turn):
     assert status["activeScope"]["turn"] == scope_b.turn_number
 
 
-def test_begin_scope_rejects_second_stream_for_same_scope(sample_turn):
+def test_begin_scope_preempts_stale_stream_for_same_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
     scheduler = InferenceRowScheduler(worker_count=0)
     scope = InferenceStreamScope(
@@ -160,13 +159,14 @@ def test_begin_scope_rejects_second_stream_for_same_scope(sample_turn):
     first_token = scheduler.begin_scope(scope)
     scheduler.enqueue_tier_ladder(session)
 
-    with pytest.raises(TableStreamScopeAlreadyActive):
-        scheduler.begin_scope(scope)
+    second_token = scheduler.begin_scope(scope)
 
-    assert scheduler.owns_table_stream(first_token)
-    assert not session.cancel_token.is_cancelled()
+    assert second_token != first_token
+    assert not scheduler.owns_table_stream(first_token)
+    assert scheduler.owns_table_stream(second_token)
+    assert session.cancel_token.is_cancelled()
     status = scheduler.global_pause_status(scope)
-    assert status["activeSessionCount"] == 1
+    assert status["activeSessionCount"] == 0
 
 
 def test_begin_scope_succeeds_after_end_inference_stream(sample_turn):

--- a/packages/api/tests/test_inference_stream_lifecycle_gaps.py
+++ b/packages/api/tests/test_inference_stream_lifecycle_gaps.py
@@ -42,7 +42,6 @@ from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.services.inference_row_persistence_service import InferenceRowPersistenceService
 from api.storage.memory_asset import MemoryAssetBackend
-from api.transport.inference_stream import TABLE_STREAM_ALREADY_ACTIVE_DETAIL
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
@@ -211,54 +210,32 @@ def test_multiplex_delivers_all_queued_completes_before_scope_deactivation(sampl
     assert complete_player_ids == {row.player_id for row in rows}
 
 
-def test_stream_conflict_does_not_preempt_first_connection_while_rows_compute(
+def test_stream_reconnect_preempts_first_connection_while_rows_compute(
     sample_turn,
     monkeypatch,
     memory_backend,
 ):
-    """Persist succeeds while a duplicate connect is rejected and the first stream runs."""
+    """Reconnect preempts the prior stream so a duplicate connect can proceed."""
     persistence = InferenceRowPersistenceService(memory_backend)
     scheduler = _install_workerless_scheduler(
         monkeypatch,
         on_row_complete=persistence.persist_row_complete,
     )
-    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
-    completed_player_id, in_flight_player_id = player_ids
-    turn_number = sample_turn.settings.turn
-
-    first_stream = iter_scores_table_inference_events(
-        sample_turn,
-        player_ids,
+    scope = InferenceStreamScope(
         game_id=628580,
         perspective=1,
-        persistence=persistence,
-        scheduler=scheduler,
+        turn_number=sample_turn.settings.turn,
     )
-    assert next(first_stream) == {"type": "globalPause", "paused": False}
+    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
+    completed_player_id = player_ids[0]
+    in_flight_player_id = player_ids[1]
+    turn_number = sample_turn.settings.turn
 
-    collected: list[dict[str, object]] = []
-    stream_error: list[BaseException] = []
-
-    def consume_first_stream() -> None:
-        try:
-            collected.extend(_collect_stream_events(first_stream))
-        except BaseException as exc:  # pragma: no cover - surfaced via stream_error
-            stream_error.append(exc)
-
-    thread = threading.Thread(target=consume_first_stream, daemon=True)
-    thread.start()
-    _wait_until(lambda: len(scheduler._runs) == len(player_ids))
-
-    completed_session = next(
-        run.session
-        for run in scheduler._runs.values()
-        if run.session.player_id == completed_player_id
-    )
-    in_flight_session = next(
-        run.session
-        for run in scheduler._runs.values()
-        if run.session.player_id == in_flight_player_id
-    )
+    first_token = scheduler.begin_scope(scope)
+    completed_session = _session_for_player(sample_turn, player_id=completed_player_id)
+    in_flight_session = _session_for_player(sample_turn, player_id=in_flight_player_id)
+    scheduler.enqueue_tier_ladder(completed_session, stream_token=first_token)
+    scheduler.enqueue_tier_ladder(in_flight_session, stream_token=first_token)
 
     scheduler._emit_row_complete(
         completed_session,
@@ -267,69 +244,21 @@ def test_stream_conflict_does_not_preempt_first_connection_while_rows_compute(
             diagnostics=_diagnostics(turn=turn_number, player_id=completed_player_id),
         ),
     )
-    in_flight_session.event_queue.put(
-        TierProgress(policy_step_id="early_game_bands", combo_count=2142, held_count=0)
-    )
 
     replacement = iter_scores_table_inference_events(
         sample_turn,
-        player_ids,
+        (),
         game_id=628580,
         perspective=1,
         persistence=persistence,
         scheduler=scheduler,
     )
-    assert next(replacement) == {
-        "type": "error",
-        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-    }
+    assert next(replacement) == {"type": "globalPause", "paused": False}
     replacement.close()
 
-    controller = controller_for_scope(
-        InferenceStreamScope(
-            game_id=628580,
-            perspective=1,
-            turn_number=turn_number,
-        )
-    )
-    assert controller is not None
-    controller.end_stream(scheduler)
-    thread.join(timeout=2.0)
-    assert not stream_error
-
-    completed_events = [
-        event
-        for event in collected
-        if event.get("type") == "complete" and event.get("playerId") == completed_player_id
-    ]
-    in_flight_completes = [
-        event
-        for event in collected
-        if event.get("type") == "complete" and event.get("playerId") == in_flight_player_id
-    ]
-    in_flight_progress = [
-        event
-        for event in collected
-        if event.get("type") == "progress" and event.get("playerId") == in_flight_player_id
-    ]
-
     assert persistence.get_row(628580, 1, turn_number, completed_player_id) is not None
-    assert len(in_flight_completes) == 0
-    assert len(in_flight_progress) >= 0
-
-    replay_stream = iter_scores_table_inference_events(
-        sample_turn,
-        (completed_player_id,),
-        game_id=628580,
-        perspective=1,
-        persistence=persistence,
-        scheduler=scheduler,
-    )
-    replay_events = [next(replay_stream), next(replay_stream)]
-    replay_stream.close()
-    assert replay_events[1]["type"] == "complete"
-    assert replay_events[1]["summary"] == "persisted on backend"
-    assert len(completed_events) in {0, 1}
+    assert in_flight_session.cancel_token.is_cancelled()
+    assert not scheduler.owns_table_stream(first_token)
 
 
 def test_progress_without_terminal_complete_when_scope_deactivates_mid_row(sample_turn):

--- a/packages/api/tests/test_inference_table_stream.py
+++ b/packages/api/tests/test_inference_table_stream.py
@@ -26,7 +26,6 @@ from api.analytics.military_score_inference.models import InferenceResult
 from api.analytics.military_score_inference.row_complete_factory import row_complete_with_summary
 from api.analytics.military_score_inference.solver import STATUS_EXACT
 from api.transport.inference_stream import (
-    TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
     stream_inference_ndjson,
 )
 
@@ -65,7 +64,7 @@ def test_table_stream_emits_global_pause_snapshot_on_connect(sample_turn):
     stream.close()
 
 
-def test_table_stream_reconnect_returns_conflict_while_active(sample_turn):
+def test_table_stream_reconnect_preempts_active_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
     active_stream = iter_scores_table_inference_events(
         sample_turn,
@@ -81,10 +80,7 @@ def test_table_stream_reconnect_returns_conflict_while_active(sample_turn):
         game_id=628580,
         perspective=1,
     )
-    assert next(replacement) == {
-        "type": "error",
-        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-    }
+    assert next(replacement) == {"type": "globalPause", "paused": False}
 
     active_stream.close()
     replacement.close()
@@ -111,11 +107,8 @@ def test_table_stream_reconnect_via_ndjson_transport(sample_turn):
     lines = list(stream_inference_ndjson(replacement_loader))
     active_stream.close()
 
-    assert len(lines) == 1
-    assert json.loads(lines[0]) == {
-        "type": "error",
-        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-    }
+    assert len(lines) >= 1
+    assert json.loads(lines[0]) == {"type": "globalPause", "paused": False}
 
 
 def test_schedule_inference_row_ignores_stale_stream_token_after_scope_end(sample_turn):
@@ -156,39 +149,34 @@ def test_schedule_inference_row_ignores_stale_stream_token_after_scope_end(sampl
     assert active_row.session.cancel_token.is_cancelled()
 
 
-def test_table_stream_conflict_does_not_cancel_in_flight_rows_for_same_scope(sample_turn):
+def test_table_stream_reconnect_preempts_in_flight_rows_for_same_scope(sample_turn):
     reset_inference_row_scheduler_for_tests()
-    scheduler = get_inference_row_scheduler()
-    player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
-
-    first_stream = iter_scores_table_inference_events(
-        sample_turn,
-        player_ids,
+    scheduler = InferenceRowScheduler(worker_count=0)
+    scope = InferenceStreamScope(
         game_id=628580,
         perspective=1,
+        turn_number=sample_turn.settings.turn,
     )
-    assert next(first_stream) == {"type": "globalPause", "paused": False}
-
-    in_flight_run_ids = set(scheduler._runs)
+    stream_token = scheduler.begin_scope(scope)
+    sessions = [
+        _session_for_player(sample_turn, player_id=row.ownerid) for row in sample_turn.scores[:2]
+    ]
+    for session in sessions:
+        scheduler.enqueue_tier_ladder(session, stream_token=stream_token)
 
     replacement = iter_scores_table_inference_events(
         sample_turn,
-        player_ids,
+        (),
         game_id=628580,
         perspective=1,
+        scheduler=scheduler,
     )
-    assert next(replacement) == {
-        "type": "error",
-        "detail": TABLE_STREAM_ALREADY_ACTIVE_DETAIL,
-    }
-
-    for run_id in in_flight_run_ids:
-        run = scheduler._runs.get(run_id)
-        assert run is not None
-        assert not run.session.cancel_token.is_cancelled()
-
-    first_stream.close()
+    assert next(replacement) == {"type": "globalPause", "paused": False}
     replacement.close()
+
+    assert not scheduler.owns_table_stream(stream_token)
+    for session in sessions:
+        assert session.cancel_token.is_cancelled()
 
 
 def test_tag_inference_stream_event_adds_player_id_except_global_pause():

--- a/packages/bff/bff/analytics/scores.py
+++ b/packages/bff/bff/analytics/scores.py
@@ -114,22 +114,26 @@ def table_from_core(core_data: dict, *, include_build_inference: bool = False) -
         columns.append(INFERENCE_COLUMN)
 
     rows: list[list[str]] = []
+    row_player_ids: list[int | None] = []
     inference_by_row: list[dict[str, object]] = []
     for row in core_data.get("rows", []):
         if not isinstance(row, dict):
             continue
+        player_id = row.get("playerId")
         table_row = [
             str(row.get("racePlayer", "")),
             *[_format_score_cell(row.get(field)) for field in TABLE_FIELDS],
         ]
         if include_build_inference:
-            inference_by_row.append(_pending_inference_stub(row.get("playerId")))
+            inference_by_row.append(_pending_inference_stub(player_id))
         rows.append(table_row)
+        row_player_ids.append(player_id if isinstance(player_id, int) else None)
 
     payload: dict[str, object] = {
         "analyticId": ANALYTIC_ID,
         "columns": columns,
         "rows": rows,
+        "rowPlayerIds": row_player_ids,
     }
     if include_build_inference:
         payload["includeBuildInference"] = True

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -109,6 +109,8 @@ def test_scores_table_returns_scoreboard_columns_and_deltas():
         "2509092 (-53869)",
         "217 (+54)",
     ]
+    assert data["rowPlayerIds"][0] == INFERENCE_PLAYER_ID
+    assert len(data["rowPlayerIds"]) == len(data["rows"])
 
 
 def test_scores_table_with_build_inference_adds_column_and_player_stubs():

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.stream.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.stream.test.tsx
@@ -18,12 +18,13 @@ vi.mock('../../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/bff')>()
   return {
     ...actual,
+    fetchAnalyticTable: vi.fn(),
     fetchFleetComponentCatalog: vi.fn(),
     fetchFleetTableStream: vi.fn(),
   }
 })
 
-import { fetchFleetComponentCatalog } from '../../api/bff'
+import { fetchAnalyticTable, fetchFleetComponentCatalog } from '../../api/bff'
 
 const scope: AnalyticShellScope = {
   gameId: '628580',
@@ -93,6 +94,12 @@ describe('FleetAnalyticTableTile stream integration', () => {
       engines: {},
       beams: {},
       torpedoes: {},
+    })
+    vi.mocked(fetchAnalyticTable).mockResolvedValue({
+      analyticId: 'scores',
+      columns: ['Race (player)'],
+      rows: [],
+      rowPlayerIds: [],
     })
   })
 

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.test.tsx
@@ -12,12 +12,13 @@ vi.mock('../../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../api/bff')>()
   return {
     ...actual,
+    fetchAnalyticTable: vi.fn(),
     fetchFleetComponentCatalog: vi.fn(),
     fetchFleetTableStream: vi.fn(),
   }
 })
 
-import { fetchFleetComponentCatalog, fetchFleetTableStream } from '../../api/bff'
+import { fetchAnalyticTable, fetchFleetComponentCatalog, fetchFleetTableStream } from '../../api/bff'
 
 const sampleScope: AnalyticShellScope = {
   gameId: '628580',
@@ -48,6 +49,12 @@ describe('FleetAnalyticTableTile', () => {
       engines: {},
       beams: {},
       torpedoes: {},
+    })
+    vi.mocked(fetchAnalyticTable).mockResolvedValue({
+      analyticId: 'scores',
+      columns: ['Race (player)'],
+      rows: [],
+      rowPlayerIds: [],
     })
     vi.mocked(fetchFleetTableStream).mockImplementation(async () => {})
   })

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTableTile.tsx
@@ -1,5 +1,6 @@
-import type { AnalyticShellScope } from '../../api/bff'
 import { FleetTableView } from './FleetTableView'
+import type { AnalyticShellScope } from '../../api/bff'
+import { useTurnRacePlayerLabels } from '../../lib/turnRacePlayerLabels'
 import { useFleetComponentCatalogQuery } from './useFleetComponentCatalogQuery'
 import { useFleetTableStream } from './useFleetTableStream'
 
@@ -15,6 +16,7 @@ export function FleetAnalyticTableTile({
   const streamEnabled = fetchEnabled && analyticScope != null
   const componentCatalog = useFleetComponentCatalogQuery(analyticScope, streamEnabled)
   const { streamPlayersById } = useFleetTableStream(analyticScope, streamEnabled)
+  const racePlayerLabels = useTurnRacePlayerLabels(analyticScope, streamEnabled)
 
   if (analyticScope == null) {
     return (
@@ -25,6 +27,10 @@ export function FleetAnalyticTableTile({
   }
 
   return (
-    <FleetTableView componentCatalog={componentCatalog} streamPlayersById={streamPlayersById} />
+    <FleetTableView
+      componentCatalog={componentCatalog}
+      streamPlayersById={streamPlayersById}
+      racePlayerLabels={racePlayerLabels}
+    />
   )
 }

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ComponentProps } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FleetAnalyticTile } from './FleetAnalyticTile'
@@ -7,7 +8,24 @@ import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
 
+vi.mock('../../api/bff', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/bff')>()
+  return {
+    ...actual,
+    fetchAnalyticTable: vi.fn(),
+  }
+})
+
+import { fetchAnalyticTable } from '../../api/bff'
+
+function createWrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
 function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <FleetAnalyticTile
       name="Fleet"
@@ -16,7 +34,8 @@ function renderTile(overrides: Partial<ComponentProps<typeof FleetAnalyticTile>>
       depressed
       onToggle={() => {}}
       {...overrides}
-    />
+    />,
+    { wrapper: createWrapper(client) }
   )
 }
 
@@ -32,6 +51,12 @@ describe('FleetAnalyticTile', () => {
       storageAvailablePerspectives: null,
     })
     seedShellViewpoint('Alice')
+    vi.mocked(fetchAnalyticTable).mockResolvedValue({
+      analyticId: 'scores',
+      columns: ['Race (player)'],
+      rows: [],
+      rowPlayerIds: [],
+    })
   })
 
   it('hides player checkboxes until expanded', () => {

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
+import { deriveAnalyticScope } from '../../shell/shellContext'
+import { useTurnRacePlayerLabels } from '../../lib/turnRacePlayerLabels'
 import { cn } from '../../lib/utils'
+import { useSessionStore } from '../../stores/session'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
+import { useShellStore } from '../../stores/shell'
+import { fleetPlayerDisplayLabel } from './fleetPlayerDisplayLabel'
 import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
 import { tileClassName } from '../tileChrome'
 
@@ -21,8 +26,37 @@ export function FleetAnalyticTile({
   onToggle,
 }: FleetAnalyticTileProps) {
   const [expanded, setExpanded] = useState(false)
+  const selectedGameId = useShellStore((s) => s.selectedGameId)
+  const gameInfoContext = useShellStore((s) => s.gameInfoContext)
+  const selectedTurn = useShellStore((s) => s.selectedTurn)
+  const perspectiveOverrideName = useShellStore((s) => s.perspectiveOverrideName)
+  const storageOnlyLoad = useShellStore((s) => s.storageOnlyLoad)
+  const storageAvailablePerspectives = useShellStore((s) => s.storageAvailablePerspectives)
+  const loginName = useSessionStore((s) => s.name)
   const { players: orderedPlayers, isPlayerVisible } = useOrderedFleetPlayers()
   const setFleetPlayerVisible = useFleetPlayerVisibilityStore((state) => state.setFleetPlayerVisible)
+  const analyticScope = useMemo(
+    () =>
+      deriveAnalyticScope({
+        selectedGameId,
+        gameInfoContext,
+        selectedTurn,
+        perspectiveOverrideName,
+        loginName,
+        storageOnlyLoad,
+        storageAvailablePerspectives,
+      }),
+    [
+      selectedGameId,
+      gameInfoContext,
+      selectedTurn,
+      perspectiveOverrideName,
+      loginName,
+      storageOnlyLoad,
+      storageAvailablePerspectives,
+    ]
+  )
+  const racePlayerLabels = useTurnRacePlayerLabels(analyticScope, supportsMode && enabled)
   const canExpand = supportsMode && enabled && orderedPlayers.length > 0
 
   useEffect(() => {
@@ -86,7 +120,9 @@ export function FleetAnalyticTile({
           className="flex min-w-0 flex-col gap-1 border-t border-[#52575d]/70 px-2 pb-2 pt-1.5 text-xs text-slate-300"
           onClick={(event) => event.stopPropagation()}
         >
-          {orderedPlayers.map((player) => (
+          {orderedPlayers.map((player) => {
+            const playerLabel = fleetPlayerDisplayLabel(player, racePlayerLabels, undefined)
+            return (
             <label key={player.playerId} className="flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
@@ -96,9 +132,10 @@ export function FleetAnalyticTile({
                 }
                 className="h-3.5 w-3.5 shrink-0 rounded border-[#52575d] bg-slate-700 accent-slate-400"
               />
-              <span className="min-w-0 truncate">{player.name}</span>
+              <span className="min-w-0 truncate">{playerLabel}</span>
             </label>
-          ))}
+            )
+          })}
         </div>
       ) : null}
     </div>

--- a/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.test.tsx
@@ -2,12 +2,29 @@ import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { FleetPlayerTableTile } from './FleetPlayerTableTile'
 import type { FleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
+import type { FleetTableRecord } from './fleetTableWireSchema'
+
+const activeRecord: FleetTableRecord = {
+  recordId: 'rec-active',
+  disposition: 'active',
+  qualifiers: {},
+  fields: {
+    shipId: { kind: 'bounded', operator: 'lte', value: 318 },
+    hull: { kind: 'known', value: 13 },
+    engine: { kind: 'known', value: 9 },
+    beams: { kind: 'options', values: [3, 5] },
+    launchers: { kind: 'unknown' },
+    builtTurn: { kind: 'known', value: 4 },
+    location: { kind: 'unknown' },
+  },
+  buildOptionSets: [],
+}
 
 const provenanceStreamSlice: FleetPlayerStreamSlice = {
   discrepancyOverlay: 'inherit',
   isComplete: false,
   isFinal: false,
-  isPending: false,
+  isPending: true,
   summary: 'Collecting turn evidence',
   error: null,
 }
@@ -24,5 +41,28 @@ describe('FleetPlayerTableTile provenance progress', () => {
 
     const tile = screen.getByRole('region', { name: 'Alice fleet table' })
     expect(within(tile).getByRole('status')).toHaveTextContent('Collecting turn evidence')
+  })
+
+  it('shows spinner alongside partial rows while materializing', () => {
+    render(
+      <FleetPlayerTableTile
+        playerName="Alice"
+        records={[activeRecord]}
+        streamSlice={{
+          records: [activeRecord],
+          discrepancyOverlay: 'inherit',
+          isComplete: false,
+          isFinal: false,
+          isPending: true,
+          summary: 'Refining fleet records',
+          error: null,
+        }}
+      />
+    )
+
+    const tile = screen.getByRole('region', { name: 'Alice fleet table' })
+    expect(within(tile).getByText('<= 318')).toBeInTheDocument()
+    expect(within(tile).getByRole('status')).toHaveTextContent('Refining fleet records')
+    expect(screen.queryByText('Waiting for fleet records.')).not.toBeInTheDocument()
   })
 })

--- a/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetPlayerTableTile.tsx
@@ -30,11 +30,7 @@ import {
 import { FleetRecordHullCell } from './FleetRecordHullCell'
 import type { FleetCountDiscrepancy, FleetTableRecord } from './fleetTableWireSchema'
 import type { FleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
-import {
-  fleetTileProgressSummary,
-  isFleetTileActivelyMaterializing,
-  isFleetTileMaterializing,
-} from './fleetTileStatus'
+import { fleetTileProgressSummary, isFleetTileMaterializing } from './fleetTileStatus'
 
 type FleetPlayerTableTileProps = {
   playerName: string
@@ -89,13 +85,10 @@ function FleetTileProgressIndicator({
   }
 
   const summary = fleetTileProgressSummary(streamSlice)
-  const activelyMaterializing = isFleetTileActivelyMaterializing(streamSlice)
 
   return (
     <p role="status" className="mt-1 inline-flex items-center gap-1.5 text-xs text-slate-300">
-      {activelyMaterializing ? (
-        <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-emerald-400" aria-hidden />
-      ) : null}
+      <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-emerald-400" aria-hidden />
       <span>{summary}</span>
     </p>
   )

--- a/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.test.tsx
@@ -6,6 +6,7 @@ import { pendingFleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
 import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useShellStore } from '../../stores/shell'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../stellar-cartography/layers'
 import type { FleetComponentCatalog, FleetTableRecord } from './fleetTableWireSchema'
 
 const testComponentCatalog: FleetComponentCatalog = {
@@ -181,6 +182,7 @@ describe('FleetTableView', () => {
       <FleetTableView
         componentCatalog={testComponentCatalog}
         streamPlayersById={streamPlayersById}
+        racePlayerLabels={new Map()}
       />
     )
 
@@ -188,6 +190,77 @@ describe('FleetTableView', () => {
     expect(tiles).toHaveLength(2)
     expect(within(tiles[0]).getByRole('heading', { level: 3 })).toHaveTextContent('Bob')
     expect(within(tiles[1]).getByRole('heading', { level: 3 })).toHaveTextContent('Alice')
+  })
+
+  it('prefers turn-scoped scoreboard labels over shell game-info names', () => {
+    useShellStore.setState({
+      selectedGameId: '628580',
+      gameInfoContext: {
+        turn: 10,
+        perspectives: [
+          { ordinal: 1, playerId: 8, name: 'dead', raceName: 'The Solar Federation' },
+        ],
+        isGameFinished: true,
+        sectorDisplayName: 'Test Sector',
+        stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+      },
+      selectedTurn: 8,
+      perspectiveOverrideName: 'dead',
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
+    useFleetPlayerVisibilityStore.getState().setFleetPlayerVisible(8, true)
+
+    const streamPlayersById = new Map([[8, pendingFleetPlayerStreamSlice()]])
+    const racePlayerLabels = new Map([[8, 'The Solar Federation (dougp314)']])
+
+    render(
+      <FleetTableView
+        componentCatalog={testComponentCatalog}
+        streamPlayersById={streamPlayersById}
+        racePlayerLabels={racePlayerLabels}
+      />
+    )
+
+    expect(
+      screen.getByRole('region', { name: 'The Solar Federation (dougp314) fleet table' })
+    ).toBeInTheDocument()
+  })
+
+  it('shows race and player name in tile headings when race is known', () => {
+    useShellStore.setState({
+      selectedGameId: '628580',
+      gameInfoContext: {
+        turn: 10,
+        perspectives: [
+          { ordinal: 1, playerId: 8, name: 'Alice', raceName: 'The Feds' },
+          { ordinal: 2, playerId: 9, name: 'Bob', raceName: 'The Evil Empire' },
+        ],
+        isGameFinished: true,
+        sectorDisplayName: 'Test Sector',
+        stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+      },
+      selectedTurn: 5,
+      perspectiveOverrideName: 'Bob',
+      storageOnlyLoad: false,
+      storageAvailablePerspectives: null,
+    })
+
+    const streamPlayersById = new Map([
+      [8, pendingFleetPlayerStreamSlice()],
+      [9, pendingFleetPlayerStreamSlice()],
+    ])
+
+    render(
+      <FleetTableView
+        componentCatalog={testComponentCatalog}
+        streamPlayersById={streamPlayersById}
+        racePlayerLabels={new Map()}
+      />
+    )
+
+    expect(screen.getByRole('region', { name: 'The Evil Empire (Bob) fleet table' })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: 'The Feds (Alice) fleet table' })).toBeInTheDocument()
   })
 
   it('hides tiles for players turned off in fleet visibility', () => {
@@ -203,6 +276,7 @@ describe('FleetTableView', () => {
       <FleetTableView
         componentCatalog={testComponentCatalog}
         streamPlayersById={streamPlayersById}
+        racePlayerLabels={new Map()}
       />
     )
 

--- a/packages/frontend/src/analytics/fleet/FleetTableView.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetTableView.tsx
@@ -1,6 +1,7 @@
 import { FleetPlayerTableTile } from './FleetPlayerTableTile'
 import type { FleetComponentCatalog } from './fleetComponentCatalog'
 import { EMPTY_FLEET_COMPONENT_CATALOG } from './fleetComponentCatalog'
+import { fleetPlayerDisplayLabel } from './fleetPlayerDisplayLabel'
 import type { FleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
 import { fleetPlayerFromStreamSlice } from './fleetTablePlayerStreamState'
 import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
@@ -8,11 +9,13 @@ import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
 type FleetTableViewProps = {
   componentCatalog?: FleetComponentCatalog
   streamPlayersById: Map<number, FleetPlayerStreamSlice>
+  racePlayerLabels: Map<number, string>
 }
 
 export function FleetTableView({
   componentCatalog = EMPTY_FLEET_COMPONENT_CATALOG,
   streamPlayersById,
+  racePlayerLabels,
 }: FleetTableViewProps) {
   const { players: visiblePlayers } = useOrderedFleetPlayers({ visibleOnly: true })
 
@@ -29,10 +32,11 @@ export function FleetTableView({
       {visiblePlayers.map((player) => {
         const streamSlice = streamPlayersById.get(player.playerId)
         const merged = fleetPlayerFromStreamSlice(streamSlice, player.name)
+        const playerLabel = fleetPlayerDisplayLabel(player, racePlayerLabels, streamSlice)
         return (
           <FleetPlayerTableTile
             key={player.playerId}
-            playerName={merged.playerName}
+            playerName={playerLabel}
             records={merged.records}
             discrepancy={merged.discrepancy}
             componentCatalog={componentCatalog}

--- a/packages/frontend/src/analytics/fleet/fleetPlayerDisplayLabel.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerDisplayLabel.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { fleetPlayerDisplayLabel } from './fleetPlayerDisplayLabel'
+import { pendingFleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
+
+describe('fleetPlayerDisplayLabel', () => {
+  const player = { playerId: 8, name: 'dead', raceName: 'The Solar Federation' }
+
+  it('prefers scoreboard race-player labels for the viewed turn', () => {
+    const labels = new Map([[8, 'The Solar Federation (dougp314)']])
+    expect(fleetPlayerDisplayLabel(player, labels, undefined)).toBe(
+      'The Solar Federation (dougp314)'
+    )
+  })
+
+  it('falls back to stream player name with shell race when scores labels are absent', () => {
+    const streamSlice = {
+      ...pendingFleetPlayerStreamSlice(),
+      playerName: 'dougp314',
+    }
+    expect(fleetPlayerDisplayLabel(player, new Map(), streamSlice)).toBe(
+      'The Solar Federation (dougp314)'
+    )
+  })
+
+  it('falls back to shell player name when stream and scores labels are absent', () => {
+    expect(fleetPlayerDisplayLabel(player, new Map(), undefined)).toBe(
+      'The Solar Federation (dead)'
+    )
+  })
+})

--- a/packages/frontend/src/analytics/fleet/fleetPlayerDisplayLabel.ts
+++ b/packages/frontend/src/analytics/fleet/fleetPlayerDisplayLabel.ts
@@ -1,0 +1,17 @@
+import { formatViewpointRowLabel } from '../../lib/displayFormatters'
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
+import type { FleetPlayerStreamSlice } from './fleetTablePlayerStreamState'
+import { fleetPlayerFromStreamSlice } from './fleetTablePlayerStreamState'
+
+export function fleetPlayerDisplayLabel(
+  player: Pick<PerspectiveRow, 'playerId' | 'name' | 'raceName'>,
+  racePlayerLabels: Map<number, string>,
+  streamSlice: FleetPlayerStreamSlice | undefined
+): string {
+  const fromScores = racePlayerLabels.get(player.playerId)
+  if (fromScores != null) {
+    return fromScores
+  }
+  const merged = fleetPlayerFromStreamSlice(streamSlice, player.name)
+  return formatViewpointRowLabel('player_and_race_names', merged.playerName, player.raceName)
+}

--- a/packages/frontend/src/analytics/fleet/fleetTablePlayerStreamState.test.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTablePlayerStreamState.test.ts
@@ -125,7 +125,7 @@ describe('reduceFleetPlayerStreamState', () => {
     })
 
     expect(next.summary).toBe('Collecting turn evidence')
-    expect(next.isPending).toBe(false)
+    expect(next.isPending).toBe(true)
   })
 
   it('marks failure from error events', () => {
@@ -248,22 +248,49 @@ describe('fleetPlayerStreamSliceFromState', () => {
       discrepancy: ledgerPlayer.discrepancy,
       isComplete: false,
       isFinal: false,
-      isPending: false,
+      isPending: true,
       summary: 'Refining fleet records',
       error: null,
     })
   })
 
-  it('publishes clear overlay when ledger has no discrepancy', () => {
+  it('publishes provenance-only slice before records arrive', () => {
     const state = reduceFleetPlayerStreamState(initialFleetPlayerStreamState(), {
-      type: 'ledger_updated',
+      type: 'provenance',
       playerId: 8,
-      ledger: { ...ledgerPlayer, discrepancy: undefined },
+      turnEvidenceAtN: false,
+      priorLedgerAtNMinus1: false,
+      isFinal: false,
     })
 
-    const slice = fleetPlayerStreamSliceFromState(state)
+    expect(fleetPlayerStreamSliceFromState(state)).toEqual({
+      discrepancyOverlay: 'inherit',
+      isComplete: false,
+      isFinal: false,
+      isPending: true,
+      summary: 'Collecting turn evidence',
+      error: null,
+    })
+  })
 
-    expect(slice?.discrepancyOverlay).toBe('clear')
-    expect(slice).not.toHaveProperty('discrepancy')
+  it('keeps records visible while pending between gap legs', () => {
+    const withRecords = reduceFleetPlayerStreamState(initialFleetPlayerStreamState(), {
+      type: 'ledger_updated',
+      playerId: 8,
+      ledger: ledgerPlayer,
+    })
+    const betweenLegs = reduceFleetPlayerStreamState(withRecords, {
+      type: 'provenance',
+      playerId: 8,
+      turnEvidenceAtN: true,
+      priorLedgerAtNMinus1: true,
+      isFinal: false,
+    })
+
+    const slice = fleetPlayerStreamSliceFromState(betweenLegs)
+
+    expect(slice?.records).toEqual([refinedRecord])
+    expect(slice?.isPending).toBe(true)
+    expect(slice?.summary).toBe('Refining fleet records')
   })
 })

--- a/packages/frontend/src/analytics/fleet/fleetTablePlayerStreamState.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTablePlayerStreamState.ts
@@ -92,7 +92,7 @@ export function reduceFleetPlayerStreamState(
       records: [...ledger.records],
       discrepancyOverlay: hasDiscrepancy ? 'set' : 'clear',
       discrepancy: ledger.discrepancy,
-      isPending: false,
+      isPending: !state.isComplete,
       summary: state.isComplete ? state.summary : 'Refining fleet records',
       error: null,
     }
@@ -103,7 +103,7 @@ export function reduceFleetPlayerStreamState(
     return {
       ...state,
       records: upsertRecord(baseRecords, event.record),
-      isPending: false,
+      isPending: !state.isComplete,
       error: null,
     }
   }
@@ -112,7 +112,7 @@ export function reduceFleetPlayerStreamState(
     return {
       ...state,
       isFinal: event.isFinal,
-      isPending: false,
+      isPending: !event.isFinal && !state.isComplete,
       summary: state.isComplete ? state.summary : provenanceSummary(event),
     }
   }
@@ -144,13 +144,17 @@ export function reduceFleetPlayerStreamState(
 export function fleetPlayerStreamSliceFromState(
   state: FleetPlayerStreamState
 ): FleetPlayerStreamSlice | null {
+  const hasProgressMetadata =
+    state.summary !== FLEET_MATERIALIZATION_PENDING_SUMMARY || state.isFinal
+
   if (
     !state.isPending &&
     state.records == null &&
     state.playerName == null &&
     state.discrepancyOverlay === 'inherit' &&
     state.error == null &&
-    !state.isComplete
+    !state.isComplete &&
+    !hasProgressMetadata
   ) {
     return null
   }

--- a/packages/frontend/src/analytics/fleet/fleetTileStatus.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTileStatus.ts
@@ -25,9 +25,3 @@ export function isFleetTileMaterializing(streamSlice: FleetPlayerStreamSlice | u
   }
   return true
 }
-
-export function isFleetTileActivelyMaterializing(
-  streamSlice: FleetPlayerStreamSlice | undefined
-): boolean {
-  return isFleetTileMaterializing(streamSlice)
-}

--- a/packages/frontend/src/analytics/fleet/fleetTileStatus.ts
+++ b/packages/frontend/src/analytics/fleet/fleetTileStatus.ts
@@ -29,8 +29,5 @@ export function isFleetTileMaterializing(streamSlice: FleetPlayerStreamSlice | u
 export function isFleetTileActivelyMaterializing(
   streamSlice: FleetPlayerStreamSlice | undefined
 ): boolean {
-  if (!isFleetTileMaterializing(streamSlice)) {
-    return false
-  }
-  return (streamSlice?.records?.length ?? 0) === 0
+  return isFleetTileMaterializing(streamSlice)
 }

--- a/packages/frontend/src/analytics/fleet/useFleetTableStream.test.tsx
+++ b/packages/frontend/src/analytics/fleet/useFleetTableStream.test.tsx
@@ -69,6 +69,69 @@ describe('useFleetTableStream', () => {
     })
   })
 
+  it('shows progressive rows during leg-by-leg gap-fill stream events', async () => {
+    const firstLegRecord: FleetTableRecord = {
+      ...refinedRecord,
+      recordId: 'rec-leg-1',
+      fields: {
+        ...refinedRecord.fields,
+        shipId: { kind: 'known', value: 1 },
+      },
+    }
+    const secondLegRecord: FleetTableRecord = {
+      ...refinedRecord,
+      recordId: 'rec-leg-2',
+      fields: {
+        ...refinedRecord.fields,
+        shipId: { kind: 'known', value: 2 },
+      },
+    }
+
+    vi.spyOn(bff, 'fetchFleetTableStream').mockImplementation(
+      async (_scope, _playerIds, handlers) => {
+        handlers.onEvent({
+          type: 'ledger_updated',
+          playerId: 8,
+          ledger: {
+            playerId: 8,
+            playerName: 'Alice',
+            records: [firstLegRecord],
+          },
+        })
+        handlers.onEvent({
+          type: 'provenance',
+          playerId: 8,
+          turnEvidenceAtN: true,
+          priorLedgerAtNMinus1: true,
+          isFinal: false,
+        })
+        handlers.onEvent({
+          type: 'ledger_updated',
+          playerId: 8,
+          ledger: {
+            playerId: 8,
+            playerName: 'Alice',
+            records: [firstLegRecord, secondLegRecord],
+          },
+        })
+        handlers.onEvent({
+          type: 'complete',
+          playerId: 8,
+          isFinal: true,
+          summary: 'Player 8 ok',
+        })
+      }
+    )
+
+    const { result } = renderHook(() => useFleetTableStream(scope, true))
+
+    await waitFor(() => {
+      const slice = result.current.streamPlayersById.get(8)
+      expect(slice?.records).toEqual([firstLegRecord, secondLegRecord])
+      expect(slice?.isComplete).toBe(true)
+    })
+  })
+
   it('updates visible players independently from stream events', async () => {
     vi.spyOn(bff, 'fetchFleetTableStream').mockImplementation(
       async (_scope, _playerIds, handlers) => {

--- a/packages/frontend/src/analytics/fleet/useFleetTableStream.test.tsx
+++ b/packages/frontend/src/analytics/fleet/useFleetTableStream.test.tsx
@@ -87,6 +87,8 @@ describe('useFleetTableStream', () => {
       },
     }
 
+    let emitRemainingEvents: (() => void) | undefined
+
     vi.spyOn(bff, 'fetchFleetTableStream').mockImplementation(
       async (_scope, _playerIds, handlers) => {
         handlers.onEvent({
@@ -98,32 +100,49 @@ describe('useFleetTableStream', () => {
             records: [firstLegRecord],
           },
         })
-        handlers.onEvent({
-          type: 'provenance',
-          playerId: 8,
-          turnEvidenceAtN: true,
-          priorLedgerAtNMinus1: true,
-          isFinal: false,
-        })
-        handlers.onEvent({
-          type: 'ledger_updated',
-          playerId: 8,
-          ledger: {
-            playerId: 8,
-            playerName: 'Alice',
-            records: [firstLegRecord, secondLegRecord],
-          },
-        })
-        handlers.onEvent({
-          type: 'complete',
-          playerId: 8,
-          isFinal: true,
-          summary: 'Player 8 ok',
+
+        await new Promise<void>((resolve) => {
+          emitRemainingEvents = () => {
+            handlers.onEvent({
+              type: 'provenance',
+              playerId: 8,
+              turnEvidenceAtN: true,
+              priorLedgerAtNMinus1: true,
+              isFinal: false,
+            })
+            handlers.onEvent({
+              type: 'ledger_updated',
+              playerId: 8,
+              ledger: {
+                playerId: 8,
+                playerName: 'Alice',
+                records: [firstLegRecord, secondLegRecord],
+              },
+            })
+            handlers.onEvent({
+              type: 'complete',
+              playerId: 8,
+              isFinal: true,
+              summary: 'Player 8 ok',
+            })
+            resolve()
+          }
         })
       }
     )
 
     const { result } = renderHook(() => useFleetTableStream(scope, true))
+
+    await waitFor(() => {
+      const slice = result.current.streamPlayersById.get(8)
+      expect(slice?.records).toEqual([firstLegRecord])
+      expect(slice?.isComplete).toBe(false)
+      expect(slice?.isPending).toBe(true)
+    })
+
+    await act(async () => {
+      emitRemainingEvents!()
+    })
 
     await waitFor(() => {
       const slice = result.current.streamPlayersById.get(8)

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -226,6 +226,8 @@ export type TableDataResponse = {
   analyticId: string
   columns: string[]
   rows: string[][]
+  /** Parallel to `rows`; host player id for each scoreboard row when known. */
+  rowPlayerIds?: Array<number | null>
   includeBuildInference?: boolean
   inferenceByRow?: Array<ScoresInferenceRowStub | ScoresInferenceRowDetail>
 }

--- a/packages/frontend/src/lib/turnRacePlayerLabels.test.ts
+++ b/packages/frontend/src/lib/turnRacePlayerLabels.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import type { TableDataResponse } from '../api/bff'
+import { turnRacePlayerLabelsFromTable } from './turnRacePlayerLabels'
+
+describe('turnRacePlayerLabelsFromTable', () => {
+  it('builds a player-id map from scoreboard rows', () => {
+    const data: TableDataResponse = {
+      analyticId: 'scores',
+      columns: ['Race (player)', 'Military'],
+      rowPlayerIds: [8, 9],
+      rows: [
+        ['The Solar Federation (dougp314)', '100'],
+        ['The Evil Empire (alice)', '90'],
+      ],
+    }
+
+    expect(turnRacePlayerLabelsFromTable(data)).toEqual(
+      new Map([
+        [8, 'The Solar Federation (dougp314)'],
+        [9, 'The Evil Empire (alice)'],
+      ])
+    )
+  })
+
+  it('returns an empty map for non-scores payloads', () => {
+    expect(
+      turnRacePlayerLabelsFromTable({
+        analyticId: 'fleet',
+        columns: [],
+        rows: [],
+      })
+    ).toEqual(new Map())
+  })
+})

--- a/packages/frontend/src/lib/turnRacePlayerLabels.ts
+++ b/packages/frontend/src/lib/turnRacePlayerLabels.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchAnalyticTable, type AnalyticShellScope, type TableDataResponse } from '../api/bff'
+import { scoresTableQueryKey } from '../analytics/scores/api'
+
+const SCORES_TABLE_LABELS_PARAMS = { includeBuildInference: false } as const
+
+export function turnRacePlayerLabelsFromTable(
+  data: TableDataResponse | undefined
+): Map<number, string> {
+  const labels = new Map<number, string>()
+  if (data?.analyticId !== 'scores') {
+    return labels
+  }
+  const playerIds = data.rowPlayerIds
+  if (!Array.isArray(playerIds)) {
+    return labels
+  }
+  for (let index = 0; index < data.rows.length; index += 1) {
+    const playerId = playerIds[index]
+    const row = data.rows[index]
+    if (typeof playerId !== 'number' || !Array.isArray(row)) {
+      continue
+    }
+    const label = row[0]
+    if (typeof label === 'string' && label.trim() !== '') {
+      labels.set(playerId, label)
+    }
+  }
+  return labels
+}
+
+export function useTurnRacePlayerLabels(
+  scope: AnalyticShellScope | null,
+  enabled: boolean
+): Map<number, string> {
+  const { data } = useQuery({
+    queryKey: [
+      'analytic',
+      'scores',
+      'table',
+      scope,
+      ...scoresTableQueryKey(SCORES_TABLE_LABELS_PARAMS),
+    ] as const,
+    queryFn: () => fetchAnalyticTable('scores', scope!, SCORES_TABLE_LABELS_PARAMS),
+    enabled: enabled && scope != null,
+  })
+  return useMemo(() => turnRacePlayerLabelsFromTable(data), [data])
+}


### PR DESCRIPTION
## Summary

- Emit progressive `ledger_updated` / `provenance` events during per-player gap-fill so fleet tiles populate rows leg-by-leg instead of waiting for the full M..N chain (#189).
- Fix fleet and inference table stream reconnect scope leaks by preempting stale scopes and treating cancelled sessions as finished in multiplex loops.
- Align fleet player labels with the scoreboard using turn-scoped `racePlayer` labels (not latest game-info usernames like `dead`).
- Restore `_try_claim_run_for_finalize` so cancelled inference tier workers cannot persist zombie row results after `cancel_row_run`.

## Test plan

- [x] `make test_api` (includes fleet stream, gap-fill coordinator, inference scheduler cancel regressions)
- [x] Fleet and inference stream reconnect tests
- [x] Frontend fleet stream integration and `fleetPlayerDisplayLabel` / `turnRacePlayerLabels` unit tests
- [ ] Manual: cold perspective gap-fill -- rows appear after first leg, update progressively to host turn
- [ ] Manual: reconnect fleet/scores table streams mid-materialization without 422 scope conflicts
- [ ] Manual: turn 8 fleet tile shows historical player name (e.g. `dougp314`) matching scoreboard

Closes #189


Made with [Cursor](https://cursor.com)