### PR TITLE
Compute orchestrator: foundation types and registration profile (#195)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -549,8 +549,20 @@ Provenance label on scores inference `complete` diagnostics (`diagnostics.fleetT
 _Avoid_: conflating with build-inference row pending/searching, treating `ConflictError` as two different fleet states
 
 **Analytic compute node**:
-One unit of analytic export ensure / materialization work keyed by `(analytic_id, game_id, perspective, turn, player_id)`. A node uses turn data loaded for that scope plus ancestor nodes from declared **analytic export ensure dependencies** (same `player_id` only). Orchestration unwinds the DAG forward by turn for gap fill; shared read-only turn inputs (e.g. fleet id bounds) are not graph edges. Batch callers fan out to N nodes; a single-player request must not widen to the full roster. See [design-analytic-exports.md](docs/design-analytic-exports.md) **Compute node model**; fleet scope fix [#179](https://github.com/SteveDraper/Planets-Console/issues/179).
+One DAG vertex of analytic work at a **compute scope** (see **Compute scope**). For row-scoped exports this is typically `(analytic_id, game_id, perspective, turn, player_id)`. Execution scheduling, parallelism, and step continuations are defined in [design-compute-orchestrator.md](docs/design-compute-orchestrator.md) ([#190](https://github.com/SteveDraper/Planets-Console/issues/190)).
 _Avoid_: perspective-batch materialization for one-player ensure, treating all-roster snapshot completeness as one player's cache hit
+
+**Compute scope**:
+Canonical identity for one cacheable orchestrator work unit: `analytic_id`, `game_id`, and per-analytic scope axes (`perspective`, `turn`, `player_id`, each concrete or **WILDCARD**), plus optional sorted **parameters** fingerprint (e.g. connection options). Declared per analytic via `ScopeKeySpec` on registration. Export `ExportScope` is the row-scoped projection used by cross-analytic query. See [design-compute-orchestrator.md](docs/design-compute-orchestrator.md).
+_Avoid_: using nullable axes alone without WILDCARD semantics; duplicating connection options in memo keys outside declared parameter_fields
+
+**Compute orchestrator**:
+Core API unified execution layer: dependency DAG from `ENSURE_DEPENDENCIES`, singleflight (`attach_inflight`), declarative step backends (`inline`, `thread`, `interpreter`, `process`), global priority pool, job wire with explicit dependency outputs, epoch-checked persist coordination. Analytics own persistence policy hooks. North-star uniform compute API for ensure, streams, table/map compute, BFF, and MCP. [design-compute-orchestrator.md](docs/design-compute-orchestrator.md), [ADR 0005](docs/adr/0005-compute-orchestrator.md).
+_Avoid_: per-analytic worker schedulers as the platform model; `ctx.query()` inside parallel workers; orchestrator-owned persistence schemas
+
+**Compute step**:
+One schedulable pool unit inside a **compute node** (e.g. scores tier job, fleet one-turn materialization leg). Nodes complete after one or more step continuations. Backend declared on `ComputeStepSpec`; not hardcoded in orchestrator.
+_Avoid_: one pool job spanning multiple compute nodes; blocking ensure inside pool workers
 
 **Fleet gap-fill coordinator** (#161, per-player scope #179):
 Per-`(gameId, perspective, playerId)` singleflight around multi-turn fleet ledger materialization so concurrent callers for the **same player** (fleet table tile, scores ensure, inference background warm) share one in-flight unwind instead of independent retry loops. Exposes an **epoch** aligned with fleet invalidation generation (per perspective); waiters for that player block with a generous timeout or retry when epoch bumps. Forward unwind runs `scores@t,P` before `fleet@t,P` for each gap turn. Requests for different players do not share one chain. Phase 1 mitigation (shipped): return cached target ledger after invalidation retries if another path already persisted it. See [design-fleet-analytic.md](docs/design-fleet-analytic.md) section 5.1.

--- a/docs/adr/0004-addendum-table-stream-session-framework.md
+++ b/docs/adr/0004-addendum-table-stream-session-framework.md
@@ -30,7 +30,7 @@ Per-analytic code keeps:
 
 - Same-scope reconnect **preempts** the prior stream token via `TableStreamScopeGuard`; there is no reject-and-retry contract.
 - Wire event schemas and Zod/BFF contracts
-- Scheduler classes (`InferenceRowScheduler`, `FleetTableStreamScheduler`)
+- Scheduler classes (`InferenceRowScheduler`, `FleetTableStreamScheduler`) worker dequeue loops -- superseded by [compute orchestrator](../design-compute-orchestrator.md) ([#190](https://github.com/SteveDraper/Planets-Console/issues/190))
 - Domain materialization / tier inference jobs
 - Cross-analytic imports between `analytics/fleet` and `analytics/military_score_inference`
 

--- a/docs/adr/0004-fleet-per-player-persistence-and-ensure-provenance.md
+++ b/docs/adr/0004-fleet-per-player-persistence-and-ensure-provenance.md
@@ -68,7 +68,7 @@ Materialize `fleet@N` for player P by:
 
 **Shared turn context** (global scoreboard totals for id bounds, accelerated homeworld seeding inputs) is computed once per `(game, perspective, turn)` from RST and read by all per-player materializers. It is not a mutable cross-player ledger.
 
-Gap-fill coordinator ([#161](https://github.com/SteveDraper/Planets-Console/issues/161)) singleflight is keyed per `(gameId, perspective, playerId)` ([#179](https://github.com/SteveDraper/Planets-Console/issues/179)). A perspective-wide lock that batch-materializes all roster players when one player is requested is **not** acceptable: it violates per-player ensure scope and the compute node model in [design-analytic-exports.md](../design-analytic-exports.md).
+Gap-fill coordinator ([#161](https://github.com/SteveDraper/Planets-Console/issues/161)) singleflight is keyed per `(gameId, perspective, playerId)` ([#179](https://github.com/SteveDraper/Planets-Console/issues/179)). A perspective-wide lock that batch-materializes all roster players when one player is requested is **not** acceptable: it violates per-player ensure scope and the [compute orchestrator](../design-compute-orchestrator.md) scope model.
 
 ### 5. Per-player invalidation
 

--- a/docs/adr/0005-compute-orchestrator.md
+++ b/docs/adr/0005-compute-orchestrator.md
@@ -1,0 +1,32 @@
+# Compute orchestrator
+
+Status: accepted
+
+## Context
+
+Turn analytics today mix three execution patterns: synchronous export ensure walks, per-analytic thread schedulers (`InferenceRowScheduler`, `FleetTableStreamScheduler`), and a process pool for offline prior mining. Dependency graphs are analytic-neutral (`walk_dependency_tree`, `ENSURE_DEPENDENCIES`), but workers block on cross-analytic `ensure_export`, pool starvation is possible, and parallelism does not span analytics. [#190](https://github.com/SteveDraper/Planets-Console/issues/190) design discussion locked a unified model.
+
+## Decision
+
+Introduce a **compute orchestrator** in Core API as the long-term uniform compute entry point. See [design-compute-orchestrator.md](../design-compute-orchestrator.md) for full specification.
+
+Locked choices:
+
+1. **Two planes** -- orchestration (DAG, singleflight, wire build, persist coordination) vs compute leaf steps (`JobWire` → `ResultWire`). Parallel workers never call `ctx.query()` or blocking ensure.
+2. **`ComputeScope`** -- generalized identity with per-analytic `ScopeKeySpec`, `WILDCARD` axes, and optional `parameters` fingerprint (connections [#110](https://github.com/SteveDraper/Planets-Console/issues/110) later).
+3. **Node vs step** -- DAG vertex = compute node; pool job = analytic-declared step with continuations until node complete. Gap-fill is many nodes, not one monolithic fleet job.
+4. **Singleflight** -- explicit `attach_inflight` state; one pool worker per scope key; waiters share leader outcome.
+5. **Scheduling** -- one global pool; priority bands (stream-attached, interactive ensure, background); scores tier-1-before-continuations fairness inside bands.
+6. **Backends** -- declarative per `step_kind` on registration: `inline | thread | interpreter | process`. Fleet materialization leg defaults to `interpreter`; scores tier to `thread`; not hardcoded in orchestrator.
+7. **Dependencies** -- orchestrator completes ancestors first; wire builders pass `DependencyOutputs` on job wire; storage read fallback only for terminal ancestor artifacts.
+8. **Persistence** -- orchestrator coordinates timing and epochs; analytic `PersistencePolicy` owns schema, write gates, merge, invalidation (ADR 0002 paths unchanged).
+9. **Table streams** -- keep [#175](https://github.com/SteveDraper/Planets-Console/issues/175) session framework; replace per-analytic scheduler worker pools with orchestrator adapters.
+10. **Phased rollout** -- v1: export ensure + stream steps; phase 2: batch `compute()`; phase 3: BFF/MCP uniform API.
+
+## Consequences
+
+- New `packages/api/api/compute/` package; extend `TurnAnalyticRegistration` with scope profile, compute profile, persistence policy, wire builders.
+- `design-analytic-exports.md` compute-graph detail defers to design-compute-orchestrator.md.
+- Environment: global `COMPUTE_ORCHESTRATOR_WORKERS` supersedes per-analytic worker env vars over migration.
+- Python 3.14 `InterpreterPoolExecutor` is the preferred parallel backend for fleet legs; `ProcessPoolExecutor` remains for extraction and opt-in CPU-bound steps.
+- Implementation slices: GitHub [#195](https://github.com/SteveDraper/Planets-Console/issues/195)–[#203](https://github.com/SteveDraper/Planets-Console/issues/203) under epic [#190](https://github.com/SteveDraper/Planets-Console/issues/190).

--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -7,6 +7,7 @@ GitHub: issue **#93**.
 Related:
 
 - [CONTEXT.md](../CONTEXT.md) -- glossary (**Analytic export**, **Analytic query context**, **Analytic export ensure**, …)
+- [Compute orchestrator](design-compute-orchestrator.md) -- DAG execution, scopes, worker pools (ADR 0005)
 - [Analytics module structure](design-analytics-structure.md) -- layer roles and registration
 - [Adding a turn analytic](design-adding-a-turn-analytic.md) -- checklist including exports
 - [Analytic persistence ADR](adr/0002-analytic-persistence.md) -- persisted slices merged by materializers
@@ -143,24 +144,17 @@ Probe and ensure unwind follow these edges. Cross-turn scopes differ, so unwind 
 
 **Fleet ensure-final gate (ADR 0004):** for `fleet@N` + `player_id`, `is_ensure_satisfied` is `true` only when that player's persisted ledger has **fleet materialization provenance** `(turnEvidenceAtN, priorLedgerAtNMinus1) = (true, true)`. File existence or partial gap-fill is insufficient. One player final does not imply all players final at the same turn document.
 
-### Compute node model
+### Compute graph and execution
 
-Each **analytic export ensure** step is one **compute node**:
+Export ensure walks a **dependency DAG** of **compute scopes** declared via `ENSURE_DEPENDENCIES`. Probe, query envelopes, path-prefix rules, and ensure-final gates in this document define the **export contract**. **Scheduling, parallelism, worker backends, job wire, singleflight, and persistence coordination** are owned by the [**compute orchestrator**](design-compute-orchestrator.md) ([ADR 0005](adr/0005-compute-orchestrator.md), epic [#190](https://github.com/SteveDraper/Planets-Console/issues/190)).
 
-```text
-(analytic_id, game_id, perspective, turn, player_id)
-```
+At a glance:
 
-| Rule | Detail |
-|------|--------|
-| **Node inputs** | Turn data the analytic loads for that turn; plus ancestor nodes reached only via declared `ENSURE_DEPENDENCIES` at the same `player_id` |
-| **No cross-player edges** | `fleet@N` depends on `scores@N` and (transitively) `fleet@(N-1)` for the **same** `player_id` only |
-| **DAG unwind** | `walk_dependency_tree` / `ensure_declared_dependencies` topologically ensure ancestors before self; gap turns `M..N` compute **forward** by turn |
-| **Dedup** | Walk dedupes `pending_ensure` by `(analytic_id, scope)`; in-flight materialization singleflight is per node (fleet: [#179](https://github.com/SteveDraper/Planets-Console/issues/179)) |
-| **Shared read-only inputs** | Global RST-derived inputs (e.g. fleet id bounds via `FleetTurnContext`) are not graph edges; cache once per turn inside a player unwind |
-| **Batch callers** | A caller that needs all roster players (e.g. fleet table compute wire) fans out to N independent nodes -- it must not widen a single-player request into an all-roster materialization |
-
-Ensure scope in v1 is already `(game_id, perspective, turn, player_id)` for row-scoped exports. **Fleet materialization** must match that grain on the ensure and gap-fill paths ([#179](https://github.com/SteveDraper/Planets-Console/issues/179)); perspective-wide snapshot materialization is not a valid shortcut for one-player ensure.
+| Topic | Where defined |
+|-------|----------------|
+| `ENSURE_DEPENDENCIES`, probe/query, `ExportScope` | This document |
+| `ComputeScope`, node lifecycle, pools, job wire | [design-compute-orchestrator.md](design-compute-orchestrator.md) |
+| Fleet per-player gap-fill grain | [design-compute-orchestrator.md](design-compute-orchestrator.md); [#179](https://github.com/SteveDraper/Planets-Console/issues/179) |
 
 ### Concurrent fleet gap-fill (scores stream + ensure)
 

--- a/docs/design-analytics-structure.md
+++ b/docs/design-analytics-structure.md
@@ -5,6 +5,7 @@ Analytics use generic HTTP routes but keep per-analytic implementation in layer-
 Related docs:
 
 - [Adding a turn analytic](design-adding-a-turn-analytic.md) -- step-by-step checklist for new analytics
+- [Compute orchestrator](design-compute-orchestrator.md) -- unified Core compute scheduling (ADR 0005)
 - [Analytic exports](design-analytic-exports.md) -- cross-analytic queries, JSONPath, materializers
 - [Connections analytic](design-connections-analytic.md) -- reference for a map analytic with query params
 - [Frontend/backend state](design-frontend-and-backend-state.md) -- shell context and turn ensure gating
@@ -31,7 +32,7 @@ Related docs:
   - `registry.py` -- `TURN_ANALYTIC_REGISTRATIONS` (aligned to the catalog), derived `TURN_ANALYTICS` handler map, `get_turn_analytic` dispatch
   - `compute_context.py` -- `AnalyticComputeContext` and `invoke_analytic_compute` for context-first handlers (`turn`, `options`, `diagnostics`, and later `query`)
 
-`TurnAnalyticService` loads `TurnInfo`, builds `TurnAnalyticsOptions`, and delegates to `get_turn_analytic(...)` in the registry.
+`TurnAnalyticService` loads `TurnInfo`, builds `TurnAnalyticsOptions`, and delegates to `get_turn_analytic(...)` in the registry. Long-term, batch compute routes through the [**compute orchestrator**](design-compute-orchestrator.md) (phase 2); export ensure and table streams migrate first ([#190](https://github.com/SteveDraper/Planets-Console/issues/190)).
 
 **Shared catalog:** `TURN_ANALYTIC_CATALOG` in `catalog.py` is the single declarative source of truth for analytic ids, SPA metadata, and order; it imports no Core compute, so BFF and `catalog_entry()` read it without pulling in the compute graph. Core **turn analytic registration** objects (`TURN_ANALYTIC_REGISTRATIONS`) reference catalog entries and bundle compute handlers plus an export-catalog placeholder; `registry.py` derives only the `TURN_ANALYTICS` handler map and aligns registrations to the catalog with `tuple_aligned_with_turn_analytic_catalog` -- the same helper the BFF uses for its descriptors. BFF attaches table/map shaping via `AnalyticDescriptor.from_catalog_entry(...)`. The alignment helper validates each layer's keys against the catalog and preserves catalog order at import; a missing or extra registration/descriptor raises `RuntimeError` on startup. Core handlers and BFF descriptors remain registered separately (cross-layer); within Core, the handler map is derived from one registration tuple.
 

--- a/docs/design-compute-orchestrator.md
+++ b/docs/design-compute-orchestrator.md
@@ -339,8 +339,9 @@ Tracked under [#190](https://github.com/SteveDraper/Planets-Console/issues/190):
 | Core scheduler | [#196](https://github.com/SteveDraper/Planets-Console/issues/196) | DAG gating, singleflight, `attach_inflight`, inline backend |
 | Worker pools | [#197](https://github.com/SteveDraper/Planets-Console/issues/197) | Global pool, priority bands, four backends |
 | Job wire + epochs | [#198](https://github.com/SteveDraper/Planets-Console/issues/198) | Wire builders, `DependencyOutputs`, invalidation re-check, persist coordination |
-| Fleet migration | [#199](https://github.com/SteveDraper/Planets-Console/issues/199) | Fleet leg steps; retire `FleetTableStreamScheduler` workers |
-| Scores migration | [#200](https://github.com/SteveDraper/Planets-Console/issues/200) | Tier steps; retire `InferenceRowScheduler` workers |
+| Fleet migration | [#199](https://github.com/SteveDraper/Planets-Console/issues/199) | Fleet leg steps; delete `FleetTableStreamScheduler` worker pool |
+| Scores migration | [#200](https://github.com/SteveDraper/Planets-Console/issues/200) | Tier steps; delete `InferenceRowScheduler` worker pool |
+| Export ensure migration | [#204](https://github.com/SteveDraper/Planets-Console/issues/204) | Ensure/gap-fill via orchestrator; retire coordinator + blocking ensure |
 | Turn cache | [#201](https://github.com/SteveDraper/Planets-Console/issues/201) | Orchestrator LRU + prefetch into job wire |
 | Phase 2 | [#202](https://github.com/SteveDraper/Planets-Console/issues/202) | Route table/map `compute()` through orchestrator |
 | Phase 3 | [#203](https://github.com/SteveDraper/Planets-Console/issues/203) | BFF / MCP uniform compute API |

--- a/docs/design-compute-orchestrator.md
+++ b/docs/design-compute-orchestrator.md
@@ -1,0 +1,354 @@
+# Design: Compute orchestrator
+
+The **compute orchestrator** is the Core API's unified execution layer for turn analytics. It schedules work on a dependency graph, runs steps through declarative worker backends, coordinates caching and invalidation, and is the long-term uniform entry point for export ensure, table streams, table/map compute, BFF proxies, and future analytic MCP.
+
+GitHub epic: [#190](https://github.com/SteveDraper/Planets-Console/issues/190).
+
+Related:
+
+- [ADR 0005](adr/0005-compute-orchestrator.md) -- locked architectural decisions
+- [Analytic exports](design-analytic-exports.md) -- export catalogs, JSONPath, probe/query envelopes (orchestrator consumes `ENSURE_DEPENDENCIES`)
+- [Analytics module structure](design-analytics-structure.md) -- layer roles and registration
+- [ADR 0004 addendum: table-stream session framework](adr/0004-addendum-table-stream-session-framework.md) -- stream multiplex/connect (orchestrator replaces per-analytic worker pools only)
+- [CONTEXT.md](../CONTEXT.md) -- glossary (**Compute scope**, **Compute orchestrator**, **Compute step**)
+
+---
+
+## Summary (human-readable model)
+
+Think of the backend as two cooperating planes:
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│  ORCHESTRATION PLANE (main interpreter)                         │
+│  • Accepts ComputeRequest(analytic, scope, step_kind, …)        │
+│  • Walks ENSURE_DEPENDENCIES → DAG of compute scopes           │
+│  • Singleflight + attach_inflight for duplicate requests         │
+│  • Builds job wire from completed dependency outputs           │
+│  • Submits ready steps to worker pools (priority bands)        │
+│  • Re-checks invalidation epoch; calls analytic persist hooks  │
+│  • Emits stream / ensure progress events                       │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │ JobWire → ResultWire (serializable)
+┌───────────────────────────▼─────────────────────────────────────┐
+│  COMPUTE PLANE (inline | thread | interpreter | process)         │
+│  • Pure leaf functions: no ctx.query(), no blocking ensure       │
+│  • Reads prefetched wire and/or storage_root (read-only)       │
+│  • Returns result wire to orchestrator                         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Compute scope** identifies one cacheable unit of work. It generalizes the earlier `(analytic, game, perspective, turn, player)` tuple:
+
+- Some analytics omit axes (e.g. connections ignore `player_id`).
+- Some add **parameters** (e.g. connection warp speed) fingerprinted into the scope key.
+
+**Compute node** = one DAG vertex at a compute scope. **Compute step** = one schedulable pool unit *inside* a node (scores: one tier; fleet: one turn leg). A node may need several step continuations before it is **complete**.
+
+**Dependencies** are never resolved by blocking inside a worker. The orchestrator completes ancestor nodes first, then passes their outputs explicitly on the dependent analytic's **job wire** (or lets the worker read the persisted artifact after the ancestor is terminal).
+
+**Persistence** is conceptually a durable cache of `compute scope → result`, but **schema, write gates, merge, and invalidation** stay per analytic via registered **persistence policy** hooks. The orchestrator coordinates *when* to persist; analytics own *what* and *how*.
+
+**North star:** all Core compute callers (export ensure, streams, table/map handlers, later BFF and MCP) submit through the same orchestrator. v1 migrates export-ensure and table-stream execution; routing batch `compute()` handlers is a follow-on phase.
+
+---
+
+## Goals
+
+1. **Analytic-neutral scheduling** -- one DAG walker, one global worker pool, one singleflight model.
+2. **True parallelism** -- cross-analytic and cross-player work shares cores; no pool starvation from blocking `ensure_export` inside workers.
+3. **Declarative execution** -- backends (`inline`, `thread`, `interpreter`, `process`) and scope key axes declared on registration, not hardcoded in the orchestrator.
+4. **Explicit dependency data** -- dependents receive ancestor outputs on job wire, not live `ctx.query()` in parallel workers.
+5. **Uniform API trajectory** -- same `ComputeRequest` surface for ensure jobs, streams, and (later) table/map compute and MCP.
+
+Non-goals (v1 / #190 epic):
+
+- Separate worker service or containers.
+- Rewiring every `TurnAnalyticService.compute()` handler (phase 2).
+- BFF/MCP uniform proxy (phase 3).
+- Connections parameter keying (ships with [#110](https://github.com/SteveDraper/Planets-Console/issues/110); mechanism defined here).
+
+---
+
+## Compute scope
+
+```python
+WILDCARD = "*"  # axis intentionally excluded from scope identity
+
+@dataclass(frozen=True)
+class ComputeScope:
+    analytic_id: str
+    game_id: int
+    perspective: int | Literal["*"] = WILDCARD
+    turn: int | Literal["*"] = WILDCARD
+    player_id: int | Literal["*"] = WILDCARD
+    parameters: tuple[tuple[str, str], ...] = ()  # canonical sorted fingerprint
+```
+
+| Concept | Meaning |
+|---------|---------|
+| **Concrete axis** | Integer (or analytic-specific value) participates in dedup, singleflight, persistence lookup |
+| **WILDCARD** | Axis does not distinguish cache entries (not "missing required field") |
+| **parameters** | Extra key material when analytic declares `parameter_fields` (connection options, etc.) |
+
+Per-analytic **scope key spec** on registration:
+
+```python
+@dataclass(frozen=True)
+class ScopeKeySpec:
+    axes: tuple[Literal["perspective", "turn", "player_id"], ...]
+    parameter_fields: tuple[str, ...] = ()
+```
+
+| Analytic (examples) | Key axes | Parameters |
+|---------------------|----------|------------|
+| scores, fleet | perspective, turn, player_id | -- |
+| connections (future) | perspective, turn | connection option fields ([#110](https://github.com/SteveDraper/Planets-Console/issues/110)) |
+| homeworld export branches | varies by path prefix | per export catalog |
+
+`ExportScope` in [design-analytic-exports.md](design-analytic-exports.md) remains the export-query projection for row-scoped analytics; orchestrator normalization maps it to `ComputeScope`.
+
+---
+
+## Dependency graph
+
+Provider-declared edges live on export catalogs today:
+
+```python
+ENSURE_DEPENDENCIES = (
+    EnsureDependency(analytic_id="fleet", turn_delta=-1, player_id="same"),
+)
+```
+
+The orchestrator builds a **DAG of compute scopes** from these edges (same walk as `walk_dependency_tree`, but execution is asynchronous and non-blocking).
+
+| Rule | Detail |
+|------|--------|
+| **Cross-player** | No edges; batch callers fan out to N scopes |
+| **Cross-turn unwind** | Gap turns `M..N` expand to forward-by-turn nodes (not one monolithic job) |
+| **Shared read-only inputs** | e.g. `FleetTurnContext` from RST -- not graph edges; prefetch once per turn in wire builder |
+| **Cycle** | Ensure-graph cycle → `ensure_cycle` (probe); resolution-stack cycle unchanged |
+
+### Node and step granularity
+
+| Level | Grain | Example |
+|-------|-------|---------|
+| **Compute node** | One DAG vertex at one scope | `scores@8,P`, `fleet@5,P` |
+| **Compute step** | One pool submission inside a node | scores tier-1; fleet one turn leg |
+| **Continuation** | Next step for same node after prior step completes | scores tier-2; invalidation retry leg |
+
+Fleet gap-fill `M..N` for one player is **`2 × (N − M + 1)` nodes** (scores + fleet per turn), not one `FleetPlayerJob` chain on a single worker.
+
+---
+
+## Node lifecycle and singleflight
+
+```text
+waiting_deps → ready → running → complete | failed
+                    ↘ attach_inflight (waiter; no pool worker)
+```
+
+| State | Meaning |
+|-------|---------|
+| **waiting_deps** | Ancestor nodes incomplete; not in ready queue |
+| **ready** | Dependencies satisfied; eligible for pool |
+| **running** | Leader step executing on a worker (or inline) |
+| **attach_inflight** | Duplicate request joins leader; **no second pool worker** |
+| **complete** | Node terminal (persisted / satisfied per analytic policy) |
+
+**Hard invariant:** pool workers never call `ensure_export` or block on another node's completion.
+
+---
+
+## Execution backends
+
+Declared per analytic on `AnalyticComputeProfile` (`ComputeStepSpec` per `step_kind`):
+
+| Backend | Use | v1 default examples |
+|---------|-----|-------------------|
+| **inline** | Cheap, dependency-free work on orchestrator thread | cache probe, materialize-from-persistence, JSONPath projection |
+| **thread** | In-process; shared memory for session state | scores tier steps (CP-SAT releases GIL) |
+| **interpreter** | `InterpreterPoolExecutor` (Python 3.14); true multi-core without process overhead | fleet materialization leg |
+| **process** | `ProcessPoolExecutor`; strongest isolation | prior-mining extraction (existing) |
+
+Registry built at import; unknown `step_kind` or backend → `RuntimeError` at startup.
+
+### Parallel worker contract
+
+Interpreter/process steps:
+
+- Receive **serializable `JobWire`** (orchestrator may prefetch `turn_wire`, `prior_ledger_wire`, dependency slices).
+- May read storage via worker-local `StorageBackend(storage_root)` when wire omits large payloads (ancestor already **complete**).
+- Return **`ResultWire`**; orchestrator persists after epoch re-check.
+- **Never** hold `AnalyticQueryContext`, schedulers, or gap-fill coordinators.
+
+Thread steps (scores tiers) may use session-bound state (`RowRun`) but still must not block on cross-node ensure.
+
+### Job wire and dependency outputs
+
+Wire builders run on the **orchestration plane** and may use `AnalyticQueryContext` to assemble inputs:
+
+```python
+def build_fleet_materialization_job_wire(
+    scope: ComputeScope,
+    *,
+    dependency_outputs: DependencyOutputs,
+) -> FleetMaterializationJobWire:
+    scores = dependency_outputs.require(
+        analytic_id="scores",
+        scope=scope.with_same_player(),
+        paths=("$.solutions", "$.meta.searchStatus"),
+    )
+    return FleetMaterializationJobWire(..., scores_held_wire=scores)
+```
+
+Leaf step:
+
+```python
+def run_fleet_materialization_leg(job: FleetMaterializationJobWire) -> FleetLegResultWire:
+    ...  # no ctx.query
+```
+
+This replaces in-worker `FleetInferenceMaterialization.held_inference_for_scoreboard_turn(...)` and stream-time `ensure_fleet_export` chains.
+
+### Caching
+
+| Layer | Mechanism |
+|-------|-----------|
+| **Orchestrator LRU** | Read-through turn cache on main interpreter |
+| **Job wire prefetch** | Dependency outputs and turns already loaded included in wire |
+| **Per-worker LRU** | Optional initializer cache for sequential legs on same worker |
+| **Persistence** | Durable cache; analytic `PersistencePolicy` hooks |
+
+Defer cross-worker shared mutable caches; prefetch-first is sufficient for v1.
+
+---
+
+## Scheduling
+
+**One global worker pool** (configurable `COMPUTE_ORCHESTRATOR_WORKERS`; replaces per-analytic `*_SCHEDULER_WORKERS` over time).
+
+**Priority bands** (high → low):
+
+1. **Stream-attached** -- scope has active table-stream token (`TableStreamScopeGuard`).
+2. **Interactive ensure** -- user-confirmed BFF export-ensure job ([#109](https://github.com/SteveDraper/Planets-Console/issues/109)).
+3. **Background** -- export warm, dependency-only materialization.
+
+**Within each band:**
+
+| Analytic | Fairness rule |
+|----------|---------------|
+| scores | Tier-1 steps before continuation steps (port from `InferenceRowScheduler`) |
+| fleet | Round-robin across distinct `(turn, player_id)` scopes |
+| cross-analytic | Round-robin across ready steps at same band |
+
+---
+
+## Invalidation epochs
+
+Fleet (and similar) expose per-player **invalidation generation** today. Orchestrator generalizes:
+
+| Checkpoint | Action |
+|------------|--------|
+| **Submit** | Record `generation_at_submit` |
+| **Complete** | If `generation != generation_at_submit`, discard result and re-queue node |
+| **Persist** | Orchestrator calls analytic `persist` hook only after epoch check |
+
+Same semantics as gap-fill coordinator leader/waiter retry, applied to all node kinds.
+
+---
+
+## Persistence ownership
+
+| Owner | Responsibility |
+|-------|----------------|
+| **Orchestrator** | When to compute; singleflight; epoch gates; invoke persist hook |
+| **Analytic** (`PersistencePolicy` on registration) | Record shape; write gates; merge (e.g. homeworld user-asserted); invalidation rules |
+
+Storage paths remain per [ADR 0002](adr/0002-analytic-persistence.md). Orchestrator is cache **coordinator**, not cache **schema** owner.
+
+---
+
+## Registration surface
+
+Extend `TurnAnalyticRegistration`:
+
+| Field | Purpose |
+|-------|---------|
+| `scope_key_spec` | Which axes and parameters form compute identity |
+| `compute_profile` | `ComputeStepSpec` list (step_kind, backend) |
+| `persistence_policy` | satisfied / persist / invalidate hooks |
+| `build_step_job_wire` | Per step_kind: scope + dependency outputs → JobWire |
+| `run_step` | Per step_kind: JobWire → ResultWire (or reference to leaf function) |
+
+Export catalog (`ENSURE_DEPENDENCIES`, materializers) stays on `export_catalog`; orchestrator reads it for the DAG.
+
+---
+
+## Relationship to table streams ([#175](https://github.com/SteveDraper/Planets-Console/issues/175))
+
+**Keep** under `packages/api/api/streaming/table_stream/`:
+
+- Multiplex, connect `finally` teardown, `TableStreamScopeGuard`, controller base, registry attach/detach.
+
+**Replace:**
+
+- `InferenceRowScheduler` and `FleetTableStreamScheduler` worker dequeue loops.
+
+**Thin adapters:**
+
+- Stream controllers submit compute steps / continuations to orchestrator and map completion to wire events.
+
+---
+
+## Callers and migration phases
+
+| Phase | Callers routed through orchestrator |
+|-------|-------------------------------------|
+| **v1 (#190 epic)** | Export ensure materialization; fleet/scores table-stream steps; internal wire builders for `ctx.query` |
+| **Phase 2** | `TurnAnalyticService.get_turn_analytics` batch compute |
+| **Phase 3** | BFF uniform proxy; analytic MCP `query_compute` |
+
+Until phase 2, table/map REST responses may still call `compute()` handlers directly; export ensure and streams migrate first.
+
+---
+
+## Package layout (target)
+
+```text
+packages/api/api/compute/
+  scope.py           # ComputeScope, ScopeKeySpec, normalization
+  profile.py         # AnalyticComputeProfile, ComputeStepSpec
+  orchestrator.py    # DAG, singleflight, submit, complete
+  pools.py           # Global pool, priority dequeue, backend dispatch
+  wire.py            # DependencyOutputs, base JobWire/ResultWire types
+  registry.py        # Built from TurnAnalyticRegistration at import
+```
+
+Existing `export_dependency_walk.py` remains the canonical ENSURE_DEPENDENCIES walk; orchestrator calls it for planning.
+
+---
+
+## Implementation slices
+
+Tracked under [#190](https://github.com/SteveDraper/Planets-Console/issues/190):
+
+| Slice | Issue | Deliverable |
+|-------|-------|-------------|
+| Foundation | [#195](https://github.com/SteveDraper/Planets-Console/issues/195) | `ComputeScope`, profiles, registry validation |
+| Core scheduler | [#196](https://github.com/SteveDraper/Planets-Console/issues/196) | DAG gating, singleflight, `attach_inflight`, inline backend |
+| Worker pools | [#197](https://github.com/SteveDraper/Planets-Console/issues/197) | Global pool, priority bands, four backends |
+| Job wire + epochs | [#198](https://github.com/SteveDraper/Planets-Console/issues/198) | Wire builders, `DependencyOutputs`, invalidation re-check, persist coordination |
+| Fleet migration | [#199](https://github.com/SteveDraper/Planets-Console/issues/199) | Fleet leg steps; retire `FleetTableStreamScheduler` workers |
+| Scores migration | [#200](https://github.com/SteveDraper/Planets-Console/issues/200) | Tier steps; retire `InferenceRowScheduler` workers |
+| Turn cache | [#201](https://github.com/SteveDraper/Planets-Console/issues/201) | Orchestrator LRU + prefetch into job wire |
+| Phase 2 | [#202](https://github.com/SteveDraper/Planets-Console/issues/202) | Route table/map `compute()` through orchestrator |
+| Phase 3 | [#203](https://github.com/SteveDraper/Planets-Console/issues/203) | BFF / MCP uniform compute API |
+
+---
+
+## Testing
+
+- Unit: scope normalization, WILDCARD keys, priority dequeue, epoch discard, dependency gating (no worker without deps).
+- Integration: fixture analytics with mutual dependencies; fleet+scores cold gap-fill parallelism; attach_inflight does not double pool workers.
+- Regression: existing `test_export_dependency_walk`, `test_gap_fill_coordinator`, scheduler fairness tests ported to orchestrator.

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -176,7 +176,7 @@ Gap-fill is **deterministic** for a given anchor, stored RST sequence, and score
 
 #### 5.1.1 Player-scoped unwind (target)
 
-A fleet materialization request is scoped to **one compute node** `(fleet, game_id, perspective, turn, player_id)` -- see [design-analytic-exports.md](design-analytic-exports.md) **Compute node model**. Gap fill for player P from turn `M` through `N` unwinds only P's ensure subgraph, forward by turn:
+A fleet materialization request is scoped to **one compute scope** `(fleet, game_id, perspective, turn, player_id)` -- see [design-compute-orchestrator.md](design-compute-orchestrator.md). Gap fill for player P from turn `M` through `N` unwinds only P's ensure subgraph, forward by turn:
 
 ```text
 scores@M,P → fleet@M,P → scores@(M+1),P → fleet@(M+1),P → … → scores@N,P → fleet@N,P

--- a/packages/api/api/analytics/registration.py
+++ b/packages/api/api/analytics/registration.py
@@ -108,3 +108,7 @@ def validate_turn_analytic_registrations(
             raise RuntimeError(
                 f"Turn analytic {analytic_id!r} must set export_catalog or export_catalog_loader"
             )
+
+        from api.compute.registry import validate_turn_analytic_compute_registration
+
+        validate_turn_analytic_compute_registration(registration)

--- a/packages/api/api/analytics/registration.py
+++ b/packages/api/api/analytics/registration.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from api.analytics.catalog import TurnAnalyticCatalogEntry
 from api.analytics.compute_context import AnalyticComputeContext
 from api.analytics.exports.catalog import AnalyticExportCatalog
+from api.validation import require_non_empty_string
 
 if TYPE_CHECKING:
     from api.compute.persistence import PersistencePolicy
@@ -55,19 +56,6 @@ def resolve_registration_export_catalog(
 _VALID_ANALYTIC_TYPES = frozenset({"base", "selectable"})
 
 
-def _require_non_empty_string(
-    value: str,
-    *,
-    field: str,
-    analytic_id: str | None = None,
-    subject: str = "catalog entry",
-) -> None:
-    if value and value.strip():
-        return
-    prefix = f"Turn analytic {analytic_id!r} " if analytic_id is not None else "Turn analytic "
-    raise RuntimeError(f"{prefix}{subject} {field} must be a non-empty string, got {value!r}")
-
-
 def validate_turn_analytic_registrations(
     registrations: tuple[TurnAnalyticRegistration, ...],
 ) -> None:
@@ -78,11 +66,11 @@ def validate_turn_analytic_registrations(
     for registration in registrations:
         entry = registration.catalog_entry
         analytic_id = entry.id
-        _require_non_empty_string(analytic_id, field="id")
+        require_non_empty_string(analytic_id, field="id")
         if analytic_id in seen_ids:
             raise RuntimeError(f"Duplicate turn analytic registration id: {analytic_id!r}")
         seen_ids.add(analytic_id)
-        _require_non_empty_string(entry.name, field="name", analytic_id=analytic_id)
+        require_non_empty_string(entry.name, field="name", analytic_id=analytic_id)
         if entry.type not in _VALID_ANALYTIC_TYPES:
             raise RuntimeError(
                 f"Turn analytic {analytic_id!r} catalog entry type must be 'base' or "

--- a/packages/api/api/analytics/registration.py
+++ b/packages/api/api/analytics/registration.py
@@ -55,11 +55,17 @@ def resolve_registration_export_catalog(
 _VALID_ANALYTIC_TYPES = frozenset({"base", "selectable"})
 
 
-def _require_non_empty_string(value: str, *, field: str, analytic_id: str | None = None) -> None:
+def _require_non_empty_string(
+    value: str,
+    *,
+    field: str,
+    analytic_id: str | None = None,
+    subject: str = "catalog entry",
+) -> None:
     if value and value.strip():
         return
     prefix = f"Turn analytic {analytic_id!r} " if analytic_id is not None else "Turn analytic "
-    raise RuntimeError(f"{prefix}catalog entry {field} must be a non-empty string, got {value!r}")
+    raise RuntimeError(f"{prefix}{subject} {field} must be a non-empty string, got {value!r}")
 
 
 def validate_turn_analytic_registrations(

--- a/packages/api/api/analytics/registration.py
+++ b/packages/api/api/analytics/registration.py
@@ -2,10 +2,17 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from api.analytics.catalog import TurnAnalyticCatalogEntry
 from api.analytics.compute_context import AnalyticComputeContext
 from api.analytics.exports.catalog import AnalyticExportCatalog
+
+if TYPE_CHECKING:
+    from api.compute.persistence import PersistencePolicy
+    from api.compute.profile import AnalyticComputeProfile
+    from api.compute.scope import ScopeKeySpec
+    from api.compute.wire import BuildStepJobWireFn, RunStepFn
 
 TurnAnalyticHandler = Callable[[AnalyticComputeContext], dict]
 ExportCatalogLoader = Callable[[], AnalyticExportCatalog]
@@ -19,6 +26,11 @@ class TurnAnalyticRegistration:
     compute: TurnAnalyticHandler
     export_catalog: AnalyticExportCatalog | None = None
     export_catalog_loader: ExportCatalogLoader | None = None
+    scope_key_spec: ScopeKeySpec | None = None
+    compute_profile: AnalyticComputeProfile | None = None
+    persistence_policy: PersistencePolicy | None = None
+    build_step_job_wires: tuple[tuple[str, BuildStepJobWireFn], ...] = ()
+    run_steps: tuple[tuple[str, RunStepFn], ...] = ()
 
 
 def resolve_registration_export_catalog(

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -7,12 +7,6 @@ from api.compute.profile import (
     ComputeBackend,
     ComputeStepSpec,
 )
-from api.compute.registry import (
-    COMPUTE_REGISTRY,
-    AnalyticComputeRegistration,
-    build_compute_registry,
-    validate_turn_analytic_compute_registration,
-)
 from api.compute.scope import (
     WILDCARD,
     ComputeScope,
@@ -22,6 +16,21 @@ from api.compute.scope import (
     normalize_export_scope_to_compute_scope,
 )
 from api.compute.wire import BuildStepJobWireFn, RunStepFn
+
+_REGISTRY_EXPORTS = frozenset({
+    "COMPUTE_REGISTRY",
+    "AnalyticComputeRegistration",
+    "build_compute_registry",
+    "validate_turn_analytic_compute_registration",
+})
+
+
+def __getattr__(name: str) -> object:
+    if name in _REGISTRY_EXPORTS:
+        from api.compute import registry as registry_module
+
+        return getattr(registry_module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     "COMPUTE_REGISTRY",

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -17,12 +17,14 @@ from api.compute.scope import (
 )
 from api.compute.wire import BuildStepJobWireFn, RunStepFn
 
-_REGISTRY_EXPORTS = frozenset({
-    "COMPUTE_REGISTRY",
-    "AnalyticComputeRegistration",
-    "build_compute_registry",
-    "validate_turn_analytic_compute_registration",
-})
+_REGISTRY_EXPORTS = frozenset(
+    {
+        "COMPUTE_REGISTRY",
+        "AnalyticComputeRegistration",
+        "build_compute_registry",
+        "validate_turn_analytic_compute_registration",
+    }
+)
 
 
 def __getattr__(name: str) -> object:
@@ -31,6 +33,7 @@ def __getattr__(name: str) -> object:
 
         return getattr(registry_module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "COMPUTE_REGISTRY",

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -1,0 +1,44 @@
+"""Compute orchestrator foundation types and registry."""
+
+from api.compute.persistence import PersistencePolicy
+from api.compute.profile import (
+    VALID_COMPUTE_BACKENDS,
+    AnalyticComputeProfile,
+    ComputeBackend,
+    ComputeStepSpec,
+)
+from api.compute.registry import (
+    COMPUTE_REGISTRY,
+    AnalyticComputeRegistration,
+    build_compute_registry,
+    validate_turn_analytic_compute_registration,
+)
+from api.compute.scope import (
+    WILDCARD,
+    ComputeScope,
+    ScopeAxis,
+    ScopeKeySpec,
+    fingerprint_parameters,
+    normalize_export_scope_to_compute_scope,
+)
+from api.compute.wire import BuildStepJobWireFn, RunStepFn
+
+__all__ = [
+    "COMPUTE_REGISTRY",
+    "WILDCARD",
+    "VALID_COMPUTE_BACKENDS",
+    "AnalyticComputeProfile",
+    "AnalyticComputeRegistration",
+    "BuildStepJobWireFn",
+    "ComputeBackend",
+    "ComputeScope",
+    "ComputeStepSpec",
+    "PersistencePolicy",
+    "RunStepFn",
+    "ScopeAxis",
+    "ScopeKeySpec",
+    "build_compute_registry",
+    "fingerprint_parameters",
+    "normalize_export_scope_to_compute_scope",
+    "validate_turn_analytic_compute_registration",
+]

--- a/packages/api/api/compute/persistence.py
+++ b/packages/api/api/compute/persistence.py
@@ -1,0 +1,30 @@
+"""Per-analytic persistence hooks for the compute orchestrator."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from api.analytics.export_context import AnalyticQueryContext
+    from api.compute.scope import ComputeScope
+
+
+class PersistencePolicy(Protocol):
+    """Analytic-owned cache schema, write gates, merge, and invalidation."""
+
+    def is_satisfied(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> bool:
+        """Return whether the scope already has a durable satisfied result."""
+        ...
+
+    def persist(
+        self,
+        ctx: AnalyticQueryContext,
+        scope: ComputeScope,
+        result_wire: object,
+    ) -> None:
+        """Persist a completed result wire after orchestrator epoch checks."""
+        ...
+
+    def invalidate(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> None:
+        """Drop or bump cached state for one compute scope."""
+        ...

--- a/packages/api/api/compute/profile.py
+++ b/packages/api/api/compute/profile.py
@@ -1,0 +1,25 @@
+"""Declarative compute execution profiles per analytic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+ComputeBackend = Literal["inline", "thread", "interpreter", "process"]
+
+VALID_COMPUTE_BACKENDS: frozenset[str] = frozenset({"inline", "thread", "interpreter", "process"})
+
+
+@dataclass(frozen=True)
+class ComputeStepSpec:
+    """One schedulable step inside a compute node."""
+
+    step_kind: str
+    backend: ComputeBackend
+
+
+@dataclass(frozen=True)
+class AnalyticComputeProfile:
+    """Declared step kinds and worker backends for one analytic."""
+
+    steps: tuple[ComputeStepSpec, ...]

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from api.analytics.registration import TurnAnalyticRegistration
+from api.analytics.registration import TurnAnalyticRegistration, _require_non_empty_string
 from api.compute.persistence import PersistencePolicy
 from api.compute.profile import VALID_COMPUTE_BACKENDS, AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import ScopeKeySpec
@@ -24,14 +24,6 @@ class AnalyticComputeRegistration:
     run_step: Mapping[str, RunStepFn]
 
 
-def _require_non_empty_string(value: str, *, field: str, analytic_id: str) -> None:
-    if value and value.strip():
-        return
-    raise RuntimeError(
-        f"Turn analytic {analytic_id!r} compute {field} must be a non-empty string, got {value!r}"
-    )
-
-
 def _mapping_from_pairs(
     pairs: tuple[tuple[str, object], ...],
     *,
@@ -40,7 +32,7 @@ def _mapping_from_pairs(
 ) -> dict[str, object]:
     mapped: dict[str, object] = {}
     for key, value in pairs:
-        _require_non_empty_string(key, field=field, analytic_id=analytic_id)
+        _require_non_empty_string(key, field=field, analytic_id=analytic_id, subject="compute")
         if key in mapped:
             raise RuntimeError(
                 f"Turn analytic {analytic_id!r} duplicate {field} step_kind: {key!r}"
@@ -59,7 +51,9 @@ def _check_persistence_policy(policy: object, *, analytic_id: str) -> None:
 
 
 def _validate_compute_step_spec(step: ComputeStepSpec, *, analytic_id: str) -> None:
-    _require_non_empty_string(step.step_kind, field="step_kind", analytic_id=analytic_id)
+    _require_non_empty_string(
+        step.step_kind, field="step_kind", analytic_id=analytic_id, subject="compute"
+    )
     if step.backend not in VALID_COMPUTE_BACKENDS:
         raise RuntimeError(
             f"Turn analytic {analytic_id!r} compute step {step.step_kind!r} has unknown "

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -6,11 +6,11 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 from api.analytics.registration import TurnAnalyticRegistration
-from api.validation import require_non_empty_string
 from api.compute.persistence import PersistencePolicy
 from api.compute.profile import VALID_COMPUTE_BACKENDS, AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import ScopeKeySpec
 from api.compute.wire import BuildStepJobWireFn, RunStepFn
+from api.validation import require_non_empty_string
 
 
 @dataclass(frozen=True)

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-from api.analytics.registration import TurnAnalyticRegistration, _require_non_empty_string
+from api.analytics.registration import TurnAnalyticRegistration
+from api.validation import require_non_empty_string
 from api.compute.persistence import PersistencePolicy
 from api.compute.profile import VALID_COMPUTE_BACKENDS, AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import ScopeKeySpec
@@ -32,7 +33,7 @@ def _mapping_from_pairs(
 ) -> dict[str, object]:
     mapped: dict[str, object] = {}
     for key, value in pairs:
-        _require_non_empty_string(key, field=field, analytic_id=analytic_id, subject="compute")
+        require_non_empty_string(key, field=field, analytic_id=analytic_id, subject="compute")
         if key in mapped:
             raise RuntimeError(
                 f"Turn analytic {analytic_id!r} duplicate {field} step_kind: {key!r}"
@@ -51,7 +52,7 @@ def _check_persistence_policy(policy: object, *, analytic_id: str) -> None:
 
 
 def _validate_compute_step_spec(step: ComputeStepSpec, *, analytic_id: str) -> None:
-    _require_non_empty_string(
+    require_non_empty_string(
         step.step_kind, field="step_kind", analytic_id=analytic_id, subject="compute"
     )
     if step.backend not in VALID_COMPUTE_BACKENDS:

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -1,0 +1,181 @@
+"""Compute orchestrator registry built from turn analytic registrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from api.analytics.registration import TurnAnalyticRegistration
+from api.compute.persistence import PersistencePolicy
+from api.compute.profile import VALID_COMPUTE_BACKENDS, AnalyticComputeProfile, ComputeStepSpec
+from api.compute.scope import ScopeKeySpec
+from api.compute.wire import BuildStepJobWireFn, RunStepFn
+
+
+@dataclass(frozen=True)
+class AnalyticComputeRegistration:
+    """Validated compute orchestrator surface for one turn analytic."""
+
+    analytic_id: str
+    scope_key_spec: ScopeKeySpec
+    compute_profile: AnalyticComputeProfile
+    persistence_policy: PersistencePolicy
+    build_step_job_wire: Mapping[str, BuildStepJobWireFn]
+    run_step: Mapping[str, RunStepFn]
+
+
+def _require_non_empty_string(value: str, *, field: str, analytic_id: str) -> None:
+    if value and value.strip():
+        return
+    raise RuntimeError(
+        f"Turn analytic {analytic_id!r} compute {field} must be a non-empty string, got {value!r}"
+    )
+
+
+def _mapping_from_pairs(
+    pairs: tuple[tuple[str, object], ...],
+    *,
+    analytic_id: str,
+    field: str,
+) -> dict[str, object]:
+    mapped: dict[str, object] = {}
+    for key, value in pairs:
+        _require_non_empty_string(key, field=field, analytic_id=analytic_id)
+        if key in mapped:
+            raise RuntimeError(
+                f"Turn analytic {analytic_id!r} duplicate {field} step_kind: {key!r}"
+            )
+        mapped[key] = value
+    return mapped
+
+
+def _check_persistence_policy(policy: object, *, analytic_id: str) -> None:
+    for hook in ("is_satisfied", "persist", "invalidate"):
+        if not callable(getattr(policy, hook, None)):
+            raise RuntimeError(
+                f"Turn analytic {analytic_id!r} persistence_policy must implement "
+                f"callable {hook!r}, got {type(policy).__name__}"
+            )
+
+
+def _validate_compute_step_spec(step: ComputeStepSpec, *, analytic_id: str) -> None:
+    _require_non_empty_string(step.step_kind, field="step_kind", analytic_id=analytic_id)
+    if step.backend not in VALID_COMPUTE_BACKENDS:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} compute step {step.step_kind!r} has unknown "
+            f"backend {step.backend!r}; expected one of "
+            f"{sorted(VALID_COMPUTE_BACKENDS)!r}"
+        )
+
+
+def validate_turn_analytic_compute_registration(
+    registration: TurnAnalyticRegistration,
+) -> AnalyticComputeRegistration | None:
+    """Validate one registration's compute surface; return None when compute is not configured."""
+    analytic_id = registration.catalog_entry.id
+    compute_profile = registration.compute_profile
+    if compute_profile is None:
+        return None
+
+    scope_key_spec = registration.scope_key_spec
+    if scope_key_spec is None:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} sets compute_profile but not scope_key_spec"
+        )
+    if not scope_key_spec.axes and not scope_key_spec.parameter_fields:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} scope_key_spec must declare at least one axis "
+            f"or parameter field"
+        )
+
+    persistence_policy = registration.persistence_policy
+    if persistence_policy is None:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} sets compute_profile but not persistence_policy"
+        )
+    _check_persistence_policy(persistence_policy, analytic_id=analytic_id)
+
+    if not compute_profile.steps:
+        raise RuntimeError(f"Turn analytic {analytic_id!r} compute_profile.steps must not be empty")
+
+    step_kinds: list[str] = []
+    for step in compute_profile.steps:
+        _validate_compute_step_spec(step, analytic_id=analytic_id)
+        if step.step_kind in step_kinds:
+            raise RuntimeError(
+                f"Turn analytic {analytic_id!r} duplicate compute step_kind: {step.step_kind!r}"
+            )
+        step_kinds.append(step.step_kind)
+    declared_step_kinds = frozenset(step_kinds)
+
+    build_step_job_wire = _mapping_from_pairs(
+        registration.build_step_job_wires,
+        analytic_id=analytic_id,
+        field="build_step_job_wires",
+    )
+    run_step = _mapping_from_pairs(
+        registration.run_steps,
+        analytic_id=analytic_id,
+        field="run_steps",
+    )
+
+    for step_kind in declared_step_kinds:
+        builder = build_step_job_wire.get(step_kind)
+        if not callable(builder):
+            raise RuntimeError(
+                f"Turn analytic {analytic_id!r} missing build_step_job_wire for "
+                f"step_kind {step_kind!r}"
+            )
+        runner = run_step.get(step_kind)
+        if not callable(runner):
+            raise RuntimeError(
+                f"Turn analytic {analytic_id!r} missing run_step for step_kind {step_kind!r}"
+            )
+
+    unknown_builders = sorted(set(build_step_job_wire) - declared_step_kinds)
+    if unknown_builders:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} unknown build_step_job_wire step_kind(s): "
+            f"{unknown_builders!r}"
+        )
+    unknown_runners = sorted(set(run_step) - declared_step_kinds)
+    if unknown_runners:
+        raise RuntimeError(
+            f"Turn analytic {analytic_id!r} unknown run_step step_kind(s): {unknown_runners!r}"
+        )
+
+    return AnalyticComputeRegistration(
+        analytic_id=analytic_id,
+        scope_key_spec=scope_key_spec,
+        compute_profile=compute_profile,
+        persistence_policy=persistence_policy,
+        build_step_job_wire=build_step_job_wire,
+        run_step=run_step,
+    )
+
+
+def build_compute_registry(
+    registrations: tuple[TurnAnalyticRegistration, ...],
+) -> dict[str, AnalyticComputeRegistration]:
+    """Build and validate the compute registry from turn analytic registrations."""
+    registry: dict[str, AnalyticComputeRegistration] = {}
+    for registration in registrations:
+        compute_registration = validate_turn_analytic_compute_registration(registration)
+        if compute_registration is None:
+            continue
+        analytic_id = compute_registration.analytic_id
+        if analytic_id in registry:
+            raise RuntimeError(f"Duplicate compute registration id: {analytic_id!r}")
+        registry[analytic_id] = compute_registration
+    return registry
+
+
+def _production_compute_registrations() -> tuple[TurnAnalyticRegistration, ...]:
+    from api.analytics.registry import TURN_ANALYTIC_REGISTRATIONS
+
+    return TURN_ANALYTIC_REGISTRATIONS
+
+
+COMPUTE_REGISTRY: dict[str, AnalyticComputeRegistration] = build_compute_registry(
+    _production_compute_registrations()
+)

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -176,6 +176,13 @@ def _production_compute_registrations() -> tuple[TurnAnalyticRegistration, ...]:
     return TURN_ANALYTIC_REGISTRATIONS
 
 
-COMPUTE_REGISTRY: dict[str, AnalyticComputeRegistration] = build_compute_registry(
-    _production_compute_registrations()
-)
+_COMPUTE_REGISTRY: dict[str, AnalyticComputeRegistration] | None = None
+
+
+def __getattr__(name: str) -> object:
+    global _COMPUTE_REGISTRY
+    if name == "COMPUTE_REGISTRY":
+        if _COMPUTE_REGISTRY is None:
+            _COMPUTE_REGISTRY = build_compute_registry(_production_compute_registrations())
+        return _COMPUTE_REGISTRY
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/api/api/compute/scope.py
+++ b/packages/api/api/compute/scope.py
@@ -1,0 +1,99 @@
+"""Compute scope identity and normalization from export scope."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+from api.analytics.export_types import ExportScope
+
+WILDCARD = "*"
+
+ScopeAxis = Literal["perspective", "turn", "player_id"]
+ScopeAxisValue = int | Literal["*"]
+
+
+@dataclass(frozen=True)
+class ScopeKeySpec:
+    """Per-analytic declaration of which axes and parameters form compute identity."""
+
+    axes: tuple[ScopeAxis, ...]
+    parameter_fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ComputeScope:
+    """Canonical identity for one cacheable orchestrator work unit."""
+
+    analytic_id: str
+    game_id: int
+    perspective: ScopeAxisValue = WILDCARD
+    turn: ScopeAxisValue = WILDCARD
+    player_id: ScopeAxisValue = WILDCARD
+    parameters: tuple[tuple[str, str], ...] = ()
+
+
+def fingerprint_parameters(
+    parameters: Mapping[str, object] | None,
+    *,
+    parameter_fields: tuple[str, ...],
+) -> tuple[tuple[str, str], ...]:
+    """Return a canonical sorted fingerprint for scope parameter fields."""
+    if not parameter_fields:
+        return ()
+    if parameters is None:
+        return tuple((field, "") for field in sorted(parameter_fields))
+    fingerprint: list[tuple[str, str]] = []
+    for field in sorted(parameter_fields):
+        if field not in parameters:
+            fingerprint.append((field, ""))
+            continue
+        fingerprint.append((field, str(parameters[field])))
+    return tuple(fingerprint)
+
+
+def _axis_value(
+    axis: ScopeAxis,
+    *,
+    export_scope: ExportScope,
+    scope_key_spec: ScopeKeySpec,
+) -> ScopeAxisValue:
+    if axis not in scope_key_spec.axes:
+        return WILDCARD
+    if axis == "perspective":
+        return export_scope.perspective
+    if axis == "turn":
+        return export_scope.turn
+    if export_scope.player_id is None:
+        raise ValueError(f"Export scope player_id is required when {axis!r} is in scope key axes")
+    return export_scope.player_id
+
+
+def normalize_export_scope_to_compute_scope(
+    export_scope: ExportScope,
+    *,
+    analytic_id: str,
+    scope_key_spec: ScopeKeySpec,
+    parameters: Mapping[str, object] | None = None,
+) -> ComputeScope:
+    """Map an export query scope to orchestrator compute scope per analytic key spec."""
+    return ComputeScope(
+        analytic_id=analytic_id,
+        game_id=export_scope.game_id,
+        perspective=_axis_value(
+            "perspective",
+            export_scope=export_scope,
+            scope_key_spec=scope_key_spec,
+        ),
+        turn=_axis_value("turn", export_scope=export_scope, scope_key_spec=scope_key_spec),
+        player_id=_axis_value(
+            "player_id",
+            export_scope=export_scope,
+            scope_key_spec=scope_key_spec,
+        ),
+        parameters=fingerprint_parameters(
+            parameters,
+            parameter_fields=scope_key_spec.parameter_fields,
+        ),
+    )

--- a/packages/api/api/compute/wire.py
+++ b/packages/api/api/compute/wire.py
@@ -1,0 +1,12 @@
+"""Serializable job and result wire types for compute leaf steps."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# Orchestration plane: scope + dependency outputs -> serializable job payload.
+BuildStepJobWireFn = Callable[..., Any]
+
+# Compute plane: job payload -> serializable result payload.
+RunStepFn = Callable[[Any], Any]

--- a/packages/api/api/validation.py
+++ b/packages/api/api/validation.py
@@ -1,0 +1,15 @@
+"""Shared validation helpers for Core API registration and configuration."""
+
+
+def require_non_empty_string(
+    value: str,
+    *,
+    field: str,
+    analytic_id: str | None = None,
+    subject: str = "catalog entry",
+) -> None:
+    """Raise RuntimeError when value is empty or whitespace-only."""
+    if value and value.strip():
+        return
+    prefix = f"Turn analytic {analytic_id!r} " if analytic_id is not None else "Turn analytic "
+    raise RuntimeError(f"{prefix}{subject} {field} must be a non-empty string, got {value!r}")

--- a/packages/api/tests/test_analytics_registry.py
+++ b/packages/api/tests/test_analytics_registry.py
@@ -179,7 +179,10 @@ def test_validate_turn_analytic_registrations_rejects_non_callable_compute():
 
 
 def test_validate_turn_analytic_registrations_rejects_invalid_compute_profile():
-    from api.analytics.registration import TurnAnalyticRegistration, validate_turn_analytic_registrations
+    from api.analytics.registration import (
+        TurnAnalyticRegistration,
+        validate_turn_analytic_registrations,
+    )
     from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
 
     base = _registration_for_validation()

--- a/packages/api/tests/test_analytics_registry.py
+++ b/packages/api/tests/test_analytics_registry.py
@@ -178,6 +178,24 @@ def test_validate_turn_analytic_registrations_rejects_non_callable_compute():
         validate_turn_analytic_registrations((_registration_for_validation(compute=object()),))
 
 
+def test_validate_turn_analytic_registrations_rejects_invalid_compute_profile():
+    from api.analytics.registration import TurnAnalyticRegistration, validate_turn_analytic_registrations
+    from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
+
+    base = _registration_for_validation()
+    registration = TurnAnalyticRegistration(
+        catalog_entry=base.catalog_entry,
+        compute=base.compute,
+        export_catalog=base.export_catalog,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="scope_key_spec"):
+        validate_turn_analytic_registrations((registration,))
+
+
 def test_validate_turn_analytic_registrations_rejects_mismatched_export_catalog_id():
     from api.analytics.catalog import TurnAnalyticCatalogEntry
     from api.analytics.exports.empty import empty_export_catalog_for

--- a/packages/api/tests/test_compute_foundation.py
+++ b/packages/api/tests/test_compute_foundation.py
@@ -1,0 +1,242 @@
+"""Tests for compute orchestrator foundation types and registry validation."""
+
+from __future__ import annotations
+
+import pytest
+from api.analytics.catalog import TurnAnalyticCatalogEntry
+from api.analytics.export_types import ExportScope
+from api.analytics.exports.empty import empty_export_catalog_for
+from api.analytics.registration import TurnAnalyticRegistration
+from api.compute import (
+    WILDCARD,
+    AnalyticComputeProfile,
+    ComputeScope,
+    ComputeStepSpec,
+    ScopeKeySpec,
+    build_compute_registry,
+    fingerprint_parameters,
+    normalize_export_scope_to_compute_scope,
+    validate_turn_analytic_compute_registration,
+)
+
+
+class _StubPersistencePolicy:
+    def is_satisfied(self, _ctx, _scope) -> bool:
+        return False
+
+    def persist(self, _ctx, _scope, _result_wire) -> None:
+        return None
+
+    def invalidate(self, _ctx, _scope) -> None:
+        return None
+
+
+def _catalog_entry(analytic_id: str = "test-analytic") -> TurnAnalyticCatalogEntry:
+    return TurnAnalyticCatalogEntry(
+        id=analytic_id,
+        name="Test",
+        supports_table=True,
+        supports_map=False,
+        type="selectable",
+    )
+
+
+def _compute_registration(**kwargs) -> TurnAnalyticRegistration:
+    analytic_id = kwargs.get("analytic_id", "test-analytic")
+    scope_key_spec = kwargs.get(
+        "scope_key_spec",
+        ScopeKeySpec(axes=("perspective", "turn", "player_id")),
+    )
+    compute_profile = kwargs.get(
+        "compute_profile",
+        AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+        ),
+    )
+    persistence_policy = kwargs.get("persistence_policy", _StubPersistencePolicy())
+    build_step_job_wires = kwargs.get(
+        "build_step_job_wires",
+        (("materialize", lambda **_kwargs: {"job": True}),),
+    )
+    run_steps = kwargs.get(
+        "run_steps",
+        (("materialize", lambda _job: {"result": True}),),
+    )
+
+    def compute(_ctx) -> dict:
+        return {"analyticId": analytic_id}
+
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(analytic_id),
+        compute=compute,
+        export_catalog=empty_export_catalog_for(analytic_id),
+        scope_key_spec=scope_key_spec,
+        compute_profile=compute_profile,
+        persistence_policy=persistence_policy,
+        build_step_job_wires=build_step_job_wires,
+        run_steps=run_steps,
+    )
+
+
+def test_normalize_export_scope_maps_declared_axes_and_wildcards_others():
+    export_scope = ExportScope(game_id=628580, perspective=1, turn=8, player_id=3)
+    scores_spec = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+    scope = normalize_export_scope_to_compute_scope(
+        export_scope,
+        analytic_id="scores",
+        scope_key_spec=scores_spec,
+    )
+    assert scope == ComputeScope(
+        analytic_id="scores",
+        game_id=628580,
+        perspective=1,
+        turn=8,
+        player_id=3,
+        parameters=(),
+    )
+
+    connections_spec = ScopeKeySpec(axes=("perspective", "turn"))
+    connections_scope = normalize_export_scope_to_compute_scope(
+        export_scope,
+        analytic_id="connections",
+        scope_key_spec=connections_spec,
+    )
+    assert connections_scope.player_id == WILDCARD
+    assert connections_scope.perspective == 1
+    assert connections_scope.turn == 8
+
+
+def test_normalize_export_scope_requires_player_id_when_axis_declared():
+    export_scope = ExportScope(game_id=1, perspective=1, turn=2, player_id=None)
+    with pytest.raises(ValueError, match="player_id is required"):
+        normalize_export_scope_to_compute_scope(
+            export_scope,
+            analytic_id="scores",
+            scope_key_spec=ScopeKeySpec(axes=("perspective", "turn", "player_id")),
+        )
+
+
+def test_fingerprint_parameters_sorts_and_stringifies():
+    spec = ScopeKeySpec(
+        axes=("perspective", "turn"),
+        parameter_fields=("warp_speed", "flare_mode"),
+    )
+    export_scope = ExportScope(game_id=1, perspective=2, turn=3)
+    scope = normalize_export_scope_to_compute_scope(
+        export_scope,
+        analytic_id="connections",
+        scope_key_spec=spec,
+        parameters={"flare_mode": "only", "warp_speed": 9, "ignored": "x"},
+    )
+    assert scope.parameters == (("flare_mode", "only"), ("warp_speed", "9"))
+
+
+def test_fingerprint_parameters_fills_missing_fields():
+    assert fingerprint_parameters(
+        {"warp_speed": 7},
+        parameter_fields=("flare_mode", "warp_speed"),
+    ) == (("flare_mode", ""), ("warp_speed", "7"))
+
+
+def test_validate_compute_registration_accepts_complete_profile():
+    registration = _compute_registration()
+    compute_registration = validate_turn_analytic_compute_registration(registration)
+    assert compute_registration is not None
+    assert compute_registration.analytic_id == "test-analytic"
+    assert "materialize" in compute_registration.build_step_job_wire
+    assert "materialize" in compute_registration.run_step
+
+
+def test_validate_compute_registration_skips_when_profile_absent():
+    registration = TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(),
+        compute=lambda _ctx: {"analyticId": "test-analytic"},
+        export_catalog=empty_export_catalog_for("test-analytic"),
+    )
+    assert validate_turn_analytic_compute_registration(registration) is None
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"scope_key_spec": None}, "scope_key_spec"),
+        ({"persistence_policy": None}, "persistence_policy"),
+        (
+            {
+                "compute_profile": AnalyticComputeProfile(steps=()),
+            },
+            "steps must not be empty",
+        ),
+        (
+            {
+                "compute_profile": AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="a", backend="thread"),) * 2,
+                ),
+            },
+            "duplicate compute step_kind",
+        ),
+        (
+            {
+                "compute_profile": AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="unknown"),),
+                ),
+            },
+            "unknown backend",
+        ),
+        (
+            {
+                "build_step_job_wires": (),
+            },
+            "missing build_step_job_wire",
+        ),
+        (
+            {
+                "run_steps": (),
+            },
+            "missing run_step",
+        ),
+        (
+            {
+                "build_step_job_wires": (
+                    ("materialize", lambda **_kwargs: {}),
+                    ("extra", lambda **_kwargs: {}),
+                ),
+            },
+            "unknown build_step_job_wire",
+        ),
+        (
+            {
+                "run_steps": (
+                    ("materialize", lambda _job: {}),
+                    ("extra", lambda _job: {}),
+                ),
+            },
+            "unknown run_step",
+        ),
+        (
+            {
+                "scope_key_spec": ScopeKeySpec(axes=(), parameter_fields=()),
+            },
+            "must declare at least one axis",
+        ),
+    ],
+)
+def test_validate_compute_registration_rejects_invalid_profiles(overrides, match):
+    registration = _compute_registration(**overrides)
+    with pytest.raises(RuntimeError, match=match):
+        validate_turn_analytic_compute_registration(registration)
+
+
+def test_build_compute_registry_rejects_duplicate_compute_ids():
+    registrations = (
+        _compute_registration(analytic_id="dup"),
+        _compute_registration(analytic_id="dup"),
+    )
+    with pytest.raises(RuntimeError, match="Duplicate compute registration"):
+        build_compute_registry(registrations)
+
+
+def test_production_compute_registry_imports_without_profiles():
+    from api.compute.registry import COMPUTE_REGISTRY
+
+    assert COMPUTE_REGISTRY == {}


### PR DESCRIPTION
## Summary

- Adds `packages/api/api/compute/` foundation: `ComputeScope`, `ScopeKeySpec`, `AnalyticComputeProfile`, `ComputeStepSpec`, `PersistencePolicy`, and registry validation built from `TurnAnalyticRegistration`.
- Extends `TurnAnalyticRegistration` with optional compute fields; import-time validation runs with existing catalog/export checks.
- Documents the compute orchestrator model in ADR 0005 and `design-compute-orchestrator.md`.
- Extracts `require_non_empty_string` to `api.validation` for shared use by analytics and compute registration validation.

Closes #195

## Test plan

- [x] `make test_api` (1142 passed)
- [x] `test_compute_foundation.py` -- scope normalization, registry validation, production empty registry
- [x] `test_analytics_registry.py` -- import-time compute profile validation


Made with [Cursor](https://cursor.com)