### PR TITLE
Compute orchestrator: core DAG scheduler and singleflight (#196)

### DIFF
--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -12,10 +12,11 @@ from api.compute.scope import (
     ComputeScope,
     ScopeAxis,
     ScopeKeySpec,
+    compute_scope_to_export_scope,
     fingerprint_parameters,
     normalize_export_scope_to_compute_scope,
 )
-from api.compute.wire import BuildStepJobWireFn, RunStepFn
+from api.compute.wire import BuildStepJobWireFn, DependencyOutputs, RunStepFn
 
 _REGISTRY_EXPORTS = frozenset(
     {
@@ -27,11 +28,39 @@ _REGISTRY_EXPORTS = frozenset(
 )
 
 
+_COMPUTE_ORCHESTRATOR_EXPORTS = frozenset(
+    {
+        "ComputeHandle",
+        "ComputeNodeRun",
+        "ComputeOrchestrator",
+        "ComputeRequest",
+        "NodeState",
+        "OrchestratorMetrics",
+        "PoolSubmitter",
+    }
+)
+
+_DAG_EXPORTS = frozenset(
+    {
+        "PlannedComputeNode",
+        "plan_compute_dag",
+    }
+)
+
+
 def __getattr__(name: str) -> object:
     if name in _REGISTRY_EXPORTS:
         from api.compute import registry as registry_module
 
         return getattr(registry_module, name)
+    if name in _COMPUTE_ORCHESTRATOR_EXPORTS:
+        from api.compute import orchestrator as orchestrator_module
+
+        return getattr(orchestrator_module, name)
+    if name in _DAG_EXPORTS:
+        from api.compute import dag as dag_module
+
+        return getattr(dag_module, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -43,14 +72,25 @@ __all__ = [
     "AnalyticComputeRegistration",
     "BuildStepJobWireFn",
     "ComputeBackend",
+    "ComputeHandle",
+    "ComputeNodeRun",
+    "ComputeOrchestrator",
+    "ComputeRequest",
     "ComputeScope",
     "ComputeStepSpec",
+    "DependencyOutputs",
+    "NodeState",
+    "OrchestratorMetrics",
     "PersistencePolicy",
+    "PlannedComputeNode",
+    "PoolSubmitter",
     "RunStepFn",
     "ScopeAxis",
     "ScopeKeySpec",
     "build_compute_registry",
+    "compute_scope_to_export_scope",
     "fingerprint_parameters",
     "normalize_export_scope_to_compute_scope",
+    "plan_compute_dag",
     "validate_turn_analytic_compute_registration",
 ]

--- a/packages/api/api/compute/dag.py
+++ b/packages/api/api/compute/dag.py
@@ -1,0 +1,91 @@
+"""DAG planning for compute orchestrator from ENSURE_DEPENDENCIES."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from api.analytics.export_context import AnalyticQueryContext
+from api.analytics.export_dependency_walk import (
+    dependency_scope_for,
+    walk_dependency_tree,
+)
+from api.analytics.export_types import ExportScope
+from api.compute.registry import AnalyticComputeRegistration
+from api.compute.scope import (
+    ComputeScope,
+    normalize_export_scope_to_compute_scope,
+)
+
+
+@dataclass(frozen=True)
+class PlannedComputeNode:
+    """One DAG vertex discovered by export dependency walk."""
+
+    scope: ComputeScope
+    export_scope: ExportScope
+    dependency_scopes: tuple[ComputeScope, ...]
+
+
+def _pending_key(analytic_id: str, export_scope: ExportScope) -> tuple[str, ExportScope]:
+    return (analytic_id, export_scope)
+
+
+def plan_compute_dag(
+    ctx: AnalyticQueryContext,
+    analytic_id: str,
+    export_scope: ExportScope,
+    *,
+    compute_registry: Mapping[str, AnalyticComputeRegistration],
+) -> tuple[PlannedComputeNode, ...]:
+    """Plan compute nodes and dependency edges from ENSURE_DEPENDENCIES walk."""
+    walk_result = walk_dependency_tree(ctx, analytic_id, export_scope, visiting=set())
+    if walk_result.turn_unavailable is not None:
+        raise ValueError(
+            f"cannot plan compute DAG: turn unavailable ({walk_result.turn_unavailable})"
+        )
+
+    pending_by_key: dict[tuple[str, ExportScope], tuple[str, ExportScope, object]] = {}
+    for pending_analytic_id, pending_scope, catalog in walk_result.pending_ensure:
+        pending_by_key[_pending_key(pending_analytic_id, pending_scope)] = (
+            pending_analytic_id,
+            pending_scope,
+            catalog,
+        )
+
+    planned: list[PlannedComputeNode] = []
+    for pending_analytic_id, pending_scope, catalog in walk_result.pending_ensure:
+        compute_registration = compute_registry.get(pending_analytic_id)
+        if compute_registration is None:
+            raise RuntimeError(
+                f"compute registry missing analytic {pending_analytic_id!r} required by DAG plan"
+            )
+        scope = normalize_export_scope_to_compute_scope(
+            pending_scope,
+            analytic_id=pending_analytic_id,
+            scope_key_spec=compute_registration.scope_key_spec,
+        )
+        dependency_scopes: list[ComputeScope] = []
+        for dependency in catalog.ensure_dependencies:
+            dependency_export_scope = dependency_scope_for(pending_scope, dependency)
+            if dependency_export_scope.turn < 1:
+                continue
+            dependency_key = _pending_key(dependency.analytic_id, dependency_export_scope)
+            if dependency_key not in pending_by_key:
+                continue
+            dependency_registration = compute_registry[dependency.analytic_id]
+            dependency_scopes.append(
+                normalize_export_scope_to_compute_scope(
+                    dependency_export_scope,
+                    analytic_id=dependency.analytic_id,
+                    scope_key_spec=dependency_registration.scope_key_spec,
+                )
+            )
+        planned.append(
+            PlannedComputeNode(
+                scope=scope,
+                export_scope=pending_scope,
+                dependency_scopes=tuple(dependency_scopes),
+            )
+        )
+    return tuple(planned)

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -41,7 +41,15 @@ class ComputeHandle:
     scope: ComputeScope
     _node: ComputeNodeRun
     is_waiter: bool = False
-    error: BaseException | None = None
+    _waiter_error: BaseException | None = field(default=None, compare=False)
+
+    @property
+    def error(self) -> BaseException | None:
+        if self.is_waiter:
+            return self._waiter_error
+        if self._node.state == "failed":
+            return self._node.error
+        return None
 
     @property
     def state(self) -> NodeState:
@@ -315,7 +323,7 @@ class ComputeOrchestrator:
         node.state = "complete"
         self._dequeue_ready(node.scope)
         for waiter in node.waiters:
-            waiter.error = None
+            waiter._waiter_error = None
         node.waiters.clear()
         self._on_dependency_terminal(node.scope)
 
@@ -326,7 +334,7 @@ class ComputeOrchestrator:
         node.error = error
         self._dequeue_ready(node.scope)
         for waiter in node.waiters:
-            waiter.error = error
+            waiter._waiter_error = error
         node.waiters.clear()
         self._on_dependency_terminal(node.scope)
 

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -188,6 +188,10 @@ class ComputeOrchestrator:
     def _refresh_node_readiness(self, node: ComputeNodeRun) -> None:
         if node.state in {"complete", "failed", "running"}:
             return
+        failed_dependency_error = self._failed_dependency_error(node)
+        if failed_dependency_error is not None:
+            self._fail_node(node, failed_dependency_error)
+            return
         if self._deps_complete(node):
             if node.state != "ready":
                 node.state = "ready"
@@ -195,6 +199,13 @@ class ComputeOrchestrator:
         else:
             node.state = "waiting_deps"
             self._dequeue_ready(node.scope)
+
+    def _failed_dependency_error(self, node: ComputeNodeRun) -> BaseException | None:
+        for dependency_scope in node.dependency_scopes:
+            dependency = self._nodes.get(dependency_scope)
+            if dependency is not None and dependency.state == "failed":
+                return dependency.error
+        return None
 
     def _deps_complete(self, node: ComputeNodeRun) -> bool:
         for dependency_scope in node.dependency_scopes:
@@ -309,12 +320,15 @@ class ComputeOrchestrator:
         self._on_dependency_terminal(node.scope)
 
     def _fail_node(self, node: ComputeNodeRun, error: BaseException) -> None:
+        if node.state == "failed":
+            return
         node.state = "failed"
         node.error = error
         self._dequeue_ready(node.scope)
         for waiter in node.waiters:
             waiter.error = error
         node.waiters.clear()
+        self._on_dependency_terminal(node.scope)
 
     def _on_dependency_terminal(self, completed_scope: ComputeScope) -> None:
         for node in self._nodes.values():

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -1,0 +1,331 @@
+"""Compute orchestrator DAG scheduler with singleflight and inline execution."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from api.analytics.export_context import AnalyticQueryContext
+from api.compute.dag import PlannedComputeNode, plan_compute_dag
+from api.compute.profile import ComputeStepSpec
+from api.compute.registry import AnalyticComputeRegistration
+from api.compute.scope import ComputeScope, compute_scope_to_export_scope
+from api.compute.wire import DependencyOutputs
+
+NodeState = Literal[
+    "waiting_deps",
+    "ready",
+    "running",
+    "attach_inflight",
+    "complete",
+    "failed",
+]
+
+PoolSubmitter = Callable[["ComputeNodeRun", ComputeStepSpec], None]
+
+
+@dataclass(frozen=True)
+class ComputeRequest:
+    """One orchestrator submission for a compute scope."""
+
+    scope: ComputeScope
+    step_kind: str | None = None
+
+
+@dataclass
+class ComputeHandle:
+    """Caller-visible orchestrator handle for one submission."""
+
+    scope: ComputeScope
+    _node: ComputeNodeRun
+    is_waiter: bool = False
+    error: BaseException | None = None
+
+    @property
+    def state(self) -> NodeState:
+        if self.is_waiter and self._node.state == "running":
+            return "attach_inflight"
+        if self.is_waiter and self._node.state == "complete":
+            return "complete"
+        if self.is_waiter and self._node.state == "failed":
+            return "failed"
+        return self._node.state
+
+    @property
+    def result_wire(self) -> object | None:
+        return self._node.result_wire
+
+
+@dataclass
+class ComputeNodeRun:
+    """Mutable orchestrator state for one compute scope."""
+
+    scope: ComputeScope
+    dependency_scopes: tuple[ComputeScope, ...]
+    state: NodeState = "waiting_deps"
+    step_index: int = 0
+    result_wire: object | None = None
+    error: BaseException | None = None
+    waiters: list[ComputeHandle] = field(default_factory=list)
+
+
+@dataclass
+class OrchestratorMetrics:
+    """Test and diagnostics counters for orchestrator dispatch."""
+
+    inline_executions: int = 0
+    pool_submissions: int = 0
+
+
+class ComputeOrchestrator:
+    """DAG scheduler with singleflight per normalized compute scope."""
+
+    def __init__(
+        self,
+        ctx: AnalyticQueryContext,
+        *,
+        compute_registry: Mapping[str, AnalyticComputeRegistration],
+        pool_submitter: PoolSubmitter | None = None,
+    ) -> None:
+        self._ctx = ctx
+        self._compute_registry = compute_registry
+        self._pool_submitter = pool_submitter
+        self._nodes: dict[ComputeScope, ComputeNodeRun] = {}
+        self._ready_queue: deque[ComputeScope] = deque()
+        self._metrics = OrchestratorMetrics()
+
+    @property
+    def metrics(self) -> OrchestratorMetrics:
+        return self._metrics
+
+    @property
+    def nodes(self) -> Mapping[ComputeScope, ComputeNodeRun]:
+        return self._nodes
+
+    def ready_scopes(self) -> tuple[ComputeScope, ...]:
+        """Return scopes currently in the ready queue."""
+        return tuple(scope for scope in self._ready_queue if self._nodes[scope].state == "ready")
+
+    def submit(self, request: ComputeRequest) -> ComputeHandle:
+        """Submit or attach to in-flight work for one compute scope."""
+        scope = request.scope
+        existing = self._nodes.get(scope)
+        if existing is not None:
+            return self._attach_to_existing(existing)
+
+        self._plan_and_register(scope)
+        for node in self._nodes.values():
+            self._refresh_node_readiness(node)
+        handle = ComputeHandle(scope=scope, _node=self._nodes[scope])
+        self._dispatch()
+        return handle
+
+    def run_until_idle(self) -> None:
+        """Drain ready inline work until no ready or running nodes remain."""
+        while self._has_pending_work():
+            self._refresh_all_readiness()
+            self._dispatch()
+            if any(node.state == "running" for node in self._nodes.values()):
+                break
+
+    def complete_pool_step(
+        self,
+        scope: ComputeScope,
+        *,
+        result_wire: object | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        """Mark a pool-submitted step complete (used by worker pool integration)."""
+        node = self._nodes[scope]
+        if node.state != "running":
+            raise RuntimeError(f"cannot complete pool step for node in state {node.state!r}")
+        if error is not None:
+            self._fail_node(node, error)
+            return
+        self._after_step_success(node, result_wire)
+
+    def _attach_to_existing(self, node: ComputeNodeRun) -> ComputeHandle:
+        if node.state in {"complete", "failed"}:
+            return ComputeHandle(scope=node.scope, _node=node)
+        handle = ComputeHandle(scope=node.scope, _node=node, is_waiter=True)
+        node.waiters.append(handle)
+        return handle
+
+    def _plan_and_register(self, root_scope: ComputeScope) -> None:
+        export_scope = compute_scope_to_export_scope(root_scope)
+        planned_nodes = plan_compute_dag(
+            self._ctx,
+            root_scope.analytic_id,
+            export_scope,
+            compute_registry=self._compute_registry,
+        )
+        for planned in planned_nodes:
+            self._register_planned_node(planned)
+        if root_scope not in self._nodes:
+            self._nodes[root_scope] = ComputeNodeRun(
+                scope=root_scope,
+                dependency_scopes=(),
+                state="complete",
+            )
+
+    def _register_planned_node(self, planned: PlannedComputeNode) -> None:
+        if planned.scope in self._nodes:
+            return
+        node = ComputeNodeRun(
+            scope=planned.scope,
+            dependency_scopes=planned.dependency_scopes,
+        )
+        self._nodes[planned.scope] = node
+
+    def _refresh_all_readiness(self) -> None:
+        for node in self._nodes.values():
+            if node.state in {"complete", "failed", "running"}:
+                continue
+            self._refresh_node_readiness(node)
+
+    def _refresh_node_readiness(self, node: ComputeNodeRun) -> None:
+        if node.state in {"complete", "failed", "running"}:
+            return
+        if self._deps_complete(node):
+            if node.state != "ready":
+                node.state = "ready"
+                self._enqueue_ready(node.scope)
+        else:
+            node.state = "waiting_deps"
+            self._dequeue_ready(node.scope)
+
+    def _deps_complete(self, node: ComputeNodeRun) -> bool:
+        for dependency_scope in node.dependency_scopes:
+            dependency = self._nodes.get(dependency_scope)
+            if dependency is None or dependency.state != "complete":
+                return False
+        return True
+
+    def _enqueue_ready(self, scope: ComputeScope) -> None:
+        if scope not in self._ready_queue:
+            self._ready_queue.append(scope)
+
+    def _dequeue_ready(self, scope: ComputeScope) -> None:
+        try:
+            self._ready_queue.remove(scope)
+        except ValueError:
+            return
+
+    def _dispatch(self) -> None:
+        while self._ready_queue:
+            scope = self._ready_queue[0]
+            node = self._nodes[scope]
+            if node.state != "ready":
+                self._ready_queue.popleft()
+                continue
+            if not self._deps_complete(node):
+                node.state = "waiting_deps"
+                self._ready_queue.popleft()
+                continue
+
+            registration = self._compute_registry[node.scope.analytic_id]
+            step = self._current_step_spec(node, registration)
+            if step.backend == "inline":
+                self._ready_queue.popleft()
+                node.state = "running"
+                self._run_inline(node, registration, step)
+                continue
+
+            if self._pool_submitter is None:
+                return
+            self._ready_queue.popleft()
+            node.state = "running"
+            self._pool_submitter(node, step)
+            self._metrics.pool_submissions += 1
+            return
+
+    def _current_step_spec(
+        self,
+        node: ComputeNodeRun,
+        registration: AnalyticComputeRegistration,
+    ) -> ComputeStepSpec:
+        steps = registration.compute_profile.steps
+        if node.step_index >= len(steps):
+            raise RuntimeError(
+                f"compute node {node.scope!r} has no step at index {node.step_index}"
+            )
+        return steps[node.step_index]
+
+    def _run_inline(
+        self,
+        node: ComputeNodeRun,
+        registration: AnalyticComputeRegistration,
+        step: ComputeStepSpec,
+    ) -> None:
+        self._metrics.inline_executions += 1
+        try:
+            job_wire = self._build_job_wire(node, registration, step)
+            result_wire = registration.run_step[step.step_kind](job_wire)
+        except BaseException as exc:
+            self._fail_node(node, exc)
+            return
+        self._after_step_success(node, result_wire)
+
+    def _build_job_wire(
+        self,
+        node: ComputeNodeRun,
+        registration: AnalyticComputeRegistration,
+        step: ComputeStepSpec,
+    ) -> object:
+        dependency_outputs = DependencyOutputs()
+        for dependency_scope in node.dependency_scopes:
+            dependency_node = self._nodes[dependency_scope]
+            if dependency_node.result_wire is None:
+                raise RuntimeError(
+                    f"dependency {dependency_scope!r} is complete without a result wire"
+                )
+            dependency_outputs.put(dependency_scope, dependency_node.result_wire)
+        builder = registration.build_step_job_wire[step.step_kind]
+        return builder(
+            node.scope,
+            dependency_outputs=dependency_outputs,
+            ctx=self._ctx,
+        )
+
+    def _after_step_success(self, node: ComputeNodeRun, result_wire: object | None) -> None:
+        registration = self._compute_registry[node.scope.analytic_id]
+        node.step_index += 1
+        if node.step_index < len(registration.compute_profile.steps):
+            node.state = "ready"
+            self._enqueue_ready(node.scope)
+            self._dispatch()
+            return
+        node.result_wire = result_wire
+        self._complete_node(node)
+
+    def _complete_node(self, node: ComputeNodeRun) -> None:
+        node.state = "complete"
+        self._dequeue_ready(node.scope)
+        for waiter in node.waiters:
+            waiter.error = None
+        node.waiters.clear()
+        self._on_dependency_terminal(node.scope)
+
+    def _fail_node(self, node: ComputeNodeRun, error: BaseException) -> None:
+        node.state = "failed"
+        node.error = error
+        self._dequeue_ready(node.scope)
+        for waiter in node.waiters:
+            waiter.error = error
+        node.waiters.clear()
+
+    def _on_dependency_terminal(self, completed_scope: ComputeScope) -> None:
+        for node in self._nodes.values():
+            if completed_scope not in node.dependency_scopes:
+                continue
+            if node.state in {"complete", "failed", "running"}:
+                continue
+            self._refresh_node_readiness(node)
+        self._dispatch()
+
+    def _has_pending_work(self) -> bool:
+        return any(
+            node.state in {"waiting_deps", "ready", "running"} for node in self._nodes.values()
+        )

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -53,12 +53,8 @@ class ComputeHandle:
 
     @property
     def state(self) -> NodeState:
-        if self.is_waiter and self._node.state == "running":
+        if self.is_waiter and self._node.state not in {"complete", "failed"}:
             return "attach_inflight"
-        if self.is_waiter and self._node.state == "complete":
-            return "complete"
-        if self.is_waiter and self._node.state == "failed":
-            return "failed"
         return self._node.state
 
     @property

--- a/packages/api/api/compute/scope.py
+++ b/packages/api/api/compute/scope.py
@@ -70,6 +70,21 @@ def _axis_value(
     return export_scope.player_id
 
 
+def compute_scope_to_export_scope(scope: ComputeScope) -> ExportScope:
+    """Map a concrete compute scope to export scope for dependency walks."""
+    if scope.perspective == WILDCARD:
+        raise ValueError("concrete perspective is required for export planning")
+    if scope.turn == WILDCARD:
+        raise ValueError("concrete turn is required for export planning")
+    player_id = None if scope.player_id == WILDCARD else scope.player_id
+    return ExportScope(
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=player_id,
+    )
+
+
 def normalize_export_scope_to_compute_scope(
     export_scope: ExportScope,
     *,

--- a/packages/api/api/compute/wire.py
+++ b/packages/api/api/compute/wire.py
@@ -2,11 +2,46 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from typing import Any
+
+from api.compute.scope import ComputeScope
 
 # Orchestration plane: scope + dependency outputs -> serializable job payload.
 BuildStepJobWireFn = Callable[..., Any]
 
 # Compute plane: job payload -> serializable result payload.
 RunStepFn = Callable[[Any], Any]
+
+
+@dataclass
+class DependencyOutputs:
+    """Ancestor result wires for job-wire builders.
+
+    Full path projection arrives in #198; this slice stores whole result wires
+    keyed by completed dependency scope.
+    """
+
+    _by_scope: dict[ComputeScope, object] = field(default_factory=dict)
+
+    def put(self, scope: ComputeScope, result_wire: object) -> None:
+        self._by_scope[scope] = result_wire
+
+    def get(self, scope: ComputeScope) -> object | None:
+        return self._by_scope.get(scope)
+
+    def require(
+        self,
+        *,
+        analytic_id: str,
+        scope: ComputeScope,
+        paths: tuple[str, ...],
+    ) -> object:
+        del analytic_id, paths
+        if scope not in self._by_scope:
+            raise KeyError(f"dependency output missing for scope {scope!r}")
+        return self._by_scope[scope]
+
+    def as_mapping(self) -> Mapping[ComputeScope, object]:
+        return self._by_scope

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -305,3 +305,44 @@ def test_submit_does_not_run_step_before_dependencies_complete(sample_turn):
 
     assert inline_calls == [ROOT_ID]
     assert orchestrator.nodes[root_scope].state == "complete"
+
+
+def test_run_until_idle_terminates_after_ancestor_failure(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    thread_registry = build_compute_registry(
+        (
+            _thread_compute_registration(ROOT_ID),
+            _thread_compute_registration(BRANCH_B_ID),
+            _thread_compute_registration(BRANCH_C_ID),
+            _thread_compute_registration(SHARED_ID),
+        )
+    )
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=thread_registry,
+        pool_submitter=lambda _node, _step: None,
+    )
+
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    branch_b_scope = _compute_scope(BRANCH_B_ID, export_scope)
+    branch_c_scope = _compute_scope(BRANCH_C_ID, export_scope)
+
+    orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    shared_failure = RuntimeError("shared step failed")
+    orchestrator.complete_pool_step(shared_scope, error=shared_failure)
+
+    orchestrator.run_until_idle()
+
+    assert orchestrator.nodes[shared_scope].state == "failed"
+    assert orchestrator.nodes[shared_scope].error is shared_failure
+    assert orchestrator.nodes[branch_b_scope].state == "failed"
+    assert orchestrator.nodes[branch_c_scope].state == "failed"
+    assert orchestrator.nodes[root_scope].state == "failed"
+    assert orchestrator.nodes[branch_b_scope].error is shared_failure
+    assert orchestrator.nodes[root_scope].error is shared_failure

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -346,3 +346,65 @@ def test_run_until_idle_terminates_after_ancestor_failure(sample_turn):
     assert orchestrator.nodes[root_scope].state == "failed"
     assert orchestrator.nodes[branch_b_scope].error is shared_failure
     assert orchestrator.nodes[root_scope].error is shared_failure
+
+
+def test_leader_handle_exposes_error_after_inline_failure(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    inline_failure = RuntimeError("inline step failed")
+
+    def failing_run_step(_job):
+        raise inline_failure
+
+    compute_registry = build_compute_registry(
+        (
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry(SHARED_ID),
+                compute=lambda _ctx: {"analyticId": SHARED_ID},
+                export_catalog=empty_export_catalog_for(SHARED_ID),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+                ),
+                persistence_policy=_StubPersistencePolicy(),
+                build_step_job_wires=(
+                    ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+                ),
+                run_steps=(("materialize", failing_run_step),),
+            ),
+        )
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert handle.state == "failed"
+    assert handle.error is inline_failure
+
+
+def test_leader_handle_exposes_error_after_pool_failure(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    thread_registry = build_compute_registry((_thread_compute_registration(SHARED_ID),))
+    pool_failure = RuntimeError("pool step failed")
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=thread_registry,
+        pool_submitter=lambda _node, _step: None,
+    )
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+    assert handle.state == "running"
+
+    orchestrator.complete_pool_step(shared_scope, error=pool_failure)
+
+    assert handle.state == "failed"
+    assert handle.error is pool_failure

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -213,6 +213,49 @@ def test_blocked_nodes_are_not_ready_until_dependencies_complete(sample_turn):
     assert pool_submissions == [SHARED_ID]
 
 
+def test_attach_inflight_while_leader_not_terminal(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    thread_registry = build_compute_registry((_thread_compute_registration(SHARED_ID),))
+
+    ready_orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=thread_registry,
+        pool_submitter=None,
+    )
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    ready_leader = ready_orchestrator.submit(ComputeRequest(scope=shared_scope))
+    ready_waiter = ready_orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert ready_orchestrator.nodes[shared_scope].state == "ready"
+    assert ready_leader.state == "ready"
+    assert ready_waiter.state == "attach_inflight"
+
+    diamond_registry = build_compute_registry(
+        (
+            _thread_compute_registration(ROOT_ID),
+            _thread_compute_registration(BRANCH_B_ID),
+            _thread_compute_registration(BRANCH_C_ID),
+            _thread_compute_registration(SHARED_ID),
+        )
+    )
+    deps_orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=diamond_registry,
+        pool_submitter=lambda _node, _step: None,
+    )
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+    deps_leader = deps_orchestrator.submit(ComputeRequest(scope=root_scope))
+    deps_waiter = deps_orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    assert deps_orchestrator.nodes[root_scope].state == "waiting_deps"
+    assert deps_leader.state == "waiting_deps"
+    assert deps_waiter.state == "attach_inflight"
+
+
 def test_attach_inflight_does_not_double_pool_workers(sample_turn):
     ctx = make_fixture_query_context(
         sample_turn,

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -73,6 +73,41 @@ def _inline_compute_registration(
     )
 
 
+def _two_step_inline_compute_registration(
+    analytic_id: str,
+    step_calls: list[str],
+) -> TurnAnalyticRegistration:
+    def run_tier1(job):
+        step_calls.append("tier1")
+        return {"result": "tier1", "scope": job["scope"]}
+
+    def run_tier2(job):
+        step_calls.append("tier2")
+        return {"result": "tier2", "scope": job["scope"]}
+
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(analytic_id),
+        compute=lambda _ctx: {"analyticId": analytic_id},
+        export_catalog=empty_export_catalog_for(analytic_id),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(
+                ComputeStepSpec(step_kind="tier1", backend="inline"),
+                ComputeStepSpec(step_kind="tier2", backend="inline"),
+            ),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("tier1", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+            ("tier2", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+        ),
+        run_steps=(
+            ("tier1", run_tier1),
+            ("tier2", run_tier2),
+        ),
+    )
+
+
 def _thread_compute_registration(analytic_id: str) -> TurnAnalyticRegistration:
     return TurnAnalyticRegistration(
         catalog_entry=_catalog_entry(analytic_id),
@@ -427,6 +462,28 @@ def test_leader_handle_exposes_error_after_inline_failure(sample_turn):
 
     assert handle.state == "failed"
     assert handle.error is inline_failure
+
+
+def test_orchestrator_runs_multi_step_inline_profile_in_order(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    step_calls: list[str] = []
+    compute_registry = build_compute_registry(
+        (_two_step_inline_compute_registration(SHARED_ID, step_calls),)
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert handle.state == "complete"
+    assert handle.result_wire == {"result": "tier2", "scope": SHARED_ID}
+    assert step_calls == ["tier1", "tier2"]
+    assert orchestrator.nodes[shared_scope].step_index == 2
+    assert orchestrator.metrics.inline_executions == 2
 
 
 def test_leader_handle_exposes_error_after_pool_failure(sample_turn):

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -1,0 +1,307 @@
+"""Tests for compute orchestrator DAG scheduler and singleflight."""
+
+from __future__ import annotations
+
+from api.analytics.catalog import TurnAnalyticCatalogEntry
+from api.analytics.export_types import ExportScope
+from api.analytics.exports.empty import empty_export_catalog_for
+from api.analytics.registration import TurnAnalyticRegistration
+from api.compute import (
+    AnalyticComputeProfile,
+    ComputeOrchestrator,
+    ComputeRequest,
+    ComputeScope,
+    ComputeStepSpec,
+    ScopeKeySpec,
+    build_compute_registry,
+    normalize_export_scope_to_compute_scope,
+    plan_compute_dag,
+)
+
+from tests.fixtures.export_framework.diamond_exports import (
+    BRANCH_B_ID,
+    BRANCH_C_ID,
+    ROOT_ID,
+    SHARED_ID,
+)
+from tests.fixtures.export_framework.harness import (
+    DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    first_player_id,
+    make_fixture_query_context,
+)
+from tests.test_compute_foundation import _StubPersistencePolicy
+
+_ROW_SCOPE_KEY = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+
+
+def _catalog_entry(analytic_id: str) -> TurnAnalyticCatalogEntry:
+    return TurnAnalyticCatalogEntry(
+        id=analytic_id,
+        name=analytic_id,
+        supports_table=True,
+        supports_map=False,
+        type="selectable",
+    )
+
+
+def _inline_compute_registration(
+    analytic_id: str,
+    *,
+    step_kind: str = "materialize",
+) -> TurnAnalyticRegistration:
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(analytic_id),
+        compute=lambda _ctx: {"analyticId": analytic_id},
+        export_catalog=empty_export_catalog_for(analytic_id),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind=step_kind, backend="inline"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            (
+                step_kind,
+                lambda scope, **_kwargs: {"scope": scope.analytic_id},
+            ),
+        ),
+        run_steps=(
+            (
+                step_kind,
+                lambda job: {"result": job["scope"]},
+            ),
+        ),
+    )
+
+
+def _thread_compute_registration(analytic_id: str) -> TurnAnalyticRegistration:
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(analytic_id),
+        compute=lambda _ctx: {"analyticId": analytic_id},
+        export_catalog=empty_export_catalog_for(analytic_id),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+        ),
+        run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
+    )
+
+
+def _diamond_compute_registry():
+    registrations = (
+        _inline_compute_registration(ROOT_ID),
+        _inline_compute_registration(BRANCH_B_ID),
+        _inline_compute_registration(BRANCH_C_ID),
+        _inline_compute_registration(SHARED_ID),
+    )
+    return build_compute_registry(registrations)
+
+
+def _export_scope(sample_turn) -> ExportScope:
+    return ExportScope(
+        game_id=sample_turn.game.id,
+        perspective=1,
+        turn=sample_turn.settings.turn,
+        player_id=first_player_id(sample_turn),
+    )
+
+
+def _compute_scope(analytic_id: str, export_scope: ExportScope) -> ComputeScope:
+    return normalize_export_scope_to_compute_scope(
+        export_scope,
+        analytic_id=analytic_id,
+        scope_key_spec=_ROW_SCOPE_KEY,
+    )
+
+
+def test_plan_compute_dag_orders_diamond_dependencies(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    compute_registry = _diamond_compute_registry()
+
+    planned = plan_compute_dag(
+        ctx,
+        ROOT_ID,
+        export_scope,
+        compute_registry=compute_registry,
+    )
+
+    planned_ids = [node.scope.analytic_id for node in planned]
+    assert planned_ids == [SHARED_ID, BRANCH_B_ID, BRANCH_C_ID, ROOT_ID]
+
+    root = planned[-1]
+    shared_scope = planned[0].scope
+    branch_b_scope = planned[1].scope
+    branch_c_scope = planned[2].scope
+    assert branch_b_scope in root.dependency_scopes
+    assert branch_c_scope in root.dependency_scopes
+    assert planned[1].dependency_scopes == (shared_scope,)
+    assert planned[2].dependency_scopes == (shared_scope,)
+
+
+def test_orchestrator_runs_diamond_dag_in_dependency_order(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    compute_registry = _diamond_compute_registry()
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+    handle = orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    assert handle.state == "complete"
+    assert handle.result_wire == {"result": ROOT_ID}
+    assert orchestrator.metrics.inline_executions == 4
+    assert orchestrator.metrics.pool_submissions == 0
+
+    execution_order = [
+        node.result_wire["result"]
+        for node in orchestrator.nodes.values()
+        if node.result_wire is not None
+    ]
+    assert execution_order.index(SHARED_ID) < execution_order.index(BRANCH_B_ID)
+    assert execution_order.index(SHARED_ID) < execution_order.index(BRANCH_C_ID)
+    assert execution_order.index(BRANCH_B_ID) < execution_order.index(ROOT_ID)
+    assert execution_order.index(BRANCH_C_ID) < execution_order.index(ROOT_ID)
+
+
+def test_blocked_nodes_are_not_ready_until_dependencies_complete(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    pool_submissions: list[str] = []
+
+    def pool_submitter(node, _step) -> None:
+        pool_submissions.append(node.scope.analytic_id)
+
+    thread_registry = build_compute_registry(
+        (
+            _thread_compute_registration(ROOT_ID),
+            _thread_compute_registration(BRANCH_B_ID),
+            _thread_compute_registration(BRANCH_C_ID),
+            _thread_compute_registration(SHARED_ID),
+        )
+    )
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=thread_registry,
+        pool_submitter=pool_submitter,
+    )
+
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+    orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    branch_b_scope = _compute_scope(BRANCH_B_ID, export_scope)
+    branch_c_scope = _compute_scope(BRANCH_C_ID, export_scope)
+
+    assert orchestrator.nodes[shared_scope].state == "running"
+    assert orchestrator.nodes[branch_b_scope].state == "waiting_deps"
+    assert orchestrator.nodes[branch_c_scope].state == "waiting_deps"
+    assert orchestrator.nodes[root_scope].state == "waiting_deps"
+    assert orchestrator.ready_scopes() == ()
+    assert pool_submissions == [SHARED_ID]
+
+
+def test_attach_inflight_does_not_double_pool_workers(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    thread_registry = build_compute_registry((_thread_compute_registration(SHARED_ID),))
+    pool_submissions: list[str] = []
+
+    def pool_submitter(node, _step) -> None:
+        pool_submissions.append(node.scope.analytic_id)
+
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=thread_registry,
+        pool_submitter=pool_submitter,
+    )
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    leader = orchestrator.submit(ComputeRequest(scope=shared_scope))
+    waiter = orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert leader.state == "running"
+    assert waiter.state == "attach_inflight"
+    assert pool_submissions == [SHARED_ID]
+    assert orchestrator.metrics.pool_submissions == 1
+
+    orchestrator.complete_pool_step(shared_scope, result_wire={"result": SHARED_ID})
+
+    assert leader.state == "complete"
+    assert waiter.state == "complete"
+
+
+def test_submit_does_not_run_step_before_dependencies_complete(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    inline_calls: list[str] = []
+
+    def run_root_step(job):
+        inline_calls.append(job["scope"])
+        return {"result": job["scope"]}
+
+    registrations = (
+        TurnAnalyticRegistration(
+            catalog_entry=_catalog_entry(ROOT_ID),
+            compute=lambda _ctx: {"analyticId": ROOT_ID},
+            export_catalog=empty_export_catalog_for(ROOT_ID),
+            scope_key_spec=_ROW_SCOPE_KEY,
+            compute_profile=AnalyticComputeProfile(
+                steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+            ),
+            persistence_policy=_StubPersistencePolicy(),
+            build_step_job_wires=(
+                ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+            ),
+            run_steps=(("materialize", run_root_step),),
+        ),
+        _thread_compute_registration(BRANCH_B_ID),
+        _thread_compute_registration(BRANCH_C_ID),
+        _thread_compute_registration(SHARED_ID),
+    )
+    compute_registry = build_compute_registry(registrations)
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=compute_registry,
+        pool_submitter=lambda _node, _step: None,
+    )
+
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    branch_b_scope = _compute_scope(BRANCH_B_ID, export_scope)
+    branch_c_scope = _compute_scope(BRANCH_C_ID, export_scope)
+
+    orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    assert inline_calls == []
+    assert orchestrator.nodes[root_scope].state == "waiting_deps"
+    assert orchestrator.nodes[shared_scope].state == "running"
+
+    orchestrator.complete_pool_step(shared_scope, result_wire={"result": SHARED_ID})
+    assert inline_calls == []
+    assert orchestrator.nodes[branch_b_scope].state == "running"
+
+    orchestrator.complete_pool_step(branch_b_scope, result_wire={"result": BRANCH_B_ID})
+    orchestrator.complete_pool_step(branch_c_scope, result_wire={"result": BRANCH_C_ID})
+    orchestrator.run_until_idle()
+
+    assert inline_calls == [ROOT_ID]
+    assert orchestrator.nodes[root_scope].state == "complete"


### PR DESCRIPTION
## Summary

- Add `plan_compute_dag` and `ComputeOrchestrator` with full node lifecycle (`waiting_deps` through `failed`), singleflight per `ComputeScope`, and inline step execution on the orchestrator thread.
- Integrate canonical `walk_dependency_tree` / `ENSURE_DEPENDENCIES` for DAG planning; pool-backed steps dispatch via injectable `PoolSubmitter` without double-submitting on attach.
- Harden failure semantics: propagate ancestor failures to dependents, expose errors on leader handles, report `attach_inflight` for all waiter handles on non-terminal nodes, and add multi-step inline continuation coverage.

Closes #196.

## Test plan

- [x] `make test_api` (1152 passed)
- [x] `pytest packages/api/tests/test_compute_orchestrator.py` -- diamond DAG ordering, blocked nodes, attach/singleflight, dependency-before-step invariant, failure propagation, handle errors, multi-step inline profile


Made with [Cursor](https://cursor.com)