### PR TITLE
Compute orchestrator: global worker pools and priority bands (#197)

### DIFF
--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -39,6 +39,7 @@ _POOL_EXPORTS = frozenset(
         "dequeue_next_work_item",
         "get_compute_worker_pool",
         "reset_compute_worker_pool_for_tests",
+        "shutdown_compute_worker_pool_for_tests",
     }
 )
 
@@ -117,5 +118,6 @@ __all__ = [
     "normalize_export_scope_to_compute_scope",
     "plan_compute_dag",
     "reset_compute_worker_pool_for_tests",
+    "shutdown_compute_worker_pool_for_tests",
     "validate_turn_analytic_compute_registration",
 ]

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -28,6 +28,20 @@ _REGISTRY_EXPORTS = frozenset(
 )
 
 
+_POOL_EXPORTS = frozenset(
+    {
+        "ComputePriorityBand",
+        "ComputeWorkerPool",
+        "PoolMetrics",
+        "PoolSubmitter",
+        "PoolWorkItem",
+        "configured_worker_count",
+        "dequeue_next_work_item",
+        "get_compute_worker_pool",
+        "reset_compute_worker_pool_for_tests",
+    }
+)
+
 _COMPUTE_ORCHESTRATOR_EXPORTS = frozenset(
     {
         "ComputeHandle",
@@ -36,7 +50,6 @@ _COMPUTE_ORCHESTRATOR_EXPORTS = frozenset(
         "ComputeRequest",
         "NodeState",
         "OrchestratorMetrics",
-        "PoolSubmitter",
     }
 )
 
@@ -57,6 +70,10 @@ def __getattr__(name: str) -> object:
         from api.compute import orchestrator as orchestrator_module
 
         return getattr(orchestrator_module, name)
+    if name in _POOL_EXPORTS:
+        from api.compute import pools as pools_module
+
+        return getattr(pools_module, name)
     if name in _DAG_EXPORTS:
         from api.compute import dag as dag_module
 
@@ -75,22 +92,30 @@ __all__ = [
     "ComputeHandle",
     "ComputeNodeRun",
     "ComputeOrchestrator",
+    "ComputePriorityBand",
     "ComputeRequest",
     "ComputeScope",
     "ComputeStepSpec",
+    "ComputeWorkerPool",
     "DependencyOutputs",
     "NodeState",
     "OrchestratorMetrics",
     "PersistencePolicy",
     "PlannedComputeNode",
+    "PoolMetrics",
     "PoolSubmitter",
+    "PoolWorkItem",
     "RunStepFn",
     "ScopeAxis",
     "ScopeKeySpec",
     "build_compute_registry",
     "compute_scope_to_export_scope",
+    "configured_worker_count",
+    "dequeue_next_work_item",
     "fingerprint_parameters",
+    "get_compute_worker_pool",
     "normalize_export_scope_to_compute_scope",
     "plan_compute_dag",
+    "reset_compute_worker_pool_for_tests",
     "validate_turn_analytic_compute_registration",
 ]

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Literal
 
 from api.analytics.export_context import AnalyticQueryContext
 from api.compute.dag import PlannedComputeNode, plan_compute_dag
+from api.compute.pools import ComputePriorityBand, ComputeWorkerPool, PoolSubmitter
 from api.compute.profile import ComputeStepSpec
 from api.compute.registry import AnalyticComputeRegistration
 from api.compute.scope import ComputeScope, compute_scope_to_export_scope
@@ -23,8 +24,6 @@ NodeState = Literal[
     "failed",
 ]
 
-PoolSubmitter = Callable[["ComputeNodeRun", ComputeStepSpec], None]
-
 
 @dataclass(frozen=True)
 class ComputeRequest:
@@ -32,6 +31,7 @@ class ComputeRequest:
 
     scope: ComputeScope
     step_kind: str | None = None
+    priority_band: ComputePriorityBand = "background"
 
 
 @dataclass
@@ -70,6 +70,7 @@ class ComputeNodeRun:
     dependency_scopes: tuple[ComputeScope, ...]
     state: NodeState = "waiting_deps"
     step_index: int = 0
+    priority_band: ComputePriorityBand = "background"
     result_wire: object | None = None
     error: BaseException | None = None
     waiters: list[ComputeHandle] = field(default_factory=list)
@@ -92,13 +93,21 @@ class ComputeOrchestrator:
         *,
         compute_registry: Mapping[str, AnalyticComputeRegistration],
         pool_submitter: PoolSubmitter | None = None,
+        worker_pool: ComputeWorkerPool | None = None,
     ) -> None:
         self._ctx = ctx
         self._compute_registry = compute_registry
+        if worker_pool is not None:
+            pool_submitter = worker_pool.attach(self)
         self._pool_submitter = pool_submitter
+        self._worker_pool = worker_pool
         self._nodes: dict[ComputeScope, ComputeNodeRun] = {}
         self._ready_queue: deque[ComputeScope] = deque()
         self._metrics = OrchestratorMetrics()
+
+    @property
+    def worker_pool(self) -> ComputeWorkerPool | None:
+        return self._worker_pool
 
     @property
     def metrics(self) -> OrchestratorMetrics:
@@ -119,12 +128,22 @@ class ComputeOrchestrator:
         if existing is not None:
             return self._attach_to_existing(existing)
 
-        self._plan_and_register(scope)
+        self._plan_and_register(scope, priority_band=request.priority_band)
         for node in self._nodes.values():
             self._refresh_node_readiness(node)
         handle = ComputeHandle(scope=scope, _node=self._nodes[scope])
         self._dispatch()
         return handle
+
+    def execute_pool_step(self, scope: ComputeScope) -> object:
+        """Run the current pool step for one scope on the calling thread."""
+        node = self._nodes[scope]
+        if node.state != "running":
+            raise RuntimeError(f"cannot execute pool step for node in state {node.state!r}")
+        registration = self._compute_registry[node.scope.analytic_id]
+        step = self._current_step_spec(node, registration)
+        job_wire = self._build_job_wire(node, registration, step)
+        return registration.run_step[step.step_kind](job_wire)
 
     def run_until_idle(self) -> None:
         """Drain ready inline work until no ready or running nodes remain."""
@@ -157,7 +176,12 @@ class ComputeOrchestrator:
         node.waiters.append(handle)
         return handle
 
-    def _plan_and_register(self, root_scope: ComputeScope) -> None:
+    def _plan_and_register(
+        self,
+        root_scope: ComputeScope,
+        *,
+        priority_band: ComputePriorityBand,
+    ) -> None:
         export_scope = compute_scope_to_export_scope(root_scope)
         planned_nodes = plan_compute_dag(
             self._ctx,
@@ -166,20 +190,27 @@ class ComputeOrchestrator:
             compute_registry=self._compute_registry,
         )
         for planned in planned_nodes:
-            self._register_planned_node(planned)
+            self._register_planned_node(planned, priority_band=priority_band)
         if root_scope not in self._nodes:
             self._nodes[root_scope] = ComputeNodeRun(
                 scope=root_scope,
                 dependency_scopes=(),
                 state="complete",
+                priority_band=priority_band,
             )
 
-    def _register_planned_node(self, planned: PlannedComputeNode) -> None:
+    def _register_planned_node(
+        self,
+        planned: PlannedComputeNode,
+        *,
+        priority_band: ComputePriorityBand,
+    ) -> None:
         if planned.scope in self._nodes:
             return
         node = ComputeNodeRun(
             scope=planned.scope,
             dependency_scopes=planned.dependency_scopes,
+            priority_band=priority_band,
         )
         self._nodes[planned.scope] = node
 
@@ -252,9 +283,24 @@ class ComputeOrchestrator:
                 return
             self._ready_queue.popleft()
             node.state = "running"
-            self._pool_submitter(node, step)
+            self._submit_pool_step(node, registration, step)
             self._metrics.pool_submissions += 1
+            continue
+
+    def _submit_pool_step(
+        self,
+        node: ComputeNodeRun,
+        registration: AnalyticComputeRegistration,
+        step: ComputeStepSpec,
+    ) -> None:
+        if self._pool_submitter is None:
+            raise RuntimeError("pool_submitter is not configured")
+        if step.backend in {"interpreter", "process"}:
+            job_wire = self._build_job_wire(node, registration, step)
+            run_step = registration.run_step[step.step_kind]
+            self._pool_submitter(node, step, job_wire=job_wire, run_step=run_step)
             return
+        self._pool_submitter(node, step)
 
     def _current_step_spec(
         self,

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -104,6 +105,8 @@ class ComputeOrchestrator:
         self._nodes: dict[ComputeScope, ComputeNodeRun] = {}
         self._ready_queue: deque[ComputeScope] = deque()
         self._metrics = OrchestratorMetrics()
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
 
     @property
     def worker_pool(self) -> ComputeWorkerPool | None:
@@ -119,39 +122,48 @@ class ComputeOrchestrator:
 
     def ready_scopes(self) -> tuple[ComputeScope, ...]:
         """Return scopes currently in the ready queue."""
-        return tuple(scope for scope in self._ready_queue if self._nodes[scope].state == "ready")
+        with self._condition:
+            return tuple(
+                scope for scope in self._ready_queue if self._nodes[scope].state == "ready"
+            )
 
     def submit(self, request: ComputeRequest) -> ComputeHandle:
         """Submit or attach to in-flight work for one compute scope."""
-        scope = request.scope
-        existing = self._nodes.get(scope)
-        if existing is not None:
-            return self._attach_to_existing(existing)
+        with self._condition:
+            scope = request.scope
+            existing = self._nodes.get(scope)
+            if existing is not None:
+                return self._attach_to_existing(existing)
 
-        self._plan_and_register(scope, priority_band=request.priority_band)
-        for node in self._nodes.values():
-            self._refresh_node_readiness(node)
-        handle = ComputeHandle(scope=scope, _node=self._nodes[scope])
-        self._dispatch()
-        return handle
+            self._plan_and_register(scope, priority_band=request.priority_band)
+            for node in self._nodes.values():
+                self._refresh_node_readiness(node)
+            handle = ComputeHandle(scope=scope, _node=self._nodes[scope])
+            self._dispatch()
+            return handle
 
     def execute_pool_step(self, scope: ComputeScope) -> object:
         """Run the current pool step for one scope on the calling thread."""
-        node = self._nodes[scope]
-        if node.state != "running":
-            raise RuntimeError(f"cannot execute pool step for node in state {node.state!r}")
-        registration = self._compute_registry[node.scope.analytic_id]
-        step = self._current_step_spec(node, registration)
-        job_wire = self._build_job_wire(node, registration, step)
-        return registration.run_step[step.step_kind](job_wire)
+        with self._condition:
+            node = self._nodes[scope]
+            if node.state != "running":
+                raise RuntimeError(f"cannot execute pool step for node in state {node.state!r}")
+            registration = self._compute_registry[node.scope.analytic_id]
+            step = self._current_step_spec(node, registration)
+            job_wire = self._build_job_wire(node, registration, step)
+            run_step = registration.run_step[step.step_kind]
+        return run_step(job_wire)
 
     def run_until_idle(self) -> None:
         """Drain ready inline work until no ready or running nodes remain."""
-        while self._has_pending_work():
-            self._refresh_all_readiness()
-            self._dispatch()
-            if any(node.state == "running" for node in self._nodes.values()):
-                break
+        while True:
+            with self._condition:
+                if not self._has_pending_work():
+                    return
+                self._refresh_all_readiness()
+                self._dispatch()
+                if any(node.state == "running" for node in self._nodes.values()):
+                    return
 
     def complete_pool_step(
         self,
@@ -161,13 +173,14 @@ class ComputeOrchestrator:
         error: BaseException | None = None,
     ) -> None:
         """Mark a pool-submitted step complete (used by worker pool integration)."""
-        node = self._nodes[scope]
-        if node.state != "running":
-            raise RuntimeError(f"cannot complete pool step for node in state {node.state!r}")
-        if error is not None:
-            self._fail_node(node, error)
-            return
-        self._after_step_success(node, result_wire)
+        with self._condition:
+            node = self._nodes[scope]
+            if node.state != "running":
+                raise RuntimeError(f"cannot complete pool step for node in state {node.state!r}")
+            if error is not None:
+                self._fail_node(node, error)
+                return
+            self._after_step_success(node, result_wire)
 
     def _attach_to_existing(self, node: ComputeNodeRun) -> ComputeHandle:
         if node.state in {"complete", "failed"}:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -278,31 +278,31 @@ class ComputeWorkerPool:
         orchestrator.complete_pool_step(scope, result_wire=result_wire)
 
 
-_process_pool: ComputeWorkerPool | None = None
-_process_pool_lock = threading.Lock()
+_global_worker_pool: ComputeWorkerPool | None = None
+_global_worker_pool_lock = threading.Lock()
 
 
 def get_compute_worker_pool() -> ComputeWorkerPool:
-    global _process_pool
-    with _process_pool_lock:
-        if _process_pool is None:
-            _process_pool = ComputeWorkerPool()
-        return _process_pool
+    global _global_worker_pool
+    with _global_worker_pool_lock:
+        if _global_worker_pool is None:
+            _global_worker_pool = ComputeWorkerPool()
+        return _global_worker_pool
 
 
 def shutdown_compute_worker_pool_for_tests() -> None:
     """Tear down the process-wide pool singleton (tests only)."""
-    global _process_pool
-    with _process_pool_lock:
-        if _process_pool is not None:
-            _process_pool.shutdown()
-            _process_pool = None
+    global _global_worker_pool
+    with _global_worker_pool_lock:
+        if _global_worker_pool is not None:
+            _global_worker_pool.shutdown()
+            _global_worker_pool = None
 
 
 def reset_compute_worker_pool_for_tests(*, worker_count: int = 0) -> ComputeWorkerPool:
-    global _process_pool
-    with _process_pool_lock:
-        if _process_pool is not None:
-            _process_pool.shutdown()
-        _process_pool = ComputeWorkerPool(worker_count=worker_count)
-        return _process_pool
+    global _global_worker_pool
+    with _global_worker_pool_lock:
+        if _global_worker_pool is not None:
+            _global_worker_pool.shutdown()
+        _global_worker_pool = ComputeWorkerPool(worker_count=worker_count)
+        return _global_worker_pool

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -58,7 +58,6 @@ class PoolWorkItem:
     backend: ComputeBackend
     priority_band: ComputePriorityBand
     step_index: int
-    sequence: int
     job_wire: object | None = None
     run_step: RunStepFn | None = None
 
@@ -110,7 +109,6 @@ class ComputeWorkerPool:
         self._worker_count = worker_count if worker_count is not None else configured_worker_count()
         self._orchestrator: ComputeOrchestrator | None = None
         self._work_queue: deque[PoolWorkItem] = deque()
-        self._sequence = 0
         self._lock = threading.Lock()
         self._condition = threading.Condition(self._lock)
         self._shutdown = False
@@ -147,7 +145,6 @@ class ComputeWorkerPool:
     ) -> None:
         """Enqueue one ready orchestrator step for pool execution."""
         with self._condition:
-            self._sequence += 1
             self._work_queue.append(
                 PoolWorkItem(
                     scope=node.scope,
@@ -155,7 +152,6 @@ class ComputeWorkerPool:
                     backend=step.backend,
                     priority_band=priority_band,
                     step_index=node.step_index,
-                    sequence=self._sequence,
                     job_wire=job_wire,
                     run_step=run_step,
                 )
@@ -203,12 +199,21 @@ class ComputeWorkerPool:
                 self._condition.wait(timeout=_DEQUEUE_WAIT_SECONDS)
             return None
 
+    def _record_backend_execution_locked(self, backend: ComputeBackend) -> None:
+        if backend == "thread":
+            self._metrics.thread_executions += 1
+        elif backend == "interpreter":
+            self._metrics.interpreter_executions += 1
+        elif backend == "process":
+            self._metrics.process_executions += 1
+
     def _execute_item(self, item: PoolWorkItem) -> None:
         orchestrator = self._orchestrator
         if orchestrator is None:
             raise RuntimeError("ComputeWorkerPool is not attached to an orchestrator")
         if item.backend == "thread":
-            self._metrics.thread_executions += 1
+            with self._condition:
+                self._record_backend_execution_locked(item.backend)
             self._complete_from_callable(orchestrator, item.scope, orchestrator.execute_pool_step)
             return
         if item.backend in {"interpreter", "process"}:
@@ -217,28 +222,26 @@ class ComputeWorkerPool:
                     f"pool step {item.step_kind!r} with backend {item.backend!r} "
                     f"requires a pre-built job wire and run_step"
                 )
-            if item.backend == "interpreter":
-                self._metrics.interpreter_executions += 1
-                executor = self._interpreter_executor_locked()
-            else:
-                self._metrics.process_executions += 1
-                executor = self._process_executor_locked()
+            with self._condition:
+                self._record_backend_execution_locked(item.backend)
+                if item.backend == "interpreter":
+                    executor = self._interpreter_executor_locked()
+                else:
+                    executor = self._process_executor_locked()
             future = executor.submit(item.run_step, item.job_wire)
             self._complete_from_future(orchestrator, item.scope, future)
             return
         raise RuntimeError(f"unsupported pool backend {item.backend!r}")
 
     def _interpreter_executor_locked(self) -> InterpreterPoolExecutor:
-        with self._condition:
-            if self._interpreter_executor is None:
-                self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
-            return self._interpreter_executor
+        if self._interpreter_executor is None:
+            self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
+        return self._interpreter_executor
 
     def _process_executor_locked(self) -> ProcessPoolExecutor:
-        with self._condition:
-            if self._process_executor is None:
-                self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
-            return self._process_executor
+        if self._process_executor is None:
+            self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
+        return self._process_executor
 
     def _shutdown_executors(self) -> None:
         with self._condition:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -8,7 +8,7 @@ from collections import deque
 from collections.abc import Callable
 from concurrent.futures import Future, InterpreterPoolExecutor, ProcessPoolExecutor
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from api.compute.profile import ComputeBackend, ComputeStepSpec
 from api.compute.scope import ComputeScope
@@ -28,7 +28,18 @@ PRIORITY_BAND_RANK: dict[ComputePriorityBand, int] = {
 _DEFAULT_WORKER_COUNT = 4
 _DEQUEUE_WAIT_SECONDS = 0.25
 
-PoolSubmitter = Callable[["ComputeNodeRun", ComputeStepSpec], None]
+
+class PoolSubmitter(Protocol):
+    """Callback the orchestrator uses to enqueue ready steps on a worker pool."""
+
+    def __call__(
+        self,
+        node: ComputeNodeRun,
+        step: ComputeStepSpec,
+        *,
+        job_wire: object | None = None,
+        run_step: RunStepFn | None = None,
+    ) -> None: ...
 
 
 def configured_worker_count() -> int:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -231,9 +231,7 @@ class ComputeWorkerPool:
     def _interpreter_executor_locked(self) -> InterpreterPoolExecutor:
         with self._condition:
             if self._interpreter_executor is None:
-                self._interpreter_executor = InterpreterPoolExecutor(
-                    max_workers=self._worker_count
-                )
+                self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
             return self._interpreter_executor
 
     def _process_executor_locked(self) -> ProcessPoolExecutor:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -229,22 +229,27 @@ class ComputeWorkerPool:
         raise RuntimeError(f"unsupported pool backend {item.backend!r}")
 
     def _interpreter_executor_locked(self) -> InterpreterPoolExecutor:
-        if self._interpreter_executor is None:
-            self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
-        return self._interpreter_executor
+        with self._condition:
+            if self._interpreter_executor is None:
+                self._interpreter_executor = InterpreterPoolExecutor(
+                    max_workers=self._worker_count
+                )
+            return self._interpreter_executor
 
     def _process_executor_locked(self) -> ProcessPoolExecutor:
-        if self._process_executor is None:
-            self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
-        return self._process_executor
+        with self._condition:
+            if self._process_executor is None:
+                self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
+            return self._process_executor
 
     def _shutdown_executors(self) -> None:
-        if self._interpreter_executor is not None:
-            self._interpreter_executor.shutdown(wait=False)
-            self._interpreter_executor = None
-        if self._process_executor is not None:
-            self._process_executor.shutdown(wait=False)
-            self._process_executor = None
+        with self._condition:
+            if self._interpreter_executor is not None:
+                self._interpreter_executor.shutdown(wait=False)
+                self._interpreter_executor = None
+            if self._process_executor is not None:
+                self._process_executor.shutdown(wait=False)
+                self._process_executor = None
 
     def _complete_from_callable(
         self,

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -285,6 +285,15 @@ def get_compute_worker_pool() -> ComputeWorkerPool:
         return _process_pool
 
 
+def shutdown_compute_worker_pool_for_tests() -> None:
+    """Tear down the process-wide pool singleton (tests only)."""
+    global _process_pool
+    with _process_pool_lock:
+        if _process_pool is not None:
+            _process_pool.shutdown()
+            _process_pool = None
+
+
 def reset_compute_worker_pool_for_tests(*, worker_count: int = 0) -> ComputeWorkerPool:
     global _process_pool
     with _process_pool_lock:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -1,0 +1,283 @@
+"""Global compute worker pool with priority bands and backend dispatch."""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future, InterpreterPoolExecutor, ProcessPoolExecutor
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from api.compute.profile import ComputeBackend, ComputeStepSpec
+from api.compute.scope import ComputeScope
+from api.compute.wire import RunStepFn
+
+if TYPE_CHECKING:
+    from api.compute.orchestrator import ComputeNodeRun, ComputeOrchestrator
+
+ComputePriorityBand = Literal["stream_attached", "interactive_ensure", "background"]
+
+PRIORITY_BAND_RANK: dict[ComputePriorityBand, int] = {
+    "stream_attached": 0,
+    "interactive_ensure": 1,
+    "background": 2,
+}
+
+_DEFAULT_WORKER_COUNT = 4
+_DEQUEUE_WAIT_SECONDS = 0.25
+
+PoolSubmitter = Callable[["ComputeNodeRun", ComputeStepSpec], None]
+
+
+def configured_worker_count() -> int:
+    raw = os.environ.get("COMPUTE_ORCHESTRATOR_WORKERS")
+    if raw is not None:
+        return max(1, int(raw))
+    return _DEFAULT_WORKER_COUNT
+
+
+@dataclass(frozen=True)
+class PoolWorkItem:
+    """One schedulable pool unit dequeued by priority band and fairness rules."""
+
+    scope: ComputeScope
+    step_kind: str
+    backend: ComputeBackend
+    priority_band: ComputePriorityBand
+    step_index: int
+    sequence: int
+    job_wire: object | None = None
+    run_step: RunStepFn | None = None
+
+
+@dataclass
+class PoolMetrics:
+    """Counters for pool dequeue and backend dispatch."""
+
+    dequeues: int = 0
+    thread_executions: int = 0
+    interpreter_executions: int = 0
+    process_executions: int = 0
+
+
+def dequeue_next_work_item(queue: deque[PoolWorkItem]) -> PoolWorkItem | None:
+    """Dequeue the next work item using priority bands and within-band fairness.
+
+    Within a band, initial steps (step_index == 0) run before continuations.
+    Among continuations, FIFO queue order provides round-robin across scopes.
+    """
+    if not queue:
+        return None
+    best_rank = min(PRIORITY_BAND_RANK[item.priority_band] for item in queue)
+    candidate_indices = [
+        index
+        for index, item in enumerate(queue)
+        if PRIORITY_BAND_RANK[item.priority_band] == best_rank
+    ]
+    for index in candidate_indices:
+        if queue[index].step_index == 0:
+            return _pop_at(queue, index)
+    return _pop_at(queue, candidate_indices[0])
+
+
+def _pop_at(queue: deque[PoolWorkItem], index: int) -> PoolWorkItem:
+    item = queue[index]
+    del queue[index]
+    return item
+
+
+class ComputeWorkerPool:
+    """Process-wide worker pool with priority dequeue and backend dispatch."""
+
+    def __init__(
+        self,
+        *,
+        worker_count: int | None = None,
+    ) -> None:
+        self._worker_count = worker_count if worker_count is not None else configured_worker_count()
+        self._orchestrator: ComputeOrchestrator | None = None
+        self._work_queue: deque[PoolWorkItem] = deque()
+        self._sequence = 0
+        self._lock = threading.Lock()
+        self._condition = threading.Condition(self._lock)
+        self._shutdown = False
+        self._workers: list[threading.Thread] = []
+        self._metrics = PoolMetrics()
+        self._interpreter_executor: InterpreterPoolExecutor | None = None
+        self._process_executor: ProcessPoolExecutor | None = None
+        for _ in range(self._worker_count):
+            thread = threading.Thread(target=self._worker_loop, daemon=True)
+            thread.start()
+            self._workers.append(thread)
+
+    @property
+    def metrics(self) -> PoolMetrics:
+        return self._metrics
+
+    @property
+    def worker_count(self) -> int:
+        return self._worker_count
+
+    def attach(self, orchestrator: ComputeOrchestrator) -> PoolSubmitter:
+        """Bind an orchestrator and return its pool submitter callback."""
+        self._orchestrator = orchestrator
+        return self._submit_from_orchestrator
+
+    def submit(
+        self,
+        node: ComputeNodeRun,
+        step: ComputeStepSpec,
+        *,
+        priority_band: ComputePriorityBand,
+        job_wire: object | None = None,
+        run_step: RunStepFn | None = None,
+    ) -> None:
+        """Enqueue one ready orchestrator step for pool execution."""
+        with self._condition:
+            self._sequence += 1
+            self._work_queue.append(
+                PoolWorkItem(
+                    scope=node.scope,
+                    step_kind=step.step_kind,
+                    backend=step.backend,
+                    priority_band=priority_band,
+                    step_index=node.step_index,
+                    sequence=self._sequence,
+                    job_wire=job_wire,
+                    run_step=run_step,
+                )
+            )
+            self._condition.notify()
+
+    def shutdown(self) -> None:
+        with self._condition:
+            self._shutdown = True
+            self._condition.notify_all()
+        for thread in self._workers:
+            thread.join(timeout=1.0)
+        self._shutdown_executors()
+
+    def _submit_from_orchestrator(
+        self,
+        node: ComputeNodeRun,
+        step: ComputeStepSpec,
+        *,
+        job_wire: object | None = None,
+        run_step: RunStepFn | None = None,
+    ) -> None:
+        self.submit(
+            node,
+            step,
+            priority_band=node.priority_band,
+            job_wire=job_wire,
+            run_step=run_step,
+        )
+
+    def _worker_loop(self) -> None:
+        while True:
+            item = self._take_next_item()
+            if item is None:
+                return
+            self._execute_item(item)
+
+    def _take_next_item(self) -> PoolWorkItem | None:
+        with self._condition:
+            while not self._shutdown:
+                item = dequeue_next_work_item(self._work_queue)
+                if item is not None:
+                    self._metrics.dequeues += 1
+                    return item
+                self._condition.wait(timeout=_DEQUEUE_WAIT_SECONDS)
+            return None
+
+    def _execute_item(self, item: PoolWorkItem) -> None:
+        orchestrator = self._orchestrator
+        if orchestrator is None:
+            raise RuntimeError("ComputeWorkerPool is not attached to an orchestrator")
+        if item.backend == "thread":
+            self._metrics.thread_executions += 1
+            self._complete_from_callable(orchestrator, item.scope, orchestrator.execute_pool_step)
+            return
+        if item.backend in {"interpreter", "process"}:
+            if item.job_wire is None or item.run_step is None:
+                raise RuntimeError(
+                    f"pool step {item.step_kind!r} with backend {item.backend!r} "
+                    f"requires a pre-built job wire and run_step"
+                )
+            if item.backend == "interpreter":
+                self._metrics.interpreter_executions += 1
+                executor = self._interpreter_executor_locked()
+            else:
+                self._metrics.process_executions += 1
+                executor = self._process_executor_locked()
+            future = executor.submit(item.run_step, item.job_wire)
+            self._complete_from_future(orchestrator, item.scope, future)
+            return
+        raise RuntimeError(f"unsupported pool backend {item.backend!r}")
+
+    def _interpreter_executor_locked(self) -> InterpreterPoolExecutor:
+        if self._interpreter_executor is None:
+            self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
+        return self._interpreter_executor
+
+    def _process_executor_locked(self) -> ProcessPoolExecutor:
+        if self._process_executor is None:
+            self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
+        return self._process_executor
+
+    def _shutdown_executors(self) -> None:
+        if self._interpreter_executor is not None:
+            self._interpreter_executor.shutdown(wait=False)
+            self._interpreter_executor = None
+        if self._process_executor is not None:
+            self._process_executor.shutdown(wait=False)
+            self._process_executor = None
+
+    def _complete_from_callable(
+        self,
+        orchestrator: ComputeOrchestrator,
+        scope: ComputeScope,
+        run_step: Callable[[ComputeScope], object],
+    ) -> None:
+        try:
+            result_wire = run_step(scope)
+        except BaseException as exc:
+            orchestrator.complete_pool_step(scope, error=exc)
+            return
+        orchestrator.complete_pool_step(scope, result_wire=result_wire)
+
+    def _complete_from_future(
+        self,
+        orchestrator: ComputeOrchestrator,
+        scope: ComputeScope,
+        future: Future[object],
+    ) -> None:
+        try:
+            result_wire = future.result()
+        except BaseException as exc:
+            orchestrator.complete_pool_step(scope, error=exc)
+            return
+        orchestrator.complete_pool_step(scope, result_wire=result_wire)
+
+
+_process_pool: ComputeWorkerPool | None = None
+_process_pool_lock = threading.Lock()
+
+
+def get_compute_worker_pool() -> ComputeWorkerPool:
+    global _process_pool
+    with _process_pool_lock:
+        if _process_pool is None:
+            _process_pool = ComputeWorkerPool()
+        return _process_pool
+
+
+def reset_compute_worker_pool_for_tests(*, worker_count: int = 0) -> ComputeWorkerPool:
+    global _process_pool
+    with _process_pool_lock:
+        if _process_pool is not None:
+            _process_pool.shutdown()
+        _process_pool = ComputeWorkerPool(worker_count=worker_count)
+        return _process_pool

--- a/packages/api/tests/compute_pool_test_helpers.py
+++ b/packages/api/tests/compute_pool_test_helpers.py
@@ -1,0 +1,10 @@
+"""Module-level helpers for compute pool integration tests (interpreter shareability)."""
+
+from __future__ import annotations
+
+INTERPRETER_BACKEND_CALLS: list[str] = []
+
+
+def run_interpreter_materialize(job: dict[str, str]) -> dict[str, str]:
+    INTERPRETER_BACKEND_CALLS.append(job["scope"])
+    return {"result": job["scope"]}

--- a/packages/api/tests/compute_pool_test_helpers.py
+++ b/packages/api/tests/compute_pool_test_helpers.py
@@ -1,10 +1,16 @@
-"""Module-level helpers for compute pool integration tests (interpreter shareability)."""
+"""Module-level helpers for compute pool integration tests (shareable run_step)."""
 
 from __future__ import annotations
 
 INTERPRETER_BACKEND_CALLS: list[str] = []
+PROCESS_BACKEND_CALLS: list[str] = []
 
 
 def run_interpreter_materialize(job: dict[str, str]) -> dict[str, str]:
     INTERPRETER_BACKEND_CALLS.append(job["scope"])
+    return {"result": job["scope"]}
+
+
+def run_process_materialize(job: dict[str, str]) -> dict[str, str]:
+    PROCESS_BACKEND_CALLS.append(job["scope"])
     return {"result": job["scope"]}

--- a/packages/api/tests/compute_pool_test_helpers.py
+++ b/packages/api/tests/compute_pool_test_helpers.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-INTERPRETER_BACKEND_CALLS: list[str] = []
-PROCESS_BACKEND_CALLS: list[str] = []
-
 
 def run_interpreter_materialize(job: dict[str, str]) -> dict[str, str]:
-    INTERPRETER_BACKEND_CALLS.append(job["scope"])
     return {"result": job["scope"]}
 
 
 def run_process_materialize(job: dict[str, str]) -> dict[str, str]:
-    PROCESS_BACKEND_CALLS.append(job["scope"])
     return {"result": job["scope"]}

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -1,5 +1,23 @@
 """Shared pytest fixtures for API package tests."""
 
+import os
+import sys
+from pathlib import Path
+
+# ``uv run pytest`` uses the console-script entry point, which breaks
+# InterpreterPoolExecutor shareability for module-level test helpers unless
+# PYTHONPATH is set before interpreter startup. Re-exec via ``python -m pytest``.
+if os.environ.get("_API_PYTEST_REEXEC") != "1":
+    argv0 = Path(sys.argv[0]).name
+    running_compute_pool_tests = any("test_compute_pools" in arg for arg in sys.argv[1:])
+    if argv0 in {"pytest", "py.test"} and running_compute_pool_tests:
+        api_root = str(Path(__file__).resolve().parent.parent)
+        pythonpath = os.environ.get("PYTHONPATH", "")
+        if api_root not in pythonpath.split(os.pathsep):
+            pythonpath = f"{api_root}{os.pathsep}{pythonpath}" if pythonpath else api_root
+        env = {**os.environ, "_API_PYTEST_REEXEC": "1", "PYTHONPATH": pythonpath}
+        os.execve(sys.executable, [sys.executable, "-m", "pytest", *sys.argv[1:]], env)
+
 import pytest
 
 from tests.fixtures.hand_seeded_prior_weights import (  # noqa: F401
@@ -17,6 +35,17 @@ from tests.fixtures.military_score_inference_prior_weights import (  # noqa: F40
 )
 
 pytest_plugins = ["tests.scores_exports_helpers"]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_compute_worker_pool(request: pytest.FixtureRequest):
+    yield
+    if request.path.name != "test_compute_pools.py":
+        return
+    from api.compute.pools import shutdown_compute_worker_pool_for_tests
+
+    shutdown_compute_worker_pool_for_tests()
+
 
 # OR-Tools / inference-corpus integration tests excluded from `make ci` (see Makefile `test_api`).
 _SLOW_TEST_NAMES = frozenset(

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -73,7 +73,6 @@ def _work_item(
     scope: ComputeScope,
     priority_band: ComputePriorityBand = "background",
     step_index: int = 0,
-    sequence: int = 0,
     backend: str = "thread",
 ) -> PoolWorkItem:
     return PoolWorkItem(
@@ -82,7 +81,6 @@ def _work_item(
         backend=backend,
         priority_band=priority_band,
         step_index=step_index,
-        sequence=sequence,
     )
 
 
@@ -93,8 +91,8 @@ def test_dequeue_prefers_stream_attached_over_background(sample_turn):
     scope_b = _scope_for_player(sample_turn, player_b)
     queue = deque(
         [
-            _work_item(scope=scope_a, priority_band="background", sequence=1),
-            _work_item(scope=scope_b, priority_band="stream_attached", sequence=2),
+            _work_item(scope=scope_a, priority_band="background"),
+            _work_item(scope=scope_b, priority_band="stream_attached"),
         ]
     )
 
@@ -112,8 +110,8 @@ def test_dequeue_prefers_interactive_ensure_over_background(sample_turn):
     scope_b = _scope_for_player(sample_turn, player_b)
     queue = deque(
         [
-            _work_item(scope=scope_a, priority_band="background", sequence=1),
-            _work_item(scope=scope_b, priority_band="interactive_ensure", sequence=2),
+            _work_item(scope=scope_a, priority_band="background"),
+            _work_item(scope=scope_b, priority_band="interactive_ensure"),
         ]
     )
 
@@ -130,8 +128,8 @@ def test_dequeue_prefers_stream_attached_over_interactive_ensure(sample_turn):
     scope_b = _scope_for_player(sample_turn, player_b)
     queue = deque(
         [
-            _work_item(scope=scope_a, priority_band="interactive_ensure", sequence=1),
-            _work_item(scope=scope_b, priority_band="stream_attached", sequence=2),
+            _work_item(scope=scope_a, priority_band="interactive_ensure"),
+            _work_item(scope=scope_b, priority_band="stream_attached"),
         ]
     )
 
@@ -150,9 +148,9 @@ def test_dequeue_tier_one_before_continuations_from_other_scopes(sample_turn):
     scope_b = _scope_for_player(sample_turn, player_ids[1])
     queue = deque(
         [
-            _work_item(scope=scope_a, step_index=0, sequence=1),
-            _work_item(scope=scope_a, step_index=1, sequence=2),
-            _work_item(scope=scope_b, step_index=0, sequence=3),
+            _work_item(scope=scope_a, step_index=0),
+            _work_item(scope=scope_a, step_index=1),
+            _work_item(scope=scope_b, step_index=0),
         ]
     )
 
@@ -172,10 +170,10 @@ def test_dequeue_continuation_round_robin_across_scopes(sample_turn):
     scope_b = _scope_for_player(sample_turn, player_ids[1])
     queue = deque(
         [
-            _work_item(scope=scope_a, step_index=1, sequence=1),
-            _work_item(scope=scope_b, step_index=1, sequence=2),
-            _work_item(scope=scope_a, step_index=2, sequence=3),
-            _work_item(scope=scope_b, step_index=2, sequence=4),
+            _work_item(scope=scope_a, step_index=1),
+            _work_item(scope=scope_b, step_index=1),
+            _work_item(scope=scope_a, step_index=2),
+            _work_item(scope=scope_b, step_index=2),
         ]
     )
 

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -26,7 +26,10 @@ from api.compute import (
     normalize_export_scope_to_compute_scope,
 )
 
-from tests.compute_pool_test_helpers import run_interpreter_materialize
+from tests.compute_pool_test_helpers import (
+    run_interpreter_materialize,
+    run_process_materialize,
+)
 from tests.fixtures.export_framework.fixture_catalog import make_fixture_catalog
 from tests.fixtures.export_framework.harness import make_fixture_query_context
 from tests.test_compute_foundation import _StubPersistencePolicy
@@ -336,6 +339,51 @@ def test_pool_dispatches_interpreter_backend(sample_turn):
     assert handle.state == "complete", handle.error
     assert handle.result_wire == {"result": _FLEET_ANALYTIC_ID}
     assert pool.metrics.interpreter_executions == 1
+
+
+def _process_backend_registration() -> TurnAnalyticRegistration:
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(_FLEET_ANALYTIC_ID),
+        compute=lambda _ctx: {"analyticId": _FLEET_ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_FLEET_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="process"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+        ),
+        run_steps=(("materialize", run_process_materialize),),
+    )
+
+
+def test_pool_dispatches_process_backend(sample_turn):
+    compute_registry = build_compute_registry((_process_backend_registration(),))
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+    scope = _scope_for_player(sample_turn, next(row.ownerid for row in sample_turn.scores))
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=scope.player_id,
+    )
+
+    handle = orchestrator.submit(ComputeRequest(scope=scope))
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if handle.state == "complete":
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert handle.state == "complete", handle.error
+    assert handle.result_wire == {"result": _FLEET_ANALYTIC_ID}
+    assert pool.metrics.process_executions == 1
 
 
 def test_configured_worker_count_reads_environment(monkeypatch: pytest.MonkeyPatch):

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -1,0 +1,348 @@
+"""Tests for compute worker pool priority dequeue and orchestrator integration."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+import pytest
+from api.analytics.catalog import TurnAnalyticCatalogEntry
+from api.analytics.export_types import ExportScope
+from api.analytics.exports.registry import merge_export_registry
+from api.analytics.registration import TurnAnalyticRegistration
+from api.compute import (
+    AnalyticComputeProfile,
+    ComputeOrchestrator,
+    ComputePriorityBand,
+    ComputeRequest,
+    ComputeScope,
+    ComputeStepSpec,
+    ComputeWorkerPool,
+    PoolWorkItem,
+    ScopeKeySpec,
+    build_compute_registry,
+    dequeue_next_work_item,
+    normalize_export_scope_to_compute_scope,
+    reset_compute_worker_pool_for_tests,
+)
+
+from tests.compute_pool_test_helpers import run_interpreter_materialize
+from tests.fixtures.export_framework.fixture_catalog import make_fixture_catalog
+from tests.fixtures.export_framework.harness import make_fixture_query_context
+from tests.test_compute_foundation import _StubPersistencePolicy
+
+_ROW_SCOPE_KEY = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+_ANALYTIC_ID = "pool-fairness"
+_FLEET_ANALYTIC_ID = "pool-fleet"
+
+_POOL_EXPORT_REGISTRY = merge_export_registry(
+    make_fixture_catalog(_ANALYTIC_ID),
+    make_fixture_catalog(_FLEET_ANALYTIC_ID),
+)
+
+
+def _catalog_entry(analytic_id: str = _ANALYTIC_ID) -> TurnAnalyticCatalogEntry:
+    return TurnAnalyticCatalogEntry(
+        id=analytic_id,
+        name=analytic_id,
+        supports_table=True,
+        supports_map=False,
+        type="selectable",
+    )
+
+
+def _scope_for_player(sample_turn, player_id: int) -> ComputeScope:
+    export_scope = ExportScope(
+        game_id=sample_turn.game.id,
+        perspective=1,
+        turn=sample_turn.settings.turn,
+        player_id=player_id,
+    )
+    return normalize_export_scope_to_compute_scope(
+        export_scope,
+        analytic_id=_ANALYTIC_ID,
+        scope_key_spec=_ROW_SCOPE_KEY,
+    )
+
+
+def _work_item(
+    *,
+    scope: ComputeScope,
+    priority_band: ComputePriorityBand = "background",
+    step_index: int = 0,
+    sequence: int = 0,
+    backend: str = "thread",
+) -> PoolWorkItem:
+    return PoolWorkItem(
+        scope=scope,
+        step_kind="tier1" if step_index == 0 else "tier2",
+        backend=backend,
+        priority_band=priority_band,
+        step_index=step_index,
+        sequence=sequence,
+    )
+
+
+def test_dequeue_prefers_stream_attached_over_background(sample_turn):
+    player_a = next(row.ownerid for row in sample_turn.scores)
+    player_b = next(row.ownerid for row in sample_turn.scores if row.ownerid != player_a)
+    scope_a = _scope_for_player(sample_turn, player_a)
+    scope_b = _scope_for_player(sample_turn, player_b)
+    queue = deque(
+        [
+            _work_item(scope=scope_a, priority_band="background", sequence=1),
+            _work_item(scope=scope_b, priority_band="stream_attached", sequence=2),
+        ]
+    )
+
+    item = dequeue_next_work_item(queue)
+
+    assert item is not None
+    assert item.scope == scope_b
+    assert item.priority_band == "stream_attached"
+
+
+def test_dequeue_prefers_interactive_ensure_over_background(sample_turn):
+    player_a = next(row.ownerid for row in sample_turn.scores)
+    player_b = next(row.ownerid for row in sample_turn.scores if row.ownerid != player_a)
+    scope_a = _scope_for_player(sample_turn, player_a)
+    scope_b = _scope_for_player(sample_turn, player_b)
+    queue = deque(
+        [
+            _work_item(scope=scope_a, priority_band="background", sequence=1),
+            _work_item(scope=scope_b, priority_band="interactive_ensure", sequence=2),
+        ]
+    )
+
+    item = dequeue_next_work_item(queue)
+
+    assert item is not None
+    assert item.scope == scope_b
+
+
+def test_dequeue_tier_one_before_continuations_from_other_scopes(sample_turn):
+    """Port of inference scheduler fairness: tier-1 before continuation steps."""
+    player_ids = [row.ownerid for row in sample_turn.scores[:2]]
+    assert len(player_ids) >= 2
+    scope_a = _scope_for_player(sample_turn, player_ids[0])
+    scope_b = _scope_for_player(sample_turn, player_ids[1])
+    queue = deque(
+        [
+            _work_item(scope=scope_a, step_index=0, sequence=1),
+            _work_item(scope=scope_a, step_index=1, sequence=2),
+            _work_item(scope=scope_b, step_index=0, sequence=3),
+        ]
+    )
+
+    first = dequeue_next_work_item(queue)
+    second = dequeue_next_work_item(queue)
+    third = dequeue_next_work_item(queue)
+
+    assert first is not None and first.scope == scope_a and first.step_index == 0
+    assert second is not None and second.scope == scope_b and second.step_index == 0
+    assert third is not None and third.scope == scope_a and third.step_index == 1
+
+
+def test_dequeue_continuation_round_robin_across_scopes(sample_turn):
+    """Continuations dequeue in FIFO order when no tier-1 work remains."""
+    player_ids = [row.ownerid for row in sample_turn.scores[:2]]
+    scope_a = _scope_for_player(sample_turn, player_ids[0])
+    scope_b = _scope_for_player(sample_turn, player_ids[1])
+    queue = deque(
+        [
+            _work_item(scope=scope_a, step_index=1, sequence=1),
+            _work_item(scope=scope_b, step_index=1, sequence=2),
+            _work_item(scope=scope_a, step_index=2, sequence=3),
+            _work_item(scope=scope_b, step_index=2, sequence=4),
+        ]
+    )
+
+    order = [dequeue_next_work_item(queue) for _ in range(4)]
+
+    assert [item.step_index for item in order if item is not None] == [1, 1, 2, 2]
+    assert [item.scope for item in order if item is not None] == [
+        scope_a,
+        scope_b,
+        scope_a,
+        scope_b,
+    ]
+
+
+def _multi_step_thread_registration(
+    execution_order: list[tuple[int, int]],
+    gate: threading.Event,
+) -> TurnAnalyticRegistration:
+    def run_tier1(job):
+        player_id = job["player_id"]
+        execution_order.append((player_id, 0))
+        gate.wait(timeout=1.0)
+        return {"result": "tier1", "player_id": player_id}
+
+    def run_tier2(job):
+        player_id = job["player_id"]
+        execution_order.append((player_id, 1))
+        gate.wait(timeout=1.0)
+        return {"result": "tier2", "player_id": player_id}
+
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(),
+        compute=lambda _ctx: {"analyticId": _ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(
+                ComputeStepSpec(step_kind="tier1", backend="thread"),
+                ComputeStepSpec(step_kind="tier2", backend="thread"),
+            ),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            (
+                "tier1",
+                lambda scope, **_kwargs: {
+                    "player_id": scope.player_id,
+                    "scope": scope.analytic_id,
+                },
+            ),
+            (
+                "tier2",
+                lambda scope, **_kwargs: {
+                    "player_id": scope.player_id,
+                    "scope": scope.analytic_id,
+                },
+            ),
+        ),
+        run_steps=(
+            ("tier1", run_tier1),
+            ("tier2", run_tier2),
+        ),
+    )
+
+
+def test_pool_tier_one_jobs_run_before_continuations_from_other_scopes(sample_turn):
+    """Integration: worker pool applies tier-1-before-continuation fairness."""
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    execution_order: list[tuple[int, int]] = []
+    gate = threading.Event()
+    gate.set()
+    compute_registry = build_compute_registry(
+        (_multi_step_thread_registration(execution_order, gate),)
+    )
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+
+    player_ids = [row.ownerid for row in sample_turn.scores[:2]]
+    scope_a = _scope_for_player(sample_turn, player_ids[0])
+    scope_b = _scope_for_player(sample_turn, player_ids[1])
+
+    orchestrator.submit(
+        ComputeRequest(scope=scope_a, priority_band="stream_attached"),
+    )
+    gate.clear()
+    time.sleep(0.05)
+    orchestrator.submit(
+        ComputeRequest(scope=scope_b, priority_band="stream_attached"),
+    )
+    gate.set()
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if len(execution_order) >= 3:
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert execution_order[:3] == [
+        (player_ids[0], 0),
+        (player_ids[1], 0),
+        (player_ids[0], 1),
+    ]
+
+
+def test_pool_continuation_jobs_round_robin_across_scopes(sample_turn):
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    execution_order: list[tuple[int, int]] = []
+    gate = threading.Event()
+    gate.set()
+    compute_registry = build_compute_registry(
+        (_multi_step_thread_registration(execution_order, gate),)
+    )
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+
+    player_ids = [row.ownerid for row in sample_turn.scores[:2]]
+    scope_a = _scope_for_player(sample_turn, player_ids[0])
+    scope_b = _scope_for_player(sample_turn, player_ids[1])
+
+    orchestrator.submit(ComputeRequest(scope=scope_a, priority_band="stream_attached"))
+    orchestrator.submit(ComputeRequest(scope=scope_b, priority_band="stream_attached"))
+    gate.set()
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if len(execution_order) >= 4:
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert execution_order[:4] == [
+        (player_ids[0], 0),
+        (player_ids[1], 0),
+        (player_ids[0], 1),
+        (player_ids[1], 1),
+    ]
+
+
+def _interpreter_backend_registration() -> TurnAnalyticRegistration:
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(_FLEET_ANALYTIC_ID),
+        compute=lambda _ctx: {"analyticId": _FLEET_ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_FLEET_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="interpreter"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+        ),
+        run_steps=(("materialize", run_interpreter_materialize),),
+    )
+
+
+def test_pool_dispatches_interpreter_backend(sample_turn):
+    compute_registry = build_compute_registry((_interpreter_backend_registration(),))
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+    scope = _scope_for_player(sample_turn, next(row.ownerid for row in sample_turn.scores))
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=scope.player_id,
+    )
+
+    handle = orchestrator.submit(ComputeRequest(scope=scope))
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if handle.state == "complete":
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert handle.state == "complete", handle.error
+    assert handle.result_wire == {"result": _FLEET_ANALYTIC_ID}
+    assert pool.metrics.interpreter_executions == 1
+
+
+def test_configured_worker_count_reads_environment(monkeypatch: pytest.MonkeyPatch):
+    from api.compute.pools import configured_worker_count
+
+    monkeypatch.setenv("COMPUTE_ORCHESTRATOR_WORKERS", "7")
+    assert configured_worker_count() == 7

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -24,7 +24,6 @@ from api.compute import (
     build_compute_registry,
     dequeue_next_work_item,
     normalize_export_scope_to_compute_scope,
-    reset_compute_worker_pool_for_tests,
 )
 
 from tests.compute_pool_test_helpers import run_interpreter_materialize
@@ -222,7 +221,6 @@ def _multi_step_thread_registration(
 
 def test_pool_tier_one_jobs_run_before_continuations_from_other_scopes(sample_turn):
     """Integration: worker pool applies tier-1-before-continuation fairness."""
-    reset_compute_worker_pool_for_tests(worker_count=1)
     execution_order: list[tuple[int, int]] = []
     gate = threading.Event()
     gate.set()
@@ -262,7 +260,6 @@ def test_pool_tier_one_jobs_run_before_continuations_from_other_scopes(sample_tu
 
 
 def test_pool_continuation_jobs_round_robin_across_scopes(sample_turn):
-    reset_compute_worker_pool_for_tests(worker_count=1)
     execution_order: list[tuple[int, int]] = []
     gate = threading.Event()
     gate.set()

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -346,3 +346,63 @@ def test_configured_worker_count_reads_environment(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setenv("COMPUTE_ORCHESTRATOR_WORKERS", "7")
     assert configured_worker_count() == 7
+
+
+def _single_step_thread_registration() -> TurnAnalyticRegistration:
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(),
+        compute=lambda _ctx: {"analyticId": _ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("materialize", lambda scope, **_kwargs: {"player_id": scope.player_id}),
+        ),
+        run_steps=(("materialize", lambda job: {"result": job["player_id"]}),),
+    )
+
+
+def test_concurrent_submit_with_multiple_pool_workers(sample_turn):
+    """Submit from several threads while pool workers complete steps concurrently."""
+    compute_registry = build_compute_registry((_single_step_thread_registration(),))
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=2)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+
+    player_ids = [row.ownerid for row in sample_turn.scores[:4]]
+    scopes = [_scope_for_player(sample_turn, player_id) for player_id in player_ids]
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def submit_scope(scope: ComputeScope) -> None:
+        try:
+            handle = orchestrator.submit(ComputeRequest(scope=scope))
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                if handle.state in {"complete", "failed"}:
+                    break
+                time.sleep(0.01)
+            if handle.state != "complete":
+                with lock:
+                    if handle.error is not None:
+                        errors.append(handle.error)
+                    else:
+                        errors.append(RuntimeError(f"scope {scope.player_id} did not complete"))
+        except BaseException as exc:
+            with lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=submit_scope, args=(scope,)) for scope in scopes]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5.0)
+
+    pool.shutdown()
+    assert errors == []
+    for scope in scopes:
+        assert orchestrator.nodes[scope].state == "complete"
+        assert orchestrator.nodes[scope].result_wire == {"result": scope.player_id}

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -123,6 +123,25 @@ def test_dequeue_prefers_interactive_ensure_over_background(sample_turn):
     assert item.scope == scope_b
 
 
+def test_dequeue_prefers_stream_attached_over_interactive_ensure(sample_turn):
+    player_a = next(row.ownerid for row in sample_turn.scores)
+    player_b = next(row.ownerid for row in sample_turn.scores if row.ownerid != player_a)
+    scope_a = _scope_for_player(sample_turn, player_a)
+    scope_b = _scope_for_player(sample_turn, player_b)
+    queue = deque(
+        [
+            _work_item(scope=scope_a, priority_band="interactive_ensure", sequence=1),
+            _work_item(scope=scope_b, priority_band="stream_attached", sequence=2),
+        ]
+    )
+
+    item = dequeue_next_work_item(queue)
+
+    assert item is not None
+    assert item.scope == scope_b
+    assert item.priority_band == "stream_attached"
+
+
 def test_dequeue_tier_one_before_continuations_from_other_scopes(sample_turn):
     """Port of inference scheduler fairness: tier-1 before continuation steps."""
     player_ids = [row.ownerid for row in sample_turn.scores[:2]]


### PR DESCRIPTION
## Summary

- Adds `ComputeWorkerPool` with a process-wide singleton (`COMPUTE_ORCHESTRATOR_WORKERS`), priority-band dequeue (stream-attached > interactive ensure > background), and backend dispatch for thread, interpreter, and process executors.
- Wires the pool into `ComputeOrchestrator` with thread-safe graph mutations and a `PoolSubmitter` protocol for orchestrator callbacks.
- Ports inference-scheduler fairness rules (tier-1 before continuations, round-robin across scopes) to unit and integration tests.

Closes #197.

## Test plan

- [x] `uv run pytest packages/api/tests/test_compute_pools.py packages/api/tests/test_compute_orchestrator.py`
- [x] Priority band dequeue unit tests (stream vs interactive vs background)
- [x] Fairness integration tests (tier-1 before continuations, continuation round-robin)
- [x] Interpreter and process backend integration tests
- [x] Concurrent multi-worker submit test


Made with [Cursor](https://cursor.com)