### PR TITLE
Compute orchestrator: job wire dependency slices and invalidation epochs (#198)

### DIFF
--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -72,6 +72,7 @@ class ComputeNodeRun:
     state: NodeState = "waiting_deps"
     step_index: int = 0
     priority_band: ComputePriorityBand = "background"
+    generation_at_submit: int | None = None
     result_wire: object | None = None
     error: BaseException | None = None
     waiters: list[ComputeHandle] = field(default_factory=list)
@@ -83,6 +84,8 @@ class OrchestratorMetrics:
 
     inline_executions: int = 0
     pool_submissions: int = 0
+    epoch_discards: int = 0
+    persist_calls: int = 0
 
 
 class ComputeOrchestrator:
@@ -288,14 +291,14 @@ class ComputeOrchestrator:
             step = self._current_step_spec(node, registration)
             if step.backend == "inline":
                 self._ready_queue.popleft()
-                node.state = "running"
+                self._begin_step_execution(node)
                 self._run_inline(node, registration, step)
                 continue
 
             if self._pool_submitter is None:
                 return
             self._ready_queue.popleft()
-            node.state = "running"
+            self._begin_step_execution(node)
             self._submit_pool_step(node, registration, step)
             self._metrics.pool_submissions += 1
             continue
@@ -363,8 +366,37 @@ class ComputeOrchestrator:
             ctx=self._ctx,
         )
 
-    def _after_step_success(self, node: ComputeNodeRun, result_wire: object | None) -> None:
+    def _begin_step_execution(self, node: ComputeNodeRun) -> None:
         registration = self._compute_registry[node.scope.analytic_id]
+        node.state = "running"
+        node.generation_at_submit = registration.persistence_policy.invalidation_generation(
+            self._ctx,
+            node.scope,
+        )
+
+    def _current_invalidation_generation(self, node: ComputeNodeRun) -> int:
+        registration = self._compute_registry[node.scope.analytic_id]
+        return registration.persistence_policy.invalidation_generation(self._ctx, node.scope)
+
+    def _is_epoch_stale(self, node: ComputeNodeRun) -> bool:
+        if node.generation_at_submit is None:
+            return False
+        return self._current_invalidation_generation(node) != node.generation_at_submit
+
+    def _retry_step_after_epoch_bump(self, node: ComputeNodeRun) -> None:
+        self._metrics.epoch_discards += 1
+        node.generation_at_submit = None
+        node.state = "ready"
+        self._enqueue_ready(node.scope)
+        self._dispatch()
+
+    def _after_step_success(self, node: ComputeNodeRun, result_wire: object | None) -> None:
+        if self._is_epoch_stale(node):
+            self._retry_step_after_epoch_bump(node)
+            return
+
+        registration = self._compute_registry[node.scope.analytic_id]
+        node.generation_at_submit = None
         node.step_index += 1
         if node.step_index < len(registration.compute_profile.steps):
             node.state = "ready"
@@ -372,6 +404,8 @@ class ComputeOrchestrator:
             self._dispatch()
             return
         node.result_wire = result_wire
+        registration.persistence_policy.persist(self._ctx, node.scope, result_wire)
+        self._metrics.persist_calls += 1
         self._complete_node(node)
 
     def _complete_node(self, node: ComputeNodeRun) -> None:

--- a/packages/api/api/compute/persistence.py
+++ b/packages/api/api/compute/persistence.py
@@ -28,3 +28,7 @@ class PersistencePolicy(Protocol):
     def invalidate(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> None:
         """Drop or bump cached state for one compute scope."""
         ...
+
+    def invalidation_generation(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> int:
+        """Return the current invalidation epoch for one compute scope."""
+        ...

--- a/packages/api/api/compute/registry.py
+++ b/packages/api/api/compute/registry.py
@@ -43,7 +43,7 @@ def _mapping_from_pairs(
 
 
 def _check_persistence_policy(policy: object, *, analytic_id: str) -> None:
-    for hook in ("is_satisfied", "persist", "invalidate"):
+    for hook in ("is_satisfied", "persist", "invalidate", "invalidation_generation"):
         if not callable(getattr(policy, hook, None)):
             raise RuntimeError(
                 f"Turn analytic {analytic_id!r} persistence_policy must implement "

--- a/packages/api/api/compute/wire.py
+++ b/packages/api/api/compute/wire.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from api.analytics.exports.jsonpath import resolve_jsonpath
 from api.compute.scope import ComputeScope
 
 # Orchestration plane: scope + dependency outputs -> serializable job payload.
@@ -17,11 +18,7 @@ RunStepFn = Callable[[Any], Any]
 
 @dataclass
 class DependencyOutputs:
-    """Ancestor result wires for job-wire builders.
-
-    Full path projection arrives in #198; this slice stores whole result wires
-    keyed by completed dependency scope.
-    """
+    """Ancestor result wires for job-wire builders."""
 
     _by_scope: dict[ComputeScope, object] = field(default_factory=dict)
 
@@ -37,11 +34,16 @@ class DependencyOutputs:
         analytic_id: str,
         scope: ComputeScope,
         paths: tuple[str, ...],
-    ) -> object:
-        del analytic_id, paths
+    ) -> dict[str, list[Any]]:
         if scope not in self._by_scope:
             raise KeyError(f"dependency output missing for scope {scope!r}")
-        return self._by_scope[scope]
+        if scope.analytic_id != analytic_id:
+            raise ValueError(
+                f"dependency scope analytic_id {scope.analytic_id!r} "
+                f"does not match required {analytic_id!r}"
+            )
+        result_wire = self._by_scope[scope]
+        return {path: resolve_jsonpath(result_wire, path) for path in paths}
 
     def as_mapping(self) -> Mapping[ComputeScope, object]:
         return self._by_scope

--- a/packages/api/tests/test_compute_foundation.py
+++ b/packages/api/tests/test_compute_foundation.py
@@ -30,6 +30,9 @@ class _StubPersistencePolicy:
     def invalidate(self, _ctx, _scope) -> None:
         return None
 
+    def invalidation_generation(self, _ctx, _scope) -> int:
+        return 0
+
 
 def _catalog_entry(analytic_id: str = "test-analytic") -> TurnAnalyticCatalogEntry:
     return TurnAnalyticCatalogEntry(

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from api.analytics.catalog import TurnAnalyticCatalogEntry
 from api.analytics.export_types import ExportScope
 from api.analytics.exports.empty import empty_export_catalog_for
@@ -18,7 +19,12 @@ from api.compute import (
     normalize_export_scope_to_compute_scope,
     plan_compute_dag,
 )
+from api.compute.profile import ComputeBackend
 
+from tests.compute_pool_test_helpers import (
+    run_interpreter_materialize,
+    run_process_materialize,
+)
 from tests.fixtures.export_framework.diamond_exports import (
     BRANCH_B_ID,
     BRANCH_C_ID,
@@ -110,19 +116,38 @@ def _two_step_inline_compute_registration(
 
 
 def _thread_compute_registration(analytic_id: str) -> TurnAnalyticRegistration:
+    return _pool_compute_registration(analytic_id, backend="thread")
+
+
+def _pool_run_step_for_backend(backend: ComputeBackend):
+    if backend == "thread":
+        return lambda job: {"result": job["scope"]}
+    if backend == "interpreter":
+        return run_interpreter_materialize
+    if backend == "process":
+        return run_process_materialize
+    raise ValueError(f"unsupported pool backend {backend!r}")
+
+
+def _pool_compute_registration(
+    analytic_id: str,
+    *,
+    backend: ComputeBackend,
+    persistence_policy: object | None = None,
+) -> TurnAnalyticRegistration:
     return TurnAnalyticRegistration(
         catalog_entry=_catalog_entry(analytic_id),
         compute=lambda _ctx: {"analyticId": analytic_id},
         export_catalog=empty_export_catalog_for(analytic_id),
         scope_key_spec=_ROW_SCOPE_KEY,
         compute_profile=AnalyticComputeProfile(
-            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+            steps=(ComputeStepSpec(step_kind="materialize", backend=backend),),
         ),
-        persistence_policy=_StubPersistencePolicy(),
+        persistence_policy=persistence_policy or _StubPersistencePolicy(),
         build_step_job_wires=(
             ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
         ),
-        run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
+        run_steps=(("materialize", _pool_run_step_for_backend(backend)),),
     )
 
 
@@ -614,33 +639,25 @@ def test_wire_builder_receives_dependency_slices(sample_turn):
     assert orchestrator.nodes[branch_b_scope].state == "complete"
 
 
-def test_stale_epoch_discards_result_and_requeues(sample_turn):
+@pytest.mark.parametrize("backend", ["thread", "interpreter", "process"])
+def test_stale_epoch_discards_result_and_requeues_pool_backend(sample_turn, backend):
     ctx = make_fixture_query_context(
         sample_turn,
         registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
     )
     export_scope = _export_scope(sample_turn)
     persistence = _RecordingPersistencePolicy()
-    pool_submissions: list[str] = []
+    pool_submissions: list[tuple[str, str]] = []
 
-    def pool_submitter(node, _step, **_kwargs) -> None:
-        pool_submissions.append(node.scope.analytic_id)
+    def pool_submitter(node, step, **_kwargs) -> None:
+        pool_submissions.append((node.scope.analytic_id, step.backend))
 
     compute_registry = build_compute_registry(
         (
-            TurnAnalyticRegistration(
-                catalog_entry=_catalog_entry(SHARED_ID),
-                compute=lambda _ctx: {"analyticId": SHARED_ID},
-                export_catalog=empty_export_catalog_for(SHARED_ID),
-                scope_key_spec=_ROW_SCOPE_KEY,
-                compute_profile=AnalyticComputeProfile(
-                    steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
-                ),
+            _pool_compute_registration(
+                SHARED_ID,
+                backend=backend,
                 persistence_policy=persistence,
-                build_step_job_wires=(
-                    ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
-                ),
-                run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
             ),
         )
     )
@@ -653,7 +670,7 @@ def test_stale_epoch_discards_result_and_requeues(sample_turn):
 
     handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
     assert handle.state == "running"
-    assert pool_submissions == [SHARED_ID]
+    assert pool_submissions == [(SHARED_ID, backend)]
     assert orchestrator.nodes[shared_scope].generation_at_submit == 0
 
     persistence.invalidate(ctx, shared_scope)
@@ -663,13 +680,60 @@ def test_stale_epoch_discards_result_and_requeues(sample_turn):
     assert orchestrator.metrics.persist_calls == 0
     assert persistence.persist_calls == []
     assert handle.state == "running"
-    assert pool_submissions == [SHARED_ID, SHARED_ID]
+    assert pool_submissions == [(SHARED_ID, backend), (SHARED_ID, backend)]
     assert orchestrator.nodes[shared_scope].generation_at_submit == 1
 
     orchestrator.complete_pool_step(shared_scope, result_wire={"result": SHARED_ID})
 
     assert handle.state == "complete"
     assert orchestrator.metrics.epoch_discards == 1
+    assert orchestrator.metrics.persist_calls == 1
+    assert persistence.persist_calls == [(shared_scope, {"result": SHARED_ID})]
+
+
+def test_stale_epoch_discards_result_and_requeues_inline(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    persistence = _RecordingPersistencePolicy()
+    run_attempts = 0
+
+    def run_materialize(job):
+        nonlocal run_attempts
+        run_attempts += 1
+        if run_attempts == 1:
+            persistence.invalidate(ctx, shared_scope)
+        return {"result": job["scope"]}
+
+    compute_registry = build_compute_registry(
+        (
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry(SHARED_ID),
+                compute=lambda _ctx: {"analyticId": SHARED_ID},
+                export_catalog=empty_export_catalog_for(SHARED_ID),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+                ),
+                persistence_policy=persistence,
+                build_step_job_wires=(
+                    ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+                ),
+                run_steps=(("materialize", run_materialize),),
+            ),
+        )
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert handle.state == "complete"
+    assert run_attempts == 2
+    assert orchestrator.metrics.epoch_discards == 1
+    assert orchestrator.metrics.inline_executions == 2
     assert orchestrator.metrics.persist_calls == 1
     assert persistence.persist_calls == [(shared_scope, {"result": SHARED_ID})]
 

--- a/packages/api/tests/test_compute_orchestrator.py
+++ b/packages/api/tests/test_compute_orchestrator.py
@@ -12,6 +12,7 @@ from api.compute import (
     ComputeRequest,
     ComputeScope,
     ComputeStepSpec,
+    DependencyOutputs,
     ScopeKeySpec,
     build_compute_registry,
     normalize_export_scope_to_compute_scope,
@@ -508,3 +509,201 @@ def test_leader_handle_exposes_error_after_pool_failure(sample_turn):
 
     assert handle.state == "failed"
     assert handle.error is pool_failure
+
+
+class _RecordingPersistencePolicy:
+    def __init__(self) -> None:
+        self.generation = 0
+        self.persist_calls: list[tuple[ComputeScope, object]] = []
+
+    def is_satisfied(self, _ctx, _scope) -> bool:
+        return False
+
+    def persist(self, _ctx, scope, result_wire) -> None:
+        self.persist_calls.append((scope, result_wire))
+
+    def invalidate(self, _ctx, _scope) -> None:
+        self.generation += 1
+
+    def invalidation_generation(self, _ctx, _scope) -> int:
+        return self.generation
+
+
+def test_dependency_outputs_require_projects_jsonpath_slices():
+    shared_scope = ComputeScope(
+        analytic_id="scores",
+        game_id=1,
+        perspective=1,
+        turn=10,
+        player_id=8,
+    )
+    outputs = DependencyOutputs()
+    outputs.put(
+        shared_scope,
+        {
+            "solutions": [{"id": 1}],
+            "meta": {"searchStatus": "complete"},
+        },
+    )
+
+    slices = outputs.require(
+        analytic_id="scores",
+        scope=shared_scope,
+        paths=("$.solutions", "$.meta.searchStatus"),
+    )
+
+    assert slices["$.solutions"] == [[{"id": 1}]]
+    assert slices["$.meta.searchStatus"] == ["complete"]
+
+
+def test_wire_builder_receives_dependency_slices(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+    branch_b_scope = _compute_scope(BRANCH_B_ID, export_scope)
+    captured: list[dict[str, object]] = []
+
+    def build_branch_b_wire(scope, *, dependency_outputs, ctx=None):
+        del ctx
+        captured.append(
+            {
+                "scope": scope.analytic_id,
+                "dependency_scopes": dict(dependency_outputs.as_mapping()),
+                "shared_result": dependency_outputs.require(
+                    analytic_id=SHARED_ID,
+                    scope=shared_scope,
+                    paths=("$.result",),
+                ),
+            }
+        )
+        return {"scope": scope.analytic_id}
+
+    compute_registry = build_compute_registry(
+        (
+            _inline_compute_registration(ROOT_ID),
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry(BRANCH_B_ID),
+                compute=lambda _ctx: {"analyticId": BRANCH_B_ID},
+                export_catalog=empty_export_catalog_for(BRANCH_B_ID),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+                ),
+                persistence_policy=_StubPersistencePolicy(),
+                build_step_job_wires=(("materialize", build_branch_b_wire),),
+                run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
+            ),
+            _inline_compute_registration(BRANCH_C_ID),
+            _inline_compute_registration(SHARED_ID),
+        )
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    root_scope = _compute_scope(ROOT_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=root_scope))
+
+    assert handle.state == "complete"
+    assert len(captured) == 1
+    assert captured[0]["scope"] == BRANCH_B_ID
+    assert shared_scope in captured[0]["dependency_scopes"]
+    assert captured[0]["dependency_scopes"][shared_scope] == {"result": SHARED_ID}
+    assert captured[0]["shared_result"] == {"$.result": [SHARED_ID]}
+    assert orchestrator.nodes[branch_b_scope].state == "complete"
+
+
+def test_stale_epoch_discards_result_and_requeues(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    persistence = _RecordingPersistencePolicy()
+    pool_submissions: list[str] = []
+
+    def pool_submitter(node, _step, **_kwargs) -> None:
+        pool_submissions.append(node.scope.analytic_id)
+
+    compute_registry = build_compute_registry(
+        (
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry(SHARED_ID),
+                compute=lambda _ctx: {"analyticId": SHARED_ID},
+                export_catalog=empty_export_catalog_for(SHARED_ID),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+                ),
+                persistence_policy=persistence,
+                build_step_job_wires=(
+                    ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+                ),
+                run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
+            ),
+        )
+    )
+    orchestrator = ComputeOrchestrator(
+        ctx,
+        compute_registry=compute_registry,
+        pool_submitter=pool_submitter,
+    )
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+    assert handle.state == "running"
+    assert pool_submissions == [SHARED_ID]
+    assert orchestrator.nodes[shared_scope].generation_at_submit == 0
+
+    persistence.invalidate(ctx, shared_scope)
+    orchestrator.complete_pool_step(shared_scope, result_wire={"result": SHARED_ID})
+
+    assert orchestrator.metrics.epoch_discards == 1
+    assert orchestrator.metrics.persist_calls == 0
+    assert persistence.persist_calls == []
+    assert handle.state == "running"
+    assert pool_submissions == [SHARED_ID, SHARED_ID]
+    assert orchestrator.nodes[shared_scope].generation_at_submit == 1
+
+    orchestrator.complete_pool_step(shared_scope, result_wire={"result": SHARED_ID})
+
+    assert handle.state == "complete"
+    assert orchestrator.metrics.epoch_discards == 1
+    assert orchestrator.metrics.persist_calls == 1
+    assert persistence.persist_calls == [(shared_scope, {"result": SHARED_ID})]
+
+
+def test_orchestrator_persists_after_inline_node_completes(sample_turn):
+    ctx = make_fixture_query_context(
+        sample_turn,
+        registry=DIAMOND_FIXTURE_EXPORT_REGISTRY,
+    )
+    export_scope = _export_scope(sample_turn)
+    persistence = _RecordingPersistencePolicy()
+    compute_registry = build_compute_registry(
+        (
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry(SHARED_ID),
+                compute=lambda _ctx: {"analyticId": SHARED_ID},
+                export_catalog=empty_export_catalog_for(SHARED_ID),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+                ),
+                persistence_policy=persistence,
+                build_step_job_wires=(
+                    ("materialize", lambda scope, **_kwargs: {"scope": scope.analytic_id}),
+                ),
+                run_steps=(("materialize", lambda job: {"result": job["scope"]}),),
+            ),
+        )
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    shared_scope = _compute_scope(SHARED_ID, export_scope)
+
+    handle = orchestrator.submit(ComputeRequest(scope=shared_scope))
+
+    assert handle.state == "complete"
+    assert orchestrator.metrics.persist_calls == 1
+    assert persistence.persist_calls == [(shared_scope, {"result": SHARED_ID})]


### PR DESCRIPTION
## Summary

- Add invalidation epoch capture at step dispatch, complete-time stale discard with re-queue, and orchestrator-owned `PersistencePolicy.persist` after the epoch gate.
- Implement `DependencyOutputs.require()` JSONPath projection so wire builders receive dependency slices instead of whole result wires.
- Extend orchestrator tests for dependency slices, persist coordination, and stale-epoch retry across inline and pool backends (`thread`, `interpreter`, `process`).

Closes #198

## Test plan

- [x] `uv run pytest packages/api/tests/test_compute_orchestrator.py packages/api/tests/test_compute_foundation.py`
- [ ] `make test_api` (full API suite)


Made with [Cursor](https://cursor.com)