### PR TITLE
Compute orchestrator: migrate fleet table stream steps (#199)

### DIFF
--- a/packages/api/api/analytics/__init__.py
+++ b/packages/api/api/analytics/__init__.py
@@ -1,32 +1,18 @@
 """Core turn analytics."""
 
-from api.analytics.catalog import (
-    TURN_ANALYTIC_CATALOG,
-    TurnAnalyticCatalogEntry,
-    catalog_entry,
-)
-from api.analytics.compute_context import AnalyticComputeContext, AnalyticQueryContext
-from api.analytics.exports.catalog import AnalyticExportCatalog
-from api.analytics.options import TurnAnalyticsOptions
-from api.analytics.registration import (
-    TurnAnalyticHandler,
-    TurnAnalyticRegistration,
-)
+from __future__ import annotations
 
-__all__ = [
-    "AnalyticComputeContext",
-    "AnalyticExportCatalog",
-    "AnalyticQueryContext",
-    "catalog_entry",
-    "TURN_ANALYTIC_CATALOG",
-    "TURN_ANALYTIC_REGISTRATIONS",
-    "TURN_ANALYTICS",
-    "TurnAnalyticCatalogEntry",
-    "TurnAnalyticHandler",
-    "TurnAnalyticRegistration",
-    "TurnAnalyticsOptions",
-    "get_turn_analytic",
-]
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "AnalyticComputeContext": ("api.analytics.compute_context", "AnalyticComputeContext"),
+    "AnalyticQueryContext": ("api.analytics.export_context", "AnalyticQueryContext"),
+    "AnalyticExportCatalog": ("api.analytics.exports.catalog", "AnalyticExportCatalog"),
+    "catalog_entry": ("api.analytics.catalog", "catalog_entry"),
+    "TURN_ANALYTIC_CATALOG": ("api.analytics.catalog", "TURN_ANALYTIC_CATALOG"),
+    "TurnAnalyticCatalogEntry": ("api.analytics.catalog", "TurnAnalyticCatalogEntry"),
+    "TurnAnalyticHandler": ("api.analytics.registration", "TurnAnalyticHandler"),
+    "TurnAnalyticRegistration": ("api.analytics.registration", "TurnAnalyticRegistration"),
+    "TurnAnalyticsOptions": ("api.analytics.options", "TurnAnalyticsOptions"),
+}
 
 _LAZY_REGISTRY_EXPORTS = frozenset(
     {
@@ -36,10 +22,22 @@ _LAZY_REGISTRY_EXPORTS = frozenset(
     }
 )
 
+__all__ = [
+    *sorted(_LAZY_EXPORTS),
+    *sorted(_LAZY_REGISTRY_EXPORTS),
+]
 
-def __getattr__(name: str):
+
+def __getattr__(name: str) -> object:
     if name in _LAZY_REGISTRY_EXPORTS:
         from api.analytics import registry as registry_module
 
         return getattr(registry_module, name)
+    spec = _LAZY_EXPORTS.get(name)
+    if spec is not None:
+        module_path, attr = spec
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, attr)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/api/api/analytics/fleet/__init__.py
+++ b/packages/api/api/analytics/fleet/__init__.py
@@ -1,74 +1,25 @@
 """Core Fleet turn analytic."""
 
-from api.analytics.catalog import catalog_entry
-from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
+from __future__ import annotations
+
 from api.analytics.fleet.constants import ANALYTIC_ID
-from api.analytics.registration import TurnAnalyticRegistration
-from api.models.game import TurnInfo
 
-
-def compute_fleet(ctx: AnalyticComputeContext) -> dict:
-    """Return the fleet acquisition ledger for the shell turn."""
-    from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
-    from api.analytics.fleet.compute_services import resolve_fleet_compute_services
-    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_compute_wire
-
-    services = resolve_fleet_compute_services(ctx)
-    snapshot = get_or_materialize_fleet_snapshot(
-        services.persistence,
-        services.game_id,
-        services.perspective,
-        ctx.turn,
-        load_turn=services.load_turn,
-        inference_materialization=services.inference_materialization,
-        query_context=ctx.exports,
-    )
-    return fleet_turn_snapshot_to_compute_wire(snapshot)
-
-
-def get_fleet(turn: TurnInfo) -> dict:
-    """Convenience entry for tests and direct callers without durable persistence."""
-    from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
-
-    return invoke_analytic_compute(
-        compute_fleet,
-        turn,
-        export_services={ANALYTIC_ID: build_ephemeral_fleet_compute_services(turn)},
-    )
-
-
-def _load_fleet_export_catalog():
-    from api.analytics.fleet.exports import EXPORT_CATALOG
-
-    return EXPORT_CATALOG
-
-
-def iter_fleet_table_stream(
-    turn: TurnInfo,
-    player_ids: tuple[int, ...],
-    *,
-    game_id: int,
-    perspective: int,
-    fleet_services,
-    persistence,
-    scheduler=None,
-):
-    """Yield NDJSON wire events for fleet table materialization on one stream."""
-    from api.analytics.fleet.fleet_table_stream_rows import iter_fleet_table_stream_events
-
-    yield from iter_fleet_table_stream_events(
-        turn,
-        player_ids,
-        game_id=game_id,
-        perspective=perspective,
-        fleet_services=fleet_services,
-        persistence=persistence,
-        scheduler=scheduler,
-    )
-
-
-REGISTRATION = TurnAnalyticRegistration(
-    catalog_entry=catalog_entry(ANALYTIC_ID),
-    compute=compute_fleet,
-    export_catalog_loader=_load_fleet_export_catalog,
+_LAZY_EXPORTS = frozenset(
+    {
+        "REGISTRATION",
+        "compute_fleet",
+        "get_fleet",
+        "iter_fleet_table_stream",
+    }
 )
+
+
+def __getattr__(name: str) -> object:
+    if name in _LAZY_EXPORTS:
+        from api.analytics.fleet import registration as registration_module
+
+        return getattr(registration_module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["ANALYTIC_ID", *_LAZY_EXPORTS]

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -9,17 +9,15 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator
 
+from api.analytics.fleet.compute_plane.turn_delta import (
+    advance_ledger_to_turn,
+    apply_fleet_turn_delta_for_player,
+)
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
-from api.analytics.fleet.inferred_acquisition_ingest import (
-    ingest_player_inferred_acquisitions,
-    ingest_turn_inferred_acquisitions,
-)
+from api.analytics.fleet.inferred_acquisition_ingest import ingest_turn_inferred_acquisitions
 from api.analytics.fleet.materialization_provenance import resolve_fleet_materialization_provenance
-from api.analytics.fleet.observation_ingest import (
-    ingest_player_ship_observations,
-    ingest_turn_ship_observations,
-)
+from api.analytics.fleet.observation_ingest import ingest_turn_ship_observations
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.turn_context import FleetTurnContext
 from api.analytics.fleet.types import (
@@ -217,19 +215,6 @@ def advance_snapshot_to_turn(
     )
 
 
-def advance_ledger_to_turn(
-    prior_ledger: FleetAcquisitionLedger,
-    turn: TurnInfo,
-) -> FleetAcquisitionLedger:
-    """Copy one player's ledger forward to shell turn T."""
-    ledger = copy.deepcopy(prior_ledger)
-    for player in iter_turn_players(turn):
-        if player.id == ledger.player_id:
-            ledger.player_name = player.username
-            break
-    return ledger
-
-
 def apply_fleet_turn_delta(
     snapshot: FleetTurnSnapshot,
     turn: TurnInfo,
@@ -248,27 +233,6 @@ def apply_fleet_turn_delta(
     )
     snapshot = ingest_turn_ship_observations(snapshot, turn, turn_context=resolved_context)
     return snapshot
-
-
-def apply_fleet_turn_delta_for_player(
-    ledger: FleetAcquisitionLedger,
-    turn_context: FleetTurnContext,
-    *,
-    game_id: int,
-    perspective: int,
-    inference_materialization: FleetInferenceMaterialization | None = None,
-) -> FleetAcquisitionLedger:
-    """Apply turn-T fleet evidence deltas for one player ledger."""
-    turn = turn_context.turn
-    ingest_player_inferred_acquisitions(
-        ledger,
-        turn,
-        game_id=game_id,
-        perspective=perspective,
-        inference_materialization=inference_materialization,
-    )
-    ingest_player_ship_observations(ledger, turn_context)
-    return ledger
 
 
 def _find_chain_anchor_for_player(

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -23,6 +23,11 @@ from api.serialization.turn import turn_info_to_json
 
 FLEET_MATERIALIZATION_LEG = "materialization_leg"
 
+# Two-phase fleet materialization:
+# 1. Interpreter leg (materialization_leg) advances the ledger without inference.
+# 2. FleetPersistencePolicy.persist refines inferred acquisitions from scores and
+#    may re-resolve provenance before put_ledger.
+
 FLEET_SCOPE_KEY_SPEC = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
 
 FLEET_COMPUTE_PROFILE = AnalyticComputeProfile(
@@ -51,7 +56,11 @@ def build_fleet_materialization_leg_job_wire(
     dependency_outputs: DependencyOutputs,
     ctx: AnalyticQueryContext | None = None,
 ) -> dict[str, Any]:
-    """Assemble a serializable job wire for one fleet materialization leg."""
+    """Assemble a serializable job wire for one fleet materialization leg.
+
+    Embeds provenance at wire-build time for the interpreter leg; persist may
+    re-resolve provenance after scores inference refines the ledger.
+    """
     from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
     from api.analytics.fleet.compute_services import resolve_fleet_services
     from api.analytics.fleet.materialization_provenance import (
@@ -122,7 +131,12 @@ def build_fleet_materialization_leg_job_wire(
 
 
 class FleetPersistencePolicy:
-    """Orchestrator persistence hooks for per-player fleet ledger scopes."""
+    """Orchestrator persistence hooks for per-player fleet ledger scopes.
+
+    ``persist`` is phase 2 of fleet materialization: when scores inference is
+    wired it refines inferred acquisitions and re-resolves provenance before
+    storing the ledger returned by the interpreter leg.
+    """
 
     def is_satisfied(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> bool:
         from api.analytics.fleet.compute_services import resolve_fleet_services
@@ -171,6 +185,7 @@ class FleetPersistencePolicy:
             raise ValueError(f"stored turn {scope.turn} is required for fleet persist")
 
         if services.inference_materialization is not None:
+            # Phase 2: scores inference may mutate the ledger and provenance.
             refine_player_inferred_acquisitions_from_scores(
                 persisted.ledger,
                 turn,

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -57,6 +57,51 @@ def _scores_scope_for_fleet(scope: ComputeScope) -> ComputeScope:
     )
 
 
+def _scores_search_status_from_dependency_outputs(
+    fleet_scope: ComputeScope,
+    dependency_outputs: DependencyOutputs,
+) -> str | None:
+    """Resolve scores searchStatus from ancestor wires when present."""
+    from api.analytics.exports.jsonpath import resolve_jsonpath
+
+    expected = _scores_scope_for_fleet(fleet_scope)
+    result_wire = dependency_outputs.get(expected)
+    if result_wire is None:
+        for dep_scope, wire in dependency_outputs.as_mapping().items():
+            if dep_scope.analytic_id != SCORES_ANALYTIC_ID:
+                continue
+            if (
+                dep_scope.game_id == fleet_scope.game_id
+                and dep_scope.perspective == fleet_scope.perspective
+                and dep_scope.turn == fleet_scope.turn
+                and dep_scope.player_id == fleet_scope.player_id
+            ):
+                result_wire = wire
+                break
+    if result_wire is None:
+        return None
+    values = resolve_jsonpath(result_wire, "$.meta.searchStatus")
+    return values[0] if values else "not_started"
+
+
+def _scores_search_status_for_fleet_leg(
+    scope: ComputeScope,
+    dependency_outputs: DependencyOutputs,
+    ctx: AnalyticQueryContext,
+) -> str:
+    """Read scores searchStatus from dependency wires or satisfied export materialization."""
+    from api.analytics.exports.jsonpath import resolve_jsonpath
+    from api.analytics.scores.exports import materialize_scores_export_tree
+
+    resolved = _scores_search_status_from_dependency_outputs(scope, dependency_outputs)
+    if resolved is not None:
+        return resolved
+    scores_export_scope = compute_scope_to_export_scope(_scores_scope_for_fleet(scope))
+    tree = materialize_scores_export_tree(ctx, scores_export_scope)
+    values = resolve_jsonpath(tree, "$.meta.searchStatus")
+    return values[0] if values else "not_started"
+
+
 def build_fleet_materialization_leg_job_wire(
     scope: ComputeScope,
     *,
@@ -102,14 +147,11 @@ def build_fleet_materialization_leg_job_wire(
     else:
         baseline_ledger_wire = fleet_acquisition_ledger_to_json(prior_persisted.ledger)
 
-    scores_scope = _scores_scope_for_fleet(scope)
-    scores_slices = dependency_outputs.require(
-        analytic_id=SCORES_ANALYTIC_ID,
-        scope=scores_scope,
-        paths=("$.meta.searchStatus",),
+    scores_search_status = _scores_search_status_for_fleet_leg(
+        scope,
+        dependency_outputs,
+        ctx,
     )
-    search_status_values = scores_slices.get("$.meta.searchStatus", [])
-    scores_search_status = search_status_values[0] if search_status_values else "not_started"
 
     services = resolve_fleet_services(ctx)
     load_turn = services.load_turn

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -11,7 +11,6 @@ from api.analytics.fleet.serialization import (
     persisted_fleet_ledger_to_json,
 )
 from api.analytics.fleet.types import PersistedFleetLedger
-from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
 from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import (
     WILDCARD,
@@ -44,62 +43,6 @@ def _fleet_prior_scope(scope: ComputeScope) -> ComputeScope | None:
         player_id=scope.player_id,
         parameters=scope.parameters,
     )
-
-
-def _scores_scope_for_fleet(scope: ComputeScope) -> ComputeScope:
-    return ComputeScope(
-        analytic_id=SCORES_ANALYTIC_ID,
-        game_id=scope.game_id,
-        perspective=scope.perspective,
-        turn=scope.turn,
-        player_id=scope.player_id,
-        parameters=(),
-    )
-
-
-def _scores_search_status_from_dependency_outputs(
-    fleet_scope: ComputeScope,
-    dependency_outputs: DependencyOutputs,
-) -> str | None:
-    """Resolve scores searchStatus from ancestor wires when present."""
-    from api.analytics.exports.jsonpath import resolve_jsonpath
-
-    expected = _scores_scope_for_fleet(fleet_scope)
-    result_wire = dependency_outputs.get(expected)
-    if result_wire is None:
-        for dep_scope, wire in dependency_outputs.as_mapping().items():
-            if dep_scope.analytic_id != SCORES_ANALYTIC_ID:
-                continue
-            if (
-                dep_scope.game_id == fleet_scope.game_id
-                and dep_scope.perspective == fleet_scope.perspective
-                and dep_scope.turn == fleet_scope.turn
-                and dep_scope.player_id == fleet_scope.player_id
-            ):
-                result_wire = wire
-                break
-    if result_wire is None:
-        return None
-    values = resolve_jsonpath(result_wire, "$.meta.searchStatus")
-    return values[0] if values else "not_started"
-
-
-def _scores_search_status_for_fleet_leg(
-    scope: ComputeScope,
-    dependency_outputs: DependencyOutputs,
-    ctx: AnalyticQueryContext,
-) -> str:
-    """Read scores searchStatus from dependency wires or satisfied export materialization."""
-    from api.analytics.exports.jsonpath import resolve_jsonpath
-    from api.analytics.scores.exports import materialize_scores_export_tree
-
-    resolved = _scores_search_status_from_dependency_outputs(scope, dependency_outputs)
-    if resolved is not None:
-        return resolved
-    scores_export_scope = compute_scope_to_export_scope(_scores_scope_for_fleet(scope))
-    tree = materialize_scores_export_tree(ctx, scores_export_scope)
-    values = resolve_jsonpath(tree, "$.meta.searchStatus")
-    return values[0] if values else "not_started"
 
 
 def build_fleet_materialization_leg_job_wire(
@@ -147,12 +90,6 @@ def build_fleet_materialization_leg_job_wire(
     else:
         baseline_ledger_wire = fleet_acquisition_ledger_to_json(prior_persisted.ledger)
 
-    scores_search_status = _scores_search_status_for_fleet_leg(
-        scope,
-        dependency_outputs,
-        ctx,
-    )
-
     services = resolve_fleet_services(ctx)
     load_turn = services.load_turn
     turn_context = FleetTurnContext.from_turn(turn)
@@ -177,7 +114,6 @@ def build_fleet_materialization_leg_job_wire(
             persisted_fleet_ledger_to_json(prior_persisted) if prior_persisted is not None else None
         ),
         "baselineLedgerWire": baseline_ledger_wire,
-        "scoresSearchStatus": scores_search_status,
         "provenanceWire": {
             "turnEvidenceAtN": provenance.turn_evidence_at_n,
             "priorLedgerAtNMinus1": provenance.prior_ledger_at_n_minus_1,

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -1,0 +1,263 @@
+"""Fleet analytic compute orchestrator registration surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.analytics.export_context import AnalyticQueryContext
+from api.analytics.fleet.serialization import (
+    fleet_acquisition_ledger_to_json,
+    persisted_fleet_ledger_from_json,
+    persisted_fleet_ledger_to_json,
+)
+from api.analytics.fleet.types import PersistedFleetLedger
+from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
+from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
+from api.compute.scope import (
+    WILDCARD,
+    ComputeScope,
+    ScopeKeySpec,
+    compute_scope_to_export_scope,
+)
+from api.compute.wire import DependencyOutputs
+from api.serialization.turn import turn_info_to_json
+
+FLEET_MATERIALIZATION_LEG = "materialization_leg"
+
+FLEET_SCOPE_KEY_SPEC = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+
+FLEET_COMPUTE_PROFILE = AnalyticComputeProfile(
+    steps=(ComputeStepSpec(step_kind=FLEET_MATERIALIZATION_LEG, backend="interpreter"),),
+)
+
+
+def _fleet_prior_scope(scope: ComputeScope) -> ComputeScope | None:
+    if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+        return None
+    if scope.turn <= 1:
+        return None
+    return ComputeScope(
+        analytic_id=scope.analytic_id,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn - 1,
+        player_id=scope.player_id,
+        parameters=scope.parameters,
+    )
+
+
+def _scores_scope_for_fleet(scope: ComputeScope) -> ComputeScope:
+    return ComputeScope(
+        analytic_id=SCORES_ANALYTIC_ID,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=scope.player_id,
+        parameters=(),
+    )
+
+
+def build_fleet_materialization_leg_job_wire(
+    scope: ComputeScope,
+    *,
+    dependency_outputs: DependencyOutputs,
+    ctx: AnalyticQueryContext | None = None,
+) -> dict[str, Any]:
+    """Assemble a serializable job wire for one fleet materialization leg."""
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+    from api.analytics.fleet.compute_services import resolve_fleet_services
+    from api.analytics.fleet.materialization_provenance import (
+        resolve_fleet_materialization_provenance,
+    )
+    from api.analytics.fleet.turn_context import FleetTurnContext
+
+    if ctx is None:
+        raise RuntimeError("fleet materialization leg job wire requires AnalyticQueryContext")
+    if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+        raise ValueError("fleet materialization leg requires concrete player_id")
+    if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+        raise ValueError("fleet materialization leg requires concrete turn")
+
+    export_scope = compute_scope_to_export_scope(scope)
+    turn = ctx.load_turn(export_scope.turn)
+    if turn is None:
+        raise ValueError(f"stored turn {export_scope.turn} is required for fleet materialization")
+
+    player_id = scope.player_id
+    prior_scope = _fleet_prior_scope(scope)
+    prior_persisted: PersistedFleetLedger | None = None
+    if prior_scope is not None:
+        prior_wire = dependency_outputs.get(prior_scope)
+        if prior_wire is not None:
+            prior_persisted = persisted_fleet_ledger_from_json(prior_wire["persistedLedgerWire"])
+
+    if prior_persisted is None:
+        baseline_ledger = ensure_fleet_baseline_for_player(
+            scope.game_id,
+            scope.perspective,
+            turn,
+            player_id,
+        )
+        baseline_ledger_wire = fleet_acquisition_ledger_to_json(baseline_ledger)
+    else:
+        baseline_ledger_wire = fleet_acquisition_ledger_to_json(prior_persisted.ledger)
+
+    scores_scope = _scores_scope_for_fleet(scope)
+    scores_slices = dependency_outputs.require(
+        analytic_id=SCORES_ANALYTIC_ID,
+        scope=scores_scope,
+        paths=("$.meta.searchStatus",),
+    )
+    search_status_values = scores_slices.get("$.meta.searchStatus", [])
+    scores_search_status = search_status_values[0] if search_status_values else "not_started"
+
+    services = resolve_fleet_services(ctx)
+    load_turn = services.load_turn
+    turn_context = FleetTurnContext.from_turn(turn)
+    provenance = resolve_fleet_materialization_provenance(
+        materialize_turn=scope.turn,
+        prior_persisted=prior_persisted,
+        turn_context=turn_context,
+        player_id=player_id,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        load_turn=load_turn,
+        inference_materialization=services.inference_materialization,
+    )
+
+    return {
+        "gameId": scope.game_id,
+        "perspective": scope.perspective,
+        "playerId": player_id,
+        "materializeTurn": scope.turn,
+        "turnWire": turn_info_to_json(turn),
+        "priorLedgerWire": (
+            persisted_fleet_ledger_to_json(prior_persisted) if prior_persisted is not None else None
+        ),
+        "baselineLedgerWire": baseline_ledger_wire,
+        "scoresSearchStatus": scores_search_status,
+        "provenanceWire": {
+            "turnEvidenceAtN": provenance.turn_evidence_at_n,
+            "priorLedgerAtNMinus1": provenance.prior_ledger_at_n_minus_1,
+        },
+    }
+
+
+class FleetPersistencePolicy:
+    """Orchestrator persistence hooks for per-player fleet ledger scopes."""
+
+    def is_satisfied(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> bool:
+        from api.analytics.fleet.compute_services import resolve_fleet_services
+
+        if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+            return False
+        if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+            return False
+        services = resolve_fleet_services(ctx)
+        return services.persistence.has_final_ledger(
+            scope.game_id,
+            scope.perspective,
+            scope.turn,
+            scope.player_id,
+        )
+
+    def persist(
+        self,
+        ctx: AnalyticQueryContext,
+        scope: ComputeScope,
+        result_wire: object,
+    ) -> None:
+        from api.analytics.fleet.compute_services import resolve_fleet_services
+        from api.analytics.fleet.inferred_acquisition_refine import (
+            refine_player_inferred_acquisitions_from_scores,
+        )
+        from api.analytics.fleet.materialization_provenance import (
+            resolve_fleet_materialization_provenance,
+        )
+        from api.analytics.fleet.turn_context import FleetTurnContext
+
+        if not isinstance(result_wire, dict):
+            raise TypeError(f"fleet result wire must be dict, got {type(result_wire).__name__}")
+        persisted_wire = result_wire.get("persistedLedgerWire")
+        if not isinstance(persisted_wire, dict):
+            raise TypeError("fleet result wire missing persistedLedgerWire object")
+        persisted = persisted_fleet_ledger_from_json(persisted_wire)
+        services = resolve_fleet_services(ctx)
+        if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+            raise ValueError("fleet persist requires concrete player_id")
+        if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+            raise ValueError("fleet persist requires concrete turn")
+
+        turn = ctx.load_turn(scope.turn)
+        if turn is None:
+            raise ValueError(f"stored turn {scope.turn} is required for fleet persist")
+
+        if services.inference_materialization is not None:
+            refine_player_inferred_acquisitions_from_scores(
+                persisted.ledger,
+                turn,
+                game_id=scope.game_id,
+                perspective=scope.perspective,
+                inference_materialization=services.inference_materialization,
+            )
+            turn_context = FleetTurnContext.from_turn(turn)
+            prior_scope = _fleet_prior_scope(scope)
+            prior_persisted = None
+            if prior_scope is not None:
+                prior_ledger = services.persistence.get_ledger(
+                    scope.game_id,
+                    scope.perspective,
+                    prior_scope.turn,
+                    scope.player_id,
+                )
+                prior_persisted = prior_ledger
+            provenance = resolve_fleet_materialization_provenance(
+                materialize_turn=scope.turn,
+                prior_persisted=prior_persisted,
+                turn_context=turn_context,
+                player_id=scope.player_id,
+                game_id=scope.game_id,
+                perspective=scope.perspective,
+                load_turn=services.load_turn,
+                inference_materialization=services.inference_materialization,
+            )
+            persisted = PersistedFleetLedger(ledger=persisted.ledger, provenance=provenance)
+
+        services.persistence.put_ledger(
+            scope.game_id,
+            scope.perspective,
+            scope.turn,
+            scope.player_id,
+            persisted,
+            defer_ledger_persisted_notification=True,
+        )
+
+    def invalidate(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> None:
+        from api.analytics.fleet.compute_services import resolve_fleet_services
+
+        if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+            return
+        if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+            return
+        services = resolve_fleet_services(ctx)
+        services.persistence.invalidate_player_ledgers_from_turn(
+            scope.game_id,
+            scope.perspective,
+            scope.turn,
+            scope.player_id,
+        )
+
+    def invalidation_generation(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> int:
+        from api.analytics.fleet.compute_services import resolve_fleet_services
+
+        if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+            return 0
+        services = resolve_fleet_services(ctx)
+        return services.persistence.invalidation_generation(
+            scope.game_id,
+            scope.perspective,
+            scope.player_id,
+        )
+
+
+FLEET_PERSISTENCE_POLICY = FleetPersistencePolicy()

--- a/packages/api/api/analytics/fleet/compute_plane/__init__.py
+++ b/packages/api/api/analytics/fleet/compute_plane/__init__.py
@@ -1,0 +1,1 @@
+"""Fleet compute-plane steps: serializable job wire in, result wire out."""

--- a/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
+++ b/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
@@ -1,4 +1,10 @@
-"""Pure fleet materialization leg for compute orchestrator interpreter steps."""
+"""Pure fleet materialization leg for compute orchestrator interpreter steps.
+
+Phase 1 of two-phase fleet materialization: advance the acquisition ledger one
+turn in the interpreter compute plane without scores inference. Phase 2 is
+``FleetPersistencePolicy.persist`` in ``compute_orchestration``, which applies
+inference and may refresh provenance before storage.
+"""
 
 from __future__ import annotations
 
@@ -20,7 +26,11 @@ from api.serialization.turn import turn_info_from_json
 
 
 def run_fleet_materialization_leg(job_wire: dict[str, Any]) -> dict[str, Any]:
-    """Materialize one fleet turn leg from a serializable job wire (compute plane)."""
+    """Materialize one fleet turn leg from a serializable job wire (compute plane).
+
+    Returns a persisted-ledger wire carrying provenance from the job wire.
+    Scores inference is deferred to the orchestration persist hook.
+    """
     turn = turn_info_from_json(job_wire["turnWire"])
     prior_ledger_wire = job_wire.get("priorLedgerWire")
     prior_persisted = (
@@ -41,7 +51,7 @@ def run_fleet_materialization_leg(job_wire: dict[str, Any]) -> dict[str, Any]:
         turn_context,
         game_id=int(job_wire["gameId"]),
         perspective=int(job_wire["perspective"]),
-        inference_materialization=None,
+        inference_materialization=None,  # phase 2 persist hook owns scores inference
     )
     provenance = fleet_materialization_provenance_from_json(job_wire["provenanceWire"])
     persisted = PersistedFleetLedger(ledger=ledger, provenance=provenance)

--- a/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
+++ b/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
@@ -1,0 +1,51 @@
+"""Pure fleet materialization leg for compute orchestrator interpreter steps."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.analytics.fleet.compute_plane.turn_delta import (
+    advance_ledger_to_turn,
+    apply_fleet_turn_delta_for_player,
+)
+from api.analytics.fleet.serialization import (
+    fleet_acquisition_ledger_from_json,
+    fleet_materialization_provenance_from_json,
+    persisted_fleet_ledger_from_json,
+    persisted_fleet_ledger_to_json,
+)
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.fleet.types import FleetAcquisitionLedger, PersistedFleetLedger
+from api.serialization.turn import turn_info_from_json
+
+
+def run_fleet_materialization_leg(job_wire: dict[str, Any]) -> dict[str, Any]:
+    """Materialize one fleet turn leg from a serializable job wire (compute plane)."""
+    turn = turn_info_from_json(job_wire["turnWire"])
+    prior_ledger_wire = job_wire.get("priorLedgerWire")
+    prior_persisted = (
+        persisted_fleet_ledger_from_json(prior_ledger_wire)
+        if prior_ledger_wire is not None
+        else None
+    )
+    prior_ledger: FleetAcquisitionLedger
+    if prior_persisted is not None:
+        prior_ledger = prior_persisted.ledger
+    else:
+        prior_ledger = fleet_acquisition_ledger_from_json(job_wire["baselineLedgerWire"])
+
+    turn_context = FleetTurnContext.from_turn(turn)
+    ledger = advance_ledger_to_turn(prior_ledger, turn)
+    ledger = apply_fleet_turn_delta_for_player(
+        ledger,
+        turn_context,
+        game_id=int(job_wire["gameId"]),
+        perspective=int(job_wire["perspective"]),
+        inference_materialization=None,
+    )
+    provenance = fleet_materialization_provenance_from_json(job_wire["provenanceWire"])
+    persisted = PersistedFleetLedger(ledger=ledger, provenance=provenance)
+    return {
+        "persistedLedgerWire": persisted_fleet_ledger_to_json(persisted),
+        "materializeTurn": int(job_wire["materializeTurn"]),
+    }

--- a/packages/api/api/analytics/fleet/compute_plane/turn_delta.py
+++ b/packages/api/api/analytics/fleet/compute_plane/turn_delta.py
@@ -1,0 +1,50 @@
+"""One-turn fleet delta materialization for the compute plane."""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING
+
+from api.analytics.fleet.inferred_acquisition_ingest import ingest_player_inferred_acquisitions
+from api.analytics.fleet.observation_ingest import ingest_player_ship_observations
+from api.analytics.fleet.turn_context import FleetTurnContext
+from api.analytics.fleet.types import FleetAcquisitionLedger
+from api.analytics.turn_roster import iter_turn_players
+from api.models.game import TurnInfo
+
+if TYPE_CHECKING:
+    from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
+
+
+def advance_ledger_to_turn(
+    prior_ledger: FleetAcquisitionLedger,
+    turn: TurnInfo,
+) -> FleetAcquisitionLedger:
+    """Copy one player's ledger forward to shell turn T."""
+    ledger = copy.deepcopy(prior_ledger)
+    for player in iter_turn_players(turn):
+        if player.id == ledger.player_id:
+            ledger.player_name = player.username
+            break
+    return ledger
+
+
+def apply_fleet_turn_delta_for_player(
+    ledger: FleetAcquisitionLedger,
+    turn_context: FleetTurnContext,
+    *,
+    game_id: int,
+    perspective: int,
+    inference_materialization: FleetInferenceMaterialization | None = None,
+) -> FleetAcquisitionLedger:
+    """Apply turn-T fleet evidence deltas for one player ledger."""
+    turn = turn_context.turn
+    ingest_player_inferred_acquisitions(
+        ledger,
+        turn,
+        game_id=game_id,
+        perspective=perspective,
+        inference_materialization=inference_materialization,
+    )
+    ingest_player_ship_observations(ledger, turn_context)
+    return ledger

--- a/packages/api/api/analytics/fleet/exports.py
+++ b/packages/api/api/analytics/fleet/exports.py
@@ -33,6 +33,7 @@ PATH_PREFIX_SCOPE_RULES = (
 
 ENSURE_DEPENDENCIES: tuple[EnsureDependency, ...] = (
     EnsureDependency(analytic_id="scores", turn_delta=0, player_id="same"),
+    EnsureDependency(analytic_id="fleet", turn_delta=-1, player_id="same"),
 )
 
 

--- a/packages/api/api/analytics/fleet/fleet_table_player_run.py
+++ b/packages/api/api/analytics/fleet/fleet_table_player_run.py
@@ -1,4 +1,4 @@
-"""Per-player fleet table stream session and background materialization job."""
+"""Per-player fleet table stream session and wire event helpers."""
 
 from __future__ import annotations
 
@@ -11,9 +11,7 @@ from dataclasses import dataclass, field
 from api.analytics.fleet.chain import (
     _find_chain_anchor_for_player,
     advance_ledger_to_turn,
-    get_or_materialize_fleet_ledger_for_player,
 )
-from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.serialization import (
     fleet_ship_record_to_json,
 )
@@ -22,12 +20,9 @@ from api.analytics.fleet.table_wire import (
     fleet_ship_record_to_table_wire,
 )
 from api.analytics.fleet.types import FleetAcquisitionLedger, FleetShipRecord, PersistedFleetLedger
-from api.analytics.turn_roster import iter_turn_players
-from api.errors import PlanetsConsoleError
 from api.models.game import TurnInfo
 from api.transport.fleet_table_stream import (
     fleet_complete_event,
-    fleet_error_event,
     fleet_ledger_updated_event,
     fleet_provenance_event,
     fleet_record_refined_event,
@@ -200,81 +195,3 @@ class FleetLedgerWireProgressTracker:
         self.wire_before = _host_turn_shaped_ledger(persisted, self.host_turn)
         self.emitted_progress = True
         return events
-
-
-def run_fleet_player_materialization_job(
-    session: FleetPlayerStreamSession,
-    *,
-    fleet_services: FleetComputeServices,
-    persistence,
-) -> None:
-    """Materialize one player's fleet ledger and enqueue stream wire events."""
-    if session.cancel_token.is_cancelled():
-        return
-
-    player_id = session.player_id
-    turn = session.turn
-    roster_ids = {player.id for player in iter_turn_players(turn)}
-    if player_id not in roster_ids:
-        session.event_queue.put(
-            fleet_error_event(f"Player {player_id} is not on turn {turn.settings.turn} roster")
-        )
-        return
-
-    turn_number = turn.settings.turn
-    before_persisted = persistence.get_ledger(
-        fleet_services.game_id,
-        fleet_services.perspective,
-        turn_number,
-        player_id,
-    )
-    progress_tracker = FleetLedgerWireProgressTracker(
-        host_turn=turn,
-        wire_before=_initial_wire_before_ledger(
-            persistence=persistence,
-            game_id=fleet_services.game_id,
-            perspective=fleet_services.perspective,
-            player_id=player_id,
-            host_turn=turn,
-            before_persisted=before_persisted,
-        ),
-    )
-
-    def on_progress(
-        persisted_leg: PersistedFleetLedger,
-        _materialize_turn: int,
-    ) -> None:
-        if session.cancel_token.is_cancelled():
-            return
-        for event in progress_tracker.leg_progress_events(persisted_leg):
-            session.event_queue.put(event)
-
-    try:
-        persisted = get_or_materialize_fleet_ledger_for_player(
-            persistence,
-            fleet_services.game_id,
-            fleet_services.perspective,
-            player_id,
-            turn,
-            load_turn=fleet_services.load_turn,
-            inference_materialization=fleet_services.inference_materialization,
-            on_progress=on_progress,
-        )
-    except PlanetsConsoleError as exc:
-        detail = str(exc) or "Fleet ledger materialization failed"
-        session.event_queue.put(fleet_error_event(detail))
-        return
-    except Exception:
-        session.event_queue.put(fleet_error_event("Fleet ledger materialization failed"))
-        return
-
-    if progress_tracker.emitted_progress:
-        session.event_queue.put(wire_materialized_complete_event(persisted))
-        return
-
-    for event in wire_materialized_player_events(
-        before=progress_tracker.wire_before,
-        persisted=persisted,
-        host_turn=turn,
-    ):
-        session.event_queue.put(event)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_connect_policy.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_connect_policy.py
@@ -95,4 +95,6 @@ class FleetTableStreamConnectPolicy:
             self.stream_scope,
             tuple(row.session for row in self.controller.current_scheduled_rows()),
             stream_token=self.stream_token,
+            turn=self.controller.turn,
+            fleet_services=self.controller.fleet_services,
         )

--- a/packages/api/api/analytics/fleet/fleet_table_stream_connect_policy.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_connect_policy.py
@@ -95,6 +95,4 @@ class FleetTableStreamConnectPolicy:
             self.stream_scope,
             tuple(row.session for row in self.controller.current_scheduled_rows()),
             stream_token=self.stream_token,
-            turn=self.controller.turn,
-            fleet_services=self.controller.fleet_services,
         )

--- a/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
@@ -119,4 +119,6 @@ class FleetTableStreamController(
             self.scope,
             tuple(row.session for row in self.current_scheduled_rows()),
             stream_token=self.stream_token,
+            host_turn=self.turn,
+            fleet_services=self.fleet_services,
         )

--- a/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
@@ -119,6 +119,4 @@ class FleetTableStreamController(
             self.scope,
             tuple(row.session for row in self.current_scheduled_rows()),
             stream_token=self.stream_token,
-            host_turn=self.turn,
-            fleet_services=self.fleet_services,
         )

--- a/packages/api/api/analytics/fleet/fleet_table_stream_registry.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_registry.py
@@ -25,6 +25,12 @@ def controller_for_scope(scope: FleetTableStreamScope) -> FleetTableStreamContro
     return _registry.controller_for_scope(scope)
 
 
+def wake_fleet_table_stream_multiplex(scope: FleetTableStreamScope) -> None:
+    controller = controller_for_scope(scope)
+    if controller is not None:
+        controller.wake_multiplex.set()
+
+
 def reschedule_fleet_table_player(scope: FleetTableStreamScope, player_id: int) -> bool:
     """Cancel and reschedule one player on the open fleet table stream for ``scope``."""
     controller = controller_for_scope(scope)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -171,15 +171,11 @@ def cleanup_fleet_table_stream_sessions(
     sessions: tuple[FleetPlayerStreamSession, ...],
     *,
     stream_token: str,
-    turn: TurnInfo | None = None,
-    fleet_services: FleetComputeServices | None = None,
 ) -> None:
     scheduler.end_fleet_table_stream(
         scope,
         sessions,
         stream_token=stream_token,
-        host_turn=turn,
-        fleet_services=fleet_services,
     )
 
 
@@ -236,8 +232,6 @@ def iter_fleet_table_stream_events(
             stream_scope,
             (),
             stream_token=stream_token,
-            turn=turn,
-            fleet_services=fleet_services,
         ),
         policy_factory=policy_factory,
         player_ids=player_ids,

--- a/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_rows.py
@@ -10,7 +10,6 @@ from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.fleet_table_player_run import (
     FleetPlayerStreamSession,
     ScheduledFleetPlayer,
-    run_fleet_player_materialization_job,
     wire_cached_player_events,
 )
 from api.analytics.fleet.fleet_table_stream_scheduler import (
@@ -90,16 +89,10 @@ def schedule_fleet_player_run(
         perspective=perspective,
     )
 
-    def materialize(active_session: FleetPlayerStreamSession) -> None:
-        run_fleet_player_materialization_job(
-            active_session,
-            fleet_services=fleet_services,
-            persistence=persistence,
-        )
-
     scheduler.enqueue_player_run(
         session,
-        materialize,
+        fleet_services=fleet_services,
+        persistence=persistence,
         stream_token=stream_token,
     )
     if stream_token is not None and not scheduler.owns_table_stream(stream_token):
@@ -178,8 +171,16 @@ def cleanup_fleet_table_stream_sessions(
     sessions: tuple[FleetPlayerStreamSession, ...],
     *,
     stream_token: str,
+    turn: TurnInfo | None = None,
+    fleet_services: FleetComputeServices | None = None,
 ) -> None:
-    scheduler.end_fleet_table_stream(scope, sessions, stream_token=stream_token)
+    scheduler.end_fleet_table_stream(
+        scope,
+        sessions,
+        stream_token=stream_token,
+        host_turn=turn,
+        fleet_services=fleet_services,
+    )
 
 
 def iter_fleet_table_stream_events(
@@ -235,6 +236,8 @@ def iter_fleet_table_stream_events(
             stream_scope,
             (),
             stream_token=stream_token,
+            turn=turn,
+            fleet_services=fleet_services,
         ),
         policy_factory=policy_factory,
         player_ids=player_ids,

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -228,28 +228,31 @@ class FleetTableStreamScheduler:
             session = run.session
             cancelled = session.cancel_token.is_cancelled()
             if node.state == "failed":
-                if not cancelled:
-                    detail = (
-                        str(node.error)
-                        if node.error is not None
-                        else "Fleet ledger materialization failed"
-                    )
-                    session.event_queue.put(fleet_error_event(detail))
+                detail = (
+                    str(node.error)
+                    if node.error is not None
+                    else "Fleet ledger materialization failed"
+                )
+                _emit_fleet_materialization_error(
+                    session, cancelled=cancelled, detail=detail
+                )
                 continue
             if node.state != "complete" or node.result_wire is None:
                 continue
             if not isinstance(node.result_wire, dict):
-                if not cancelled:
-                    session.event_queue.put(
-                        fleet_error_event("Fleet ledger materialization failed")
-                    )
+                _emit_fleet_materialization_error(
+                    session,
+                    cancelled=cancelled,
+                    detail="Fleet ledger materialization failed",
+                )
                 continue
             persisted_wire = node.result_wire.get("persistedLedgerWire")
             if not isinstance(persisted_wire, dict):
-                if not cancelled:
-                    session.event_queue.put(
-                        fleet_error_event("Fleet ledger materialization failed")
-                    )
+                _emit_fleet_materialization_error(
+                    session,
+                    cancelled=cancelled,
+                    detail="Fleet ledger materialization failed",
+                )
                 continue
             persisted = persisted_fleet_ledger_from_json(persisted_wire)
             for event in _node_complete_stream_events(
@@ -279,6 +282,16 @@ class FleetTableStreamScheduler:
 
     def _invalidate_retained_state_locked(self) -> None:
         self._preempt_active_table_stream_locked()
+
+
+def _emit_fleet_materialization_error(
+    session: FleetPlayerStreamSession,
+    *,
+    cancelled: bool,
+    detail: str,
+) -> None:
+    if not cancelled:
+        session.event_queue.put(fleet_error_event(detail))
 
 
 def _node_complete_stream_events(

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -46,7 +46,6 @@ class _FleetPlayerOrchestratorRun:
     host_turn_number: int
     progress_tracker: FleetLedgerWireProgressTracker
     root_scope: ComputeScope
-    emitted_progress: bool = False
 
 
 class FleetTableStreamScheduler:
@@ -253,24 +252,24 @@ class FleetTableStreamScheduler:
                     )
                 continue
             persisted = persisted_fleet_ledger_from_json(persisted_wire)
+            tracker = run.progress_tracker
             if scope.turn < run.host_turn_number:
                 if cancelled:
                     continue
-                for event in run.progress_tracker.leg_progress_events(persisted):
+                for event in tracker.leg_progress_events(persisted):
                     session.event_queue.put(event)
-                with self._lock:
-                    run.emitted_progress = True
                 continue
-            if run.emitted_progress or run.progress_tracker.emitted_progress:
-                if scope.turn == run.host_turn_number:
-                    for event in run.progress_tracker.leg_progress_events(persisted):
-                        session.event_queue.put(event)
+            if scope.turn != run.host_turn_number:
+                continue
+            if tracker.emitted_progress:
+                for event in tracker.leg_progress_events(persisted):
+                    session.event_queue.put(event)
                 session.event_queue.put(wire_materialized_complete_event(persisted))
                 continue
             if cancelled:
                 continue
             for event in wire_materialized_player_events(
-                before=run.progress_tracker.wire_before,
+                before=tracker.wire_before,
                 persisted=persisted,
                 host_turn=session.turn,
             ):

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -167,8 +167,6 @@ class FleetTableStreamScheduler:
         sessions: tuple[FleetPlayerStreamSession, ...],
         *,
         stream_token: str,
-        host_turn: TurnInfo | None = None,
-        fleet_services: FleetComputeServices | None = None,
     ) -> None:
         with self._lock:
             self._scope_guard.end_table_stream_locked(scope, stream_token)

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass
 
-from api.analytics.export_context import make_analytic_query_context
+from api.analytics.export_context import AnalyticQueryContext, make_analytic_query_context
 from api.analytics.fleet.compute_services import FleetComputeServices
 from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.fleet_table_player_run import (
@@ -37,7 +37,7 @@ __all__ = [
 class _FleetStreamOrchestratorBinding:
     orchestrator: ComputeOrchestrator
     unregister_listener: object
-    query_context_id: int
+    query_context: AnalyticQueryContext
 
 
 @dataclass
@@ -177,9 +177,8 @@ class FleetTableStreamScheduler:
                 session.cancel_token.cancel()
                 self._runs.pop(session.run_id, None)
             binding = self._stream_bindings.pop(stream_token, None)
-            if binding is not None and fleet_services is not None and host_turn is not None:
-                query_ctx = _query_context_for_services(fleet_services, host_turn=host_turn)
-                release_orchestrator_for_context(query_ctx)
+            if binding is not None:
+                release_orchestrator_for_context(binding.query_context)
             if binding is not None and callable(binding.unregister_listener):
                 binding.unregister_listener()
 
@@ -201,7 +200,7 @@ class FleetTableStreamScheduler:
         binding = _FleetStreamOrchestratorBinding(
             orchestrator=orchestrator,
             unregister_listener=unregister,
-            query_context_id=id(query_ctx),
+            query_context=query_ctx,
         )
         self._stream_bindings[stream_token] = binding
         return binding

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -1,54 +1,65 @@
-"""Process-wide scheduler for fleet table stream per-player materialization jobs."""
+"""Process-wide scheduler adapter for fleet table stream orchestrator submissions."""
 
 from __future__ import annotations
 
-import os
 import threading
-from collections import deque
-from collections.abc import Callable
 from dataclasses import dataclass
 
+from api.analytics.export_context import make_analytic_query_context
+from api.analytics.fleet.compute_services import FleetComputeServices
+from api.analytics.fleet.constants import ANALYTIC_ID
 from api.analytics.fleet.fleet_table_player_run import (
+    FleetLedgerWireProgressTracker,
     FleetPlayerStreamSession,
+    _initial_wire_before_ledger,
+    wire_materialized_complete_event,
+    wire_materialized_player_events,
 )
 from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.fleet.serialization import persisted_fleet_ledger_from_json
+from api.analytics.options import TurnAnalyticsOptions
+from api.compute.orchestrator import ComputeNodeRun, ComputeOrchestrator, ComputeRequest
+from api.compute.runtime import orchestrator_for_context, release_orchestrator_for_context
+from api.compute.scope import ComputeScope
+from api.models.game import TurnInfo
 from api.streaming.table_stream.scope_guard import TableStreamScopeGuard
+from api.transport.fleet_table_stream import fleet_error_event
 
 __all__ = [
     "FleetTableStreamScheduler",
     "get_fleet_table_stream_scheduler",
+    "reset_fleet_table_stream_scheduler_for_tests",
 ]
-from api.transport.fleet_table_stream import fleet_error_event
-
-_DEFAULT_WORKER_COUNT = 4
-_DEQUEUE_WAIT_SECONDS = 0.25
 
 
-@dataclass(frozen=True)
-class FleetPlayerJob:
+@dataclass
+class _FleetStreamOrchestratorBinding:
+    orchestrator: ComputeOrchestrator
+    unregister_listener: object
+    query_context_id: int
+
+
+@dataclass
+class _FleetPlayerOrchestratorRun:
     session: FleetPlayerStreamSession
-    materialize: Callable[[FleetPlayerStreamSession], None]
+    host_turn_number: int
+    progress_tracker: FleetLedgerWireProgressTracker
+    root_scope: ComputeScope
+    emitted_progress: bool = False
 
 
 class FleetTableStreamScheduler:
-    """Fair scheduler: one materialization job per player on a table stream."""
+    """Fair scheduler: one orchestrator submission per player on a table stream."""
 
-    def __init__(self, worker_count: int = _DEFAULT_WORKER_COUNT) -> None:
-        self._work_queue: deque[FleetPlayerJob] = deque()
-        self._runs: dict[str, FleetPlayerStreamSession] = {}
+    def __init__(self) -> None:
+        self._runs: dict[str, _FleetPlayerOrchestratorRun] = {}
         self._lock = threading.Lock()
-        self._condition = threading.Condition(self._lock)
-        self._worker_count = worker_count
-        self._workers: list[threading.Thread] = []
-        self._shutdown = False
         self._scope_guard = TableStreamScopeGuard[FleetTableStreamScope]()
-        for _ in range(worker_count):
-            thread = threading.Thread(target=self._worker_loop, daemon=True)
-            thread.start()
-            self._workers.append(thread)
+        self._stream_bindings: dict[str, _FleetStreamOrchestratorBinding] = {}
 
     def begin_scope(self, scope: FleetTableStreamScope) -> str:
-        with self._condition:
+        with self._lock:
             return self._scope_guard.begin_scope_locked(
                 scope,
                 on_same_scope_preempt=self._preempt_active_table_stream_locked,
@@ -56,11 +67,11 @@ class FleetTableStreamScheduler:
             )
 
     def owns_table_stream(self, stream_token: str) -> bool:
-        with self._condition:
+        with self._lock:
             return self._scope_guard.owns_table_stream_locked(stream_token)
 
     def active_scope_matches(self, scope: FleetTableStreamScope) -> bool:
-        with self._condition:
+        with self._lock:
             return self._scope_guard.active_scope_matches_locked(scope)
 
     def row_run_for_player(
@@ -68,8 +79,9 @@ class FleetTableStreamScheduler:
         scope: FleetTableStreamScope,
         player_id: int,
     ) -> FleetPlayerStreamSession | None:
-        with self._condition:
-            for session in self._runs.values():
+        with self._lock:
+            for run in self._runs.values():
+                session = run.session
                 if (
                     session.game_id == scope.game_id
                     and session.perspective == scope.perspective
@@ -82,34 +94,73 @@ class FleetTableStreamScheduler:
     def enqueue_player_run(
         self,
         session: FleetPlayerStreamSession,
-        materialize: Callable[[FleetPlayerStreamSession], None],
         *,
+        fleet_services: FleetComputeServices,
+        persistence: FleetSnapshotPersistenceService,
         stream_token: str | None = None,
     ) -> FleetPlayerStreamSession | None:
-        with self._condition:
+        with self._lock:
             if (
                 stream_token is not None
                 and self._scope_guard.active_table_stream_token != stream_token
             ):
                 return None
             for existing in self._runs.values():
-                if existing.player_id == session.player_id:
-                    return existing
-            self._runs[session.run_id] = session
-            self._work_queue.append(FleetPlayerJob(session=session, materialize=materialize))
-            self._condition.notify()
+                if existing.session.player_id == session.player_id:
+                    return existing.session
+
+            if stream_token is None:
+                return None
+
+            binding = self._binding_for_stream_locked(
+                stream_token,
+                host_turn=session.turn,
+                fleet_services=fleet_services,
+            )
+            host_turn_number = session.turn.settings.turn
+            player_id = session.player_id
+            before_persisted = persistence.get_ledger(
+                fleet_services.game_id,
+                fleet_services.perspective,
+                host_turn_number,
+                player_id,
+            )
+            progress_tracker = FleetLedgerWireProgressTracker(
+                host_turn=session.turn,
+                wire_before=_initial_wire_before_ledger(
+                    persistence=persistence,
+                    game_id=fleet_services.game_id,
+                    perspective=fleet_services.perspective,
+                    player_id=player_id,
+                    host_turn=session.turn,
+                    before_persisted=before_persisted,
+                ),
+            )
+            root_scope = ComputeScope(
+                analytic_id=ANALYTIC_ID,
+                game_id=fleet_services.game_id,
+                perspective=fleet_services.perspective,
+                turn=host_turn_number,
+                player_id=player_id,
+            )
+            run = _FleetPlayerOrchestratorRun(
+                session=session,
+                host_turn_number=host_turn_number,
+                progress_tracker=progress_tracker,
+                root_scope=root_scope,
+            )
+            self._runs[session.run_id] = run
+            binding.orchestrator.submit(
+                ComputeRequest(scope=root_scope, priority_band="stream_attached")
+            )
             return session
 
     def cancel_player_run(self, run_id: str) -> None:
-        with self._condition:
-            session = self._runs.get(run_id)
-            if session is not None:
-                session.cancel_token.cancel()
-            self._work_queue = deque(
-                job for job in self._work_queue if job.session.run_id != run_id
-            )
+        with self._lock:
+            run = self._runs.get(run_id)
+            if run is not None:
+                run.session.cancel_token.cancel()
             self._runs.pop(run_id, None)
-            self._condition.notify_all()
 
     def end_fleet_table_stream(
         self,
@@ -117,75 +168,168 @@ class FleetTableStreamScheduler:
         sessions: tuple[FleetPlayerStreamSession, ...],
         *,
         stream_token: str,
+        host_turn: TurnInfo | None = None,
+        fleet_services: FleetComputeServices | None = None,
     ) -> None:
-        with self._condition:
+        with self._lock:
             self._scope_guard.end_table_stream_locked(scope, stream_token)
             for session in sessions:
                 session.cancel_token.cancel()
-                self._work_queue = deque(
-                    job for job in self._work_queue if job.session.run_id != session.run_id
-                )
                 self._runs.pop(session.run_id, None)
-            self._condition.notify_all()
+            binding = self._stream_bindings.pop(stream_token, None)
+            if binding is not None and fleet_services is not None and host_turn is not None:
+                query_ctx = _query_context_for_services(fleet_services, host_turn=host_turn)
+                release_orchestrator_for_context(query_ctx)
+            if binding is not None and callable(binding.unregister_listener):
+                binding.unregister_listener()
+
+    def _binding_for_stream_locked(
+        self,
+        stream_token: str,
+        *,
+        host_turn: TurnInfo,
+        fleet_services: FleetComputeServices,
+    ) -> _FleetStreamOrchestratorBinding:
+        existing = self._stream_bindings.get(stream_token)
+        if existing is not None:
+            return existing
+        query_ctx = _query_context_for_services(fleet_services, host_turn=host_turn)
+        orchestrator = orchestrator_for_context(query_ctx)
+        unregister = orchestrator.register_node_complete_listener(
+            lambda scope, node: self._on_orchestrator_node_complete(scope, node)
+        )
+        binding = _FleetStreamOrchestratorBinding(
+            orchestrator=orchestrator,
+            unregister_listener=unregister,
+            query_context_id=id(query_ctx),
+        )
+        self._stream_bindings[stream_token] = binding
+        return binding
+
+    def _on_orchestrator_node_complete(
+        self,
+        scope: ComputeScope,
+        node: ComputeNodeRun,
+    ) -> None:
+        if scope.analytic_id != ANALYTIC_ID:
+            return
+        if scope.turn == "*" or not isinstance(scope.turn, int):
+            return
+        if scope.player_id == "*" or not isinstance(scope.player_id, int):
+            return
+
+        with self._lock:
+            matching_runs = [
+                run
+                for run in self._runs.values()
+                if run.session.player_id == scope.player_id
+                and run.session.game_id == scope.game_id
+                and run.session.perspective == scope.perspective
+                and scope.turn <= run.host_turn_number
+            ]
+
+        for run in matching_runs:
+            session = run.session
+            cancelled = session.cancel_token.is_cancelled()
+            if node.state == "failed":
+                if not cancelled:
+                    detail = (
+                        str(node.error)
+                        if node.error is not None
+                        else "Fleet ledger materialization failed"
+                    )
+                    session.event_queue.put(fleet_error_event(detail))
+                continue
+            if node.state != "complete" or node.result_wire is None:
+                continue
+            if not isinstance(node.result_wire, dict):
+                if not cancelled:
+                    session.event_queue.put(
+                        fleet_error_event("Fleet ledger materialization failed")
+                    )
+                continue
+            persisted_wire = node.result_wire.get("persistedLedgerWire")
+            if not isinstance(persisted_wire, dict):
+                if not cancelled:
+                    session.event_queue.put(
+                        fleet_error_event("Fleet ledger materialization failed")
+                    )
+                continue
+            persisted = persisted_fleet_ledger_from_json(persisted_wire)
+            if scope.turn < run.host_turn_number:
+                if cancelled:
+                    continue
+                for event in run.progress_tracker.leg_progress_events(persisted):
+                    session.event_queue.put(event)
+                with self._lock:
+                    run.emitted_progress = True
+                continue
+            if run.emitted_progress or run.progress_tracker.emitted_progress:
+                if scope.turn == run.host_turn_number:
+                    for event in run.progress_tracker.leg_progress_events(persisted):
+                        session.event_queue.put(event)
+                session.event_queue.put(wire_materialized_complete_event(persisted))
+                continue
+            if cancelled:
+                continue
+            for event in wire_materialized_player_events(
+                before=run.progress_tracker.wire_before,
+                persisted=persisted,
+                host_turn=session.turn,
+            ):
+                session.event_queue.put(event)
 
     def _preempt_active_table_stream_locked(self) -> None:
-        """Cancel in-flight player runs so a reconnect can own this scope."""
-        for session in self._runs.values():
-            session.cancel_token.cancel()
+        for run in self._runs.values():
+            run.session.cancel_token.cancel()
         self._runs.clear()
-        self._work_queue.clear()
+        for stream_token, binding in list(self._stream_bindings.items()):
+            if callable(binding.unregister_listener):
+                binding.unregister_listener()
+            self._stream_bindings.pop(stream_token, None)
 
     def _invalidate_retained_state_locked(self) -> None:
         self._preempt_active_table_stream_locked()
 
-    def _worker_loop(self) -> None:
-        while True:
-            with self._condition:
-                while not self._shutdown and not self._work_queue:
-                    self._condition.wait(timeout=_DEQUEUE_WAIT_SECONDS)
-                if self._shutdown:
-                    return
-                job = self._work_queue.popleft()
-            if job.session.cancel_token.is_cancelled():
-                continue
-            try:
-                job.materialize(job.session)
-            except Exception:
-                if job.session.event_queue.empty():
-                    job.session.event_queue.put(
-                        fleet_error_event("Fleet ledger materialization failed")
-                    )
-                continue
-            if job.session.event_queue.empty():
-                job.session.event_queue.put(
-                    fleet_error_event("Fleet ledger materialization ended without stream events")
-                )
+
+def _query_context_for_services(
+    fleet_services: FleetComputeServices,
+    *,
+    host_turn,
+):
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
+
+    export_services: dict[str, object] = {ANALYTIC_ID: fleet_services}
+    if fleet_services.inference_materialization is not None:
+        scores_services = fleet_services.inference_materialization.inference.scores_services
+    else:
+        scores_services = ScoresExportContext()
+    export_services[SCORES_ANALYTIC_ID] = scores_services
+    return make_analytic_query_context(
+        host_turn,
+        TurnAnalyticsOptions(),
+        load_turn=fleet_services.load_turn,
+        export_services=export_services,
+    )
 
 
 _process_scheduler: FleetTableStreamScheduler | None = None
 _process_scheduler_lock = threading.Lock()
 
 
-def _configured_worker_count() -> int:
-    raw = os.environ.get("FLEET_TABLE_STREAM_SCHEDULER_WORKERS")
-    if raw is not None:
-        return max(1, int(raw))
-    return _DEFAULT_WORKER_COUNT
-
-
 def get_fleet_table_stream_scheduler() -> FleetTableStreamScheduler:
     global _process_scheduler
     with _process_scheduler_lock:
         if _process_scheduler is None:
-            _process_scheduler = FleetTableStreamScheduler(worker_count=_configured_worker_count())
+            _process_scheduler = FleetTableStreamScheduler()
         return _process_scheduler
 
 
 def reset_fleet_table_stream_scheduler_for_tests() -> None:
     global _process_scheduler
+    from api.compute.runtime import reset_orchestrators_for_tests
+
     with _process_scheduler_lock:
-        if _process_scheduler is not None:
-            _process_scheduler._shutdown = True
-            with _process_scheduler._condition:
-                _process_scheduler._condition.notify_all()
-        _process_scheduler = FleetTableStreamScheduler(worker_count=0)
+        _process_scheduler = FleetTableStreamScheduler()
+    reset_orchestrators_for_tests()

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -16,6 +16,7 @@ from api.analytics.fleet.fleet_table_player_run import (
     wire_materialized_complete_event,
     wire_materialized_player_events,
 )
+from api.analytics.fleet.fleet_table_stream_registry import wake_fleet_table_stream_multiplex
 from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.serialization import persisted_fleet_ledger_from_json
@@ -255,15 +256,18 @@ class FleetTableStreamScheduler:
                 )
                 continue
             persisted = persisted_fleet_ledger_from_json(persisted_wire)
-            for event in _node_complete_stream_events(
+            stream_events = _node_complete_stream_events(
                 scope_turn=scope.turn,
                 host_turn_number=run.host_turn_number,
                 tracker=run.progress_tracker,
                 persisted=persisted,
                 session_turn=session.turn,
                 cancelled=cancelled,
-            ):
+            )
+            for event in stream_events:
                 session.event_queue.put(event)
+            if stream_events:
+                _wake_multiplex_for_session(session)
 
     def _release_stream_binding_locked(
         self,
@@ -292,6 +296,17 @@ def _emit_fleet_materialization_error(
 ) -> None:
     if not cancelled:
         session.event_queue.put(fleet_error_event(detail))
+        _wake_multiplex_for_session(session)
+
+
+def _wake_multiplex_for_session(session: FleetPlayerStreamSession) -> None:
+    wake_fleet_table_stream_multiplex(
+        FleetTableStreamScope(
+            game_id=session.game_id,
+            perspective=session.perspective,
+            turn_number=session.turn.settings.turn,
+        )
+    )
 
 
 def _node_complete_stream_events(

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -330,7 +330,7 @@ def _node_complete_stream_events(
 def _query_context_for_services(
     fleet_services: FleetComputeServices,
     *,
-    host_turn,
+    host_turn: TurnInfo,
 ):
     from api.analytics.scores.export_services import ScoresExportContext
     from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -18,6 +18,7 @@ from api.analytics.fleet.fleet_table_player_run import (
 from api.analytics.fleet.fleet_table_stream_scope import FleetTableStreamScope
 from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.fleet.serialization import persisted_fleet_ledger_from_json
+from api.analytics.fleet.types import PersistedFleetLedger
 from api.analytics.options import TurnAnalyticsOptions
 from api.compute.orchestrator import ComputeNodeRun, ComputeOrchestrator, ComputeRequest
 from api.compute.runtime import orchestrator_for_context, release_orchestrator_for_context
@@ -250,26 +251,13 @@ class FleetTableStreamScheduler:
                     )
                 continue
             persisted = persisted_fleet_ledger_from_json(persisted_wire)
-            tracker = run.progress_tracker
-            if scope.turn < run.host_turn_number:
-                if cancelled:
-                    continue
-                for event in tracker.leg_progress_events(persisted):
-                    session.event_queue.put(event)
-                continue
-            if scope.turn != run.host_turn_number:
-                continue
-            if tracker.emitted_progress:
-                for event in tracker.leg_progress_events(persisted):
-                    session.event_queue.put(event)
-                session.event_queue.put(wire_materialized_complete_event(persisted))
-                continue
-            if cancelled:
-                continue
-            for event in wire_materialized_player_events(
-                before=tracker.wire_before,
+            for event in _node_complete_stream_events(
+                scope_turn=scope.turn,
+                host_turn_number=run.host_turn_number,
+                tracker=run.progress_tracker,
                 persisted=persisted,
-                host_turn=session.turn,
+                session_turn=session.turn,
+                cancelled=cancelled,
             ):
                 session.event_queue.put(event)
 
@@ -291,6 +279,39 @@ class FleetTableStreamScheduler:
 
     def _invalidate_retained_state_locked(self) -> None:
         self._preempt_active_table_stream_locked()
+
+
+def _node_complete_stream_events(
+    *,
+    scope_turn: int,
+    host_turn_number: int,
+    tracker: FleetLedgerWireProgressTracker,
+    persisted: PersistedFleetLedger,
+    session_turn: TurnInfo,
+    cancelled: bool,
+) -> tuple[dict[str, object], ...]:
+    if scope_turn < host_turn_number:
+        if cancelled:
+            return ()
+        return tracker.leg_progress_events(persisted)
+
+    if scope_turn != host_turn_number:
+        return ()
+
+    if tracker.emitted_progress:
+        return (
+            *tracker.leg_progress_events(persisted),
+            wire_materialized_complete_event(persisted),
+        )
+
+    if cancelled:
+        return ()
+
+    return wire_materialized_player_events(
+        before=tracker.wire_before,
+        persisted=persisted,
+        host_turn=session_turn,
+    )
 
 
 def _query_context_for_services(

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -234,9 +234,7 @@ class FleetTableStreamScheduler:
                     if node.error is not None
                     else "Fleet ledger materialization failed"
                 )
-                _emit_fleet_materialization_error(
-                    session, cancelled=cancelled, detail=detail
-                )
+                _emit_fleet_materialization_error(session, cancelled=cancelled, detail=detail)
                 continue
             if node.state != "complete" or node.result_wire is None:
                 continue

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -178,9 +178,7 @@ class FleetTableStreamScheduler:
                 self._runs.pop(session.run_id, None)
             binding = self._stream_bindings.pop(stream_token, None)
             if binding is not None:
-                release_orchestrator_for_context(binding.query_context)
-            if binding is not None and callable(binding.unregister_listener):
-                binding.unregister_listener()
+                self._release_stream_binding_locked(binding)
 
     def _binding_for_stream_locked(
         self,
@@ -278,14 +276,21 @@ class FleetTableStreamScheduler:
             ):
                 session.event_queue.put(event)
 
+    def _release_stream_binding_locked(
+        self,
+        binding: _FleetStreamOrchestratorBinding,
+    ) -> None:
+        release_orchestrator_for_context(binding.query_context)
+        if callable(binding.unregister_listener):
+            binding.unregister_listener()
+
     def _preempt_active_table_stream_locked(self) -> None:
         for run in self._runs.values():
             run.session.cancel_token.cancel()
         self._runs.clear()
-        for stream_token, binding in list(self._stream_bindings.items()):
-            if callable(binding.unregister_listener):
-                binding.unregister_listener()
-            self._stream_bindings.pop(stream_token, None)
+        for stream_token in list(self._stream_bindings):
+            binding = self._stream_bindings.pop(stream_token)
+            self._release_stream_binding_locked(binding)
 
     def _invalidate_retained_state_locked(self) -> None:
         self._preempt_active_table_stream_locked()

--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from api.analytics.export_context import AnalyticQueryContext, make_analytic_query_context
@@ -37,7 +38,7 @@ __all__ = [
 @dataclass
 class _FleetStreamOrchestratorBinding:
     orchestrator: ComputeOrchestrator
-    unregister_listener: object
+    unregister_listener: Callable[[], None]
     query_context: AnalyticQueryContext
 
 
@@ -266,8 +267,7 @@ class FleetTableStreamScheduler:
         binding: _FleetStreamOrchestratorBinding,
     ) -> None:
         release_orchestrator_for_context(binding.query_context)
-        if callable(binding.unregister_listener):
-            binding.unregister_listener()
+        binding.unregister_listener()
 
     def _preempt_active_table_stream_locked(self) -> None:
         for run in self._runs.values():

--- a/packages/api/api/analytics/fleet/id_bound_ingest.py
+++ b/packages/api/api/analytics/fleet/id_bound_ingest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import uuid
 
-from api.analytics.fleet.scoreboard_counts import max_ship_id_bound_for_inferred_record
 from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -25,6 +24,8 @@ def tighten_inferred_ship_id_bounds(
     shell_turn: int,
 ) -> None:
     """Apply host-turn-appropriate id bounds to inferred rows on this shell turn."""
+    from api.analytics.fleet.scoreboard_counts import max_ship_id_bound_for_inferred_record
+
     for record in ledger.records:
         if record.disposition != "active":
             continue

--- a/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
+++ b/packages/api/api/analytics/fleet/inferred_acquisition_ingest.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import uuid
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
-from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
-from api.analytics.fleet.scoreboard_counts import iter_current_turn_scores
+from api.analytics.fleet.scoreboard_ship_totals import iter_current_turn_scores
 from api.analytics.fleet.serialization import append_fleet_evidence_event
 from api.analytics.fleet.types import (
     FleetAcquisitionLedger,
@@ -17,15 +16,12 @@ from api.analytics.fleet.types import (
     FleetShipRecordFields,
     FleetTurnSnapshot,
 )
-from api.analytics.scores.placeholder_targets import (
-    ScoreboardPlaceholderTarget,
-    homeworld_starting_freighter_hull_id,
-    homeworld_starting_inventory_counts,
-    scoreboard_placeholder_targets,
-    should_seed_homeworld_starting_inventory,
-)
 from api.models.game import TurnInfo
 from api.models.player import Score
+
+if TYPE_CHECKING:
+    from api.analytics.fleet.held_solutions import FleetInferenceMaterialization
+    from api.analytics.fleet.scoreboard_placeholder_targets import ScoreboardPlaceholderTarget
 
 SCOREBOARD_SOURCE = "scoreboard"
 
@@ -62,6 +58,11 @@ def ingest_player_inferred_acquisitions(
     turn_number = turn.settings.turn
     score = _score_for_player(turn, ledger.player_id)
     if score is not None:
+        from api.analytics.fleet.scoreboard_placeholder_targets import (
+            scoreboard_placeholder_targets,
+            should_seed_homeworld_starting_inventory,
+        )
+
         if should_seed_homeworld_starting_inventory(turn):
             _ensure_homeworld_starting_inventory_rows(
                 ledger,
@@ -105,6 +106,10 @@ def _ensure_homeworld_starting_inventory_rows(
     shell_turn: int,
 ) -> None:
     """Seed homeworld starting ships not represented in accelerated scoreboard deltas."""
+    from api.analytics.fleet.scoreboard_placeholder_targets import (
+        homeworld_starting_inventory_counts,
+    )
+
     freighters, warships = homeworld_starting_inventory_counts(turn)
     _ensure_starting_inventory_rows(
         ledger,
@@ -173,6 +178,10 @@ def _starting_inventory_hull_field(
     ship_class: FleetShipClass,
 ) -> FleetFieldKnown | FleetFieldUnknown:
     if ship_class == "freighter":
+        from api.analytics.fleet.scoreboard_placeholder_targets import (
+            homeworld_starting_freighter_hull_id,
+        )
+
         return FleetFieldKnown(homeworld_starting_freighter_hull_id())
     return FleetFieldUnknown()
 

--- a/packages/api/api/analytics/fleet/registration.py
+++ b/packages/api/api/analytics/fleet/registration.py
@@ -1,0 +1,92 @@
+"""Fleet turn analytic registration and public compute entrypoints."""
+
+from api.analytics.catalog import catalog_entry
+from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
+from api.analytics.fleet.compute_orchestration import (
+    FLEET_COMPUTE_PROFILE,
+    FLEET_MATERIALIZATION_LEG,
+    FLEET_PERSISTENCE_POLICY,
+    FLEET_SCOPE_KEY_SPEC,
+    build_fleet_materialization_leg_job_wire,
+)
+from api.analytics.fleet.constants import ANALYTIC_ID
+from api.analytics.registration import TurnAnalyticRegistration
+from api.models.game import TurnInfo
+
+
+def _run_fleet_materialization_leg(job_wire: dict[str, object]) -> dict[str, object]:
+    from api.analytics.fleet.compute_plane.materialization_leg import run_fleet_materialization_leg
+
+    return run_fleet_materialization_leg(job_wire)
+
+
+def compute_fleet(ctx: AnalyticComputeContext) -> dict:
+    """Return the fleet acquisition ledger for the shell turn."""
+    from api.analytics.fleet.chain import get_or_materialize_fleet_snapshot
+    from api.analytics.fleet.compute_services import resolve_fleet_compute_services
+    from api.analytics.fleet.serialization import fleet_turn_snapshot_to_compute_wire
+
+    services = resolve_fleet_compute_services(ctx)
+    snapshot = get_or_materialize_fleet_snapshot(
+        services.persistence,
+        services.game_id,
+        services.perspective,
+        ctx.turn,
+        load_turn=services.load_turn,
+        inference_materialization=services.inference_materialization,
+        query_context=ctx.exports,
+    )
+    return fleet_turn_snapshot_to_compute_wire(snapshot)
+
+
+def get_fleet(turn: TurnInfo) -> dict:
+    """Convenience entry for tests and direct callers without durable persistence."""
+    from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+
+    return invoke_analytic_compute(
+        compute_fleet,
+        turn,
+        export_services={ANALYTIC_ID: build_ephemeral_fleet_compute_services(turn)},
+    )
+
+
+def _load_fleet_export_catalog():
+    from api.analytics.fleet.exports import EXPORT_CATALOG
+
+    return EXPORT_CATALOG
+
+
+def iter_fleet_table_stream(
+    turn: TurnInfo,
+    player_ids: tuple[int, ...],
+    *,
+    game_id: int,
+    perspective: int,
+    fleet_services,
+    persistence,
+    scheduler=None,
+):
+    """Yield NDJSON wire events for fleet table materialization on one stream."""
+    from api.analytics.fleet.fleet_table_stream_rows import iter_fleet_table_stream_events
+
+    yield from iter_fleet_table_stream_events(
+        turn,
+        player_ids,
+        game_id=game_id,
+        perspective=perspective,
+        fleet_services=fleet_services,
+        persistence=persistence,
+        scheduler=scheduler,
+    )
+
+
+REGISTRATION = TurnAnalyticRegistration(
+    catalog_entry=catalog_entry(ANALYTIC_ID),
+    compute=compute_fleet,
+    export_catalog_loader=_load_fleet_export_catalog,
+    scope_key_spec=FLEET_SCOPE_KEY_SPEC,
+    compute_profile=FLEET_COMPUTE_PROFILE,
+    persistence_policy=FLEET_PERSISTENCE_POLICY,
+    build_step_job_wires=((FLEET_MATERIALIZATION_LEG, build_fleet_materialization_leg_job_wire),),
+    run_steps=((FLEET_MATERIALIZATION_LEG, _run_fleet_materialization_leg),),
+)

--- a/packages/api/api/analytics/fleet/scoreboard_counts.py
+++ b/packages/api/api/analytics/fleet/scoreboard_counts.py
@@ -4,21 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 
-from api.analytics.scores.placeholder_targets import (
-    homeworld_starting_inventory_counts,
-    is_first_reliable_accelerated_shell_turn,
+from api.analytics.fleet.scoreboard_ship_totals import (
+    compute_max_ship_id_bound,
+    iter_current_turn_scores,
 )
 from api.analytics.turn_roster import iter_turn_players
 from api.models.game import TurnInfo
 from api.models.player import Score
-
-
-def iter_current_turn_scores(turn: TurnInfo) -> Iterator[Score]:
-    """Yield scoreboard rows for the shell turn."""
-    turn_number = turn.settings.turn
-    for score in turn.scores:
-        if score.turn == turn_number:
-            yield score
 
 
 def _current_turn_scores(turn: TurnInfo) -> Iterator[Score]:
@@ -49,18 +41,6 @@ def global_net_delta_from_scores(turn: TurnInfo) -> int:
     return sum(score.shipchange + score.freighterchange for score in _current_turn_scores(turn))
 
 
-def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
-    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas.
-
-    Returns None when the current turn has no scoreboard rows; callers must skip
-    id-bound tightening rather than inferring from visible ship lists.
-    """
-    scores = list(_current_turn_scores(turn))
-    if not scores:
-        return None
-    return _max_ship_id_bound_from_scores(scores)
-
-
 def _max_ship_id_bound_from_scores(scores: list[Score]) -> int:
     total = sum(score.capitalships + score.freighters for score in scores)
     net = sum(score.shipchange + score.freighterchange for score in scores)
@@ -86,6 +66,10 @@ def global_ship_count_at_synthetic_prior(turn: TurnInfo) -> int | None:
 
 def global_homeworld_starting_ship_id_bound(turn: TurnInfo) -> int:
     """Upper bound on ids after each player receives homeworld starting ships."""
+    from api.analytics.fleet.scoreboard_placeholder_targets import (
+        homeworld_starting_inventory_counts,
+    )
+
     freighters, warships = homeworld_starting_inventory_counts(turn)
     per_player = warships + freighters
     if per_player <= 0:
@@ -101,6 +85,10 @@ def max_ship_id_bound_for_inferred_record(
     is_starting_inventory: bool,
 ) -> int | None:
     """Resolve the id upper bound for one inferred placeholder on this shell turn."""
+    from api.analytics.fleet.scoreboard_placeholder_targets import (
+        is_first_reliable_accelerated_shell_turn,
+    )
+
     if is_starting_inventory:
         bound = global_homeworld_starting_ship_id_bound(turn)
         return bound if bound > 0 else None

--- a/packages/api/api/analytics/fleet/scoreboard_placeholder_targets.py
+++ b/packages/api/api/analytics/fleet/scoreboard_placeholder_targets.py
@@ -1,0 +1,82 @@
+"""Scoreboard placeholder build counts shared by fleet materialization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from api.concepts.accelerated_scoreboard import (
+    HOMEBASE_STARTING_FREIGHTER_HULL_ID,
+    accelerated_inference_segments,
+    is_first_reliable_scoreboard_turn,
+    starting_scoreboard_snapshot,
+)
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+
+@dataclass(frozen=True)
+class ScoreboardPlaceholderTarget:
+    """One inferred placeholder group keyed by host turn."""
+
+    host_turn: int
+    warship_delta: int
+    freighter_delta: int
+
+
+def homeworld_starting_freighter_hull_id() -> int:
+    return HOMEBASE_STARTING_FREIGHTER_HULL_ID
+
+
+def homeworld_starting_inventory_counts(turn: TurnInfo) -> tuple[int, int]:
+    """Return (freighters, warships) seeded at game start."""
+    baseline = starting_scoreboard_snapshot(turn.settings)
+    return baseline.freighters, baseline.capitalships
+
+
+def is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
+    """Return whether this shell turn is the first reliable accelerated scoreboard row."""
+    return is_first_reliable_scoreboard_turn(shell_turn, turn.settings)
+
+
+def should_seed_homeworld_starting_inventory(turn: TurnInfo) -> bool:
+    """Return whether homeworld starting ships should be seeded on this shell turn."""
+    return is_first_reliable_accelerated_shell_turn(turn.settings.turn, turn)
+
+
+def scoreboard_placeholder_targets(
+    score: Score,
+    turn: TurnInfo,
+) -> tuple[ScoreboardPlaceholderTarget, ...] | None:
+    """Return placeholder build targets for accelerated segments or normal scoreboard deltas."""
+    segments = accelerated_inference_segments(score, turn)
+    if segments is not None:
+        return tuple(
+            ScoreboardPlaceholderTarget(
+                host_turn=segment.host_turn,
+                warship_delta=segment.warship_delta,
+                freighter_delta=segment.freighter_delta,
+            )
+            for segment in segments
+        )
+
+    turn_number = turn.settings.turn
+    targets: list[ScoreboardPlaceholderTarget] = []
+    warship_builds = max(0, score.shipchange)
+    freighter_builds = max(0, score.freighterchange)
+    if warship_builds > 0:
+        targets.append(
+            ScoreboardPlaceholderTarget(
+                host_turn=turn_number,
+                warship_delta=warship_builds,
+                freighter_delta=0,
+            )
+        )
+    if freighter_builds > 0:
+        targets.append(
+            ScoreboardPlaceholderTarget(
+                host_turn=turn_number,
+                warship_delta=0,
+                freighter_delta=freighter_builds,
+            )
+        )
+    return tuple(targets) if targets else None

--- a/packages/api/api/analytics/fleet/scoreboard_ship_totals.py
+++ b/packages/api/api/analytics/fleet/scoreboard_ship_totals.py
@@ -1,0 +1,31 @@
+"""Scoreboard ship totals derived from TurnInfo score rows (compute-plane safe)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+from api.models.game import TurnInfo
+from api.models.player import Score
+
+
+def iter_current_turn_scores(turn: TurnInfo) -> Iterator[Score]:
+    """Yield scoreboard rows for the shell turn."""
+    turn_number = turn.settings.turn
+    for score in turn.scores:
+        if score.turn == turn_number:
+            yield score
+
+
+def compute_max_ship_id_bound(turn: TurnInfo) -> int | None:
+    """Upper-bound unknown ship ids from current-turn scoreboard totals and deltas.
+
+    Returns None when the current turn has no scoreboard rows; callers must skip
+    id-bound tightening rather than inferring from visible ship lists.
+    """
+    scores = list(iter_current_turn_scores(turn))
+    if not scores:
+        return None
+    total = sum(score.capitalships + score.freighters for score in scores)
+    net = sum(score.shipchange + score.freighterchange for score in scores)
+    builds = sum(max(0, score.shipchange) + max(0, score.freighterchange) for score in scores)
+    return total - net + builds

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -34,8 +34,7 @@ from api.analytics.fleet.types import (
     FleetTurnSnapshot,
     PersistedFleetLedger,
 )
-from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
-from api.errors import ValidationError
+from api.exceptions import ValidationError
 
 
 def _require_object_list(raw: object, *, field_name: str) -> list[dict[str, Any]]:
@@ -186,11 +185,18 @@ def _resolved_fleet_component_id(component_id: int) -> int | None:
 
 
 def fleet_build_option_set_from_inference_ship_build(
-    ship_build: InferenceSolutionShipBuild,
+    ship_build: object,
     *,
     solution_rank_weight: int,
 ) -> FleetBuildOptionSet:
     """Map one inference solution ship build into a fleet build option set."""
+    from api.analytics.military_score_inference.models import InferenceSolutionShipBuild
+
+    if not isinstance(ship_build, InferenceSolutionShipBuild):
+        raise TypeError(
+            "ship_build must be InferenceSolutionShipBuild, "
+            f"got {type(ship_build).__name__}",
+        )
     combo_id = ship_build.combo_id or None
     return FleetBuildOptionSet(
         combo_id=combo_id,

--- a/packages/api/api/analytics/fleet/serialization.py
+++ b/packages/api/api/analytics/fleet/serialization.py
@@ -194,8 +194,7 @@ def fleet_build_option_set_from_inference_ship_build(
 
     if not isinstance(ship_build, InferenceSolutionShipBuild):
         raise TypeError(
-            "ship_build must be InferenceSolutionShipBuild, "
-            f"got {type(ship_build).__name__}",
+            f"ship_build must be InferenceSolutionShipBuild, got {type(ship_build).__name__}",
         )
     combo_id = ship_build.combo_id or None
     return FleetBuildOptionSet(

--- a/packages/api/api/analytics/fleet/turn_context.py
+++ b/packages/api/api/analytics/fleet/turn_context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from api.analytics.fleet.scoreboard_counts import compute_max_ship_id_bound
+from api.analytics.fleet.scoreboard_ship_totals import compute_max_ship_id_bound
 from api.models.game import TurnInfo
 
 

--- a/packages/api/api/analytics/registry.py
+++ b/packages/api/api/analytics/registry.py
@@ -9,7 +9,7 @@ from api.analytics.catalog import (
 )
 from api.analytics.compute_context import make_analytic_compute_context
 from api.analytics.connections import REGISTRATION as CONNECTIONS_REGISTRATION
-from api.analytics.fleet import REGISTRATION as FLEET_REGISTRATION
+from api.analytics.fleet.registration import REGISTRATION as FLEET_REGISTRATION
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.registration import (
     TurnAnalyticHandler,

--- a/packages/api/api/analytics/scores/__init__.py
+++ b/packages/api/api/analytics/scores/__init__.py
@@ -14,6 +14,14 @@ from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import
 )
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.registration import TurnAnalyticRegistration
+from api.analytics.scores.compute_orchestration import (
+    SCORES_COMPUTE_PROFILE,
+    SCORES_MATERIALIZE,
+    SCORES_PERSISTENCE_POLICY,
+    SCORES_SCOPE_KEY_SPEC,
+    build_scores_materialize_job_wire,
+    run_scores_materialize,
+)
 from api.analytics.scores.inference import get_scores_row_inference as get_scores_row_inference
 from api.analytics.scores_assets import ANALYTIC_ID
 from api.analytics.turn_roster import players_by_id as turn_players_by_id
@@ -113,4 +121,9 @@ REGISTRATION = TurnAnalyticRegistration(
     catalog_entry=catalog_entry(ANALYTIC_ID),
     compute=compute_scores_table,
     export_catalog_loader=_load_scores_export_catalog,
+    scope_key_spec=SCORES_SCOPE_KEY_SPEC,
+    compute_profile=SCORES_COMPUTE_PROFILE,
+    persistence_policy=SCORES_PERSISTENCE_POLICY,
+    build_step_job_wires=((SCORES_MATERIALIZE, build_scores_materialize_job_wire),),
+    run_steps=((SCORES_MATERIALIZE, run_scores_materialize),),
 )

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -1,0 +1,99 @@
+"""Scores analytic compute orchestrator registration surface (minimal until #200)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from api.analytics.export_context import AnalyticQueryContext
+from api.analytics.export_types import ExportScope
+from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
+from api.compute.scope import ComputeScope, ScopeKeySpec, compute_scope_to_export_scope
+
+SCORES_MATERIALIZE = "materialize"
+
+SCORES_SCOPE_KEY_SPEC = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+
+SCORES_COMPUTE_PROFILE = AnalyticComputeProfile(
+    steps=(ComputeStepSpec(step_kind=SCORES_MATERIALIZE, backend="inline"),),
+)
+
+
+def build_scores_materialize_job_wire(
+    scope: ComputeScope,
+    *,
+    dependency_outputs: object,
+    ctx: AnalyticQueryContext | None = None,
+) -> dict[str, Any]:
+    """Materialize scores export tree on the orchestration plane."""
+    from api.analytics.scores.exports import ensure_scores_export, materialize_scores_export_tree
+
+    del dependency_outputs
+    if ctx is None:
+        raise RuntimeError("scores materialize job wire requires AnalyticQueryContext")
+    export_scope = compute_scope_to_export_scope(scope)
+    ensure_scores_export(ctx, export_scope)
+    tree = materialize_scores_export_tree(ctx, export_scope)
+    return {"exportTree": tree}
+
+
+def run_scores_materialize(job_wire: dict[str, Any]) -> dict[str, Any]:
+    """Inline scores step returns the prefetched export tree."""
+    return job_wire["exportTree"]
+
+
+class ScoresPersistencePolicy:
+    """Orchestrator persistence hooks for per-player scores inference scopes."""
+
+    def is_satisfied(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> bool:
+        from api.analytics.scores.exports import is_scores_export_ensure_satisfied
+
+        export_scope = _export_scope_for_compute(scope)
+        if export_scope is None:
+            return False
+        return is_scores_export_ensure_satisfied(ctx, export_scope)
+
+    def persist(
+        self,
+        ctx: AnalyticQueryContext,
+        scope: ComputeScope,
+        result_wire: object,
+    ) -> None:
+        del ctx, scope, result_wire
+
+    def invalidate(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> None:
+        from api.analytics.scores.export_services import resolve_scores_services
+
+        export_scope = _export_scope_for_compute(scope)
+        if export_scope is None:
+            return
+        services = resolve_scores_services(ctx)
+        if services.persistence is None or export_scope.player_id is None:
+            return
+        services.persistence.delete_row(
+            export_scope.game_id,
+            export_scope.perspective,
+            export_scope.turn,
+            export_scope.player_id,
+        )
+
+    def invalidation_generation(self, ctx: AnalyticQueryContext, scope: ComputeScope) -> int:
+        del ctx, scope
+        return 0
+
+
+def _export_scope_for_compute(scope: ComputeScope) -> ExportScope | None:
+    if scope.player_id == "*" or not isinstance(scope.player_id, int):
+        return None
+    if scope.turn == "*" or not isinstance(scope.turn, int):
+        return None
+    if scope.perspective == "*" or not isinstance(scope.perspective, int):
+        return None
+    return ExportScope(
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=scope.player_id,
+    )
+
+
+SCORES_PERSISTENCE_POLICY = ScoresPersistencePolicy()

--- a/packages/api/api/analytics/scores/placeholder_targets.py
+++ b/packages/api/api/analytics/scores/placeholder_targets.py
@@ -1,10 +1,10 @@
 """Public scores boundary for scoreboard placeholder metadata.
 
 Fleet and other analytics consumers should import placeholder-target helpers
-from this module rather than from ``scoreboard_placeholder_targets`` directly.
+from ``api.analytics.fleet.scoreboard_placeholder_targets`` or this re-export.
 """
 
-from api.analytics.scores.scoreboard_placeholder_targets import (
+from api.analytics.fleet.scoreboard_placeholder_targets import (
     ScoreboardPlaceholderTarget,
     homeworld_starting_freighter_hull_id,
     homeworld_starting_inventory_counts,

--- a/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
+++ b/packages/api/api/analytics/scores/scoreboard_placeholder_targets.py
@@ -1,82 +1,19 @@
 """Scoreboard placeholder build counts exposed through the scores analytic."""
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-
-from api.analytics.military_score_inference.accelerated_start import (
-    HOMEBASE_STARTING_FREIGHTER_HULL_ID,
-    accelerated_inference_segments,
-    is_first_reliable_scoreboard_turn,
-    starting_scoreboard_snapshot,
+from api.analytics.fleet.scoreboard_placeholder_targets import (
+    ScoreboardPlaceholderTarget,
+    homeworld_starting_freighter_hull_id,
+    homeworld_starting_inventory_counts,
+    is_first_reliable_accelerated_shell_turn,
+    scoreboard_placeholder_targets,
+    should_seed_homeworld_starting_inventory,
 )
-from api.models.game import TurnInfo
-from api.models.player import Score
 
-
-@dataclass(frozen=True)
-class ScoreboardPlaceholderTarget:
-    """One inferred placeholder group keyed by host turn."""
-
-    host_turn: int
-    warship_delta: int
-    freighter_delta: int
-
-
-def homeworld_starting_freighter_hull_id() -> int:
-    return HOMEBASE_STARTING_FREIGHTER_HULL_ID
-
-
-def homeworld_starting_inventory_counts(turn: TurnInfo) -> tuple[int, int]:
-    """Return (freighters, warships) seeded at game start."""
-    baseline = starting_scoreboard_snapshot(turn.settings)
-    return baseline.freighters, baseline.capitalships
-
-
-def is_first_reliable_accelerated_shell_turn(shell_turn: int, turn: TurnInfo) -> bool:
-    """Return whether this shell turn is the first reliable accelerated scoreboard row."""
-    return is_first_reliable_scoreboard_turn(shell_turn, turn.settings)
-
-
-def should_seed_homeworld_starting_inventory(turn: TurnInfo) -> bool:
-    """Return whether homeworld starting ships should be seeded on this shell turn."""
-    return is_first_reliable_accelerated_shell_turn(turn.settings.turn, turn)
-
-
-def scoreboard_placeholder_targets(
-    score: Score,
-    turn: TurnInfo,
-) -> tuple[ScoreboardPlaceholderTarget, ...] | None:
-    """Return placeholder build targets for accelerated segments or normal scoreboard deltas."""
-    segments = accelerated_inference_segments(score, turn)
-    if segments is not None:
-        return tuple(
-            ScoreboardPlaceholderTarget(
-                host_turn=segment.host_turn,
-                warship_delta=segment.warship_delta,
-                freighter_delta=segment.freighter_delta,
-            )
-            for segment in segments
-        )
-
-    turn_number = turn.settings.turn
-    targets: list[ScoreboardPlaceholderTarget] = []
-    warship_builds = max(0, score.shipchange)
-    freighter_builds = max(0, score.freighterchange)
-    if warship_builds > 0:
-        targets.append(
-            ScoreboardPlaceholderTarget(
-                host_turn=turn_number,
-                warship_delta=warship_builds,
-                freighter_delta=0,
-            )
-        )
-    if freighter_builds > 0:
-        targets.append(
-            ScoreboardPlaceholderTarget(
-                host_turn=turn_number,
-                warship_delta=0,
-                freighter_delta=freighter_builds,
-            )
-        )
-    return tuple(targets) if targets else None
+__all__ = (
+    "ScoreboardPlaceholderTarget",
+    "homeworld_starting_freighter_hull_id",
+    "homeworld_starting_inventory_counts",
+    "is_first_reliable_accelerated_shell_turn",
+    "scoreboard_placeholder_targets",
+    "should_seed_homeworld_starting_inventory",
+)

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -103,8 +103,10 @@ class ComputeOrchestrator:
     ) -> None:
         self._ctx = ctx
         self._compute_registry = compute_registry
+        self._pool_registration_id: int | None = None
         if worker_pool is not None:
-            pool_submitter = worker_pool.attach(self)
+            self._pool_registration_id = worker_pool.register(self)
+            pool_submitter = worker_pool.submitter_for(self._pool_registration_id)
         self._pool_submitter = pool_submitter
         self._worker_pool = worker_pool
         self._nodes: dict[ComputeScope, ComputeNodeRun] = {}
@@ -117,6 +119,10 @@ class ComputeOrchestrator:
     @property
     def worker_pool(self) -> ComputeWorkerPool | None:
         return self._worker_pool
+
+    @property
+    def pool_registration_id(self) -> int | None:
+        return self._pool_registration_id
 
     @property
     def metrics(self) -> OrchestratorMetrics:

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import threading
 from collections import deque
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -15,6 +15,8 @@ from api.compute.profile import ComputeStepSpec
 from api.compute.registry import AnalyticComputeRegistration
 from api.compute.scope import ComputeScope, compute_scope_to_export_scope
 from api.compute.wire import DependencyOutputs
+
+NodeCompleteListener = Callable[[ComputeScope, "ComputeNodeRun"], None]
 
 NodeState = Literal[
     "waiting_deps",
@@ -110,6 +112,7 @@ class ComputeOrchestrator:
         self._metrics = OrchestratorMetrics()
         self._lock = threading.Lock()
         self._condition = threading.Condition(self._lock)
+        self._node_complete_listeners: list[NodeCompleteListener] = []
 
     @property
     def worker_pool(self) -> ComputeWorkerPool | None:
@@ -118,6 +121,23 @@ class ComputeOrchestrator:
     @property
     def metrics(self) -> OrchestratorMetrics:
         return self._metrics
+
+    def register_node_complete_listener(
+        self,
+        listener: NodeCompleteListener,
+    ) -> Callable[[], None]:
+        """Register a node completion listener; return an unregister callable."""
+        with self._condition:
+            self._node_complete_listeners.append(listener)
+
+        def unregister() -> None:
+            with self._condition:
+                try:
+                    self._node_complete_listeners.remove(listener)
+                except ValueError:
+                    return
+
+        return unregister
 
     @property
     def nodes(self) -> Mapping[ComputeScope, ComputeNodeRun]:
@@ -414,6 +434,7 @@ class ComputeOrchestrator:
         for waiter in node.waiters:
             waiter._waiter_error = None
         node.waiters.clear()
+        self._notify_node_complete(node)
         self._on_dependency_terminal(node.scope)
 
     def _fail_node(self, node: ComputeNodeRun, error: BaseException) -> None:
@@ -425,7 +446,13 @@ class ComputeOrchestrator:
         for waiter in node.waiters:
             waiter._waiter_error = error
         node.waiters.clear()
+        self._notify_node_complete(node)
         self._on_dependency_terminal(node.scope)
+
+    def _notify_node_complete(self, node: ComputeNodeRun) -> None:
+        listeners = tuple(self._node_complete_listeners)
+        for listener in listeners:
+            listener(node.scope, node)
 
     def _on_dependency_terminal(self, completed_scope: ComputeScope) -> None:
         for node in self._nodes.values():

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -53,6 +53,7 @@ def configured_worker_count() -> int:
 class PoolWorkItem:
     """One schedulable pool unit dequeued by priority band and fairness rules."""
 
+    orchestrator_id: int
     scope: ComputeScope
     step_kind: str
     backend: ComputeBackend
@@ -107,7 +108,8 @@ class ComputeWorkerPool:
         worker_count: int | None = None,
     ) -> None:
         self._worker_count = worker_count if worker_count is not None else configured_worker_count()
-        self._orchestrator: ComputeOrchestrator | None = None
+        self._orchestrators: dict[int, ComputeOrchestrator] = {}
+        self._next_orchestrator_id = 0
         self._work_queue: deque[PoolWorkItem] = deque()
         self._lock = threading.Lock()
         self._condition = threading.Condition(self._lock)
@@ -129,13 +131,32 @@ class ComputeWorkerPool:
     def worker_count(self) -> int:
         return self._worker_count
 
-    def attach(self, orchestrator: ComputeOrchestrator) -> PoolSubmitter:
-        """Bind an orchestrator and return its pool submitter callback."""
-        self._orchestrator = orchestrator
-        return self._submit_from_orchestrator
+    def register(self, orchestrator: ComputeOrchestrator) -> int:
+        """Register an orchestrator for pool completion routing; return its registration id."""
+        with self._condition:
+            orchestrator_id = self._next_orchestrator_id
+            self._next_orchestrator_id += 1
+            self._orchestrators[orchestrator_id] = orchestrator
+            return orchestrator_id
+
+    def unregister(self, orchestrator_id: int) -> None:
+        """Remove an orchestrator and drop any queued work for it."""
+        with self._condition:
+            self._orchestrators.pop(orchestrator_id, None)
+            if self._work_queue:
+                self._work_queue = deque(
+                    item
+                    for item in self._work_queue
+                    if item.orchestrator_id != orchestrator_id
+                )
+
+    def submitter_for(self, orchestrator_id: int) -> PoolSubmitter:
+        """Return a pool submitter callback bound to one orchestrator registration."""
+        return self._make_submitter(orchestrator_id)
 
     def submit(
         self,
+        orchestrator_id: int,
         node: ComputeNodeRun,
         step: ComputeStepSpec,
         *,
@@ -147,6 +168,7 @@ class ComputeWorkerPool:
         with self._condition:
             self._work_queue.append(
                 PoolWorkItem(
+                    orchestrator_id=orchestrator_id,
                     scope=node.scope,
                     step_kind=step.step_kind,
                     backend=step.backend,
@@ -166,21 +188,24 @@ class ComputeWorkerPool:
             thread.join(timeout=1.0)
         self._shutdown_executors(wait=wait_for_interpreters)
 
-    def _submit_from_orchestrator(
-        self,
-        node: ComputeNodeRun,
-        step: ComputeStepSpec,
-        *,
-        job_wire: object | None = None,
-        run_step: RunStepFn | None = None,
-    ) -> None:
-        self.submit(
-            node,
-            step,
-            priority_band=node.priority_band,
-            job_wire=job_wire,
-            run_step=run_step,
-        )
+    def _make_submitter(self, orchestrator_id: int) -> PoolSubmitter:
+        def _submit_from_orchestrator(
+            node: ComputeNodeRun,
+            step: ComputeStepSpec,
+            *,
+            job_wire: object | None = None,
+            run_step: RunStepFn | None = None,
+        ) -> None:
+            self.submit(
+                orchestrator_id,
+                node,
+                step,
+                priority_band=node.priority_band,
+                job_wire=job_wire,
+                run_step=run_step,
+            )
+
+        return _submit_from_orchestrator
 
     def _worker_loop(self) -> None:
         while True:
@@ -207,14 +232,22 @@ class ComputeWorkerPool:
         elif backend == "process":
             self._metrics.process_executions += 1
 
+    def _lookup_orchestrator(self, orchestrator_id: int) -> ComputeOrchestrator | None:
+        with self._condition:
+            return self._orchestrators.get(orchestrator_id)
+
     def _execute_item(self, item: PoolWorkItem) -> None:
-        orchestrator = self._orchestrator
+        orchestrator = self._lookup_orchestrator(item.orchestrator_id)
         if orchestrator is None:
-            raise RuntimeError("ComputeWorkerPool is not attached to an orchestrator")
+            return
         if item.backend == "thread":
             with self._condition:
                 self._record_backend_execution_locked(item.backend)
-            self._complete_from_callable(orchestrator, item.scope, orchestrator.execute_pool_step)
+            self._complete_from_callable(
+                item.orchestrator_id,
+                item.scope,
+                orchestrator.execute_pool_step,
+            )
             return
         if item.backend in {"interpreter", "process"}:
             if item.job_wire is None or item.run_step is None:
@@ -229,7 +262,7 @@ class ComputeWorkerPool:
                 else:
                     executor = self._process_executor_locked()
             future = executor.submit(item.run_step, item.job_wire)
-            self._complete_from_future(orchestrator, item.scope, future)
+            self._complete_from_future(item.orchestrator_id, item.scope, future)
             return
         raise RuntimeError(f"unsupported pool backend {item.backend!r}")
 
@@ -254,29 +287,50 @@ class ComputeWorkerPool:
 
     def _complete_from_callable(
         self,
-        orchestrator: ComputeOrchestrator,
+        orchestrator_id: int,
         scope: ComputeScope,
         run_step: Callable[[ComputeScope], object],
     ) -> None:
         try:
             result_wire = run_step(scope)
         except BaseException as exc:
-            orchestrator.complete_pool_step(scope, error=exc)
+            self._complete_pool_step_if_registered(orchestrator_id, scope, error=exc)
             return
-        orchestrator.complete_pool_step(scope, result_wire=result_wire)
+        self._complete_pool_step_if_registered(
+            orchestrator_id,
+            scope,
+            result_wire=result_wire,
+        )
 
     def _complete_from_future(
         self,
-        orchestrator: ComputeOrchestrator,
+        orchestrator_id: int,
         scope: ComputeScope,
         future: Future[object],
     ) -> None:
         try:
             result_wire = future.result()
         except BaseException as exc:
-            orchestrator.complete_pool_step(scope, error=exc)
+            self._complete_pool_step_if_registered(orchestrator_id, scope, error=exc)
             return
-        orchestrator.complete_pool_step(scope, result_wire=result_wire)
+        self._complete_pool_step_if_registered(
+            orchestrator_id,
+            scope,
+            result_wire=result_wire,
+        )
+
+    def _complete_pool_step_if_registered(
+        self,
+        orchestrator_id: int,
+        scope: ComputeScope,
+        *,
+        result_wire: object | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        orchestrator = self._lookup_orchestrator(orchestrator_id)
+        if orchestrator is None:
+            return
+        orchestrator.complete_pool_step(scope, result_wire=result_wire, error=error)
 
 
 _global_worker_pool: ComputeWorkerPool | None = None

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -145,9 +145,7 @@ class ComputeWorkerPool:
             self._orchestrators.pop(orchestrator_id, None)
             if self._work_queue:
                 self._work_queue = deque(
-                    item
-                    for item in self._work_queue
-                    if item.orchestrator_id != orchestrator_id
+                    item for item in self._work_queue if item.orchestrator_id != orchestrator_id
                 )
 
     def submitter_for(self, orchestrator_id: int) -> PoolSubmitter:

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -158,13 +158,13 @@ class ComputeWorkerPool:
             )
             self._condition.notify()
 
-    def shutdown(self) -> None:
+    def shutdown(self, *, wait_for_interpreters: bool = False) -> None:
         with self._condition:
             self._shutdown = True
             self._condition.notify_all()
         for thread in self._workers:
             thread.join(timeout=1.0)
-        self._shutdown_executors()
+        self._shutdown_executors(wait=wait_for_interpreters)
 
     def _submit_from_orchestrator(
         self,
@@ -243,13 +243,13 @@ class ComputeWorkerPool:
             self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
         return self._process_executor
 
-    def _shutdown_executors(self) -> None:
+    def _shutdown_executors(self, *, wait: bool = False) -> None:
         with self._condition:
             if self._interpreter_executor is not None:
-                self._interpreter_executor.shutdown(wait=False)
+                self._interpreter_executor.shutdown(wait=wait, cancel_futures=wait)
                 self._interpreter_executor = None
             if self._process_executor is not None:
-                self._process_executor.shutdown(wait=False)
+                self._process_executor.shutdown(wait=wait, cancel_futures=wait)
                 self._process_executor = None
 
     def _complete_from_callable(
@@ -296,7 +296,7 @@ def shutdown_compute_worker_pool_for_tests() -> None:
     global _global_worker_pool
     with _global_worker_pool_lock:
         if _global_worker_pool is not None:
-            _global_worker_pool.shutdown()
+            _global_worker_pool.shutdown(wait_for_interpreters=True)
             _global_worker_pool = None
 
 
@@ -304,6 +304,6 @@ def reset_compute_worker_pool_for_tests(*, worker_count: int = 0) -> ComputeWork
     global _global_worker_pool
     with _global_worker_pool_lock:
         if _global_worker_pool is not None:
-            _global_worker_pool.shutdown()
+            _global_worker_pool.shutdown(wait_for_interpreters=True)
         _global_worker_pool = ComputeWorkerPool(worker_count=worker_count)
         return _global_worker_pool

--- a/packages/api/api/compute/runtime.py
+++ b/packages/api/api/compute/runtime.py
@@ -1,0 +1,46 @@
+"""Process-wide compute orchestrator wiring for production callers."""
+
+from __future__ import annotations
+
+import threading
+
+from api.analytics.export_context import AnalyticQueryContext
+from api.compute.orchestrator import ComputeOrchestrator
+from api.compute.pools import ComputeWorkerPool, get_compute_worker_pool
+from api.compute.registry import COMPUTE_REGISTRY
+
+_orchestrator_lock = threading.Lock()
+_orchestrators_by_ctx_id: dict[int, ComputeOrchestrator] = {}
+
+
+def orchestrator_for_context(
+    ctx: AnalyticQueryContext,
+    *,
+    worker_pool: ComputeWorkerPool | None = None,
+) -> ComputeOrchestrator:
+    """Return a compute orchestrator bound to one query context and the global worker pool."""
+    ctx_id = id(ctx)
+    with _orchestrator_lock:
+        existing = _orchestrators_by_ctx_id.get(ctx_id)
+        if existing is not None:
+            return existing
+        pool = worker_pool if worker_pool is not None else get_compute_worker_pool()
+        orchestrator = ComputeOrchestrator(
+            ctx,
+            compute_registry=COMPUTE_REGISTRY,
+            worker_pool=pool,
+        )
+        _orchestrators_by_ctx_id[ctx_id] = orchestrator
+        return orchestrator
+
+
+def release_orchestrator_for_context(ctx: AnalyticQueryContext) -> None:
+    """Drop a cached orchestrator for one query context (stream teardown)."""
+    with _orchestrator_lock:
+        _orchestrators_by_ctx_id.pop(id(ctx), None)
+
+
+def reset_orchestrators_for_tests() -> None:
+    """Clear cached orchestrators (tests only)."""
+    with _orchestrator_lock:
+        _orchestrators_by_ctx_id.clear()

--- a/packages/api/api/compute/runtime.py
+++ b/packages/api/api/compute/runtime.py
@@ -37,7 +37,13 @@ def orchestrator_for_context(
 def release_orchestrator_for_context(ctx: AnalyticQueryContext) -> None:
     """Drop a cached orchestrator for one query context (stream teardown)."""
     with _orchestrator_lock:
-        _orchestrators_by_ctx_id.pop(id(ctx), None)
+        orchestrator = _orchestrators_by_ctx_id.pop(id(ctx), None)
+    if orchestrator is None:
+        return
+    registration_id = orchestrator.pool_registration_id
+    worker_pool = orchestrator.worker_pool
+    if registration_id is not None and worker_pool is not None:
+        worker_pool.unregister(registration_id)
 
 
 def reset_orchestrators_for_tests() -> None:

--- a/packages/api/api/concepts/accelerated_scoreboard.py
+++ b/packages/api/api/concepts/accelerated_scoreboard.py
@@ -1,0 +1,184 @@
+"""Accelerated-start scoreboard helpers safe for compute-plane imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from api.models.game import GameSettings, TurnInfo
+from api.models.player import Score
+
+HOMEBASE_STARBASE_DEFENSE_POSTS = 100
+HOMEBASE_STARBASE_FIGHTERS = 20
+HOMEBASE_PLANET_DEFENSE_POSTS = 20
+HOMEBASE_STARTING_FREIGHTERS = 1
+HOMEBASE_STARTING_FREIGHTER_HULL_ID = 16
+HOMEBASE_STARTING_CAPITAL_SHIPS = 0
+HOMEBASE_STARTING_STARBASES = 1
+
+ACCEL_WINDOW_SEGMENT_ID = "accel_window"
+REPORTED_HOST_TURN_SEGMENT_ID = "reported_host_turn"
+
+STARBASE_FIGHTER_SCORE_DELTA_2X = 125
+STARBASE_DEFENSE_POST_SCORE_DELTA_2X = 15
+PLANET_DEFENSE_POST_SCORE_DELTA_2X = 11
+
+
+@dataclass(frozen=True)
+class ScoreboardSnapshot:
+    militaryscore: int
+    capitalships: int
+    freighters: int
+    starbases: int
+    prioritypoints: int = 0
+
+
+@dataclass(frozen=True)
+class AcceleratedInferenceSegment:
+    segment_id: str
+    host_turn: int
+    military_delta_2x: int
+    warship_delta: int
+    freighter_delta: int
+    priority_point_delta: int
+
+
+@dataclass(frozen=True)
+class AcceleratedWindowShipBuilds:
+    inferred_prior_to_reported_host_turn: ScoreboardSnapshot
+    turn_one_baseline: ScoreboardSnapshot
+    freighters_built_before_reported_host_turn: int
+    warships_built_before_reported_host_turn: int
+    freighters_built_on_reported_host_turn: int
+    warships_built_on_reported_host_turn: int
+
+
+def accelerated_turn_count(settings: GameSettings) -> int:
+    return max(0, settings.acceleratedturns)
+
+
+def is_first_reliable_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:
+    accelerated = accelerated_turn_count(settings)
+    return accelerated > 0 and turn_number == accelerated
+
+
+def homeworld_baseline_military_2x(settings: GameSettings) -> int:
+    if not settings.homeworldhasstarbase:
+        return 0
+    return (
+        STARBASE_DEFENSE_POST_SCORE_DELTA_2X * HOMEBASE_STARBASE_DEFENSE_POSTS
+        + STARBASE_FIGHTER_SCORE_DELTA_2X * HOMEBASE_STARBASE_FIGHTERS
+        + PLANET_DEFENSE_POST_SCORE_DELTA_2X * HOMEBASE_PLANET_DEFENSE_POSTS
+    )
+
+
+def starting_scoreboard_snapshot(settings: GameSettings) -> ScoreboardSnapshot:
+    if not settings.homeworldhasstarbase:
+        return ScoreboardSnapshot(
+            militaryscore=0,
+            capitalships=HOMEBASE_STARTING_CAPITAL_SHIPS,
+            freighters=0,
+            starbases=0,
+        )
+    return ScoreboardSnapshot(
+        militaryscore=homeworld_baseline_military_2x(settings) // 2,
+        capitalships=HOMEBASE_STARTING_CAPITAL_SHIPS,
+        freighters=HOMEBASE_STARTING_FREIGHTERS,
+        starbases=HOMEBASE_STARTING_STARBASES,
+    )
+
+
+def cumulative_military_delta_2x(score: Score, settings: GameSettings) -> int:
+    return 2 * score.militaryscore - homeworld_baseline_military_2x(settings)
+
+
+def reported_host_military_delta_2x(score: Score) -> int:
+    return 2 * score.militarychange
+
+
+def accelerated_window_military_delta_2x(score: Score, turn: TurnInfo) -> int:
+    if not is_first_reliable_scoreboard_turn(turn.settings.turn, turn.settings):
+        return 0
+    return cumulative_military_delta_2x(score, turn.settings) - reported_host_military_delta_2x(
+        score
+    )
+
+
+def synthetic_scoreboard_before_reported_deltas(score: Score) -> ScoreboardSnapshot:
+    return ScoreboardSnapshot(
+        militaryscore=score.militaryscore - score.militarychange,
+        capitalships=score.capitalships - score.shipchange,
+        freighters=score.freighters - score.freighterchange,
+        starbases=score.starbases - score.starbasechange,
+        prioritypoints=score.prioritypoints - score.prioritypointchange,
+    )
+
+
+def infer_accelerated_window_ship_builds(
+    score: Score,
+    turn: TurnInfo,
+) -> AcceleratedWindowShipBuilds | None:
+    if not is_first_reliable_scoreboard_turn(turn.settings.turn, turn.settings):
+        return None
+
+    baseline = starting_scoreboard_snapshot(turn.settings)
+    prior_to_reported_host_turn = synthetic_scoreboard_before_reported_deltas(score)
+    return AcceleratedWindowShipBuilds(
+        inferred_prior_to_reported_host_turn=prior_to_reported_host_turn,
+        turn_one_baseline=baseline,
+        freighters_built_before_reported_host_turn=max(
+            0, prior_to_reported_host_turn.freighters - baseline.freighters
+        ),
+        warships_built_before_reported_host_turn=max(
+            0, prior_to_reported_host_turn.capitalships - baseline.capitalships
+        ),
+        freighters_built_on_reported_host_turn=max(0, score.freighterchange),
+        warships_built_on_reported_host_turn=max(0, score.shipchange),
+    )
+
+
+def accelerated_inference_segments(
+    score: Score,
+    turn: TurnInfo,
+) -> tuple[AcceleratedInferenceSegment, ...] | None:
+    if not is_first_reliable_scoreboard_turn(turn.settings.turn, turn.settings):
+        return None
+
+    builds = infer_accelerated_window_ship_builds(score, turn)
+    if builds is None:
+        return None
+
+    reported_host_turn = turn.settings.turn - 1
+    accel_host_turn = turn.settings.turn - 2
+    segments: list[AcceleratedInferenceSegment] = []
+
+    accel_segment = AcceleratedInferenceSegment(
+        segment_id=ACCEL_WINDOW_SEGMENT_ID,
+        host_turn=accel_host_turn,
+        military_delta_2x=accelerated_window_military_delta_2x(score, turn),
+        warship_delta=builds.warships_built_before_reported_host_turn,
+        freighter_delta=builds.freighters_built_before_reported_host_turn,
+        priority_point_delta=0,
+    )
+    if _segment_has_inference_targets(accel_segment):
+        segments.append(accel_segment)
+
+    segments.append(
+        AcceleratedInferenceSegment(
+            segment_id=REPORTED_HOST_TURN_SEGMENT_ID,
+            host_turn=reported_host_turn,
+            military_delta_2x=reported_host_military_delta_2x(score),
+            warship_delta=score.shipchange,
+            freighter_delta=score.freighterchange,
+            priority_point_delta=score.prioritypointchange,
+        )
+    )
+    return tuple(segments)
+
+
+def _segment_has_inference_targets(segment: AcceleratedInferenceSegment) -> bool:
+    return (
+        segment.military_delta_2x != 0
+        or segment.warship_delta != 0
+        or segment.freighter_delta != 0
+        or segment.priority_point_delta != 0
+    )

--- a/packages/api/api/errors.py
+++ b/packages/api/api/errors.py
@@ -1,9 +1,6 @@
-"""Exception hierarchy and HTTP exception handling for the Core API.
+"""FastAPI HTTP exception handling for the Core API."""
 
-All package-raised exceptions should inherit from CoreAPIError (or a descendant).
-Each exception class may override `http_error` (default 500) to control the
-HTTP status returned to the client.
-"""
+from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
@@ -12,73 +9,30 @@ from typing import Type
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
+from api.exceptions import (
+    ConflictError,
+    CoreAPIError,
+    FleetMaterializationTimeoutError,
+    LoginCredentialsRequiredError,
+    NotFoundError,
+    PlanetsConsoleError,
+    UpstreamPlanetsError,
+    ValidationError,
+)
+
+__all__ = [
+    "ConflictError",
+    "CoreAPIError",
+    "FleetMaterializationTimeoutError",
+    "LoginCredentialsRequiredError",
+    "NotFoundError",
+    "PlanetsConsoleError",
+    "UpstreamPlanetsError",
+    "ValidationError",
+    "make_http_exception_handler",
+]
+
 logger = logging.getLogger(__name__)
-
-
-class PlanetsConsoleError(Exception):
-    """Base for all server-side exceptions that map to an HTTP status.
-
-    Subclass this in each package (CoreAPIError, BFFError) so that handlers
-    can return the exception's http_error as the response status.
-    """
-
-    http_error: int = 500
-
-    def __init__(self, message: str = "", *, http_error: int | None = None) -> None:
-        super().__init__(message)
-        if http_error is not None:
-            self.http_error = http_error
-
-
-class CoreAPIError(PlanetsConsoleError):
-    """Root exception for the Core REST API package.
-
-    All exceptions raised by the Core API should inherit from this (or a
-    descendant). Override the class attribute `http_error` for a fixed status
-    per exception type, or pass `http_error=` to the constructor for one-off
-    overrides.
-    """
-
-    http_error: int = 500
-
-
-# --- Store / storage layer exceptions (design §6) ---
-
-
-class NotFoundError(CoreAPIError):
-    """Path does not exist (read/update/delete)."""
-
-    http_error: int = 404
-
-
-class ConflictError(CoreAPIError):
-    """Create on existing path, or update would change node type."""
-
-    http_error: int = 409
-
-
-class ValidationError(CoreAPIError):
-    """Invalid payload/path (e.g. reserved @ key, malformed path segment)."""
-
-    http_error: int = 422
-
-
-class LoginCredentialsRequiredError(CoreAPIError):
-    """Stored API key is missing and no password was supplied for refresh."""
-
-    http_error: int = 401
-
-
-class UpstreamPlanetsError(CoreAPIError):
-    """Planets.nu HTTP or transport failure, or an unusable response body."""
-
-    http_error: int = 502
-
-
-class FleetMaterializationTimeoutError(CoreAPIError):
-    """Coordinated fleet gap-fill did not complete within the waiter timeout."""
-
-    http_error: int = 504
 
 
 def make_http_exception_handler(

--- a/packages/api/api/exceptions.py
+++ b/packages/api/api/exceptions.py
@@ -1,0 +1,74 @@
+"""Exception hierarchy for the Core API (transport-free).
+
+All package-raised exceptions should inherit from CoreAPIError (or a descendant).
+Each exception class may override `http_error` (default 500) to control the
+HTTP status returned to the client when handled by the FastAPI layer.
+"""
+
+from __future__ import annotations
+
+
+class PlanetsConsoleError(Exception):
+    """Base for all server-side exceptions that map to an HTTP status.
+
+    Subclass this in each package (CoreAPIError, BFFError) so that handlers
+    can return the exception's http_error as the response status.
+    """
+
+    http_error: int = 500
+
+    def __init__(self, message: str = "", *, http_error: int | None = None) -> None:
+        super().__init__(message)
+        if http_error is not None:
+            self.http_error = http_error
+
+
+class CoreAPIError(PlanetsConsoleError):
+    """Root exception for the Core REST API package.
+
+    All exceptions raised by the Core API should inherit from this (or a
+    descendant). Override the class attribute `http_error` for a fixed status
+    per exception type, or pass `http_error=` to the constructor for one-off
+    overrides.
+    """
+
+    http_error: int = 500
+
+
+# --- Store / storage layer exceptions (design §6) ---
+
+
+class NotFoundError(CoreAPIError):
+    """Path does not exist (read/update/delete)."""
+
+    http_error: int = 404
+
+
+class ConflictError(CoreAPIError):
+    """Create on existing path, or update would change node type."""
+
+    http_error: int = 409
+
+
+class ValidationError(CoreAPIError):
+    """Invalid payload/path (e.g. reserved @ key, malformed path segment)."""
+
+    http_error: int = 422
+
+
+class LoginCredentialsRequiredError(CoreAPIError):
+    """Stored API key is missing and no password was supplied for refresh."""
+
+    http_error: int = 401
+
+
+class UpstreamPlanetsError(CoreAPIError):
+    """Planets.nu HTTP or transport failure, or an unusable response body."""
+
+    http_error: int = 502
+
+
+class FleetMaterializationTimeoutError(CoreAPIError):
+    """Coordinated fleet gap-fill did not complete within the waiter timeout."""
+
+    http_error: int = 504

--- a/packages/api/tests/conftest.py
+++ b/packages/api/tests/conftest.py
@@ -47,6 +47,32 @@ def _isolate_global_compute_worker_pool(request: pytest.FixtureRequest):
     shutdown_compute_worker_pool_for_tests()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_fleet_table_stream_compute_state(request: pytest.FixtureRequest):
+    """Reset orchestrator and worker pool between fleet stream tests."""
+    if "test_fleet_table_stream" not in request.path.name:
+        yield
+        return
+    from api.analytics.fleet.fleet_table_stream_registry import (
+        reset_fleet_table_stream_registry_for_tests,
+    )
+    from api.analytics.fleet.fleet_table_stream_scheduler import (
+        reset_fleet_table_stream_scheduler_for_tests,
+    )
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+    from api.compute.runtime import reset_orchestrators_for_tests
+
+    reset_fleet_table_stream_registry_for_tests()
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    reset_fleet_table_stream_scheduler_for_tests()
+    yield
+    reset_fleet_table_stream_registry_for_tests()
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    reset_fleet_table_stream_scheduler_for_tests()
+
+
 # OR-Tools / inference-corpus integration tests excluded from `make ci` (see Makefile `test_api`).
 _SLOW_TEST_NAMES = frozenset(
     {

--- a/packages/api/tests/test_compute_foundation.py
+++ b/packages/api/tests/test_compute_foundation.py
@@ -239,7 +239,49 @@ def test_build_compute_registry_rejects_duplicate_compute_ids():
         build_compute_registry(registrations)
 
 
-def test_production_compute_registry_imports_without_profiles():
+def test_production_compute_registry_imports_fleet_and_scores():
     from api.compute.registry import COMPUTE_REGISTRY
 
-    assert COMPUTE_REGISTRY == {}
+    assert "fleet" in COMPUTE_REGISTRY
+    assert "scores" in COMPUTE_REGISTRY
+
+
+def test_fleet_compute_profile_uses_interpreter_backend():
+    from api.analytics.fleet.compute_orchestration import FLEET_COMPUTE_PROFILE
+
+    assert len(FLEET_COMPUTE_PROFILE.steps) == 1
+    assert FLEET_COMPUTE_PROFILE.steps[0].backend == "interpreter"
+
+
+def test_fleet_materialization_leg_import_does_not_load_transport_stack():
+    """Compute-plane materialization leg must not pull FastAPI or Pydantic."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    api_root = Path(__file__).resolve().parent.parent
+    script = """
+import sys
+from api.analytics.fleet.compute_plane.materialization_leg import run_fleet_materialization_leg
+blocked = [
+    name
+    for name in sys.modules
+    if name == "fastapi"
+    or name.startswith("fastapi.")
+    or name == "pydantic"
+    or name.startswith("pydantic.")
+    or name == "pydantic_core"
+    or name.startswith("pydantic_core.")
+]
+if blocked:
+    raise SystemExit(f"unexpected transport modules: {blocked}")
+if run_fleet_materialization_leg is None:
+    raise SystemExit("run_fleet_materialization_leg import failed")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=api_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -468,3 +468,88 @@ def test_concurrent_submit_with_multiple_pool_workers(sample_turn):
     for scope in scopes:
         assert orchestrator.nodes[scope].state == "complete"
         assert orchestrator.nodes[scope].result_wire == {"result": scope.player_id}
+
+
+def _fleet_materialization_leg_registration() -> TurnAnalyticRegistration:
+    from api.analytics.fleet.compute_orchestration import FLEET_MATERIALIZATION_LEG
+    from api.analytics.fleet.compute_plane.materialization_leg import run_fleet_materialization_leg
+
+    def build_job_wire(scope, *, dependency_outputs, ctx=None, **_kwargs):
+        del dependency_outputs
+        from api.analytics.fleet.serialization import fleet_acquisition_ledger_to_json
+        from api.analytics.fleet.types import FleetAcquisitionLedger
+        from api.serialization.turn import turn_info_to_json
+
+        if ctx is None:
+            raise RuntimeError("fleet leg test job wire requires AnalyticQueryContext")
+        turn = ctx.load_turn(scope.turn)
+        if turn is None:
+            raise RuntimeError(f"turn {scope.turn} required for fleet leg test job wire")
+        from api.analytics.turn_roster import iter_turn_players
+
+        player_name = next(
+            (player.username for player in iter_turn_players(turn) if player.id == scope.player_id),
+            f"player-{scope.player_id}",
+        )
+        baseline = FleetAcquisitionLedger(
+            player_id=scope.player_id,
+            player_name=player_name,
+        )
+        return {
+            "gameId": scope.game_id,
+            "perspective": scope.perspective,
+            "playerId": scope.player_id,
+            "materializeTurn": scope.turn,
+            "turnWire": turn_info_to_json(turn),
+            "priorLedgerWire": None,
+            "baselineLedgerWire": fleet_acquisition_ledger_to_json(baseline),
+            "provenanceWire": {
+                "turnEvidenceAtN": False,
+                "priorLedgerAtNMinus1": False,
+            },
+        }
+
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(_FLEET_ANALYTIC_ID),
+        compute=lambda _ctx: {"analyticId": _FLEET_ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_FLEET_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(
+                ComputeStepSpec(step_kind=FLEET_MATERIALIZATION_LEG, backend="interpreter"),
+            ),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=((FLEET_MATERIALIZATION_LEG, build_job_wire),),
+        run_steps=((FLEET_MATERIALIZATION_LEG, run_fleet_materialization_leg),),
+    )
+
+
+def test_pool_dispatches_fleet_materialization_leg_interpreter(sample_turn):
+    compute_registry = build_compute_registry((_fleet_materialization_leg_registration(),))
+    ctx = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+    scope = _scope_for_player(sample_turn, next(row.ownerid for row in sample_turn.scores))
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=scope.game_id,
+        perspective=scope.perspective,
+        turn=scope.turn,
+        player_id=scope.player_id,
+    )
+
+    handle = orchestrator.submit(ComputeRequest(scope=scope))
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if handle.state == "complete":
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert handle.state == "complete", handle.error
+    assert isinstance(handle.result_wire, dict)
+    assert "persistedLedgerWire" in handle.result_wire
+    assert handle.result_wire["materializeTurn"] == scope.turn
+    assert pool.metrics.interpreter_executions == 1

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -515,9 +515,7 @@ def _fleet_materialization_leg_registration() -> TurnAnalyticRegistration:
         export_catalog=make_fixture_catalog(_FLEET_ANALYTIC_ID),
         scope_key_spec=_ROW_SCOPE_KEY,
         compute_profile=AnalyticComputeProfile(
-            steps=(
-                ComputeStepSpec(step_kind=FLEET_MATERIALIZATION_LEG, backend="interpreter"),
-            ),
+            steps=(ComputeStepSpec(step_kind=FLEET_MATERIALIZATION_LEG, backend="interpreter"),),
         ),
         persistence_policy=_StubPersistencePolicy(),
         build_step_job_wires=((FLEET_MATERIALIZATION_LEG, build_job_wire),),

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -74,8 +74,10 @@ def _work_item(
     priority_band: ComputePriorityBand = "background",
     step_index: int = 0,
     backend: str = "thread",
+    orchestrator_id: int = 0,
 ) -> PoolWorkItem:
     return PoolWorkItem(
+        orchestrator_id=orchestrator_id,
         scope=scope,
         step_kind="tier1" if step_index == 0 else "tier2",
         backend=backend,
@@ -425,6 +427,65 @@ def _single_step_thread_registration() -> TurnAnalyticRegistration:
         ),
         run_steps=(("materialize", lambda job: {"result": job["player_id"]}),),
     )
+
+
+def _gated_single_step_thread_registration(
+    gate: threading.Event,
+) -> TurnAnalyticRegistration:
+    def run_materialize(job):
+        gate.wait(timeout=1.0)
+        return {"result": job["player_id"]}
+
+    return TurnAnalyticRegistration(
+        catalog_entry=_catalog_entry(),
+        compute=lambda _ctx: {"analyticId": _ANALYTIC_ID},
+        export_catalog=make_fixture_catalog(_ANALYTIC_ID),
+        scope_key_spec=_ROW_SCOPE_KEY,
+        compute_profile=AnalyticComputeProfile(
+            steps=(ComputeStepSpec(step_kind="materialize", backend="thread"),),
+        ),
+        persistence_policy=_StubPersistencePolicy(),
+        build_step_job_wires=(
+            ("materialize", lambda scope, **_kwargs: {"player_id": scope.player_id}),
+        ),
+        run_steps=(("materialize", run_materialize),),
+    )
+
+
+def test_two_orchestrators_shared_pool_interleaved_submits(sample_turn):
+    """Two orchestrators on one pool each receive their own pool completions."""
+    gate = threading.Event()
+    compute_registry = build_compute_registry((_gated_single_step_thread_registration(gate),))
+    ctx_a = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    ctx_b = make_fixture_query_context(sample_turn, registry=_POOL_EXPORT_REGISTRY)
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator_a = ComputeOrchestrator(ctx_a, compute_registry=compute_registry, worker_pool=pool)
+    orchestrator_b = ComputeOrchestrator(ctx_b, compute_registry=compute_registry, worker_pool=pool)
+
+    player_ids = [row.ownerid for row in sample_turn.scores[:2]]
+    scope_a = _scope_for_player(sample_turn, player_ids[0])
+    scope_b = _scope_for_player(sample_turn, player_ids[1])
+
+    gate.set()
+    handle_a = orchestrator_a.submit(ComputeRequest(scope=scope_a))
+    gate.clear()
+    time.sleep(0.05)
+    handle_b = orchestrator_b.submit(ComputeRequest(scope=scope_b))
+    gate.set()
+
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if handle_a.state == "complete" and handle_b.state == "complete":
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert handle_a.state == "complete", handle_a.error
+    assert handle_b.state == "complete", handle_b.error
+    assert orchestrator_a.nodes[scope_a].result_wire == {"result": player_ids[0]}
+    assert orchestrator_b.nodes[scope_b].result_wire == {"result": player_ids[1]}
+    assert scope_b not in orchestrator_a.nodes
+    assert scope_a not in orchestrator_b.nodes
 
 
 def test_concurrent_submit_with_multiple_pool_workers(sample_turn):

--- a/packages/api/tests/test_fleet_exports.py
+++ b/packages/api/tests/test_fleet_exports.py
@@ -41,6 +41,7 @@ def test_export_registry_includes_non_empty_fleet_catalog():
     assert not catalog.is_empty
     assert catalog.ensure_dependencies == (
         EnsureDependency(analytic_id="scores", turn_delta=0, player_id="same"),
+        EnsureDependency(analytic_id="fleet", turn_delta=-1, player_id="same"),
     )
     assert catalog.materialize_export_tree is not None
     assert catalog.ensure_export is not None

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -743,7 +743,6 @@ def test_orchestrator_node_complete_emits_complete_after_progress_when_session_c
         host_turn_number=112,
         progress_tracker=progress_tracker,
         root_scope=scope,
-        emitted_progress=True,
     )
     scheduler._on_orchestrator_node_complete(
         scope,

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -131,7 +131,7 @@ def _events_for_players(
 
 def test_fleet_table_stream_early_close_releases_scope_for_reconnect(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     services = build_ephemeral_fleet_compute_services(
         sample_turn,
         game_id=628580,
@@ -182,7 +182,7 @@ def test_fleet_table_stream_early_close_releases_scope_for_reconnect(sample_turn
 
 def test_fleet_table_stream_reconnect_preempts_active_scope(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     scope = FleetTableStreamScope(
         game_id=628580,
         perspective=1,
@@ -200,7 +200,7 @@ def test_fleet_table_stream_reconnect_preempts_active_scope(sample_turn):
 
 def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     scope = FleetTableStreamScope(
         game_id=628580,
         perspective=1,
@@ -251,7 +251,7 @@ def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
 
 def test_cached_final_ledger_replays_terminal_events_without_scheduling(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     services = build_ephemeral_fleet_compute_services(
         sample_turn,
         game_id=628580,
@@ -291,28 +291,71 @@ def test_cached_final_ledger_replays_terminal_events_without_scheduling(sample_t
 def test_gap_fill_stream_emits_incremental_ledger_updates_before_complete(
     persistence,
     load_turn,
+    memory_backend,
 ):
     """Gap-fill M..N emits ledger_updated after each leg, then complete."""
+    from api.analytics.fleet.held_solutions import (
+        FleetInferenceMaterialization,
+        FleetInferenceSupport,
+    )
+    from api.analytics.military_score_inference.solver import STATUS_EXACT
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+
+    from tests.scores_exports_helpers import put_persisted_row
+
     turn_110 = load_turn(110)
     assert turn_110 is not None
     turn_112 = load_turn(112)
     assert turn_112 is not None
     player_id = turn_112.scores[0].ownerid
 
-    persistence.put_snapshot(
+    persistence.put_ledger(
         628580,
         1,
         110,
-        ensure_fleet_baseline(628580, 1, turn_110),
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, turn_110, player_id),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
     )
 
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    for turn_number in (111, 112):
+        put_persisted_row(
+            inference_persistence,
+            turn_112,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for gap-fill stream",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=turn_number,
+        )
+
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=1)
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    scheduler = FleetTableStreamScheduler()
     services = FleetComputeServices(
         persistence=persistence,
         game_id=628580,
         perspective=1,
         load_turn=load_turn,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(scores_services=scores_services),
+            load_turn=load_turn,
+        ),
     )
 
     events = _events_for_players(
@@ -403,7 +446,7 @@ def test_initial_wire_before_ledger_shapes_cached_host_turn(sample_turn, persist
 
 def test_multi_player_stream_emits_tagged_terminal_events(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     services = build_ephemeral_fleet_compute_services(
         sample_turn,
         game_id=628580,
@@ -440,7 +483,7 @@ def test_multi_player_stream_emits_tagged_terminal_events(sample_turn):
 
 def test_player_event_ordering_provenance_before_complete(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     services = build_ephemeral_fleet_compute_services(
         sample_turn,
         game_id=628580,
@@ -478,13 +521,29 @@ def test_player_event_ordering_provenance_before_complete(sample_turn):
 
 def test_schedule_dedupes_in_flight_player_runs(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+
+    reset_compute_worker_pool_for_tests(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
     services = build_ephemeral_fleet_compute_services(
         sample_turn,
         game_id=628580,
         perspective=1,
     )
     player_id = sample_turn.scores[0].ownerid
+    services.persistence.put_ledger(
+        628580,
+        1,
+        sample_turn.settings.turn,
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+    )
     scope = FleetTableStreamScope(
         game_id=628580,
         perspective=1,
@@ -516,9 +575,14 @@ def test_schedule_dedupes_in_flight_player_runs(sample_turn):
         assert second is not None
         assert first.session.run_id == second.session.run_id
         assert len(scheduler._runs) == 1
-        assert len(scheduler._work_queue) == 1
     finally:
-        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+        scheduler.end_fleet_table_stream(
+            scope,
+            (),
+            stream_token=stream_token,
+            host_turn=sample_turn,
+            fleet_services=services,
+        )
 
 
 def test_tag_fleet_table_stream_event_adds_player_id():
@@ -552,20 +616,26 @@ def test_drain_available_multiplex_events_returns_queued_events_without_blocking
     assert events[0]["playerId"] == 8
 
 
-def test_materialization_job_emits_complete_after_progress_when_session_cancelled(
+def test_orchestrator_node_complete_emits_complete_after_progress_when_session_cancelled(
     persistence,
     load_turn,
 ):
     """A cancelled session still receives complete after successful gap-fill."""
-    from unittest.mock import patch
-
-    from api.analytics.fleet.chain import ensure_fleet_baseline, ensure_fleet_baseline_for_player
-    from api.analytics.fleet.compute_services import FleetComputeServices
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+    from api.analytics.fleet.constants import ANALYTIC_ID
     from api.analytics.fleet.fleet_table_player_run import (
+        FleetLedgerWireProgressTracker,
         FleetPlayerStreamSession,
-        run_fleet_player_materialization_job,
+        _initial_wire_before_ledger,
     )
+    from api.analytics.fleet.fleet_table_stream_scheduler import (
+        FleetTableStreamScheduler,
+        _FleetPlayerOrchestratorRun,
+    )
+    from api.analytics.fleet.serialization import persisted_fleet_ledger_to_json
     from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+    from api.compute.orchestrator import ComputeNodeRun
+    from api.compute.scope import ComputeScope
 
     turn_110 = load_turn(110)
     assert turn_110 is not None
@@ -581,11 +651,17 @@ def test_materialization_job_emits_complete_after_progress_when_session_cancelle
         game_id=628580,
         perspective=1,
     )
-    services = FleetComputeServices(
-        persistence=persistence,
-        game_id=628580,
-        perspective=1,
-        load_turn=load_turn,
+    before_persisted = persistence.get_ledger(628580, 1, 112, player_id)
+    progress_tracker = FleetLedgerWireProgressTracker(
+        host_turn=turn_112,
+        wire_before=_initial_wire_before_ledger(
+            persistence=persistence,
+            game_id=628580,
+            perspective=1,
+            player_id=player_id,
+            host_turn=turn_112,
+            before_persisted=before_persisted,
+        ),
     )
     final_persisted = PersistedFleetLedger(
         ledger=ensure_fleet_baseline_for_player(628580, 1, turn_112, player_id),
@@ -594,22 +670,36 @@ def test_materialization_job_emits_complete_after_progress_when_session_cancelle
             prior_ledger_at_n_minus_1=True,
         ),
     )
+    for event in progress_tracker.leg_progress_events(final_persisted):
+        session.event_queue.put(event)
+    session.cancel_token.cancel()
 
-    def materialize_with_cancel(*args, on_progress=None, **kwargs):
-        if on_progress is not None:
-            on_progress(final_persisted, 112)
-        session.cancel_token.cancel()
-        return final_persisted
-
-    with patch(
-        "api.analytics.fleet.fleet_table_player_run.get_or_materialize_fleet_ledger_for_player",
-        side_effect=materialize_with_cancel,
-    ):
-        run_fleet_player_materialization_job(
-            session,
-            fleet_services=services,
-            persistence=persistence,
-        )
+    scope = ComputeScope(
+        analytic_id=ANALYTIC_ID,
+        game_id=628580,
+        perspective=1,
+        turn=112,
+        player_id=player_id,
+    )
+    scheduler = FleetTableStreamScheduler()
+    scheduler._runs[session.run_id] = _FleetPlayerOrchestratorRun(
+        session=session,
+        host_turn_number=112,
+        progress_tracker=progress_tracker,
+        root_scope=scope,
+        emitted_progress=True,
+    )
+    scheduler._on_orchestrator_node_complete(
+        scope,
+        ComputeNodeRun(
+            scope=scope,
+            dependency_scopes=(),
+            state="complete",
+            result_wire={
+                "persistedLedgerWire": persisted_fleet_ledger_to_json(final_persisted),
+            },
+        ),
+    )
 
     events: list[dict[str, object]] = []
     while not session.event_queue.empty():
@@ -622,7 +712,10 @@ def test_materialization_job_emits_complete_after_progress_when_session_cancelle
 @pytest.mark.slow
 def test_concurrent_multi_player_materialization_completes(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=2)
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+
+    reset_compute_worker_pool_for_tests(worker_count=2)
+    scheduler = FleetTableStreamScheduler()
     player_ids = tuple(player.id for player in list(iter_turn_players(sample_turn))[:3])
     events = _events_for_players(sample_turn, player_ids, scheduler=scheduler)
     assert {

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -636,8 +636,6 @@ def test_schedule_dedupes_in_flight_player_runs(sample_turn):
             scope,
             (),
             stream_token=stream_token,
-            host_turn=sample_turn,
-            fleet_services=services,
         )
 
 

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -198,6 +198,62 @@ def test_fleet_table_stream_reconnect_preempts_active_scope(sample_turn):
     scheduler.end_fleet_table_stream(scope, (), stream_token=second_token)
 
 
+def test_fleet_table_stream_reconnect_preempt_releases_orchestrator_cache(sample_turn):
+    from api.compute import runtime as compute_runtime
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+    from api.compute.runtime import reset_orchestrators_for_tests
+
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=1)
+    reset_fleet_table_stream_scheduler_for_tests()
+    scheduler = FleetTableStreamScheduler()
+    services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    services.persistence.put_ledger(
+        628580,
+        1,
+        sample_turn.settings.turn,
+        player_id,
+        PersistedFleetLedger(
+            ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+            provenance=FleetMaterializationProvenance(
+                turn_evidence_at_n=True,
+                prior_ledger_at_n_minus_1=True,
+            ),
+        ),
+    )
+    scope = FleetTableStreamScope(
+        game_id=628580,
+        perspective=1,
+        turn_number=sample_turn.settings.turn,
+    )
+    stream_token = scheduler.begin_scope(scope)
+    scheduled = schedule_fleet_player_run(
+        scheduler,
+        turn=sample_turn,
+        player_id=player_id,
+        game_id=628580,
+        perspective=1,
+        fleet_services=services,
+        persistence=services.persistence,
+        stream_token=stream_token,
+    )
+    assert scheduled is not None
+    assert len(compute_runtime._orchestrators_by_ctx_id) == 1
+    assert len(scheduler._stream_bindings) == 1
+
+    second_token = scheduler.begin_scope(scope)
+
+    assert len(compute_runtime._orchestrators_by_ctx_id) == 0
+    assert len(scheduler._stream_bindings) == 0
+
+    scheduler.end_fleet_table_stream(scope, (), stream_token=second_token)
+
+
 def test_fleet_table_stream_reconnect_via_ndjson_transport(sample_turn):
     reset_fleet_table_stream_scheduler_for_tests()
     scheduler = FleetTableStreamScheduler()

--- a/packages/api/tests/test_fleet_table_stream.py
+++ b/packages/api/tests/test_fleet_table_stream.py
@@ -765,14 +765,83 @@ def test_orchestrator_node_complete_emits_complete_after_progress_when_session_c
 
 
 @pytest.mark.slow
-def test_concurrent_multi_player_materialization_completes(sample_turn):
+def test_concurrent_multi_player_materialization_completes(
+    persistence,
+    load_turn,
+    memory_backend,
+):
+    # Anchor at turn 110: empty persistence with ephemeral turn_chain_through(111)
+    # forces a cold-start gap-fill of turns 1..111 per player (111 legs x 3 players).
+    from api.analytics.fleet.held_solutions import (
+        FleetInferenceMaterialization,
+        FleetInferenceSupport,
+    )
+    from api.analytics.military_score_inference.solver import STATUS_EXACT
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+    from api.services.inference_row_persistence_service import InferenceRowPersistenceService
+
+    from tests.scores_exports_helpers import put_persisted_row
+
+    turn_110 = load_turn(110)
+    assert turn_110 is not None
+    turn_111 = load_turn(111)
+    assert turn_111 is not None
+    player_ids = tuple(player.id for player in list(iter_turn_players(turn_111))[:3])
+
+    for player_id in player_ids:
+        persistence.put_ledger(
+            628580,
+            1,
+            110,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, turn_110, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    for player_id in player_ids:
+        put_persisted_row(
+            inference_persistence,
+            turn_111,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for concurrent materialization",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=111,
+        )
+
     reset_fleet_table_stream_scheduler_for_tests()
     from api.compute.pools import reset_compute_worker_pool_for_tests
 
     reset_compute_worker_pool_for_tests(worker_count=2)
     scheduler = FleetTableStreamScheduler()
-    player_ids = tuple(player.id for player in list(iter_turn_players(sample_turn))[:3])
-    events = _events_for_players(sample_turn, player_ids, scheduler=scheduler)
+    services = FleetComputeServices(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        load_turn=load_turn,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(scores_services=scores_services),
+            load_turn=load_turn,
+        ),
+    )
+    events = _events_for_players(
+        turn_111,
+        player_ids,
+        scheduler=scheduler,
+        services=services,
+    )
     assert {
         event["playerId"]
         for event in events

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
-from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.compute_services import (
+    FleetComputeServices,
+    turn_chain_through,
+)
 from api.analytics.fleet.fleet_table_stream_registry import (
     controller_for_scope,
     reset_fleet_table_stream_registry_for_tests,
@@ -42,8 +45,13 @@ def memory_backend():
 
 
 def _install_workerless_scheduler(monkeypatch: pytest.MonkeyPatch) -> FleetTableStreamScheduler:
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+    from api.compute.runtime import reset_orchestrators_for_tests
+
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=1)
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
 
     def _get_scheduler() -> FleetTableStreamScheduler:
         return scheduler
@@ -90,7 +98,8 @@ def _run_ids_for_players(
     player_ids: tuple[int, ...],
 ) -> dict[int, str]:
     mapping: dict[int, str] = {}
-    for session in scheduler._runs.values():
+    for run in scheduler._runs.values():
+        session = run.session
         if session.player_id in player_ids:
             mapping[session.player_id] = session.run_id
     return mapping
@@ -125,21 +134,84 @@ def test_all_cached_replay_keeps_stream_open_for_evidence_invalidation_integrati
     memory_backend,
 ):
     """All-cached replay: evidence invalidation reschedules on the open stream."""
+    from api.analytics.fleet.held_solutions import (
+        FleetInferenceMaterialization,
+        FleetInferenceSupport,
+    )
+    from api.analytics.military_score_inference.solver import STATUS_EXACT
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+    from tests.scores_exports_helpers import put_persisted_row
+
     reset_fleet_table_stream_registry_for_tests()
     scheduler = _install_workerless_scheduler(monkeypatch)
     player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
     turn_number = sample_turn.settings.turn
-    services = build_ephemeral_fleet_compute_services(
-        sample_turn,
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    for player_id in player_ids:
+        put_persisted_row(
+            inference_persistence,
+            sample_turn,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for fleet stream invalidation",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=turn_number,
+        )
+
+    stored_turns = turn_chain_through(sample_turn)
+
+    def load_turn(turn: int):
+        return stored_turns.get(turn)
+
+    services = FleetComputeServices(
+        persistence=FleetSnapshotPersistenceService(memory_backend),
         game_id=628580,
         perspective=1,
+        load_turn=load_turn,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(scores_services=scores_services),
+            load_turn=load_turn,
+        ),
     )
     fleet_persistence = services.persistence
-    inference_persistence = InferenceRowPersistenceService(memory_backend)
     invalidation = InferenceInvalidationService(
         inference_persistence,
         fleet_persistence=fleet_persistence,
     )
+    for player_id in player_ids:
+        fleet_persistence.put_ledger(
+            628580,
+            1,
+            turn_number - 1,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+        put_persisted_row(
+            inference_persistence,
+            sample_turn,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for fleet stream invalidation prior turn",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=turn_number - 1,
+        )
     _seed_cached_ledgers(
         fleet_persistence,
         sample_turn,
@@ -186,12 +258,15 @@ def test_all_cached_replay_keeps_stream_open_for_evidence_invalidation_integrati
     assert fleet_persistence.get_ledger(628580, 1, turn_number, target_player_id) is None
 
     rescheduled_run = scheduler._runs[_run_ids_for_players(scheduler, player_ids)[target_player_id]]
-    rescheduled_run.event_queue.put(
+    rescheduled_run.session.event_queue.put(
         fleet_complete_event(
             is_final=True,
             summary="after evidence invalidation on cached row",
         )
     )
+    controller = controller_for_scope(scope)
+    if controller is not None:
+        controller.wake_multiplex.set()
 
     _wait_until(
         lambda: any(
@@ -220,21 +295,84 @@ def test_evidence_invalidation_reschedules_player_on_open_stream_integration(
     memory_backend,
 ):
     """Integration: invalidation while iter_fleet_table_stream_events multiplex is active."""
+    from api.analytics.fleet.held_solutions import (
+        FleetInferenceMaterialization,
+        FleetInferenceSupport,
+    )
+    from api.analytics.military_score_inference.solver import STATUS_EXACT
+    from api.analytics.scores.export_services import ScoresExportContext
+    from api.serialization.inference_row_persistence import PersistedInferenceRow
+
+    from tests.scores_exports_helpers import put_persisted_row
+
     reset_fleet_table_stream_registry_for_tests()
     scheduler = _install_workerless_scheduler(monkeypatch)
     player_ids = tuple(row.ownerid for row in sample_turn.scores[:2])
     turn_number = sample_turn.settings.turn
-    services = build_ephemeral_fleet_compute_services(
-        sample_turn,
+    inference_persistence = InferenceRowPersistenceService(memory_backend)
+    scores_services = ScoresExportContext(persistence=inference_persistence)
+    for player_id in player_ids:
+        put_persisted_row(
+            inference_persistence,
+            sample_turn,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for fleet stream invalidation",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=turn_number,
+        )
+
+    stored_turns = turn_chain_through(sample_turn)
+
+    def load_turn(turn: int):
+        return stored_turns.get(turn)
+
+    services = FleetComputeServices(
+        persistence=FleetSnapshotPersistenceService(memory_backend),
         game_id=628580,
         perspective=1,
+        load_turn=load_turn,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(scores_services=scores_services),
+            load_turn=load_turn,
+        ),
     )
     fleet_persistence = services.persistence
-    inference_persistence = InferenceRowPersistenceService(memory_backend)
     invalidation = InferenceInvalidationService(
         inference_persistence,
         fleet_persistence=fleet_persistence,
     )
+    for player_id in player_ids:
+        fleet_persistence.put_ledger(
+            628580,
+            1,
+            turn_number - 1,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
+        put_persisted_row(
+            inference_persistence,
+            sample_turn,
+            player_id,
+            PersistedInferenceRow(
+                status=STATUS_EXACT,
+                summary="seeded for fleet stream invalidation prior turn",
+                solution_count=0,
+                is_complete=True,
+                solutions=[],
+            ),
+            host_turn=turn_number - 1,
+        )
     _seed_cached_ledgers(
         fleet_persistence,
         sample_turn,

--- a/packages/api/tests/test_table_stream_scope_teardown.py
+++ b/packages/api/tests/test_table_stream_scope_teardown.py
@@ -6,7 +6,10 @@ import json
 from pathlib import Path
 
 import pytest
-from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.compute_services import (
+    FleetComputeServices,
+    build_ephemeral_fleet_compute_services,
+)
 from api.analytics.fleet.fleet_table_stream_rows import iter_fleet_table_stream_events
 from api.analytics.fleet.fleet_table_stream_scheduler import (
     FleetTableStreamScheduler,
@@ -69,8 +72,13 @@ def _install_scores_scheduler(monkeypatch: pytest.MonkeyPatch) -> InferenceRowSc
 
 
 def _install_fleet_scheduler(monkeypatch: pytest.MonkeyPatch) -> FleetTableStreamScheduler:
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+    from api.compute.runtime import reset_orchestrators_for_tests
+
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=1)
     reset_fleet_table_stream_scheduler_for_tests()
-    scheduler = FleetTableStreamScheduler(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
 
     def _get_scheduler() -> FleetTableStreamScheduler:
         return scheduler
@@ -315,7 +323,10 @@ def test_fleet_lost_ownership_mid_connect_releases_scope_for_reconnect(
     monkeypatch,
     persistence,
 ):
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
     from api.analytics.fleet.fleet_table_stream_rows import resolve_player_stream_admission
+    from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+    from api.analytics.turn_roster import iter_turn_players
 
     scheduler = _install_fleet_scheduler(monkeypatch)
     services = build_ephemeral_fleet_compute_services(
@@ -323,7 +334,28 @@ def test_fleet_lost_ownership_mid_connect_releases_scope_for_reconnect(
         game_id=628580,
         perspective=1,
     )
-    player_ids = tuple(row.ownerid for row in sample_turn.scores[:3])
+    services = FleetComputeServices(
+        persistence=persistence,
+        game_id=services.game_id,
+        perspective=services.perspective,
+        load_turn=services.load_turn,
+        inference_materialization=services.inference_materialization,
+    )
+    player_ids = tuple(player.id for player in list(iter_turn_players(sample_turn))[:3])
+    for player_id in player_ids:
+        persistence.put_ledger(
+            628580,
+            1,
+            sample_turn.settings.turn,
+            player_id,
+            PersistedFleetLedger(
+                ledger=ensure_fleet_baseline_for_player(628580, 1, sample_turn, player_id),
+                provenance=FleetMaterializationProvenance(
+                    turn_evidence_at_n=True,
+                    prior_ledger_at_n_minus_1=True,
+                ),
+            ),
+        )
     admission_calls = 0
     preempting_stream = None
     original_resolve = resolve_player_stream_admission


### PR DESCRIPTION
## Summary

- Migrate fleet table stream materialization from a dedicated scheduler worker queue to orchestrator `materialization_leg` nodes (interpreter backend), one node per `(fleet, turn, player)`.
- Thin `FleetTableStreamScheduler` into a stream adapter: binds per-stream orchestrators, submits scopes, and bridges node-complete callbacks to NDJSON wire events (with multiplex wake on enqueue).
- Add fleet/scores compute orchestration registration, isolate interpreter compute plane (`compute_plane/`), split exception hierarchy for import boundaries, and route pool completions through per-orchestrator registration.

Closes #199.

## Test plan

- [x] `make test_api` (full API suite)
- [x] `pytest tests/test_fleet_table_stream.py tests/test_fleet_table_stream_invalidation.py tests/test_table_stream_scope_teardown.py tests/test_compute_foundation.py`
- [ ] Manual: open fleet table stream on a game with gap-fill needed; confirm per-leg `ledger_updated` events and terminal `complete` per player
- [ ] Manual: multi-player stream completes in parallel (no single-worker bottleneck)


Made with [Cursor](https://cursor.com)