### PR TITLE
Compute orchestrator: turn cache and job wire prefetch (#201)

### DIFF
--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from api.analytics.export_context import AnalyticQueryContext
@@ -18,7 +19,9 @@ from api.compute.scope import (
     ScopeKeySpec,
     compute_scope_to_export_scope,
 )
+from api.compute.turn_cache import OrchestratorTurnCache
 from api.compute.wire import DependencyOutputs
+from api.models.game import TurnInfo
 from api.serialization.turn import turn_info_to_json
 
 FLEET_MATERIALIZATION_LEG = "materialization_leg"
@@ -55,6 +58,7 @@ def build_fleet_materialization_leg_job_wire(
     *,
     dependency_outputs: DependencyOutputs,
     ctx: AnalyticQueryContext | None = None,
+    turn_cache: OrchestratorTurnCache | None = None,
 ) -> dict[str, Any]:
     """Assemble a serializable job wire for one fleet materialization leg.
 
@@ -76,17 +80,26 @@ def build_fleet_materialization_leg_job_wire(
         raise ValueError("fleet materialization leg requires concrete turn")
 
     export_scope = compute_scope_to_export_scope(scope)
-    turn = ctx.load_turn(export_scope.turn)
+    load_turn = _orchestrator_load_turn(ctx=ctx, turn_cache=turn_cache)
+    turn = load_turn(export_scope.turn)
     if turn is None:
         raise ValueError(f"stored turn {export_scope.turn} is required for fleet materialization")
 
     player_id = scope.player_id
+    services = resolve_fleet_services(ctx)
     prior_scope = _fleet_prior_scope(scope)
     prior_persisted: PersistedFleetLedger | None = None
     if prior_scope is not None:
         prior_wire = dependency_outputs.get(prior_scope)
         if prior_wire is not None:
             prior_persisted = persisted_fleet_ledger_from_json(prior_wire["persistedLedgerWire"])
+        if prior_persisted is None:
+            prior_persisted = services.persistence.get_ledger(
+                scope.game_id,
+                scope.perspective,
+                prior_scope.turn,
+                player_id,
+            )
 
     if prior_persisted is None:
         baseline_ledger = ensure_fleet_baseline_for_player(
@@ -99,8 +112,6 @@ def build_fleet_materialization_leg_job_wire(
     else:
         baseline_ledger_wire = fleet_acquisition_ledger_to_json(prior_persisted.ledger)
 
-    services = resolve_fleet_services(ctx)
-    load_turn = services.load_turn
     turn_context = FleetTurnContext.from_turn(turn)
     provenance = resolve_fleet_materialization_provenance(
         materialize_turn=scope.turn,
@@ -254,3 +265,17 @@ class FleetPersistencePolicy:
 
 
 FLEET_PERSISTENCE_POLICY = FleetPersistencePolicy()
+
+
+def _orchestrator_load_turn(
+    *,
+    ctx: AnalyticQueryContext | None,
+    turn_cache: OrchestratorTurnCache | None,
+) -> Callable[[int], TurnInfo | None]:
+    if turn_cache is not None:
+        return turn_cache.get
+    if ctx is not None:
+        return ctx.load_turn
+    raise RuntimeError(
+        "fleet materialization leg job wire requires AnalyticQueryContext or turn_cache"
+    )

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from typing import Any
 
 from api.analytics.export_context import AnalyticQueryContext
@@ -19,9 +18,7 @@ from api.compute.scope import (
     ScopeKeySpec,
     compute_scope_to_export_scope,
 )
-from api.compute.turn_cache import OrchestratorTurnCache
 from api.compute.wire import DependencyOutputs
-from api.models.game import TurnInfo
 from api.serialization.turn import turn_info_to_json
 
 FLEET_MATERIALIZATION_LEG = "materialization_leg"
@@ -58,7 +55,6 @@ def build_fleet_materialization_leg_job_wire(
     *,
     dependency_outputs: DependencyOutputs,
     ctx: AnalyticQueryContext | None = None,
-    turn_cache: OrchestratorTurnCache | None = None,
 ) -> dict[str, Any]:
     """Assemble a serializable job wire for one fleet materialization leg.
 
@@ -80,8 +76,7 @@ def build_fleet_materialization_leg_job_wire(
         raise ValueError("fleet materialization leg requires concrete turn")
 
     export_scope = compute_scope_to_export_scope(scope)
-    load_turn = _orchestrator_load_turn(ctx=ctx, turn_cache=turn_cache)
-    turn = load_turn(export_scope.turn)
+    turn = ctx.load_turn(export_scope.turn)
     if turn is None:
         raise ValueError(f"stored turn {export_scope.turn} is required for fleet materialization")
 
@@ -120,7 +115,7 @@ def build_fleet_materialization_leg_job_wire(
         player_id=player_id,
         game_id=scope.game_id,
         perspective=scope.perspective,
-        load_turn=load_turn,
+        load_turn=ctx.load_turn,
         inference_materialization=services.inference_materialization,
     )
 
@@ -265,17 +260,3 @@ class FleetPersistencePolicy:
 
 
 FLEET_PERSISTENCE_POLICY = FleetPersistencePolicy()
-
-
-def _orchestrator_load_turn(
-    *,
-    ctx: AnalyticQueryContext | None,
-    turn_cache: OrchestratorTurnCache | None,
-) -> Callable[[int], TurnInfo | None]:
-    if turn_cache is not None:
-        return turn_cache.get
-    if ctx is not None:
-        return ctx.load_turn
-    raise RuntimeError(
-        "fleet materialization leg job wire requires AnalyticQueryContext or turn_cache"
-    )

--- a/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
+++ b/packages/api/api/analytics/fleet/compute_plane/materialization_leg.py
@@ -22,7 +22,7 @@ from api.analytics.fleet.serialization import (
 )
 from api.analytics.fleet.turn_context import FleetTurnContext
 from api.analytics.fleet.types import FleetAcquisitionLedger, PersistedFleetLedger
-from api.serialization.turn import turn_info_from_json
+from api.compute.worker_turn_cache import turn_from_materialization_job_wire
 
 
 def run_fleet_materialization_leg(job_wire: dict[str, Any]) -> dict[str, Any]:
@@ -31,7 +31,7 @@ def run_fleet_materialization_leg(job_wire: dict[str, Any]) -> dict[str, Any]:
     Returns a persisted-ledger wire carrying provenance from the job wire.
     Scores inference is deferred to the orchestration persist hook.
     """
-    turn = turn_info_from_json(job_wire["turnWire"])
+    turn = turn_from_materialization_job_wire(job_wire)
     prior_ledger_wire = job_wire.get("priorLedgerWire")
     prior_persisted = (
         persisted_fleet_ledger_from_json(prior_ledger_wire)

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -8,6 +8,7 @@ from api.analytics.export_context import AnalyticQueryContext
 from api.analytics.export_types import ExportScope
 from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import ComputeScope, ScopeKeySpec, compute_scope_to_export_scope
+from api.compute.wire import DependencyOutputs
 
 SCORES_MATERIALIZE = "materialize"
 
@@ -21,7 +22,7 @@ SCORES_COMPUTE_PROFILE = AnalyticComputeProfile(
 def build_scores_materialize_job_wire(
     scope: ComputeScope,
     *,
-    dependency_outputs: object,
+    dependency_outputs: DependencyOutputs,
     ctx: AnalyticQueryContext | None = None,
 ) -> dict[str, Any]:
     """Materialize scores export tree on the orchestration plane."""

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -16,7 +16,7 @@ from api.compute.scope import (
     fingerprint_parameters,
     normalize_export_scope_to_compute_scope,
 )
-from api.compute.wire import BuildStepJobWireFn, DependencyOutputs, RunStepFn
+from api.compute.wire import BuildStepJobWireFn, BuildStepJobWireKwargs, DependencyOutputs, RunStepFn
 
 _REGISTRY_EXPORTS = frozenset(
     {
@@ -89,6 +89,7 @@ __all__ = [
     "AnalyticComputeProfile",
     "AnalyticComputeRegistration",
     "BuildStepJobWireFn",
+    "BuildStepJobWireKwargs",
     "ComputeBackend",
     "ComputeHandle",
     "ComputeNodeRun",

--- a/packages/api/api/compute/__init__.py
+++ b/packages/api/api/compute/__init__.py
@@ -16,7 +16,12 @@ from api.compute.scope import (
     fingerprint_parameters,
     normalize_export_scope_to_compute_scope,
 )
-from api.compute.wire import BuildStepJobWireFn, BuildStepJobWireKwargs, DependencyOutputs, RunStepFn
+from api.compute.wire import (
+    BuildStepJobWireFn,
+    BuildStepJobWireKwargs,
+    DependencyOutputs,
+    RunStepFn,
+)
 
 _REGISTRY_EXPORTS = frozenset(
     {

--- a/packages/api/api/compute/lru_cache.py
+++ b/packages/api/api/compute/lru_cache.py
@@ -1,0 +1,34 @@
+"""Bounded LRU cache backed by OrderedDict."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LruCache(Generic[K, V]):
+    """Insert-or-update with move-to-end; evict least-recently-used past maxsize."""
+
+    def __init__(self, maxsize: int) -> None:
+        self._maxsize = maxsize
+        self._entries: OrderedDict[K, V] = OrderedDict()
+
+    def get(self, key: K) -> V | None:
+        """Return cached value and mark key as recently used, or None."""
+        value = self._entries.get(key)
+        if value is not None:
+            self._entries.move_to_end(key)
+        return value
+
+    def put(self, key: K, value: V) -> None:
+        """Insert or update and evict LRU entries when over capacity."""
+        self._entries[key] = value
+        self._entries.move_to_end(key)
+        while len(self._entries) > self._maxsize:
+            self._entries.popitem(last=False)
+
+    def clear(self) -> None:
+        self._entries.clear()

--- a/packages/api/api/compute/orchestrator.py
+++ b/packages/api/api/compute/orchestrator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from collections import deque
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from api.analytics.export_context import AnalyticQueryContext
@@ -14,6 +14,7 @@ from api.compute.pools import ComputePriorityBand, ComputeWorkerPool, PoolSubmit
 from api.compute.profile import ComputeStepSpec
 from api.compute.registry import AnalyticComputeRegistration
 from api.compute.scope import ComputeScope, compute_scope_to_export_scope
+from api.compute.turn_cache import OrchestratorTurnCache
 from api.compute.wire import DependencyOutputs
 
 NodeCompleteListener = Callable[[ComputeScope, "ComputeNodeRun"], None]
@@ -102,6 +103,8 @@ class ComputeOrchestrator:
         worker_pool: ComputeWorkerPool | None = None,
     ) -> None:
         self._ctx = ctx
+        self._turn_cache = OrchestratorTurnCache(ctx.load_turn)
+        self._cached_ctx = replace(ctx, load_turn=self._turn_cache.get)
         self._compute_registry = compute_registry
         self._pool_registration_id: int | None = None
         if worker_pool is not None:
@@ -127,6 +130,10 @@ class ComputeOrchestrator:
     @property
     def metrics(self) -> OrchestratorMetrics:
         return self._metrics
+
+    @property
+    def turn_cache(self) -> OrchestratorTurnCache:
+        return self._turn_cache
 
     def register_node_complete_listener(
         self,
@@ -226,11 +233,12 @@ class ComputeOrchestrator:
     ) -> None:
         export_scope = compute_scope_to_export_scope(root_scope)
         planned_nodes = plan_compute_dag(
-            self._ctx,
+            self._cached_ctx,
             root_scope.analytic_id,
             export_scope,
             compute_registry=self._compute_registry,
         )
+        self._turn_cache.prefetch_planned_nodes(planned_nodes)
         for planned in planned_nodes:
             self._register_planned_node(planned, priority_band=priority_band)
         if root_scope not in self._nodes:
@@ -389,7 +397,7 @@ class ComputeOrchestrator:
         return builder(
             node.scope,
             dependency_outputs=dependency_outputs,
-            ctx=self._ctx,
+            ctx=self._cached_ctx,
         )
 
     def _begin_step_execution(self, node: ComputeNodeRun) -> None:
@@ -430,7 +438,7 @@ class ComputeOrchestrator:
             self._dispatch()
             return
         node.result_wire = result_wire
-        registration.persistence_policy.persist(self._ctx, node.scope, result_wire)
+        registration.persistence_policy.persist(self._cached_ctx, node.scope, result_wire)
         self._metrics.persist_calls += 1
         self._complete_node(node)
 

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Literal, Protocol
 from api.compute.profile import ComputeBackend, ComputeStepSpec
 from api.compute.scope import ComputeScope
 from api.compute.wire import RunStepFn
+from api.compute.worker_turn_cache import init_worker_turn_cache, worker_deserialize_calls
 
 if TYPE_CHECKING:
     from api.compute.orchestrator import ComputeNodeRun, ComputeOrchestrator
@@ -186,6 +187,14 @@ class ComputeWorkerPool:
             thread.join(timeout=1.0)
         self._shutdown_executors(wait=wait_for_interpreters)
 
+    def worker_deserialize_calls_for_tests(self) -> int:
+        """Return turn-wire deserialize count from an interpreter pool worker (tests only)."""
+        with self._condition:
+            executor = self._interpreter_executor
+            if executor is None:
+                return 0
+        return executor.submit(worker_deserialize_calls).result()
+
     def _make_submitter(self, orchestrator_id: int) -> PoolSubmitter:
         def _submit_from_orchestrator(
             node: ComputeNodeRun,
@@ -266,12 +275,18 @@ class ComputeWorkerPool:
 
     def _interpreter_executor_locked(self) -> InterpreterPoolExecutor:
         if self._interpreter_executor is None:
-            self._interpreter_executor = InterpreterPoolExecutor(max_workers=self._worker_count)
+            self._interpreter_executor = InterpreterPoolExecutor(
+                max_workers=self._worker_count,
+                initializer=init_worker_turn_cache,
+            )
         return self._interpreter_executor
 
     def _process_executor_locked(self) -> ProcessPoolExecutor:
         if self._process_executor is None:
-            self._process_executor = ProcessPoolExecutor(max_workers=self._worker_count)
+            self._process_executor = ProcessPoolExecutor(
+                max_workers=self._worker_count,
+                initializer=init_worker_turn_cache,
+            )
         return self._process_executor
 
     def _shutdown_executors(self, *, wait: bool = False) -> None:

--- a/packages/api/api/compute/turn_cache.py
+++ b/packages/api/api/compute/turn_cache.py
@@ -1,0 +1,59 @@
+"""Read-through LRU turn cache for the compute orchestration plane."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+from api.compute.dag import PlannedComputeNode
+from api.compute.lru_cache import LruCache
+from api.compute.scope import WILDCARD, ComputeScope
+from api.models.game import TurnInfo
+
+_DEFAULT_MAXSIZE = 128
+
+
+@dataclass
+class OrchestratorTurnCache:
+    """Avoid repeated storage reads for ``TurnInfo`` on the main interpreter."""
+
+    load_turn: Callable[[int], TurnInfo | None]
+    maxsize: int = _DEFAULT_MAXSIZE
+    _cache: LruCache[int, TurnInfo] = field(init=False, repr=False)
+    _underlying_load_calls: int = field(default=0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._cache = LruCache(self.maxsize)
+
+    @property
+    def underlying_load_calls(self) -> int:
+        """Number of calls that reached the wrapped ``load_turn`` (tests/diagnostics)."""
+        return self._underlying_load_calls
+
+    def get(self, turn_number: int) -> TurnInfo | None:
+        """Read-through LRU lookup for one stored turn number."""
+        cached = self._cache.get(turn_number)
+        if cached is not None:
+            return cached
+
+        self._underlying_load_calls += 1
+        turn = self.load_turn(turn_number)
+        if turn is not None:
+            self._cache.put(turn_number, turn)
+        return turn
+
+    def prefetch(self, turn_number: int) -> TurnInfo | None:
+        """Warm the cache for one turn (same semantics as :meth:`get`)."""
+        return self.get(turn_number)
+
+    def prefetch_planned_nodes(self, planned_nodes: Iterable[PlannedComputeNode]) -> None:
+        """Warm turns referenced by a planned compute DAG."""
+        for planned in planned_nodes:
+            self._prefetch_scope_turn(planned.scope)
+            for dependency_scope in planned.dependency_scopes:
+                self._prefetch_scope_turn(dependency_scope)
+
+    def _prefetch_scope_turn(self, scope: ComputeScope) -> None:
+        if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+            return
+        self.prefetch(scope.turn)

--- a/packages/api/api/compute/wire.py
+++ b/packages/api/api/compute/wire.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 
 from api.analytics.exports.jsonpath import resolve_jsonpath
 from api.compute.scope import ComputeScope
 
-# Orchestration plane: scope + dependency outputs -> serializable job payload.
-BuildStepJobWireFn = Callable[..., Any]
+if TYPE_CHECKING:
+    from api.analytics.export_context import AnalyticQueryContext
 
 # Compute plane: job payload -> serializable result payload.
 RunStepFn = Callable[[Any], Any]
@@ -47,3 +47,17 @@ class DependencyOutputs:
 
     def as_mapping(self) -> Mapping[ComputeScope, object]:
         return self._by_scope
+
+
+class BuildStepJobWireKwargs(TypedDict):
+    """Keyword arguments passed to job-wire builders by the orchestrator."""
+
+    dependency_outputs: DependencyOutputs
+    ctx: AnalyticQueryContext | None
+
+
+# Orchestration plane: scope + dependency outputs -> serializable job payload.
+BuildStepJobWireFn = Callable[
+    [ComputeScope, Unpack[BuildStepJobWireKwargs]],
+    Any,
+]

--- a/packages/api/api/compute/worker_turn_cache.py
+++ b/packages/api/api/compute/worker_turn_cache.py
@@ -1,0 +1,54 @@
+"""Per-worker LRU for deserializing prefetched turn wires in compute plane steps."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any
+
+from api.models.game import TurnInfo
+from api.serialization.turn import turn_info_from_json
+
+_DEFAULT_MAXSIZE = 32
+
+_cache: OrderedDict[tuple[int, int, int], TurnInfo] = OrderedDict()
+_deserialize_calls = 0
+
+
+def init_worker_turn_cache() -> None:
+    """Reset worker-local turn cache (pool initializer)."""
+    global _deserialize_calls
+    _cache.clear()
+    _deserialize_calls = 0
+
+
+def worker_deserialize_calls() -> int:
+    """Number of JSON deserializations performed in this worker (tests/diagnostics)."""
+    return _deserialize_calls
+
+
+def reset_worker_deserialize_calls_for_tests() -> None:
+    """Reset deserialize counter in the current worker (tests only)."""
+    global _deserialize_calls
+    _deserialize_calls = 0
+
+
+def turn_from_materialization_job_wire(job_wire: dict[str, Any]) -> TurnInfo:
+    """Deserialize ``turnWire`` once per worker for repeated legs at the same turn."""
+    global _deserialize_calls
+    key = (
+        int(job_wire["gameId"]),
+        int(job_wire["perspective"]),
+        int(job_wire["materializeTurn"]),
+    )
+    cached = _cache.get(key)
+    if cached is not None:
+        _cache.move_to_end(key)
+        return cached
+
+    _deserialize_calls += 1
+    turn = turn_info_from_json(job_wire["turnWire"])
+    _cache[key] = turn
+    _cache.move_to_end(key)
+    while len(_cache) > _DEFAULT_MAXSIZE:
+        _cache.popitem(last=False)
+    return turn

--- a/packages/api/api/compute/worker_turn_cache.py
+++ b/packages/api/api/compute/worker_turn_cache.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
 from typing import Any
 
+from api.compute.lru_cache import LruCache
 from api.models.game import TurnInfo
 from api.serialization.turn import turn_info_from_json
 
 _DEFAULT_MAXSIZE = 32
 
-_cache: OrderedDict[tuple[int, int, int], TurnInfo] = OrderedDict()
+_cache = LruCache[tuple[int, int, int], TurnInfo](_DEFAULT_MAXSIZE)
 _deserialize_calls = 0
 
 
@@ -42,13 +42,9 @@ def turn_from_materialization_job_wire(job_wire: dict[str, Any]) -> TurnInfo:
     )
     cached = _cache.get(key)
     if cached is not None:
-        _cache.move_to_end(key)
         return cached
 
     _deserialize_calls += 1
     turn = turn_info_from_json(job_wire["turnWire"])
-    _cache[key] = turn
-    _cache.move_to_end(key)
-    while len(_cache) > _DEFAULT_MAXSIZE:
-        _cache.popitem(last=False)
+    _cache.put(key, turn)
     return turn

--- a/packages/api/tests/test_compute_turn_cache.py
+++ b/packages/api/tests/test_compute_turn_cache.py
@@ -1,0 +1,320 @@
+"""Tests for compute orchestrator turn cache and job wire prefetch."""
+
+from __future__ import annotations
+
+import time
+
+from api.analytics.catalog import TurnAnalyticCatalogEntry
+from api.analytics.export_context import make_analytic_query_context
+from api.analytics.exports.empty import empty_export_catalog_for
+from api.analytics.fleet.compute_orchestration import build_fleet_materialization_leg_job_wire
+from api.analytics.fleet.compute_services import build_ephemeral_fleet_compute_services
+from api.analytics.fleet.registration import REGISTRATION as FLEET_REGISTRATION
+from api.analytics.fleet.serialization import (
+    persisted_fleet_ledger_from_json,
+    persisted_fleet_ledger_to_json,
+)
+from api.analytics.fleet.types import FleetMaterializationProvenance, PersistedFleetLedger
+from api.analytics.options import TurnAnalyticsOptions
+from api.analytics.registration import TurnAnalyticRegistration
+from api.analytics.scores import REGISTRATION as SCORES_REGISTRATION
+from api.analytics.scores.export_services import ScoresExportContext
+from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
+from api.compute import (
+    AnalyticComputeProfile,
+    ComputeOrchestrator,
+    ComputeRequest,
+    ComputeScope,
+    ComputeStepSpec,
+    ComputeWorkerPool,
+    DependencyOutputs,
+    ScopeKeySpec,
+    build_compute_registry,
+)
+from api.compute.turn_cache import OrchestratorTurnCache
+from api.compute.worker_turn_cache import (
+    reset_worker_deserialize_calls_for_tests,
+    turn_from_materialization_job_wire,
+    worker_deserialize_calls,
+)
+from api.serialization.turn import turn_info_from_json, turn_info_to_json
+
+from tests.fixtures.export_framework.harness import build_stored_turn_chain
+from tests.test_compute_foundation import _StubPersistencePolicy
+
+_ROW_SCOPE_KEY = ScopeKeySpec(axes=("perspective", "turn", "player_id"))
+_FLEET_ANALYTIC_ID = "fleet"
+
+
+def _catalog_entry(analytic_id: str) -> TurnAnalyticCatalogEntry:
+    return TurnAnalyticCatalogEntry(
+        id=analytic_id,
+        name=analytic_id,
+        supports_table=True,
+        supports_map=False,
+        type="selectable",
+    )
+
+
+def test_orchestrator_turn_cache_avoids_duplicate_underlying_loads(sample_turn) -> None:
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=3)
+    load_calls: list[int] = []
+
+    def counting_load(turn_number: int):
+        load_calls.append(turn_number)
+        turn = stored_turns.get(turn_number)
+        if turn is None:
+            return None
+        return turn_info_from_json(turn_info_to_json(turn))
+
+    cache = OrchestratorTurnCache(counting_load)
+    cache.get(2)
+    cache.get(2)
+    cache.get(3)
+    cache.get(2)
+
+    assert load_calls == [2, 3]
+
+
+def test_fleet_job_wire_includes_prefetched_turn_wire(sample_turn) -> None:
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
+    fleet_services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+        stored_turns=stored_turns,
+    )
+    ctx = make_analytic_query_context(
+        stored_turns[2],
+        TurnAnalyticsOptions(),
+        load_turn=fleet_services.load_turn,
+        export_services={
+            _FLEET_ANALYTIC_ID: fleet_services,
+            SCORES_ANALYTIC_ID: ScoresExportContext(),
+        },
+    )
+    cache = OrchestratorTurnCache(ctx.load_turn)
+    player_id = next(row.ownerid for row in sample_turn.scores)
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=628580,
+        perspective=1,
+        turn=2,
+        player_id=player_id,
+    )
+
+    job_wire = build_fleet_materialization_leg_job_wire(
+        scope,
+        dependency_outputs=DependencyOutputs(),
+        ctx=ctx,
+        turn_cache=cache,
+    )
+
+    assert "turnWire" in job_wire
+    assert job_wire["materializeTurn"] == 2
+    assert turn_info_from_json(job_wire["turnWire"]).settings.turn == 2
+
+
+def test_fleet_job_wire_prefetches_prior_ledger_from_persistence(sample_turn) -> None:
+    from api.analytics.fleet.chain import ensure_fleet_baseline_for_player
+
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
+    fleet_services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+        stored_turns=stored_turns,
+    )
+    ctx = make_analytic_query_context(
+        stored_turns[2],
+        TurnAnalyticsOptions(),
+        load_turn=fleet_services.load_turn,
+        export_services={
+            _FLEET_ANALYTIC_ID: fleet_services,
+            SCORES_ANALYTIC_ID: ScoresExportContext(),
+        },
+    )
+    player_id = next(row.ownerid for row in sample_turn.scores)
+    prior_persisted = PersistedFleetLedger(
+        ledger=ensure_fleet_baseline_for_player(628580, 1, stored_turns[1], player_id),
+        provenance=FleetMaterializationProvenance(
+            turn_evidence_at_n=True,
+            prior_ledger_at_n_minus_1=True,
+        ),
+    )
+    fleet_services.persistence.put_ledger(
+        628580,
+        1,
+        1,
+        player_id,
+        prior_persisted,
+    )
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=628580,
+        perspective=1,
+        turn=2,
+        player_id=player_id,
+    )
+
+    job_wire = build_fleet_materialization_leg_job_wire(
+        scope,
+        dependency_outputs=DependencyOutputs(),
+        ctx=ctx,
+    )
+
+    assert job_wire["priorLedgerWire"] is not None
+    loaded_prior = persisted_fleet_ledger_from_json(job_wire["priorLedgerWire"])
+    assert loaded_prior.ledger.player_id == player_id
+    expected_prior = fleet_services.persistence.get_ledger(628580, 1, 1, player_id)
+    assert expected_prior is not None
+    assert persisted_fleet_ledger_to_json(loaded_prior) == persisted_fleet_ledger_to_json(
+        expected_prior
+    )
+    assert job_wire["baselineLedgerWire"] == persisted_fleet_ledger_to_json(expected_prior)[
+        "ledger"
+    ]
+
+
+def test_orchestrator_exposes_cached_load_turn(sample_turn) -> None:
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
+    load_calls: list[int] = []
+
+    def counting_load(turn_number: int):
+        load_calls.append(turn_number)
+        return stored_turns.get(turn_number)
+
+    ctx = make_analytic_query_context(
+        stored_turns[2],
+        TurnAnalyticsOptions(),
+        load_turn=counting_load,
+    )
+    compute_registry = build_compute_registry(
+        (
+            TurnAnalyticRegistration(
+                catalog_entry=_catalog_entry("cache-probe"),
+                compute=lambda _ctx: {"analyticId": "cache-probe"},
+                export_catalog=empty_export_catalog_for("cache-probe"),
+                scope_key_spec=_ROW_SCOPE_KEY,
+                compute_profile=AnalyticComputeProfile(
+                    steps=(ComputeStepSpec(step_kind="materialize", backend="inline"),),
+                ),
+                persistence_policy=_StubPersistencePolicy(),
+                build_step_job_wires=(("materialize", lambda *_a, **_k: {}),),
+                run_steps=(("materialize", lambda job: job),),
+            ),
+        )
+    )
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    orchestrator.turn_cache.get(2)
+    orchestrator.turn_cache.get(2)
+
+    assert load_calls == [2]
+
+
+def test_orchestrator_dag_plan_and_wire_build_share_turn_cache(sample_turn) -> None:
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
+    fleet_services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+        stored_turns=stored_turns,
+    )
+    load_calls: list[int] = []
+
+    def counting_load(turn_number: int):
+        load_calls.append(turn_number)
+        return fleet_services.load_turn(turn_number)
+
+    ctx = make_analytic_query_context(
+        stored_turns[2],
+        TurnAnalyticsOptions(),
+        load_turn=counting_load,
+        export_services={
+            _FLEET_ANALYTIC_ID: fleet_services,
+            SCORES_ANALYTIC_ID: ScoresExportContext(),
+        },
+    )
+    compute_registry = build_compute_registry((FLEET_REGISTRATION, SCORES_REGISTRATION))
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry)
+    player_id = next(row.ownerid for row in sample_turn.scores)
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=628580,
+        perspective=1,
+        turn=2,
+        player_id=player_id,
+    )
+
+    handle = orchestrator.submit(ComputeRequest(scope=scope))
+    del handle
+
+    assert all(load_calls.count(turn) == 1 for turn in set(load_calls))
+    assert {1, 2}.issubset(set(load_calls))
+
+
+def test_worker_turn_cache_reuses_turn_wire_deserialize(sample_turn) -> None:
+    reset_worker_deserialize_calls_for_tests()
+    turn = sample_turn
+    job_wire = {
+        "gameId": turn.game.id,
+        "perspective": turn.player.id,
+        "materializeTurn": turn.settings.turn,
+        "turnWire": turn_info_to_json(turn),
+    }
+
+    first = turn_from_materialization_job_wire(job_wire)
+    second = turn_from_materialization_job_wire(job_wire)
+
+    assert first.settings.turn == second.settings.turn
+    assert worker_deserialize_calls() == 1
+
+
+def test_pool_fleet_leg_uses_prefetched_turn_wire(sample_turn) -> None:
+    stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
+    fleet_services = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+        stored_turns=stored_turns,
+    )
+    ctx = make_analytic_query_context(
+        stored_turns[2],
+        TurnAnalyticsOptions(),
+        load_turn=fleet_services.load_turn,
+        export_services={
+            _FLEET_ANALYTIC_ID: fleet_services,
+            SCORES_ANALYTIC_ID: ScoresExportContext(),
+        },
+    )
+    compute_registry = build_compute_registry((FLEET_REGISTRATION, SCORES_REGISTRATION))
+    pool = ComputeWorkerPool(worker_count=1)
+    orchestrator = ComputeOrchestrator(ctx, compute_registry=compute_registry, worker_pool=pool)
+    player_id = next(row.ownerid for row in sample_turn.scores)
+    scope = ComputeScope(
+        analytic_id=_FLEET_ANALYTIC_ID,
+        game_id=628580,
+        perspective=1,
+        turn=2,
+        player_id=player_id,
+    )
+
+    handle = orchestrator.submit(ComputeRequest(scope=scope))
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if handle.state == "complete":
+            break
+        time.sleep(0.01)
+
+    pool.shutdown()
+    assert handle.state == "complete", handle.error
+    assert isinstance(handle.result_wire, dict)
+    assert "persistedLedgerWire" in handle.result_wire
+
+    built = build_fleet_materialization_leg_job_wire(
+        scope,
+        dependency_outputs=DependencyOutputs(),
+        ctx=ctx,
+        turn_cache=orchestrator.turn_cache,
+    )
+    assert "turnWire" in built

--- a/packages/api/tests/test_compute_turn_cache.py
+++ b/packages/api/tests/test_compute_turn_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from dataclasses import replace
 
 from api.analytics.catalog import TurnAnalyticCatalogEntry
 from api.analytics.export_context import make_analytic_query_context
@@ -94,6 +95,7 @@ def test_fleet_job_wire_includes_prefetched_turn_wire(sample_turn) -> None:
         },
     )
     cache = OrchestratorTurnCache(ctx.load_turn)
+    cached_ctx = replace(ctx, load_turn=cache.get)
     player_id = next(row.ownerid for row in sample_turn.scores)
     scope = ComputeScope(
         analytic_id=_FLEET_ANALYTIC_ID,
@@ -106,8 +108,7 @@ def test_fleet_job_wire_includes_prefetched_turn_wire(sample_turn) -> None:
     job_wire = build_fleet_materialization_leg_job_wire(
         scope,
         dependency_outputs=DependencyOutputs(),
-        ctx=ctx,
-        turn_cache=cache,
+        ctx=cached_ctx,
     )
 
     assert "turnWire" in job_wire
@@ -314,7 +315,6 @@ def test_pool_fleet_leg_uses_prefetched_turn_wire(sample_turn) -> None:
     built = build_fleet_materialization_leg_job_wire(
         scope,
         dependency_outputs=DependencyOutputs(),
-        ctx=ctx,
-        turn_cache=orchestrator.turn_cache,
+        ctx=replace(ctx, load_turn=orchestrator.turn_cache.get),
     )
     assert "turnWire" in built

--- a/packages/api/tests/test_compute_turn_cache.py
+++ b/packages/api/tests/test_compute_turn_cache.py
@@ -172,9 +172,9 @@ def test_fleet_job_wire_prefetches_prior_ledger_from_persistence(sample_turn) ->
     assert persisted_fleet_ledger_to_json(loaded_prior) == persisted_fleet_ledger_to_json(
         expected_prior
     )
-    assert job_wire["baselineLedgerWire"] == persisted_fleet_ledger_to_json(expected_prior)[
-        "ledger"
-    ]
+    assert (
+        job_wire["baselineLedgerWire"] == persisted_fleet_ledger_to_json(expected_prior)["ledger"]
+    )
 
 
 def test_orchestrator_exposes_cached_load_turn(sample_turn) -> None:

--- a/packages/api/tests/test_compute_turn_cache.py
+++ b/packages/api/tests/test_compute_turn_cache.py
@@ -271,7 +271,8 @@ def test_worker_turn_cache_reuses_turn_wire_deserialize(sample_turn) -> None:
     assert worker_deserialize_calls() == 1
 
 
-def test_pool_fleet_leg_uses_prefetched_turn_wire(sample_turn) -> None:
+def test_pool_fleet_leg_deserializes_turn_wire_once_in_worker(sample_turn) -> None:
+    reset_worker_deserialize_calls_for_tests()
     stored_turns = build_stored_turn_chain(sample_turn, through_turn=2)
     fleet_services = build_ephemeral_fleet_compute_services(
         sample_turn,
@@ -307,14 +308,10 @@ def test_pool_fleet_leg_uses_prefetched_turn_wire(sample_turn) -> None:
             break
         time.sleep(0.01)
 
-    pool.shutdown()
     assert handle.state == "complete", handle.error
     assert isinstance(handle.result_wire, dict)
     assert "persistedLedgerWire" in handle.result_wire
+    assert pool.metrics.interpreter_executions == 1
+    assert pool.worker_deserialize_calls_for_tests() == 1
 
-    built = build_fleet_materialization_leg_job_wire(
-        scope,
-        dependency_outputs=DependencyOutputs(),
-        ctx=replace(ctx, load_turn=orchestrator.turn_cache.get),
-    )
-    assert "turnWire" in built
+    pool.shutdown()


### PR DESCRIPTION
## Summary

- Add orchestrator read-through LRU for `TurnInfo` during DAG planning and job-wire building, with per-worker turn-wire deserialize caching in the compute pool.
- Prefetch prior fleet ledgers from persistence when the ancestor scope is satisfied but absent from in-graph `dependency_outputs`, closing the partial-cache-hit gap.
- Simplify the cache boundary so wire builders use `ctx.load_turn` via orchestrator `_cached_ctx` only; extract shared `LruCache` and type `BuildStepJobWireFn` kwargs.

Closes #201

## Test plan

- [x] `make test` (lint, api, bff, frontend, scripts)
- [x] `test_compute_turn_cache.py` -- orchestrator turn dedup, fleet wire prefetch (turn + ledger), worker deserialize dedup, pool integration
- [x] `test_compute_orchestrator.py` and `test_compute_pools.py` -- existing orchestrator/pool contracts unchanged


Made with [Cursor](https://cursor.com)