### PR TITLE
Raise early inference tech gates from prior-turn fleet max tech (#227)

### DIFF
--- a/assets/analytics/scores/tier_policy.yaml
+++ b/assets/analytics/scores/tier_policy.yaml
@@ -1,6 +1,11 @@
 # Inference search tier ladder (sketch A, section 8.5.3).
 # filters.*.all widens eligibility (see tier_policy.py module docstring).
 # filters.*.techLevels narrows by component techlevel; ids derived at runtime.
+# filters.*.raiseMaxTechFromPriorFleet (#227): raise techLevels ceiling from
+# prior-turn fleet max tech when that overlay is applied; omit the step when
+# every flagged axis already saturates the turn catalog. Distinct from #226
+# hullCollisionTwinWiden (score twins without fleet proof) and from
+# allowShipOnlyExactEarlyStop (ladder stop after a ship-only exact).
 #
 # Fleet-informed torp admission + ranking (#87, section 8.8): early torp tiers use
 # belief-set ids only; inference torp escape tier (penultimate step, alpha > 0) admits
@@ -97,12 +102,15 @@ steps:
     filters:
       hulls:
         techLevels: [1, 2, 3, 4, 5, 6]
+        raiseMaxTechFromPriorFleet: true
       engines:
         all: true
       beams:
         techLevels: [1, 2, 3, 4, 5]
+        raiseMaxTechFromPriorFleet: true
       launchers:
         techLevels: [1, 2, 3, 4, 5]
+        raiseMaxTechFromPriorFleet: true
     beamSlotCounts: none
     launcherSlotCounts: none
     aggregateAllowlist: {}
@@ -114,12 +122,15 @@ steps:
     filters:
       hulls:
         techLevels: [1, 2, 3, 4, 5, 6]
+        raiseMaxTechFromPriorFleet: true
       engines:
         all: true
       beams:
         techLevels: [1, 2, 3, 4, 5]
+        raiseMaxTechFromPriorFleet: true
       launchers:
         techLevels: [1, 2, 3, 4, 5, 6, 7, 8]
+        raiseMaxTechFromPriorFleet: true
     beamSlotCounts: none
     launcherSlotCounts: none
     aggregateAllowlist: {}
@@ -129,17 +140,21 @@ steps:
 
   # After widen_launchers so twin combos that need launcher tech >5 (e.g. Gamma on
   # Resolute) are expressible. Hull admission is runtime-conditional via twin asset
-  # includeComponentIds overlay (#226); static hull band stays tech 1--6.
+  # includeComponentIds overlay (#226); static hull band stays tech 1--6, raised from
+  # prior fleet when raiseMaxTechFromPriorFleet applies (#227).
   - id: collision_hull_widen
     filters:
       hulls:
         techLevels: [1, 2, 3, 4, 5, 6]
+        raiseMaxTechFromPriorFleet: true
       engines:
         all: true
       beams:
         techLevels: [1, 2, 3, 4, 5]
+        raiseMaxTechFromPriorFleet: true
       launchers:
         techLevels: [1, 2, 3, 4, 5, 6, 7, 8]
+        raiseMaxTechFromPriorFleet: true
     beamSlotCounts: none
     launcherSlotCounts: none
     aggregateAllowlist: {}
@@ -156,8 +171,10 @@ steps:
         all: true
       beams:
         techLevels: [1, 2, 3, 4, 5]
+        raiseMaxTechFromPriorFleet: true
       launchers:
         techLevels: [1, 2, 3, 4, 5, 6, 7, 8]
+        raiseMaxTechFromPriorFleet: true
     beamSlotCounts: none
     launcherSlotCounts: none
     aggregateAllowlist: {}

--- a/docs/design-military-score-build-inference-implementation.md
+++ b/docs/design-military-score-build-inference-implementation.md
@@ -574,6 +574,7 @@ Per-step fields (informal schema; exact YAML shape is implementation-owned):
 |----------|---------|
 | `all: true` | **Widened** eligibility on that axis (not "every turn-catalog id"). **hulls:** all buildable hull ids for the player, no tech band. **engines / beams / launchers:** player `active*` intersect turn catalog; **empty active list jumps to full turn catalog** for that axis. Mutually exclusive with `techLevels`. |
 | `techLevels: [...]` | Non-empty tech-level allowlist; component ids derived at runtime. **hulls:** intersect buildable hull set. **Other axes:** filter turn catalog by `techlevel`. Required when `all` is false or absent. |
+| `raiseMaxTechFromPriorFleet` | When `true` on a `techLevels` axis, raise the band ceiling from prior-turn fleet max tech (`1..max(configured_max, observed_max)`) when fleet input status is `applied` (#227; section 8.5.8). Mutually exclusive with `all`. Default `false`. |
 | `componentIds: [...]` | Optional future refinement: further restrict resolved ids (e.g. when multiple ids share a tech level). Parsed but unused in v1 eligibility unless non-empty. |
 
 Static YAML steps widen by **strict superset on `techLevels` lists** or by switching an axis from `techLevels` to `all: true` (one-way; cannot narrow back).
@@ -641,7 +642,7 @@ Do not emit `exact-with-deferred-risk` for band-feasible multisets in #77; that 
 
 **#78** proposed a global **inference tier policy overlay** merged at `resolve_tier_policies` time. That mechanism was removed unused: no production caller, and fleet torp needs are covered by **inference fleet probability overlay** (section 8.8). Catalog widening that depends on prior-step solutions uses step-local fields instead -- notably `includeComponentIds` on steps with `hullCollisionTwinWiden: true` for **hull collision twin** admission (#226; section 8.5.7).
 
-**Distinct from #87 / #156:** fleet-informed **ranking** and torp **aggregate admission** use **inference fleet probability overlay** (section 8.8), not component-filter widens.
+**Distinct from #87 / #156 / #227:** fleet-informed **ranking** and torp **aggregate admission** use **inference fleet probability overlay** (section 8.8). Early **tech-band admission** raises from prior-fleet max tech use step-local `raiseMaxTechFromPriorFleet` (section 8.5.8), not a global resolve-time overlay.
 
 #### 8.5.7 Hull collision twin assets and conditional widen (#226)
 
@@ -675,6 +676,18 @@ uv run python scripts/early_stop_hull_collisions.py --game-type campaign --game-
 ```
 
 The human-readable census report remains the default stdout; `--write-asset` also writes the machine-readable twin table (full-race census only -- omit `--race`). Missing category assets fall back to standard (same spirit as prior weights).
+
+#### 8.5.8 Raise early tech gates from prior-turn fleet (#227)
+
+Companion to hull collision twin widen (#226). Twins cover **score collisions without fleet proof**; this mechanism covers **tech already evidenced on the prior-turn fleet**.
+
+When a step axis sets `raiseMaxTechFromPriorFleet: true` and prior-fleet input status is `applied`, replace that axis's `techLevels` with `1 .. max(configured_constant, observed_max)` where `configured_constant = max(techLevels)` and `observed_max` is the max catalog `techlevel` over component ids on that axis from the player's prior-turn fleet records (same `has_final_ledger` provenance as section 8.8 torp overlay; empty/pending/unavailable leaves the YAML constant unchanged).
+
+**Skip:** when prior-fleet input is **applied** and every flagged axis on the step saturates (`effective_max >= max techlevel in the turn catalog` for that axis) and the step does **not** open hulls via `filters.hulls.all`, omit the step (no solve; advance; do not treat as `no_new_exact_signatures`). Pending/unavailable fleet never skips via this rule (YAML constants unchanged; step still solves). Steps such as `widen_hulls` still run so hull `all` widening is not dropped.
+
+**Production YAML:** flag enabled on hulls/beams/launchers for `early_game_bands`, `widen_launchers`, and `collision_hull_widen`, and on beams/launchers for `widen_hulls` (monotonicity when earlier steps raised those axes). Distinct from #156 tech-gap **penalties** (ranking only).
+
+Diagnostics under `priorFleetTechRaise`: per-axis configured/observed/effective/catalog max, `saturated`, and `skippedDueToPriorFleetTechSaturation`.
 
 ### 8.6 Score-equivalent combos (solver-side merge)
 
@@ -714,6 +727,8 @@ fleetInferenceTuning:
 - Ambiguous rows: **union** of launcher ids across all **fleet build option set** tuples
 
 Empty when no active row has a positive launcher id in any option set. **Absent overlay behaves like empty belief set** (turn 1 included) -- not legacy admit-all torps on early tiers.
+
+The same prior-turn fleet resolution also exposes **per-axis max tech** (`max_tech_by_axis`: `hulls` / `engines` / `beams` / `launchers`) for early tech-gate **admission** (#227; section 8.5.8). That path reuses final-ledger provenance; it does not read `$.composition.maxTechLevel` from the export tree. #156 tech-gap penalties (when implemented) remain ranking-only and are separate from admission.
 
 #### 8.8.2 Torp aggregate (#87)
 

--- a/packages/api/api/analytics/fleet/composition_export.py
+++ b/packages/api/api/analytics/fleet/composition_export.py
@@ -2,22 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Protocol
 
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.belief_set_components import component_ids_for_record_on_axis
 from api.analytics.fleet.export_scope import ledgers_for_scope
+from api.analytics.fleet.max_tech import max_tech_by_axis_from_fleet_records
 from api.analytics.fleet.types import (
     FleetShipRecord,
     FleetTurnSnapshot,
-)
-from api.concepts.turn_component_catalog import (
-    beams_by_id,
-    engines_by_id,
-    hulls_by_id,
-    torpedos_by_id,
 )
 from api.models.game import TurnInfo
 
@@ -26,39 +19,19 @@ from api.models.game import TurnInfo
 class _CompositionAxisSpec:
     field_name: str
     histogram_output_key: str
-    max_tech_key: str
-    catalog_key: str
 
 
 _COMPOSITION_AXIS_SPECS: tuple[_CompositionAxisSpec, ...] = (
-    _CompositionAxisSpec("hull", "hullTypes", "hulls", "hulls"),
-    _CompositionAxisSpec("engine", "engineTypes", "engines", "engines"),
-    _CompositionAxisSpec("beams", "beamTypes", "beams", "beams"),
-    _CompositionAxisSpec("launchers", "launcherTypes", "launchers", "launchers"),
+    _CompositionAxisSpec("hull", "hullTypes"),
+    _CompositionAxisSpec("engine", "engineTypes"),
+    _CompositionAxisSpec("beams", "beamTypes"),
+    _CompositionAxisSpec("launchers", "launcherTypes"),
 )
-
-
-class _TechLevelComponent(Protocol):
-    techlevel: int
 
 
 def _increment_histogram(histogram: dict[str, int], component_id: int) -> None:
     key = str(component_id)
     histogram[key] = histogram.get(key, 0) + 1
-
-
-def _max_tech_level(
-    component_ids: Iterable[int],
-    catalog: dict[int, _TechLevelComponent],
-) -> int | None:
-    max_level: int | None = None
-    for component_id in component_ids:
-        component = catalog.get(component_id)
-        if component is None:
-            continue
-        if max_level is None or component.techlevel > max_level:
-            max_level = component.techlevel
-    return max_level
 
 
 def _active_records_for_scope(
@@ -103,33 +76,19 @@ def build_fleet_composition_branch(
     if scope.player_id is None:
         return _empty_fleet_composition_branch()
 
+    active_records = _active_records_for_scope(snapshot, scope)
     histograms: dict[str, dict[str, int]] = {
         axis.histogram_output_key: {} for axis in _COMPOSITION_AXIS_SPECS
     }
 
-    for record in _active_records_for_scope(snapshot, scope):
+    for record in active_records:
         for axis in _COMPOSITION_AXIS_SPECS:
             histogram = histograms[axis.histogram_output_key]
             for component_id in component_ids_for_record_on_axis(record, axis.field_name):
                 _increment_histogram(histogram, component_id)
 
-    catalogs: dict[str, dict[int, _TechLevelComponent]] = {
-        "hulls": hulls_by_id(turn),
-        "engines": engines_by_id(turn),
-        "beams": beams_by_id(turn),
-        "launchers": torpedos_by_id(turn),
-    }
-
-    max_tech_level: dict[str, int] = {}
-    for axis in _COMPOSITION_AXIS_SPECS:
-        if axis_max := _max_tech_level(
-            (int(key) for key in histograms[axis.histogram_output_key]),
-            catalogs[axis.catalog_key],
-        ):
-            max_tech_level[axis.max_tech_key] = axis_max
-
     return {
         **histograms,
         "torpedoTypesLoaded": {},
-        "maxTechLevel": max_tech_level,
+        "maxTechLevel": max_tech_by_axis_from_fleet_records(active_records, turn),
     }

--- a/packages/api/api/analytics/fleet/max_tech.py
+++ b/packages/api/api/analytics/fleet/max_tech.py
@@ -1,0 +1,89 @@
+"""Max component tech levels from fleet ship records and turn catalogs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Protocol
+
+from api.analytics.fleet.belief_set_components import component_ids_for_axis_from_records
+from api.analytics.fleet.types import FleetShipRecord
+from api.concepts.turn_component_catalog import (
+    beams_by_id,
+    engines_by_id,
+    hulls_by_id,
+    torpedos_by_id,
+)
+from api.models.game import TurnInfo
+
+# Export / inference keys match tier-policy filter axis names.
+MAX_TECH_AXIS_KEYS: tuple[str, ...] = ("hulls", "engines", "beams", "launchers")
+
+_AXIS_FIELD_BY_KEY: dict[str, str] = {
+    "hulls": "hull",
+    "engines": "engine",
+    "beams": "beams",
+    "launchers": "launchers",
+}
+
+
+class _TechLevelComponent(Protocol):
+    techlevel: int
+
+
+def max_tech_level_for_component_ids(
+    component_ids: Iterable[int],
+    catalog: Mapping[int, _TechLevelComponent],
+) -> int | None:
+    """Highest ``techlevel`` among ``component_ids`` present in ``catalog``."""
+    max_level: int | None = None
+    for component_id in component_ids:
+        component = catalog.get(component_id)
+        if component is None:
+            continue
+        if max_level is None or component.techlevel > max_level:
+            max_level = component.techlevel
+    return max_level
+
+
+def max_tech_in_turn_catalog(turn: TurnInfo, axis_key: str) -> int | None:
+    """Highest techlevel present in the turn catalog for one export/filter axis."""
+    catalogs = _catalogs_by_axis(turn)
+    catalog = catalogs.get(axis_key)
+    if catalog is None or not catalog:
+        return None
+    return max(component.techlevel for component in catalog.values())
+
+
+def max_tech_by_axis_from_fleet_records(
+    records: Iterable[FleetShipRecord],
+    turn: TurnInfo,
+    *,
+    active_only: bool = True,
+) -> dict[str, int]:
+    """Per-axis max tech from fleet records (keys: hulls/engines/beams/launchers).
+
+    Axes with no known component ids (or ids missing from the turn catalog) are omitted.
+    """
+    catalogs = _catalogs_by_axis(turn)
+    record_list = list(records)
+    result: dict[str, int] = {}
+    for axis_key in MAX_TECH_AXIS_KEYS:
+        field_name = _AXIS_FIELD_BY_KEY[axis_key]
+        component_ids = component_ids_for_axis_from_records(
+            record_list,
+            field_name,
+            active_only=active_only,
+        )
+        axis_max = max_tech_level_for_component_ids(component_ids, catalogs[axis_key])
+        if axis_max is not None:
+            result[axis_key] = axis_max
+    return result
+
+
+def _catalogs_by_axis(turn: TurnInfo) -> dict[str, dict[int, _TechLevelComponent]]:
+    return {
+        "hulls": hulls_by_id(turn),
+        "engines": engines_by_id(turn),
+        "beams": beams_by_id(turn),
+        "launchers": torpedos_by_id(turn),
+    }

--- a/packages/api/api/analytics/military_score_inference/analytic.py
+++ b/packages/api/api/analytics/military_score_inference/analytic.py
@@ -233,6 +233,7 @@ def _run_accelerated_backfill_inference(
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
     fleet_torp_input_status: FleetTorpInputStatus | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     backfill = _try_accelerated_backfill_inference(
         score,
@@ -240,6 +241,7 @@ def _run_accelerated_backfill_inference(
         load_scoreboard_turn=load_scoreboard_turn,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     if backfill is not None:
         return backfill
@@ -253,6 +255,7 @@ def _run_accelerated_split_inference_path(
     *,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     payload, reported_observation, reported_catalog, _ = run_accelerated_split_inference(
         score,
@@ -260,6 +263,7 @@ def _run_accelerated_split_inference_path(
         segments,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     return payload, reported_observation, reported_catalog
 
@@ -270,6 +274,7 @@ def _run_policy_ladder_inference(
     *,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[
     InferenceResult,
@@ -283,6 +288,7 @@ def _run_policy_ladder_inference(
         turn,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         time_limit_seconds=time_limit_seconds,
     )
 
@@ -336,6 +342,7 @@ def _run_solver_inference_path(
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
     fleet_torp_input_status: FleetTorpInputStatus | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     if path == InferencePath.ACCELERATED_SPLIT:
@@ -346,6 +353,7 @@ def _run_solver_inference_path(
             accelerated_segments,
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
+            prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         )
 
     solve_catalog = catalog
@@ -357,6 +365,7 @@ def _run_solver_inference_path(
                     turn,
                     resolved_mask=resolved_mask,
                     fleet_torp_overlay=fleet_torp_overlay,
+                    prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
                     time_limit_seconds=time_limit_seconds,
                 )
             )
@@ -415,6 +424,7 @@ def run_inference_with_artifacts(
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
     fleet_torp_input_status: FleetTorpInputStatus | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
     time_limit_seconds: float | None = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None]:
     """Run inference once; return API payload plus observation and catalog for re-checks.
@@ -445,6 +455,7 @@ def run_inference_with_artifacts(
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
             fleet_torp_input_status=fleet_torp_input_status,
+            prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         )
     return _run_solver_inference_path(
         path,
@@ -456,6 +467,7 @@ def run_inference_with_artifacts(
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
         fleet_torp_input_status=fleet_torp_input_status,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         time_limit_seconds=time_limit_seconds,
     )
 
@@ -467,6 +479,7 @@ def _try_accelerated_backfill_inference(
     load_scoreboard_turn: ScoreboardTurnLoader | None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> tuple[dict[str, object], InferenceObservation, ActionCatalog | None] | None:
     """Fill unreliable accelerated rows from the first reliable split when that turn is stored."""
     if load_scoreboard_turn is None:
@@ -491,6 +504,7 @@ def _try_accelerated_backfill_inference(
         backfill_source.segments,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     segment_payload = _segment_payload_for_host_turn(
         payload,

--- a/packages/api/api/analytics/military_score_inference/inference_accelerated.py
+++ b/packages/api/api/analytics/military_score_inference/inference_accelerated.py
@@ -98,6 +98,7 @@ def run_accelerated_segment_policy_ladder(
     on_admitted: Callable[[InferenceSolution], None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> AcceleratedSegmentResult:
     """Run the policy ladder for one accelerated segment."""
     observation = observation_from_accelerated_segment(score, turn, segment)
@@ -115,6 +116,7 @@ def run_accelerated_segment_policy_ladder(
         on_admitted=on_admitted,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     return AcceleratedSegmentResult(
         segment=segment,
@@ -226,6 +228,7 @@ def run_accelerated_split_inference(
     time_limit_seconds: float = DEFAULT_INFERENCE_TIME_LIMIT_SECONDS,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> tuple[
     dict[str, object],
     InferenceObservation,
@@ -255,6 +258,7 @@ def run_accelerated_split_inference(
             time_limit_seconds=per_segment_time,
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
+            prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         )
         if segment.is_streaming_target:
             reported_observation = ladder_result.observation

--- a/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_orchestration.py
@@ -93,11 +93,13 @@ class InferenceStreamOrchestration:
         *,
         resolved_mask: ResolvedHullCatalogMask | None = None,
         fleet_torp_overlay: FleetTorpOverlay | None = None,
+        prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
     ) -> PolicyLadderState:
         return PolicyLadderState(
             policy_steps=tuple(resolve_tier_policies(None)),
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
+            prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         )
 
     def record_segment_ladder_complete(

--- a/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_rows.py
@@ -196,6 +196,7 @@ def schedule_inference_row(
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
     fleet_torp_input_status: FleetTorpInputStatus | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
     export_services: Mapping[str, object] | None = None,
     stream_token: str | None = None,
 ) -> ScheduledInferenceRow | None:
@@ -222,6 +223,7 @@ def schedule_inference_row(
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
         fleet_torp_input_status=fleet_torp_input_status,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     orchestration = create_inference_stream_orchestration(
         path,

--- a/packages/api/api/analytics/military_score_inference/inference_stream_session.py
+++ b/packages/api/api/analytics/military_score_inference/inference_stream_session.py
@@ -36,6 +36,7 @@ class InferenceRowStreamSession:
     resolved_mask: ResolvedHullCatalogMask | None = None
     fleet_torp_overlay: FleetTorpOverlay | None = None
     fleet_torp_input_status: FleetTorpInputStatus | None = None
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None
     cancel_token: InferenceCancelToken = field(default_factory=InferenceCancelToken)
     event_queue: queue.Queue[InferenceStreamDomainEvent] = field(default_factory=queue.Queue)
     run_id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -98,11 +98,7 @@ class InferenceTableStreamController(
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_resolution.overlay,
             fleet_torp_input_status=fleet_resolution.input_status,
-            prior_fleet_max_tech_by_axis=(
-                dict(fleet_resolution.max_tech_by_axis)
-                if fleet_resolution.input_status == "applied"
-                else None
-            ),
+            prior_fleet_max_tech_by_axis=fleet_resolution.prior_fleet_max_tech_for_admission(),
             export_services=self.export_services,
             stream_token=self.stream_token,
         )

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -98,6 +98,11 @@ class InferenceTableStreamController(
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_resolution.overlay,
             fleet_torp_input_status=fleet_resolution.input_status,
+            prior_fleet_max_tech_by_axis=(
+                dict(fleet_resolution.max_tech_by_axis)
+                if fleet_resolution.input_status == "applied"
+                else None
+            ),
             export_services=self.export_services,
             stream_token=self.stream_token,
         )

--- a/packages/api/api/analytics/military_score_inference/policy_ladder.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder.py
@@ -155,6 +155,7 @@ def solve_with_policy_ladder(
     on_admitted: Callable[[InferenceSolution], None] | None = None,
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> tuple[
     InferenceResult,
     ActionCatalog | None,
@@ -169,6 +170,7 @@ def solve_with_policy_ladder(
         resolved_max_solutions=resolved_max_solutions,
         resolved_mask=resolved_mask,
         fleet_torp_overlay=fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
     )
     while not state.ladder_complete and state.next_step_index < len(state.policy_steps):
         if cancel_token is not None and cancel_token.is_cancelled():

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_state.py
@@ -45,6 +45,7 @@ class PolicyLadderState:
     started_at: float = field(default_factory=time.monotonic)
     resolved_mask: ResolvedHullCatalogMask | None = None
     fleet_torp_overlay: FleetTorpOverlay | None = None
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None
     hull_collision_twins: HullCollisionTwinsAsset | None = None
     hull_collision_twins_path: str | None = None
     hull_collision_twins_fell_back: bool = False

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
@@ -347,27 +347,6 @@ def _finish_skipped_policy_step(
         state.ladder_complete = True
 
 
-def _finish_skipped_collision_widen_step(
-    state: PolicyLadderState,
-    *,
-    policy_step: InferenceTierPolicyStep,
-    policy_step_index: int,
-    turn: TurnInfo,
-    observation: InferenceObservation,
-    collision_widen: CollisionHullWidenPlan,
-    seed_count: int,
-) -> None:
-    _finish_skipped_policy_step(
-        state,
-        policy_step=policy_step,
-        policy_step_index=policy_step_index,
-        turn=turn,
-        observation=observation,
-        seed_count=seed_count,
-        collision_widen=collision_widen,
-    )
-
-
 def _make_incremental_admitter(
     state: PolicyLadderState,
     on_admitted: Callable[[InferenceSolution], None] | None,
@@ -471,14 +450,14 @@ def run_policy_ladder_tier_step(
             twins_fell_back=state.hull_collision_twins_fell_back,
         )
         if collision_widen.skipped:
-            _finish_skipped_collision_widen_step(
+            _finish_skipped_policy_step(
                 state,
                 policy_step=policy_step,
                 policy_step_index=step_index,
                 turn=turn,
                 observation=observation,
-                collision_widen=collision_widen,
                 seed_count=len(state.band_seeds),
+                collision_widen=collision_widen,
             )
             return
         policy_step = collision_widen.policy_step

--- a/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
+++ b/packages/api/api/analytics/military_score_inference/policy_ladder_tier_step.py
@@ -32,6 +32,10 @@ from api.analytics.military_score_inference.models import (
     InferenceSolution,
 )
 from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
+from api.analytics.military_score_inference.prior_fleet_tech_raise import (
+    PriorFleetTechRaisePlan,
+    resolve_prior_fleet_tech_raise_plan,
+)
 from api.analytics.military_score_inference.solver import (
     STATUS_INVALID_PROBLEM,
     STATUS_STOPPED,
@@ -241,6 +245,7 @@ def _policy_step_diagnostics(
     seed_count: int,
     band_residual_2x: int | None,
     collision_widen: CollisionHullWidenPlan | None = None,
+    prior_fleet_tech_raise: PriorFleetTechRaisePlan | None = None,
 ) -> dict[str, object]:
     catalog_context = turn_catalog_context_for_policy_step(
         turn,
@@ -265,6 +270,8 @@ def _policy_step_diagnostics(
     }
     if collision_widen is not None:
         diagnostics.update(collision_widen.to_diagnostics())
+    if prior_fleet_tech_raise is not None:
+        diagnostics.update(prior_fleet_tech_raise.to_diagnostics())
     return diagnostics
 
 
@@ -304,15 +311,16 @@ def _maybe_early_stop_after_step(
     return True
 
 
-def _finish_skipped_collision_widen_step(
+def _finish_skipped_policy_step(
     state: PolicyLadderState,
     *,
     policy_step: InferenceTierPolicyStep,
     policy_step_index: int,
     turn: TurnInfo,
     observation: InferenceObservation,
-    collision_widen: CollisionHullWidenPlan,
     seed_count: int,
+    collision_widen: CollisionHullWidenPlan | None = None,
+    prior_fleet_tech_raise: PriorFleetTechRaisePlan | None = None,
 ) -> None:
     state.step_diagnostics.append(
         _policy_step_diagnostics(
@@ -324,6 +332,7 @@ def _finish_skipped_collision_widen_step(
             seed_count=seed_count,
             band_residual_2x=None,
             collision_widen=collision_widen,
+            prior_fleet_tech_raise=prior_fleet_tech_raise,
         )
     )
     state.next_step_index = policy_step_index + 1
@@ -336,6 +345,27 @@ def _finish_skipped_collision_widen_step(
         return
     if state.next_step_index >= len(state.policy_steps):
         state.ladder_complete = True
+
+
+def _finish_skipped_collision_widen_step(
+    state: PolicyLadderState,
+    *,
+    policy_step: InferenceTierPolicyStep,
+    policy_step_index: int,
+    turn: TurnInfo,
+    observation: InferenceObservation,
+    collision_widen: CollisionHullWidenPlan,
+    seed_count: int,
+) -> None:
+    _finish_skipped_policy_step(
+        state,
+        policy_step=policy_step,
+        policy_step_index=policy_step_index,
+        turn=turn,
+        observation=observation,
+        seed_count=seed_count,
+        collision_widen=collision_widen,
+    )
 
 
 def _make_incremental_admitter(
@@ -452,6 +482,26 @@ def run_policy_ladder_tier_step(
             )
             return
         policy_step = collision_widen.policy_step
+
+    prior_fleet_tech_raise = resolve_prior_fleet_tech_raise_plan(
+        policy_step,
+        turn=turn,
+        prior_fleet_max_tech_by_axis=state.prior_fleet_max_tech_by_axis,
+    )
+    if prior_fleet_tech_raise is not None:
+        if prior_fleet_tech_raise.skipped:
+            _finish_skipped_policy_step(
+                state,
+                policy_step=prior_fleet_tech_raise.policy_step,
+                policy_step_index=step_index,
+                turn=turn,
+                observation=observation,
+                seed_count=len(state.band_seeds),
+                collision_widen=collision_widen,
+                prior_fleet_tech_raise=prior_fleet_tech_raise,
+            )
+            return
+        policy_step = prior_fleet_tech_raise.policy_step
 
     player_race_id = player_by_id(turn, observation.player_id).raceid
     catalog = build_action_catalog_from_turn(
@@ -587,6 +637,7 @@ def run_policy_ladder_tier_step(
             seed_count=len(seeds_for_step),
             band_residual_2x=band_residual_2x,
             collision_widen=collision_widen,
+            prior_fleet_tech_raise=prior_fleet_tech_raise,
         )
     )
 

--- a/packages/api/api/analytics/military_score_inference/prior_fleet_tech_raise.py
+++ b/packages/api/api/analytics/military_score_inference/prior_fleet_tech_raise.py
@@ -1,0 +1,135 @@
+"""Raise early tech bands from prior-turn fleet max tech (#227)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+
+from api.analytics.fleet.max_tech import max_tech_in_turn_catalog
+from api.analytics.military_score_inference.tier_policy import (
+    FILTER_AXES,
+    ComponentFilter,
+    FilterAxis,
+    InferenceCatalogFilters,
+    InferenceTierPolicyStep,
+)
+from api.models.game import TurnInfo
+
+
+@dataclass(frozen=True)
+class PriorFleetTechRaisePlan:
+    """Resolved tech-band raise (and optional skip) for one policy step."""
+
+    policy_step: InferenceTierPolicyStep
+    skipped: bool
+    axes: tuple[dict[str, object], ...]
+
+    def to_diagnostics(self) -> dict[str, object]:
+        return {
+            "priorFleetTechRaise": {
+                "skippedDueToPriorFleetTechSaturation": self.skipped,
+                "axes": list(self.axes),
+            }
+        }
+
+
+def _configured_max_tech(component_filter: ComponentFilter) -> int | None:
+    if component_filter.all or not component_filter.tech_levels:
+        return None
+    return max(component_filter.tech_levels)
+
+
+def _raised_tech_levels(effective_max: int) -> tuple[int, ...]:
+    return tuple(range(1, effective_max + 1))
+
+
+def _axis_raise_record(
+    axis: FilterAxis,
+    component_filter: ComponentFilter,
+    *,
+    observed_max: int | None,
+    catalog_max: int | None,
+) -> tuple[ComponentFilter, dict[str, object], bool]:
+    """Return (possibly raised filter, diagnostics row, saturated?)."""
+    configured_max = _configured_max_tech(component_filter)
+    if configured_max is None:
+        raise ValueError(
+            f"raiseMaxTechFromPriorFleet on {axis} requires a non-empty techLevels band"
+        )
+    effective_max = configured_max
+    if observed_max is not None and observed_max > effective_max:
+        effective_max = observed_max
+    raised_filter = replace(
+        component_filter,
+        tech_levels=_raised_tech_levels(effective_max),
+    )
+    saturated = catalog_max is not None and effective_max >= catalog_max
+    return (
+        raised_filter,
+        {
+            "axis": axis,
+            "configuredMaxTech": configured_max,
+            "observedMaxTech": observed_max,
+            "effectiveMaxTech": effective_max,
+            "catalogMaxTech": catalog_max,
+            "saturated": saturated,
+        },
+        saturated,
+    )
+
+
+def resolve_prior_fleet_tech_raise_plan(
+    policy_step: InferenceTierPolicyStep,
+    *,
+    turn: TurnInfo,
+    prior_fleet_max_tech_by_axis: Mapping[str, int] | None,
+) -> PriorFleetTechRaisePlan | None:
+    """Apply ``raiseMaxTechFromPriorFleet``; return None when the step has no flagged axes.
+
+    When every flagged axis is already at (or above) turn-catalog max after raising,
+    and the step has no ``all: true`` axis (those still need a solve to widen),
+    ``skipped`` is True and the ladder should omit the step without solving.
+    """
+    flagged: list[FilterAxis] = [
+        axis
+        for axis in FILTER_AXES
+        if policy_step.filters.axis_filter(axis).raise_max_tech_from_prior_fleet
+    ]
+    if not flagged:
+        return None
+
+    observed = prior_fleet_max_tech_by_axis
+    observed_map = observed or {}
+    raised_by_axis: dict[str, ComponentFilter] = {}
+    axis_rows: list[dict[str, object]] = []
+    saturated_flags: list[bool] = []
+    for axis in flagged:
+        component_filter = policy_step.filters.axis_filter(axis)
+        raised_filter, row, saturated = _axis_raise_record(
+            axis,
+            component_filter,
+            observed_max=observed_map.get(axis),
+            catalog_max=max_tech_in_turn_catalog(turn, axis),
+        )
+        raised_by_axis[axis] = raised_filter
+        axis_rows.append(row)
+        saturated_flags.append(saturated)
+
+    filters = InferenceCatalogFilters(
+        hulls=raised_by_axis.get("hulls", policy_step.filters.hulls),
+        engines=raised_by_axis.get("engines", policy_step.filters.engines),
+        beams=raised_by_axis.get("beams", policy_step.filters.beams),
+        launchers=raised_by_axis.get("launchers", policy_step.filters.launchers),
+    )
+    has_hulls_all = policy_step.filters.hulls.all
+    # Only omit steps when prior-fleet input was applied. Pending/unavailable keep
+    # YAML constants and still solve (sample catalogs may have max tech below the
+    # configured band; skipping those would drop early tiers incorrectly).
+    fleet_applied = prior_fleet_max_tech_by_axis is not None
+    return PriorFleetTechRaisePlan(
+        policy_step=replace(policy_step, filters=filters),
+        # Do not skip steps that open hulls to ``all`` (e.g. widen_hulls); saturation
+        # only omits pure tech-band constrained steps.
+        skipped=fleet_applied and all(saturated_flags) and not has_hulls_all,
+        axes=tuple(axis_rows),
+    )

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from api.analytics.export_context import make_analytic_query_context
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.constants import ANALYTIC_ID as FLEET_ANALYTIC_ID
 from api.analytics.fleet.export_scope import ledgers_for_scope
+from api.analytics.fleet.max_tech import max_tech_by_axis_from_fleet_records
 from api.analytics.fleet.types import FleetShipRecord, FleetTurnSnapshot
 from api.analytics.military_score_inference.fleet_torp_overlay import (
     FleetTorpOverlay,
@@ -26,10 +27,41 @@ FleetTorpInputStatus = Literal["not_applicable", "pending", "applied", "unavaila
 
 @dataclass(frozen=True)
 class PriorTurnFleetTorpResolution:
-    """Prior-turn fleet torp overlay plus provenance for inference diagnostics."""
+    """Prior-turn fleet torp overlay plus provenance for inference diagnostics.
+
+    When ``input_status`` is ``applied``, ``max_tech_by_axis`` holds per-axis max
+    catalog techlevels observed on the prior fleet (keys ``hulls``/``engines``/
+    ``beams``/``launchers``; axes with no evidence omitted). Otherwise the mapping
+    is empty and early tech gates keep their YAML constants (#227).
+    """
 
     overlay: FleetTorpOverlay | None
     input_status: FleetTorpInputStatus
+    max_tech_by_axis: dict[str, int] = field(default_factory=dict)
+
+
+def records_for_scope(
+    snapshot: FleetTurnSnapshot,
+    scope: ExportScope,
+) -> list[FleetShipRecord]:
+    records: list[FleetShipRecord] = []
+    for ledger in ledgers_for_scope(snapshot, scope):
+        records.extend(ledger.records)
+    return records
+
+
+def resolution_from_fleet_records(
+    records: list[FleetShipRecord],
+    *,
+    prior_turn: TurnInfo,
+    input_status: FleetTorpInputStatus = "applied",
+) -> PriorTurnFleetTorpResolution:
+    belief = launcher_belief_set_from_fleet_records(records)
+    return PriorTurnFleetTorpResolution(
+        overlay=FleetTorpOverlay(belief_set=belief),
+        input_status=input_status,
+        max_tech_by_axis=max_tech_by_axis_from_fleet_records(records, prior_turn),
+    )
 
 
 _FLEET_TORP_INPUT_STATUSES: frozenset[str] = frozenset(
@@ -180,12 +212,10 @@ def _load_prior_turn_fleet_snapshot(
 def _overlay_from_snapshot(
     snapshot: FleetTurnSnapshot,
     scope: ExportScope,
-) -> FleetTorpOverlay:
-    records: list[FleetShipRecord] = []
-    for ledger in ledgers_for_scope(snapshot, scope):
-        records.extend(ledger.records)
-    belief = launcher_belief_set_from_fleet_records(records)
-    return FleetTorpOverlay(belief_set=belief)
+    *,
+    prior_turn: TurnInfo,
+) -> PriorTurnFleetTorpResolution:
+    return resolution_from_fleet_records(records_for_scope(snapshot, scope), prior_turn=prior_turn)
 
 
 def resolve_prior_turn_fleet_torp_overlay(
@@ -201,7 +231,8 @@ def resolve_prior_turn_fleet_torp_overlay(
 
     Returns overlay plus ``input_status`` for inference diagnostics. Callers
     treat ``overlay is None`` as an empty belief set via
-    ``effective_fleet_torp_overlay``.
+    ``effective_fleet_torp_overlay``. When applied, also returns
+    ``max_tech_by_axis`` for early tech-gate admission (#227).
 
     When ``ensure`` is false, reads only persisted fleet snapshots and does not
     run export ensure (for inference table-stream scheduling).
@@ -240,10 +271,7 @@ def resolve_prior_turn_fleet_torp_overlay(
     if snapshot is None:
         return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
 
-    return PriorTurnFleetTorpResolution(
-        overlay=_overlay_from_snapshot(snapshot, scope),
-        input_status="applied",
-    )
+    return _overlay_from_snapshot(snapshot, scope, prior_turn=prior_turn_info)
 
 
 def schedule_background_prior_turn_fleet_warm(

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -39,6 +39,16 @@ class PriorTurnFleetTorpResolution:
     input_status: FleetTorpInputStatus
     max_tech_by_axis: dict[str, int] = field(default_factory=dict)
 
+    def prior_fleet_max_tech_for_admission(self) -> dict[str, int] | None:
+        """Prior-fleet max tech for early inference gates, or ``None`` when not applied.
+
+        Callers that admit prior-fleet tech into inference must use this helper
+        rather than re-encoding the ``input_status == "applied"`` gate.
+        """
+        if self.input_status != "applied":
+            return None
+        return dict(self.max_tech_by_axis)
+
 
 def records_for_scope(
     snapshot: FleetTurnSnapshot,

--- a/packages/api/api/analytics/military_score_inference/tier_policy.py
+++ b/packages/api/api/analytics/military_score_inference/tier_policy.py
@@ -47,12 +47,15 @@ class ComponentFilter:
     Optional ``include_component_ids`` unions extra ids into the resolved set (runtime twin
     widen when ``hullCollisionTwinWiden`` is set; intersected with buildable / catalog ids
     at resolve).
+    Optional ``raise_max_tech_from_prior_fleet`` raises the tech band ceiling from prior-turn
+    fleet max tech when that overlay is applied (#227).
     """
 
     all: bool = False
     tech_levels: tuple[int, ...] = ()
     component_ids: tuple[int, ...] = ()
     include_component_ids: tuple[int, ...] = ()
+    raise_max_tech_from_prior_fleet: bool = False
 
     def to_snapshot(self) -> dict[str, object]:
         if self.all:
@@ -63,6 +66,8 @@ class ComponentFilter:
             snapshot["componentIds"] = list(self.component_ids)
         if self.include_component_ids:
             snapshot["includeComponentIds"] = list(self.include_component_ids)
+        if self.raise_max_tech_from_prior_fleet:
+            snapshot["raiseMaxTechFromPriorFleet"] = True
         return snapshot
 
 
@@ -175,6 +180,16 @@ def _parse_include_component_ids(raw: object, *, axis: str, step_id: str) -> tup
     return tuple(sorted(set(ids)))
 
 
+def _parse_raise_max_tech_from_prior_fleet(raw: object, *, axis: str, step_id: str) -> bool:
+    if raw is None:
+        return False
+    if not isinstance(raw, bool):
+        raise ValueError(
+            f"step {step_id}: filters.{axis}.raiseMaxTechFromPriorFleet must be a boolean"
+        )
+    return raw
+
+
 def _parse_component_filter(raw: object, *, axis: str, step_id: str) -> ComponentFilter:
     if not isinstance(raw, dict):
         raise ValueError(f"step {step_id}: filters.{axis} must be a mapping")
@@ -185,9 +200,18 @@ def _parse_component_filter(raw: object, *, axis: str, step_id: str) -> Componen
         axis=axis,
         step_id=step_id,
     )
+    raise_max_tech = _parse_raise_max_tech_from_prior_fleet(
+        raw.get("raiseMaxTechFromPriorFleet"),
+        axis=axis,
+        step_id=step_id,
+    )
     if use_all:
         if "techLevels" in raw:
             raise ValueError(f"step {step_id}: filters.{axis} cannot set both all and techLevels")
+        if raise_max_tech:
+            raise ValueError(
+                f"step {step_id}: filters.{axis}.raiseMaxTechFromPriorFleet requires techLevels"
+            )
         return ComponentFilter(
             all=True,
             component_ids=component_ids,
@@ -199,6 +223,7 @@ def _parse_component_filter(raw: object, *, axis: str, step_id: str) -> Componen
         tech_levels=tech_levels,
         component_ids=component_ids,
         include_component_ids=include_component_ids,
+        raise_max_tech_from_prior_fleet=raise_max_tech,
     )
 
 

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -134,9 +134,7 @@ def _apply_fleet_resolution_to_row_run(
     session = run.session
     session.fleet_torp_overlay = resolution.overlay
     session.fleet_torp_input_status = resolution.input_status
-    session.prior_fleet_max_tech_by_axis = (
-        dict(resolution.max_tech_by_axis) if resolution.input_status == "applied" else None
-    )
+    session.prior_fleet_max_tech_by_axis = resolution.prior_fleet_max_tech_for_admission()
     ladder_state = run.ladder_state
     if ladder_state is not None:
         ladder_state.fleet_torp_overlay = resolution.overlay

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -7,13 +7,8 @@ from typing import Any
 from api.analytics.export_context import AnalyticQueryContext
 from api.analytics.export_types import ExportScope
 from api.analytics.fleet.constants import ANALYTIC_ID as FLEET_ANALYTIC_ID
-from api.analytics.fleet.export_scope import ledgers_for_scope
 from api.analytics.fleet.serialization import persisted_fleet_ledger_from_json
 from api.analytics.fleet.types import FleetTurnSnapshot
-from api.analytics.military_score_inference.fleet_torp_overlay import (
-    FleetTorpOverlay,
-    launcher_belief_set_from_fleet_records,
-)
 from api.analytics.military_score_inference.inference_row_runner import (
     InferenceTierJobCallbacks,
     TierJobOutcome,
@@ -22,6 +17,8 @@ from api.analytics.military_score_inference.inference_row_runner import (
 from api.analytics.military_score_inference.inference_stream_domain_events import RowComplete
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
     PriorTurnFleetTorpResolution,
+    records_for_scope,
+    resolution_from_fleet_records,
     resolve_prior_turn_fleet_torp_overlay,
 )
 from api.analytics.military_score_inference.row_run import RowRun
@@ -71,10 +68,12 @@ def _scores_prior_fleet_scope(scope: ComputeScope) -> ComputeScope | None:
     )
 
 
-def _overlay_from_persisted_fleet_wire(
+def _resolution_from_persisted_fleet_wire(
     persisted_wire: dict[str, object],
     export_scope: ExportScope,
-) -> FleetTorpOverlay:
+    *,
+    prior_turn,
+) -> PriorTurnFleetTorpResolution:
     persisted = persisted_fleet_ledger_from_json(persisted_wire)
     snapshot = FleetTurnSnapshot(
         analytic_id=FLEET_ANALYTIC_ID,
@@ -83,11 +82,8 @@ def _overlay_from_persisted_fleet_wire(
         turn=export_scope.turn,
         players=[persisted.ledger],
     )
-    records = []
-    for ledger in ledgers_for_scope(snapshot, export_scope):
-        records.extend(ledger.records)
-    belief = launcher_belief_set_from_fleet_records(records)
-    return FleetTorpOverlay(belief_set=belief)
+    records = records_for_scope(snapshot, export_scope)
+    return resolution_from_fleet_records(records, prior_turn=prior_turn)
 
 
 def _resolve_prior_fleet_for_tier_wire(
@@ -107,13 +103,15 @@ def _resolve_prior_fleet_for_tier_wire(
         return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
 
     prior_export_scope = compute_scope_to_export_scope(prior_fleet_scope)
+    prior_turn = ctx.load_turn(prior_fleet_scope.turn)
     fleet_result_wire = dependency_outputs.get(prior_fleet_scope)
-    if isinstance(fleet_result_wire, dict):
+    if isinstance(fleet_result_wire, dict) and prior_turn is not None:
         persisted_wire = fleet_result_wire.get("persistedLedgerWire")
         if isinstance(persisted_wire, dict):
-            return PriorTurnFleetTorpResolution(
-                overlay=_overlay_from_persisted_fleet_wire(persisted_wire, prior_export_scope),
-                input_status="applied",
+            return _resolution_from_persisted_fleet_wire(
+                persisted_wire,
+                prior_export_scope,
+                prior_turn=prior_turn,
             )
 
     turn = ctx.load_turn(export_scope.turn)
@@ -136,9 +134,13 @@ def _apply_fleet_resolution_to_row_run(
     session = run.session
     session.fleet_torp_overlay = resolution.overlay
     session.fleet_torp_input_status = resolution.input_status
+    session.prior_fleet_max_tech_by_axis = (
+        dict(resolution.max_tech_by_axis) if resolution.input_status == "applied" else None
+    )
     ladder_state = run.ladder_state
     if ladder_state is not None:
         ladder_state.fleet_torp_overlay = resolution.overlay
+        ladder_state.prior_fleet_max_tech_by_axis = session.prior_fleet_max_tech_by_axis
 
 
 def build_scores_materialize_job_wire(

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -222,6 +222,11 @@ def _run_prior_turn_sync_ensure(
         resolved_mask=inputs.resolved_mask,
         fleet_torp_overlay=fleet_resolution.overlay,
         fleet_torp_input_status=fleet_resolution.input_status,
+        prior_fleet_max_tech_by_axis=(
+            dict(fleet_resolution.max_tech_by_axis)
+            if fleet_resolution.input_status == "applied"
+            else None
+        ),
     )
     status = str(inference.get("status", ""))
     if services.persistence is not None and is_persistable_inference_status(status):
@@ -310,6 +315,11 @@ def _ensure_current_turn_scheduler(
         resolved_mask=inputs.resolved_mask,
         fleet_torp_overlay=fleet_resolution.overlay,
         fleet_torp_input_status=fleet_resolution.input_status,
+        prior_fleet_max_tech_by_axis=(
+            dict(fleet_resolution.max_tech_by_axis)
+            if fleet_resolution.input_status == "applied"
+            else None
+        ),
         export_services=ctx.export_services,
         stream_token=inputs.stream_token,
     )

--- a/packages/api/api/analytics/scores/exports.py
+++ b/packages/api/api/analytics/scores/exports.py
@@ -222,11 +222,7 @@ def _run_prior_turn_sync_ensure(
         resolved_mask=inputs.resolved_mask,
         fleet_torp_overlay=fleet_resolution.overlay,
         fleet_torp_input_status=fleet_resolution.input_status,
-        prior_fleet_max_tech_by_axis=(
-            dict(fleet_resolution.max_tech_by_axis)
-            if fleet_resolution.input_status == "applied"
-            else None
-        ),
+        prior_fleet_max_tech_by_axis=fleet_resolution.prior_fleet_max_tech_for_admission(),
     )
     status = str(inference.get("status", ""))
     if services.persistence is not None and is_persistable_inference_status(status):
@@ -315,11 +311,7 @@ def _ensure_current_turn_scheduler(
         resolved_mask=inputs.resolved_mask,
         fleet_torp_overlay=fleet_resolution.overlay,
         fleet_torp_input_status=fleet_resolution.input_status,
-        prior_fleet_max_tech_by_axis=(
-            dict(fleet_resolution.max_tech_by_axis)
-            if fleet_resolution.input_status == "applied"
-            else None
-        ),
+        prior_fleet_max_tech_by_axis=fleet_resolution.prior_fleet_max_tech_for_admission(),
         export_services=ctx.export_services,
         stream_token=inputs.stream_token,
     )

--- a/packages/api/api/analytics/scores/inference.py
+++ b/packages/api/api/analytics/scores/inference.py
@@ -25,6 +25,7 @@ def get_scores_row_inference(
     resolved_mask: ResolvedHullCatalogMask | None = None,
     fleet_torp_overlay: FleetTorpOverlay | None = None,
     fleet_torp_input_status: FleetTorpInputStatus | None = None,
+    prior_fleet_max_tech_by_axis: dict[str, int] | None = None,
 ) -> dict[str, object]:
     """Run military score build inference for one scoreboard row."""
     score = next((row for row in turn.scores if row.ownerid == player_id), None)
@@ -48,5 +49,6 @@ def get_scores_row_inference(
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_torp_overlay,
             fleet_torp_input_status=fleet_torp_input_status,
+            prior_fleet_max_tech_by_axis=prior_fleet_max_tech_by_axis,
         )
     return {"playerId": player_id, **inference}

--- a/packages/api/api/analytics/scores/tier_row_run_registry.py
+++ b/packages/api/api/analytics/scores/tier_row_run_registry.py
@@ -50,6 +50,7 @@ def initialize_tier_ladder_state(
         run.ladder_state = orchestration.new_ladder_state(
             resolved_mask=session.resolved_mask,
             fleet_torp_overlay=session.fleet_torp_overlay,
+            prior_fleet_max_tech_by_axis=session.prior_fleet_max_tech_by_axis,
         )
         return
     policy_steps = tuple(resolve_tier_policies(None))
@@ -57,6 +58,7 @@ def initialize_tier_ladder_state(
         policy_steps=policy_steps,
         resolved_mask=session.resolved_mask,
         fleet_torp_overlay=session.fleet_torp_overlay,
+        prior_fleet_max_tech_by_axis=session.prior_fleet_max_tech_by_axis,
     )
 
 

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -201,6 +201,11 @@ class TurnAnalyticService:
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_resolution.overlay,
             fleet_torp_input_status=fleet_resolution.input_status,
+            prior_fleet_max_tech_by_axis=(
+                dict(fleet_resolution.max_tech_by_axis)
+                if fleet_resolution.input_status == "applied"
+                else None
+            ),
         )
 
     def iter_scores_table_inference_stream(

--- a/packages/api/api/services/turn_analytic_service.py
+++ b/packages/api/api/services/turn_analytic_service.py
@@ -201,11 +201,7 @@ class TurnAnalyticService:
             resolved_mask=resolved_mask,
             fleet_torp_overlay=fleet_resolution.overlay,
             fleet_torp_input_status=fleet_resolution.input_status,
-            prior_fleet_max_tech_by_axis=(
-                dict(fleet_resolution.max_tech_by_axis)
-                if fleet_resolution.input_status == "applied"
-                else None
-            ),
+            prior_fleet_max_tech_by_axis=fleet_resolution.prior_fleet_max_tech_for_admission(),
         )
 
     def iter_scores_table_inference_stream(

--- a/packages/api/tests/test_prior_fleet_tech_raise.py
+++ b/packages/api/tests/test_prior_fleet_tech_raise.py
@@ -1,0 +1,239 @@
+"""Tests for prior-fleet tech raise admission (#227)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from api.analytics.fleet.max_tech import (
+    max_tech_by_axis_from_fleet_records,
+    max_tech_in_turn_catalog,
+)
+from api.analytics.fleet.types import (
+    FleetFieldKnown,
+    FleetShipRecord,
+    FleetShipRecordFields,
+)
+from api.analytics.military_score_inference.component_eligibility import (
+    turn_catalog_context_for_policy_step,
+)
+from api.analytics.military_score_inference.prior_fleet_tech_raise import (
+    resolve_prior_fleet_tech_raise_plan,
+)
+from api.analytics.military_score_inference.tier_policy import (
+    ComponentFilter,
+    InferenceCatalogFilters,
+    InferenceTierPolicyStep,
+    resolve_tier_policies,
+)
+from api.models.components import Hull
+
+from tests.fixtures.military_score_inference import _observation
+
+
+def test_policy_loader_parses_raise_max_tech_from_prior_fleet():
+    steps = resolve_tier_policies()
+    early = steps[0]
+    assert early.filters.hulls.raise_max_tech_from_prior_fleet is True
+    assert early.filters.beams.raise_max_tech_from_prior_fleet is True
+    assert early.filters.launchers.raise_max_tech_from_prior_fleet is True
+    assert early.filters.engines.raise_max_tech_from_prior_fleet is False
+    assert early.filters.hulls.to_snapshot()["raiseMaxTechFromPriorFleet"] is True
+
+
+def test_policy_loader_rejects_raise_flag_with_all():
+    from api.analytics.military_score_inference.tier_policy import parse_tier_policy_steps
+
+    document = {
+        "steps": [
+            {
+                "id": "bad",
+                "filters": {
+                    "hulls": {"all": True, "raiseMaxTechFromPriorFleet": True},
+                    "engines": {"all": True},
+                    "beams": {"all": True},
+                    "launchers": {"all": True},
+                },
+                "alpha": 0,
+            }
+        ]
+    }
+    try:
+        parse_tier_policy_steps(document)
+    except ValueError as exc:
+        assert "raiseMaxTechFromPriorFleet requires techLevels" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def _hull_with_tech(base: Hull, *, hull_id: int, tech_level: int, name: str) -> Hull:
+    return replace(
+        base,
+        id=hull_id,
+        name=name,
+        techlevel=tech_level,
+    )
+
+
+def _turn_with_tech7_hull(sample_turn):
+    template = sample_turn.hulls[0]
+    tech7 = _hull_with_tech(template, hull_id=9007, tech_level=7, name="Tech7 Test Hull")
+    # Ensure player can build it: extend racehulls if present.
+    racehulls = list(getattr(sample_turn, "racehulls", []) or [])
+    if racehulls and 9007 not in racehulls:
+        # racehulls may be per-race structure; fall back to appending hull only.
+        pass
+    return replace(sample_turn, hulls=list(sample_turn.hulls) + [tech7])
+
+
+def test_max_tech_by_axis_from_fleet_records_hull_tech_7(sample_turn):
+    turn = _turn_with_tech7_hull(sample_turn)
+    records = [
+        FleetShipRecord(
+            record_id="resolute",
+            disposition="active",
+            fields=FleetShipRecordFields(hull=FleetFieldKnown(9007)),
+        )
+    ]
+    max_tech = max_tech_by_axis_from_fleet_records(records, turn)
+    assert max_tech["hulls"] == 7
+    assert "beams" not in max_tech
+
+
+def test_pending_fleet_max_tech_none_does_not_raise(sample_turn):
+    early = resolve_tier_policies()[0]
+    plan = resolve_prior_fleet_tech_raise_plan(
+        early,
+        turn=sample_turn,
+        prior_fleet_max_tech_by_axis=None,
+    )
+    assert plan is not None
+    assert plan.skipped is False
+    assert plan.policy_step.filters.hulls.tech_levels == early.filters.hulls.tech_levels
+
+
+def test_raise_hull_band_to_include_tech_7(sample_turn):
+    turn = _turn_with_tech7_hull(sample_turn)
+    # Keep beams/launchers catalog max above early YAML constants so only hull
+    # observation is in play (otherwise constant>=catalog saturation skips the step).
+    beam_template = turn.beams[0]
+    torp_template = turn.torpedos[0]
+    turn = replace(
+        turn,
+        beams=list(turn.beams)
+        + [replace(beam_template, id=9101, name="Tech10 Beam", techlevel=10)],
+        torpedos=list(turn.torpedos)
+        + [replace(torp_template, id=9102, name="Tech10 Torp", techlevel=10)],
+    )
+    racehulls = list(turn.racehulls)
+    if racehulls and 9007 not in racehulls:
+        turn = replace(turn, racehulls=racehulls + [9007])
+    observation = _observation(warship_delta=1, freighter_delta=1, starbases_owned=5)
+    early = resolve_tier_policies()[0]
+
+    unraised = turn_catalog_context_for_policy_step(turn, observation.player_id, early)
+    assert 9007 not in unraised.buildable_hull_ids
+
+    plan = resolve_prior_fleet_tech_raise_plan(
+        early,
+        turn=turn,
+        prior_fleet_max_tech_by_axis={"hulls": 7},
+    )
+    assert plan is not None
+    assert plan.skipped is False
+    assert max(plan.policy_step.filters.hulls.tech_levels) == 7
+    raised = turn_catalog_context_for_policy_step(turn, observation.player_id, plan.policy_step)
+    assert 9007 in raised.buildable_hull_ids
+    hull_diag = next(row for row in plan.axes if row["axis"] == "hulls")
+    assert hull_diag["configuredMaxTech"] == 6
+    assert hull_diag["observedMaxTech"] == 7
+    assert hull_diag["effectiveMaxTech"] == 7
+
+
+def test_skip_when_all_flagged_axes_saturate_catalog(sample_turn):
+    early = resolve_tier_policies()[0]
+    observed = {
+        "hulls": max_tech_in_turn_catalog(sample_turn, "hulls"),
+        "beams": max_tech_in_turn_catalog(sample_turn, "beams"),
+        "launchers": max_tech_in_turn_catalog(sample_turn, "launchers"),
+    }
+    plan = resolve_prior_fleet_tech_raise_plan(
+        early,
+        turn=sample_turn,
+        prior_fleet_max_tech_by_axis=observed,
+    )
+    assert plan is not None
+    assert plan.skipped is True
+    assert plan.to_diagnostics()["priorFleetTechRaise"]["skippedDueToPriorFleetTechSaturation"]
+
+
+def test_widen_hulls_does_not_skip_when_beams_launchers_saturate(sample_turn):
+    widen_hulls = next(step for step in resolve_tier_policies() if step.id == "widen_hulls")
+    observed = {
+        "beams": max_tech_in_turn_catalog(sample_turn, "beams"),
+        "launchers": max_tech_in_turn_catalog(sample_turn, "launchers"),
+    }
+    plan = resolve_prior_fleet_tech_raise_plan(
+        widen_hulls,
+        turn=sample_turn,
+        prior_fleet_max_tech_by_axis=observed,
+    )
+    assert plan is not None
+    assert plan.skipped is False
+    assert plan.policy_step.filters.hulls.all is True
+
+
+def test_consecutive_raised_steps_stay_monotonic(sample_turn):
+    step_a = InferenceTierPolicyStep(
+        id="a",
+        filters=InferenceCatalogFilters(
+            hulls=ComponentFilter(
+                tech_levels=(1, 2, 3, 4, 5, 6),
+                raise_max_tech_from_prior_fleet=True,
+            ),
+            engines=ComponentFilter(all=True),
+            beams=ComponentFilter(
+                tech_levels=(1, 2, 3, 4, 5),
+                raise_max_tech_from_prior_fleet=True,
+            ),
+            launchers=ComponentFilter(
+                tech_levels=(1, 2, 3, 4, 5),
+                raise_max_tech_from_prior_fleet=True,
+            ),
+        ),
+        beam_slot_counts="none",
+        launcher_slot_counts="none",
+        aggregate_allowlist={},
+        alpha=50,
+    )
+    step_b = replace(
+        step_a,
+        id="b",
+        filters=replace(
+            step_a.filters,
+            launchers=ComponentFilter(
+                tech_levels=(1, 2, 3, 4, 5, 6, 7, 8),
+                raise_max_tech_from_prior_fleet=True,
+            ),
+        ),
+    )
+    observed = {"hulls": 7, "beams": 5, "launchers": 6}
+    plan_a = resolve_prior_fleet_tech_raise_plan(
+        step_a,
+        turn=sample_turn,
+        prior_fleet_max_tech_by_axis=observed,
+    )
+    plan_b = resolve_prior_fleet_tech_raise_plan(
+        step_b,
+        turn=sample_turn,
+        prior_fleet_max_tech_by_axis=observed,
+    )
+    assert plan_a is not None and plan_b is not None
+    assert (
+        plan_a.policy_step.filters.hulls.tech_levels == plan_b.policy_step.filters.hulls.tech_levels
+    )
+    assert max(plan_a.policy_step.filters.hulls.tech_levels) == 7
+    assert max(plan_a.policy_step.filters.launchers.tech_levels) == 6
+    assert max(plan_b.policy_step.filters.launchers.tech_levels) == 8
+    assert set(plan_a.policy_step.filters.launchers.tech_levels) <= set(
+        plan_b.policy_step.filters.launchers.tech_levels
+    )

--- a/packages/api/tests/test_prior_fleet_tech_raise.py
+++ b/packages/api/tests/test_prior_fleet_tech_raise.py
@@ -16,6 +16,10 @@ from api.analytics.fleet.types import (
 from api.analytics.military_score_inference.component_eligibility import (
     turn_catalog_context_for_policy_step,
 )
+from api.analytics.military_score_inference.policy_ladder_state import PolicyLadderState
+from api.analytics.military_score_inference.policy_ladder_tier_step import (
+    run_policy_ladder_tier_step,
+)
 from api.analytics.military_score_inference.prior_fleet_tech_raise import (
     resolve_prior_fleet_tech_raise_plan,
 )
@@ -149,21 +153,142 @@ def test_raise_hull_band_to_include_tech_7(sample_turn):
     assert hull_diag["effectiveMaxTech"] == 7
 
 
-def test_skip_when_all_flagged_axes_saturate_catalog(sample_turn):
-    early = resolve_tier_policies()[0]
-    observed = {
+def _saturated_prior_fleet_max_tech(sample_turn) -> dict[str, int]:
+    return {
         "hulls": max_tech_in_turn_catalog(sample_turn, "hulls"),
         "beams": max_tech_in_turn_catalog(sample_turn, "beams"),
         "launchers": max_tech_in_turn_catalog(sample_turn, "launchers"),
     }
+
+
+def test_skip_when_all_flagged_axes_saturate_catalog(sample_turn):
+    early = resolve_tier_policies()[0]
     plan = resolve_prior_fleet_tech_raise_plan(
         early,
         turn=sample_turn,
-        prior_fleet_max_tech_by_axis=observed,
+        prior_fleet_max_tech_by_axis=_saturated_prior_fleet_max_tech(sample_turn),
     )
     assert plan is not None
     assert plan.skipped is True
     assert plan.to_diagnostics()["priorFleetTechRaise"]["skippedDueToPriorFleetTechSaturation"]
+
+
+def test_ladder_skips_early_step_when_prior_fleet_tech_saturates(
+    sample_turn,
+    monkeypatch,
+) -> None:
+    """Saturation skip must advance the ladder without invoking the solver."""
+    from api.analytics.military_score_inference.analytic import build_inference_observation
+
+    early = resolve_tier_policies()[0]
+    assert early.filters.hulls.raise_max_tech_from_prior_fleet is True
+    state = PolicyLadderState(
+        policy_steps=tuple(resolve_tier_policies()),
+        prior_fleet_max_tech_by_axis=_saturated_prior_fleet_max_tech(sample_turn),
+    )
+    observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+
+    def _solver_must_not_run(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("solver must not run when prior-fleet tech saturates")
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder_tier_step._solve_seed_progression",
+        _solver_must_not_run,
+    )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder_tier_step._solve_catalog",
+        _solver_must_not_run,
+    )
+
+    run_policy_ladder_tier_step(
+        state,
+        observation,
+        sample_turn,
+        time_limit_seconds=None,
+    )
+
+    assert early.id in state.policy_steps_attempted
+    assert state.next_step_index == 1
+    assert state.ladder_complete is False
+    assert len(state.step_diagnostics) == 1
+    diag = state.step_diagnostics[0]
+    assert diag["policyStepId"] == early.id
+    raise_diag = diag["priorFleetTechRaise"]
+    assert raise_diag["skippedDueToPriorFleetTechSaturation"] is True
+    axes = {row["axis"]: row for row in raise_diag["axes"]}
+    assert set(axes) == {"hulls", "beams", "launchers"}
+    assert all(row["saturated"] is True for row in axes.values())
+
+
+def test_ladder_does_not_skip_early_step_when_prior_fleet_pending(
+    sample_turn,
+    monkeypatch,
+) -> None:
+    """Pending prior-fleet max tech keeps the YAML band and still solves."""
+    from api.analytics.military_score_inference.analytic import build_inference_observation
+    from api.analytics.military_score_inference.models import InferenceResult
+    from api.analytics.military_score_inference.solver import STATUS_NO_EXACT_SOLUTION
+
+    early = resolve_tier_policies()[0]
+    state = PolicyLadderState(
+        policy_steps=tuple(resolve_tier_policies()),
+        prior_fleet_max_tech_by_axis=None,
+    )
+    observation = build_inference_observation(sample_turn.scores[0], sample_turn)
+    solve_calls: list[str] = []
+
+    def fake_solve_catalog(
+        _observation,
+        _catalog,
+        *,
+        race_id=None,
+        max_solutions,
+        time_limit_seconds,
+        military_score_alpha=0,
+        fixed_combo_counts=None,
+        combo_count_neighborhood=0,
+        cancel_token=None,
+        on_solution=None,
+    ):
+        del race_id, max_solutions, time_limit_seconds, military_score_alpha
+        del fixed_combo_counts, combo_count_neighborhood, cancel_token, on_solution
+        solve_calls.append(_catalog.policy_step_id)
+        from api.analytics.military_score_inference.actions import build_inference_problem
+
+        problem = build_inference_problem(_observation, _catalog, max_solutions=1)
+        return (
+            InferenceResult(
+                status=STATUS_NO_EXACT_SOLUTION,
+                solutions=(),
+                diagnostics={},
+            ),
+            problem,
+        )
+
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder_tier_step._solve_seed_progression",
+        lambda *args, **kwargs: (None, None),
+    )
+    monkeypatch.setattr(
+        "api.analytics.military_score_inference.policy_ladder_tier_step._solve_catalog",
+        fake_solve_catalog,
+    )
+
+    run_policy_ladder_tier_step(
+        state,
+        observation,
+        sample_turn,
+        time_limit_seconds=None,
+    )
+
+    assert early.id in state.policy_steps_attempted
+    assert early.id in solve_calls
+    assert state.next_step_index == 1
+    diag = state.step_diagnostics[0]
+    assert diag["policyStepId"] == early.id
+    raise_diag = diag["priorFleetTechRaise"]
+    assert raise_diag["skippedDueToPriorFleetTechSaturation"] is False
 
 
 def test_widen_hulls_does_not_skip_when_beams_launchers_saturate(sample_turn):

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -19,6 +19,7 @@ from api.analytics.fleet.types import (
     PersistedFleetLedger,
 )
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    PriorTurnFleetTorpResolution,
     resolve_prior_turn_fleet_torp_overlay,
     schedule_background_prior_turn_fleet_warm,
 )
@@ -26,6 +27,27 @@ from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import
 from tests.export_chain_test_fixtures import export_chain_query_context, seed_fleet_unwind_through
 from tests.fleet_chain_test_turns import HOST_TURN
 from tests.fleet_exports_helpers import host_turn_at
+
+
+def test_prior_fleet_max_tech_for_admission_applied_returns_copy():
+    resolution = PriorTurnFleetTorpResolution(
+        overlay=None,
+        input_status="applied",
+        max_tech_by_axis={"hulls": 7, "engines": 5},
+    )
+    admitted = resolution.prior_fleet_max_tech_for_admission()
+    assert admitted == {"hulls": 7, "engines": 5}
+    assert admitted is not resolution.max_tech_by_axis
+
+
+def test_prior_fleet_max_tech_for_admission_non_applied_returns_none():
+    for status in ("not_applicable", "pending", "unavailable"):
+        resolution = PriorTurnFleetTorpResolution(
+            overlay=None,
+            input_status=status,
+            max_tech_by_axis={"hulls": 7},
+        )
+        assert resolution.prior_fleet_max_tech_for_admission() is None
 
 
 def _host_turn_context(sample_turn, persistence, *, seed_player_ids: int | None = None):

--- a/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
+++ b/packages/api/tests/test_prior_turn_fleet_torp_overlay.py
@@ -66,6 +66,7 @@ def test_resolve_prior_turn_overlay_readonly_skips_query_when_unpersisted(sample
 
     assert resolution.overlay is None
     assert resolution.input_status == "pending"
+    assert resolution.max_tech_by_axis == {}
 
 
 def test_resolve_prior_turn_overlay_readonly_pending_on_partial_ledger(sample_turn, persistence):
@@ -189,6 +190,7 @@ def test_resolve_prior_turn_overlay_readonly_uses_persisted_snapshot(sample_turn
     assert resolution.overlay is not None
     assert resolution.overlay.belief_set.torp_ids == frozenset({4, 8})
     assert resolution.input_status == "applied"
+    assert isinstance(resolution.max_tech_by_axis, dict)
 
 
 def test_scores_tier_wire_applies_prior_fleet_dependency_output(sample_turn, persistence):


### PR DESCRIPTION
## Summary
- Raise early `techLevels` bands (`hulls` / `beams` / `launchers`) from prior-turn fleet max tech when `raiseMaxTechFromPriorFleet` is set and fleet input is applied (#227).
- Skip saturated constrained tiers (catalog-max rule) without solving; keep `widen_hulls` when hulls open to `all`.
- Share max-tech computation via `fleet/max_tech.py`, own admission on `PriorTurnFleetTorpResolution.prior_fleet_max_tech_for_admission()`, and cover plan + ladder skip with unit/integration tests.

Closes #227.

## Test plan
- [ ] `cd packages/api && uv run pytest tests/test_prior_fleet_tech_raise.py tests/test_prior_turn_fleet_torp_overlay.py -q`
- [ ] Confirm YAML flags on `early_game_bands` / `widen_launchers` / `collision_hull_widen` / `widen_hulls` parse and reject `raiseMaxTechFromPriorFleet` with `all: true`
- [ ] Scenario with prior-turn tech-7 hull (Resolute-style): early tier admits it without waiting for `widen_hulls` / twin widen
- [ ] Applied fleet that saturates catalog max: early step omitted; diagnostics include `priorFleetTechRaise.skippedDueToPriorFleetTechSaturation`
- [ ] Pending/unavailable prior fleet: YAML bands unchanged; step still solves


Made with [Cursor](https://cursor.com)