### PR TITLE
Fix scores/fleet ensure for mid-accelerated games

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,7 +177,7 @@ Idempotent producer step before materialization: bring one **analytic export** s
 _Avoid_: mutating query (vague), read-only export materializer, user visit order as prerequisite, sync CP-SAT inside scores ensure/materialize
 
 **Analytic export ensure baseline**:
-The point where an ensure-unwind chain stops without further **analytic export ensure dependencies**. **Analytic-specific:** e.g. **fleet** at turn 1 has no prior fleet (implicit empty composition); **scores** at turn 1 does not require **fleet** at turn 0 -- game-start neutral priors apply. **Storage floor:** if turn *T−1* is not stored for the **perspective**, probe reports `turn_not_stored` (root **unavailable**), not a neutral baseline -- distinct from authoritative empty export data at turn 1.
+The point where an ensure-unwind chain stops without further **analytic export ensure dependencies**. **Analytic-specific:** e.g. **fleet** at turn 1 has no prior fleet (implicit empty composition); **scores** at turn 1 does not require **fleet** at turn 0 -- game-start neutral priors apply. **Accelerated-start floor:** when `acceleratedturns = N` (`N > 0`) and the requesting scope is at or above **N**, turn **N** is the ensure/materialization baseline (deps on turns `1..N-1` are skipped). **Storage floor:** if a dependency turn at or above the ensure floor is not stored for the **perspective**, probe reports `turn_not_stored` (root **unavailable**), not a neutral baseline -- distinct from authoritative empty export data at turn 1 / accelerated turn N.
 _Avoid_: global turn-1 shortcut without per-analytic rules, silent fallback to ambient turn when a prior turn is missing
 
 **Analytic export ensure dependency**:

--- a/docs/design-analytic-exports.md
+++ b/docs/design-analytic-exports.md
@@ -190,7 +190,8 @@ Unwind stops when:
 
 1. **Already satisfied** -- step is persisted/terminal or in-flight with attachable state.
 2. **Analytic-specific baseline** -- e.g. **fleet** @ turn 1 has implicit empty composition; **scores** @ turn 1 has no **fleet** @ turn 0 (game-start neutral priors).
-3. **Storage floor** -- if turn *T−1* is not stored for the **perspective**, probe reports `turn_not_stored` (root **unavailable**), not a neutral baseline.
+3. **Accelerated-start floor** -- when `settings.acceleratedturns = N` (`N > 0`) and the requesting scope turn is **at or above N**, ensure unwind and fleet gap-fill treat turn **N** (first reliable scoreboard row) as the baseline. Dependencies on turns `1..N-1` are skipped (same as turn 0), even if those turns are stored, because scoreboard data there is unreliable and peer views are often missing while accelerated start is still open. Scopes below N still use the ordinary turn-1 baseline.
+4. **Storage floor** -- if a dependency turn *at or above* the ensure floor is not stored for the **perspective**, probe reports `turn_not_stored` (root **unavailable**), not a neutral baseline.
 
 ---
 

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -108,7 +108,7 @@ Display default: highest **inference solution rank weight** option set. Row expa
 
 ### 4.2 Inferred row placeholders
 
-When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement queries **scores** at the scoreboard turn for each placeholder `builtTurn` and applies top-level **`$.solutions`** only (no reads of **`$.diagnostics`**). On the first reliable accelerated shell turn, `builtTurn < shellTurn` placeholders resolve from backfill rows (`scores@(builtTurn + 1)`); same-turn placeholders use `scores@shellTurn`. Placeholder metadata (targets, homeworld baselines, accelerated-shell gating) is consumed via `api.analytics.scores.placeholder_targets`.
+When scoreboard shows `+2 warship` and inference is `in_progress` with 0 solutions: create **two** inferred rows with unknown specs. Refine as solutions stream in. Fleet refinement queries **scores** at the scoreboard turn for each placeholder `builtTurn` and applies top-level **`$.solutions`** only (no reads of **`$.diagnostics`**). On the first reliable accelerated shell turn, `builtTurn < shellTurn` placeholders resolve from backfill rows (`scores@(builtTurn + 1)`); same-turn placeholders use `scores@shellTurn`. When `scores@(builtTurn + 1)` is **not stored** (common while accelerated start is still open), refine loads the matching **`hostTurnTargets`** entry from the first reliable row (`scores@N`) instead. Placeholder metadata (targets, homeworld baselines, accelerated-shell gating) is consumed via `api.analytics.scores.placeholder_targets`.
 
 ### 4.3 Observation-inference merge
 

--- a/packages/api/api/analytics/export_dependency_walk.py
+++ b/packages/api/api/analytics/export_dependency_walk.py
@@ -24,9 +24,6 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 K = TypeVar("K")
 
-# Accelerated-start ensure floor applies only to the scores/fleet dependency pair.
-_ACCELERATED_ENSURE_ANALYTICS = frozenset({"scores", "fleet"})
-
 
 def _settings_for_ensure_scope(
     ctx: AnalyticQueryContext,
@@ -41,16 +38,12 @@ def _settings_for_ensure_scope(
 def ensure_dependency_turn_floor(
     ctx: AnalyticQueryContext,
     scope: ExportScope,
-    *,
-    analytic_id: str,
-    dependency_analytic_id: str,
 ) -> int:
-    """Return the ensure floor for one dependency edge (1, or accelerated N)."""
-    if (
-        analytic_id not in _ACCELERATED_ENSURE_ANALYTICS
-        or dependency_analytic_id not in _ACCELERATED_ENSURE_ANALYTICS
-    ):
-        return 1
+    """Return the ensure floor for dependency edges (1, or accelerated N).
+
+    Floor is a game-domain rule from settings + requesting scope turn -- not
+    gated by analytic id.
+    """
     settings = _settings_for_ensure_scope(ctx, scope)
     if settings is None:
         return 1
@@ -94,12 +87,7 @@ def walk_dependency_tree(
 
         for dependency in catalog.ensure_dependencies:
             dependency_scope = dependency_scope_for(scope, dependency)
-            turn_floor = ensure_dependency_turn_floor(
-                ctx,
-                scope,
-                analytic_id=analytic_id,
-                dependency_analytic_id=dependency.analytic_id,
-            )
+            turn_floor = ensure_dependency_turn_floor(ctx, scope)
             if dependency_scope.turn < turn_floor:
                 continue
 

--- a/packages/api/api/analytics/export_dependency_walk.py
+++ b/packages/api/api/analytics/export_dependency_walk.py
@@ -15,12 +15,46 @@ from api.analytics.export_types import (
 )
 from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.ensure_validation import validate_ensure_dependency_target
+from api.concepts.accelerated_scoreboard import export_ensure_turn_floor
+from api.models.game import GameSettings
 
 if TYPE_CHECKING:
     from api.analytics.export_context import AnalyticQueryContext
 
 T = TypeVar("T")
 K = TypeVar("K")
+
+# Accelerated-start ensure floor applies only to the scores/fleet dependency pair.
+_ACCELERATED_ENSURE_ANALYTICS = frozenset({"scores", "fleet"})
+
+
+def _settings_for_ensure_scope(
+    ctx: AnalyticQueryContext,
+    scope: ExportScope,
+) -> GameSettings | None:
+    turn = ctx.load_turn(scope.turn)
+    if turn is None:
+        turn = ctx.load_turn(ctx.ambient_turn)
+    return turn.settings if turn is not None else None
+
+
+def ensure_dependency_turn_floor(
+    ctx: AnalyticQueryContext,
+    scope: ExportScope,
+    *,
+    analytic_id: str,
+    dependency_analytic_id: str,
+) -> int:
+    """Return the ensure floor for one dependency edge (1, or accelerated N)."""
+    if (
+        analytic_id not in _ACCELERATED_ENSURE_ANALYTICS
+        or dependency_analytic_id not in _ACCELERATED_ENSURE_ANALYTICS
+    ):
+        return 1
+    settings = _settings_for_ensure_scope(ctx, scope)
+    if settings is None:
+        return 1
+    return export_ensure_turn_floor(settings, scope_turn=scope.turn)
 
 
 @dataclass
@@ -60,7 +94,13 @@ def walk_dependency_tree(
 
         for dependency in catalog.ensure_dependencies:
             dependency_scope = dependency_scope_for(scope, dependency)
-            if dependency_scope.turn < 1:
+            turn_floor = ensure_dependency_turn_floor(
+                ctx,
+                scope,
+                analytic_id=analytic_id,
+                dependency_analytic_id=dependency.analytic_id,
+            )
+            if dependency_scope.turn < turn_floor:
                 continue
 
             if ctx.load_turn(dependency_scope.turn) is None:
@@ -170,6 +210,7 @@ def _is_at_baseline(
     scope: ExportScope,
     catalog: AnalyticExportCatalog,
 ) -> bool:
+    """Game-start baseline only (turn 1). Accelerated floor N still needs ensure work."""
     if scope.turn <= 1 and not catalog.ensure_dependencies:
         return True
     if scope.turn <= 1:

--- a/packages/api/api/analytics/export_dependency_walk.py
+++ b/packages/api/api/analytics/export_dependency_walk.py
@@ -15,7 +15,7 @@ from api.analytics.export_types import (
 )
 from api.analytics.exports.catalog import AnalyticExportCatalog
 from api.analytics.exports.ensure_validation import validate_ensure_dependency_target
-from api.concepts.accelerated_scoreboard import export_ensure_turn_floor
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.models.game import GameSettings
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ def ensure_dependency_turn_floor(
     settings = _settings_for_ensure_scope(ctx, scope)
     if settings is None:
         return 1
-    return export_ensure_turn_floor(settings, scope_turn=scope.turn)
+    return accelerated_ensure_floor(settings, scope.turn)
 
 
 @dataclass

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -274,6 +274,17 @@ def _roster_player_ids(turn: TurnInfo) -> list[int]:
     return [player.id for player in iter_turn_players(turn)]
 
 
+def _chain_floor(
+    load_turn: Callable[[int], TurnInfo | None],
+    target_turn: int,
+) -> int:
+    """Lowest turn fleet gap-fill may require when targeting ``target_turn``."""
+    target_info = load_turn(target_turn)
+    if target_info is None:
+        return 1
+    return accelerated_ensure_floor(target_info.settings, target_turn)
+
+
 def _find_gap_start_turn(
     persistence: FleetSnapshotPersistenceService,
     game_id: int,
@@ -282,12 +293,7 @@ def _find_gap_start_turn(
     load_turn: Callable[[int], TurnInfo | None],
 ) -> int:
     """Return the first turn in ``floor..target_turn`` lacking an ensure-final snapshot."""
-    target_info = load_turn(target_turn)
-    chain_floor = (
-        accelerated_ensure_floor(target_info.settings, target_turn)
-        if target_info is not None
-        else 1
-    )
+    chain_floor = _chain_floor(load_turn, target_turn)
     for turn_number in range(chain_floor, target_turn + 1):
         turn_info = load_turn(turn_number)
         if turn_info is None:
@@ -314,12 +320,7 @@ def _find_gap_start_turn_for_player(
     load_turn: Callable[[int], TurnInfo | None],
 ) -> int:
     """Return the first turn in ``floor..target_turn`` lacking ensure-final ledger for P."""
-    target_info = load_turn(target_turn)
-    chain_floor = (
-        accelerated_ensure_floor(target_info.settings, target_turn)
-        if target_info is not None
-        else 1
-    )
+    chain_floor = _chain_floor(load_turn, target_turn)
     for turn_number in range(chain_floor, target_turn + 1):
         if load_turn(turn_number) is None:
             continue

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -26,6 +26,7 @@ from api.analytics.fleet.types import (
     PersistedFleetLedger,
 )
 from api.analytics.turn_roster import iter_turn_players
+from api.concepts.accelerated_scoreboard import fleet_chain_start_floor
 from api.errors import ConflictError, NotFoundError, ValidationError
 from api.models.game import TurnInfo
 
@@ -241,8 +242,10 @@ def _find_chain_anchor_for_player(
     perspective: int,
     player_id: int,
     turn_number: int,
+    *,
+    min_anchor_turn: int = 1,
 ) -> tuple[int, PersistedFleetLedger | None]:
-    for prior_turn_number in range(turn_number - 1, 0, -1):
+    for prior_turn_number in range(turn_number - 1, min_anchor_turn - 1, -1):
         prior_ledger = persistence.get_ledger(
             game_id,
             perspective,
@@ -257,9 +260,11 @@ def _find_chain_anchor_for_player(
 def _first_stored_rst_turn(
     load_turn: Callable[[int], TurnInfo | None],
     turn_number: int,
+    *,
+    min_turn: int = 1,
 ) -> int | None:
-    """Return the lowest stored RST turn in ``1..turn_number``, if any."""
-    for stored_turn_number in range(1, turn_number + 1):
+    """Return the lowest stored RST turn in ``min_turn..turn_number``, if any."""
+    for stored_turn_number in range(min_turn, turn_number + 1):
         if load_turn(stored_turn_number) is not None:
             return stored_turn_number
     return None
@@ -276,8 +281,14 @@ def _find_gap_start_turn(
     target_turn: int,
     load_turn: Callable[[int], TurnInfo | None],
 ) -> int:
-    """Return the first turn in ``1..target_turn`` lacking an ensure-final snapshot."""
-    for turn_number in range(1, target_turn + 1):
+    """Return the first turn in ``floor..target_turn`` lacking an ensure-final snapshot."""
+    target_info = load_turn(target_turn)
+    chain_floor = (
+        fleet_chain_start_floor(target_turn, target_info.settings)
+        if target_info is not None
+        else 1
+    )
+    for turn_number in range(chain_floor, target_turn + 1):
         turn_info = load_turn(turn_number)
         if turn_info is None:
             continue
@@ -302,8 +313,14 @@ def _find_gap_start_turn_for_player(
     target_turn: int,
     load_turn: Callable[[int], TurnInfo | None],
 ) -> int:
-    """Return the first turn in ``1..target_turn`` lacking ensure-final ledger for P."""
-    for turn_number in range(1, target_turn + 1):
+    """Return the first turn in ``floor..target_turn`` lacking ensure-final ledger for P."""
+    target_info = load_turn(target_turn)
+    chain_floor = (
+        fleet_chain_start_floor(target_turn, target_info.settings)
+        if target_info is not None
+        else 1
+    )
+    for turn_number in range(chain_floor, target_turn + 1):
         if load_turn(turn_number) is None:
             continue
         if not persistence.has_final_ledger(game_id, perspective, turn_number, player_id):
@@ -446,11 +463,13 @@ def _materialize_fleet_ledger_chain_for_player(
             turn_context_cache[materialize_turn] = FleetTurnContext.from_turn(turn_info)
         return turn_context_cache[materialize_turn]
 
-    def require_prior_rst(materialize_turn: int, *, allow_missing_prefix_rst: bool) -> None:
-        if materialize_turn <= 1:
+    chain_floor = fleet_chain_start_floor(turn_number, turn.settings)
+
+    def require_prior_rst(materialize_turn: int, *, allow_missing_prior_rst: bool) -> None:
+        if materialize_turn <= chain_floor:
             return
         prior_turn_number = materialize_turn - 1
-        if allow_missing_prefix_rst:
+        if allow_missing_prior_rst:
             return
         if cached_load(prior_turn_number) is None:
             raise NotFoundError(
@@ -464,15 +483,20 @@ def _materialize_fleet_ledger_chain_for_player(
         perspective,
         player_id,
         turn_number,
+        min_anchor_turn=chain_floor,
     )
-    first_stored_rst = _first_stored_rst_turn(cached_load, turn_number)
+    first_stored_rst = _first_stored_rst_turn(
+        cached_load,
+        turn_number,
+        min_turn=chain_floor,
+    )
     skip_missing_prefix_rst = (
         anchor_turn == 0
-        and turn_number > 1
+        and turn_number > chain_floor
         and first_stored_rst is not None
-        and first_stored_rst > 1
+        and first_stored_rst > chain_floor
     )
-    start_turn = anchor_turn + 1
+    start_turn = anchor_turn + 1 if anchor_turn >= chain_floor else chain_floor
     current_ledger = anchor_persisted.ledger if anchor_persisted is not None else None
     current_persisted = anchor_persisted
 
@@ -499,36 +523,36 @@ def _materialize_fleet_ledger_chain_for_player(
         )
         current_persisted = None
     elif anchor_turn == 0:
-        turn_one = require_turn(1)
+        baseline_turn = require_turn(chain_floor)
         current_persisted = _materialize_and_persist_player_turn(
             coherence,
-            materialize_turn=1,
+            materialize_turn=chain_floor,
             player_id=player_id,
             prior_persisted=None,
             prior_ledger=ensure_fleet_baseline_for_player(
                 game_id,
                 perspective,
-                turn_one,
+                baseline_turn,
                 player_id,
             ),
-            turn_info=turn_one,
-            turn_context=cached_turn_context_for(1, turn_one),
+            turn_info=baseline_turn,
+            turn_context=cached_turn_context_for(chain_floor, baseline_turn),
             game_id=game_id,
             perspective=perspective,
             load_turn=cached_load,
             inference_materialization=resolved_inference_materialization,
         )
-        emit_leg_progress(current_persisted, 1)
-        if turn_number == 1:
+        emit_leg_progress(current_persisted, chain_floor)
+        if turn_number == chain_floor:
             return current_persisted
-        start_turn = 2
+        start_turn = chain_floor + 1
 
     assert current_ledger is not None
 
     for materialize_turn in range(start_turn, turn_number + 1):
         require_prior_rst(
             materialize_turn,
-            allow_missing_prefix_rst=skip_missing_prefix_rst and materialize_turn == start_turn,
+            allow_missing_prior_rst=skip_missing_prefix_rst and materialize_turn == start_turn,
         )
         turn_info = require_turn(materialize_turn)
         current_persisted = _materialize_and_persist_player_turn(

--- a/packages/api/api/analytics/fleet/chain.py
+++ b/packages/api/api/analytics/fleet/chain.py
@@ -26,7 +26,7 @@ from api.analytics.fleet.types import (
     PersistedFleetLedger,
 )
 from api.analytics.turn_roster import iter_turn_players
-from api.concepts.accelerated_scoreboard import fleet_chain_start_floor
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.errors import ConflictError, NotFoundError, ValidationError
 from api.models.game import TurnInfo
 
@@ -284,7 +284,7 @@ def _find_gap_start_turn(
     """Return the first turn in ``floor..target_turn`` lacking an ensure-final snapshot."""
     target_info = load_turn(target_turn)
     chain_floor = (
-        fleet_chain_start_floor(target_turn, target_info.settings)
+        accelerated_ensure_floor(target_info.settings, target_turn)
         if target_info is not None
         else 1
     )
@@ -316,7 +316,7 @@ def _find_gap_start_turn_for_player(
     """Return the first turn in ``floor..target_turn`` lacking ensure-final ledger for P."""
     target_info = load_turn(target_turn)
     chain_floor = (
-        fleet_chain_start_floor(target_turn, target_info.settings)
+        accelerated_ensure_floor(target_info.settings, target_turn)
         if target_info is not None
         else 1
     )
@@ -463,7 +463,7 @@ def _materialize_fleet_ledger_chain_for_player(
             turn_context_cache[materialize_turn] = FleetTurnContext.from_turn(turn_info)
         return turn_context_cache[materialize_turn]
 
-    chain_floor = fleet_chain_start_floor(turn_number, turn.settings)
+    chain_floor = accelerated_ensure_floor(turn.settings, turn_number)
 
     def require_prior_rst(materialize_turn: int, *, allow_missing_prior_rst: bool) -> None:
         if materialize_turn <= chain_floor:

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -21,7 +21,7 @@ from api.compute.scope import (
     compute_scope_to_export_scope,
 )
 from api.compute.wire import DependencyOutputs
-from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.models.game import GameSettings
 from api.serialization.turn import turn_info_to_json
 
@@ -47,7 +47,7 @@ def _fleet_prior_scope(
 ) -> ComputeScope | None:
     if scope.turn == WILDCARD or not isinstance(scope.turn, int):
         return None
-    if settings is not None and is_export_ensure_baseline_turn(scope.turn, settings):
+    if settings is not None and scope.turn == accelerated_ensure_floor(settings, scope.turn):
         return None
     if scope.turn <= 1:
         return None

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -21,6 +21,8 @@ from api.compute.scope import (
     compute_scope_to_export_scope,
 )
 from api.compute.wire import DependencyOutputs
+from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
+from api.models.game import GameSettings
 from api.serialization.turn import turn_info_to_json
 
 FLEET_MATERIALIZATION_LEG = "materialization_leg"
@@ -38,8 +40,14 @@ FLEET_COMPUTE_PROFILE = AnalyticComputeProfile(
 )
 
 
-def _fleet_prior_scope(scope: ComputeScope) -> ComputeScope | None:
+def _fleet_prior_scope(
+    scope: ComputeScope,
+    *,
+    settings: GameSettings | None = None,
+) -> ComputeScope | None:
     if scope.turn == WILDCARD or not isinstance(scope.turn, int):
+        return None
+    if settings is not None and is_export_ensure_baseline_turn(scope.turn, settings):
         return None
     if scope.turn <= 1:
         return None
@@ -85,7 +93,7 @@ def build_fleet_materialization_leg_job_wire(
 
     player_id = scope.player_id
     services = resolve_fleet_services(ctx)
-    prior_scope = _fleet_prior_scope(scope)
+    prior_scope = _fleet_prior_scope(scope, settings=turn.settings)
     prior_persisted: PersistedFleetLedger | None = None
     if prior_scope is not None:
         prior_wire = dependency_outputs.get(prior_scope)
@@ -233,7 +241,7 @@ class FleetPersistencePolicy:
                 inference_materialization=services.inference_materialization,
             )
             turn_context = FleetTurnContext.from_turn(turn)
-            prior_scope = _fleet_prior_scope(scope)
+            prior_scope = _fleet_prior_scope(scope, settings=turn.settings)
             prior_persisted = None
             if prior_scope is not None:
                 prior_ledger = services.persistence.get_ledger(

--- a/packages/api/api/analytics/fleet/compute_orchestration.py
+++ b/packages/api/api/analytics/fleet/compute_orchestration.py
@@ -43,13 +43,11 @@ FLEET_COMPUTE_PROFILE = AnalyticComputeProfile(
 def _fleet_prior_scope(
     scope: ComputeScope,
     *,
-    settings: GameSettings | None = None,
+    settings: GameSettings,
 ) -> ComputeScope | None:
     if scope.turn == WILDCARD or not isinstance(scope.turn, int):
         return None
-    if settings is not None and scope.turn == accelerated_ensure_floor(settings, scope.turn):
-        return None
-    if scope.turn <= 1:
+    if scope.turn <= accelerated_ensure_floor(settings, scope.turn):
         return None
     return ComputeScope(
         analytic_id=scope.analytic_id,

--- a/packages/api/api/analytics/fleet/held_solutions.py
+++ b/packages/api/api/analytics/fleet/held_solutions.py
@@ -11,7 +11,10 @@ from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.scores.export_precedence import SearchStatus
 from api.analytics.scores.export_services import ScoresExportContext
 from api.analytics.scores.exports import held_scores_for_scope
-from api.analytics.scores.host_turn_export import scores_scoreboard_turn_for_placeholder_refine
+from api.analytics.scores.host_turn_export import (
+    resolve_accelerated_backfill_payload_when_scoreboard_turn_missing,
+    scores_scoreboard_turn_for_placeholder_refine,
+)
 from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
 from api.models.game import TurnInfo
 
@@ -52,26 +55,42 @@ class FleetInferenceSupport:
             return FleetHeldInference(search_status="not_started", solutions=())
 
         query_turn = load_turn(scoreboard_turn)
-        if query_turn is None:
-            return FleetHeldInference(search_status="not_started", solutions=())
+        if query_turn is not None:
+            ctx = make_analytic_query_context(
+                turn,
+                TurnAnalyticsOptions(),
+                load_turn=load_turn,
+                export_services={SCORES_ANALYTIC_ID: self.scores_services},
+            )
+            scope = ExportScope(
+                game_id=game_id,
+                perspective=perspective,
+                turn=scoreboard_turn,
+                player_id=player_id,
+            )
+            resolved = held_scores_for_scope(ctx, scope, turn=query_turn)
+            payload = resolved.payload
+            return FleetHeldInference(
+                search_status=resolved.decision.search_status,
+                solutions=tuple(payload.solutions),
+            )
 
-        ctx = make_analytic_query_context(
-            turn,
-            TurnAnalyticsOptions(),
-            load_turn=load_turn,
-            export_services={SCORES_ANALYTIC_ID: self.scores_services},
-        )
-        scope = ExportScope(
-            game_id=game_id,
-            perspective=perspective,
-            turn=scoreboard_turn,
+        persistence = self.scores_services.persistence
+
+        def get_persisted_row(row_turn: int, row_player_id: int):
+            return persistence.get_row(game_id, perspective, row_turn, row_player_id)
+
+        backfill = resolve_accelerated_backfill_payload_when_scoreboard_turn_missing(
+            scoreboard_turn=scoreboard_turn,
+            settings=turn.settings,
+            get_persisted_row=get_persisted_row,
             player_id=player_id,
         )
-        resolved = held_scores_for_scope(ctx, scope, turn=query_turn)
-        payload = resolved.payload
+        if backfill is None:
+            return FleetHeldInference(search_status="not_started", solutions=())
         return FleetHeldInference(
-            search_status=resolved.decision.search_status,
-            solutions=tuple(payload.solutions),
+            search_status=backfill.search_status,
+            solutions=tuple(backfill.solutions),
         )
 
     def held_inference_for_placeholder(

--- a/packages/api/api/analytics/fleet/held_solutions.py
+++ b/packages/api/api/analytics/fleet/held_solutions.py
@@ -12,7 +12,7 @@ from api.analytics.scores.export_precedence import SearchStatus
 from api.analytics.scores.export_services import ScoresExportContext
 from api.analytics.scores.exports import held_scores_for_scope
 from api.analytics.scores.host_turn_export import (
-    resolve_accelerated_backfill_payload_when_scoreboard_turn_missing,
+    accelerated_backfill_host_turn_payload,
     scores_scoreboard_turn_for_placeholder_refine,
 )
 from api.analytics.scores_assets import ANALYTIC_ID as SCORES_ANALYTIC_ID
@@ -80,7 +80,7 @@ class FleetInferenceSupport:
         def get_persisted_row(row_turn: int, row_player_id: int):
             return persistence.get_row(game_id, perspective, row_turn, row_player_id)
 
-        backfill = resolve_accelerated_backfill_payload_when_scoreboard_turn_missing(
+        backfill = accelerated_backfill_host_turn_payload(
             scoreboard_turn=scoreboard_turn,
             settings=turn.settings,
             get_persisted_row=get_persisted_row,

--- a/packages/api/api/analytics/fleet/materialization_provenance.py
+++ b/packages/api/api/analytics/fleet/materialization_provenance.py
@@ -19,6 +19,7 @@ from api.analytics.scores.export_precedence import (
 from api.analytics.scores.export_snapshot import (
     gather_scores_materialization_probe_snapshot,
 )
+from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
 from api.models.game import TurnInfo
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 
@@ -43,9 +44,10 @@ def resolve_fleet_materialization_provenance(
     terminal ``scores@N`` evidence for this player (not merely an ensure-admitted
     in-progress ``RowRun``); ingest and sightings are not re-verified here.
     """
-    prior_ledger_at_n_minus_1 = materialize_turn == 1 or (
-        prior_persisted is not None and prior_persisted.provenance.is_final
-    )
+    prior_ledger_at_n_minus_1 = is_export_ensure_baseline_turn(
+        materialize_turn,
+        turn_context.turn.settings,
+    ) or (prior_persisted is not None and prior_persisted.provenance.is_final)
     turn_evidence_at_n = _is_turn_evidence_closed(
         materialize_turn=materialize_turn,
         turn_context=turn_context,

--- a/packages/api/api/analytics/fleet/materialization_provenance.py
+++ b/packages/api/api/analytics/fleet/materialization_provenance.py
@@ -19,7 +19,7 @@ from api.analytics.scores.export_precedence import (
 from api.analytics.scores.export_snapshot import (
     gather_scores_materialization_probe_snapshot,
 )
-from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.models.game import TurnInfo
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 
@@ -44,9 +44,9 @@ def resolve_fleet_materialization_provenance(
     terminal ``scores@N`` evidence for this player (not merely an ensure-admitted
     in-progress ``RowRun``); ingest and sightings are not re-verified here.
     """
-    prior_ledger_at_n_minus_1 = is_export_ensure_baseline_turn(
-        materialize_turn,
-        turn_context.turn.settings,
+    prior_ledger_at_n_minus_1 = (
+        materialize_turn
+        == accelerated_ensure_floor(turn_context.turn.settings, materialize_turn)
     ) or (prior_persisted is not None and prior_persisted.provenance.is_final)
     turn_evidence_at_n = _is_turn_evidence_closed(
         materialize_turn=materialize_turn,

--- a/packages/api/api/analytics/fleet/materialization_provenance.py
+++ b/packages/api/api/analytics/fleet/materialization_provenance.py
@@ -45,8 +45,7 @@ def resolve_fleet_materialization_provenance(
     in-progress ``RowRun``); ingest and sightings are not re-verified here.
     """
     prior_ledger_at_n_minus_1 = (
-        materialize_turn
-        == accelerated_ensure_floor(turn_context.turn.settings, materialize_turn)
+        materialize_turn == accelerated_ensure_floor(turn_context.turn.settings, materialize_turn)
     ) or (prior_persisted is not None and prior_persisted.provenance.is_final)
     turn_evidence_at_n = _is_turn_evidence_closed(
         materialize_turn=materialize_turn,

--- a/packages/api/api/analytics/military_score_inference/accelerated_start.py
+++ b/packages/api/api/analytics/military_score_inference/accelerated_start.py
@@ -27,6 +27,12 @@ from api.analytics.military_score_inference.scoring import (
     starbase_defense_post_score_delta_2x,
     starbase_fighter_score_delta_2x,
 )
+from api.concepts.accelerated_scoreboard import (
+    accelerated_turn_count,  # noqa: F401
+    first_reliable_accelerated_scoreboard_turn,  # noqa: F401
+    is_first_reliable_scoreboard_turn,
+    is_unreliable_accelerated_scoreboard_turn,
+)
 from api.models.game import GameSettings, TurnInfo
 from api.models.player import Score
 
@@ -88,29 +94,6 @@ class AcceleratedWindowShipBuilds:
     warships_built_before_reported_host_turn: int
     freighters_built_on_reported_host_turn: int
     warships_built_on_reported_host_turn: int
-
-
-def accelerated_turn_count(settings: GameSettings) -> int:
-    """Return N when accelerated start is enabled, else 0."""
-    return max(0, settings.acceleratedturns)
-
-
-def is_unreliable_accelerated_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:
-    """Return whether persisted scoreboard rows omit reliable totals on this turn."""
-    accelerated = accelerated_turn_count(settings)
-    return accelerated > 0 and 1 <= turn_number < accelerated
-
-
-def is_first_reliable_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:
-    """Return whether this is the first host turn with a filled-in scoreboard row."""
-    accelerated = accelerated_turn_count(settings)
-    return accelerated > 0 and turn_number == accelerated
-
-
-def first_reliable_accelerated_scoreboard_turn(settings: GameSettings) -> int | None:
-    """Scoreboard turn that runs the accelerated split solve, when accelerated start is enabled."""
-    accelerated = accelerated_turn_count(settings)
-    return accelerated if accelerated > 0 else None
 
 
 def scoreboard_host_turn(scoreboard_turn: int) -> int | None:

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -17,7 +17,7 @@ from api.analytics.military_score_inference.fleet_torp_overlay import (
     launcher_belief_set_from_fleet_records,
 )
 from api.analytics.options import TurnAnalyticsOptions
-from api.concepts.accelerated_scoreboard import fleet_chain_start_floor
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.models.game import TurnInfo
 
 if TYPE_CHECKING:
@@ -250,7 +250,7 @@ def resolve_prior_turn_fleet_torp_overlay(
     """
     host_turn = turn.settings.turn
     prior_turn = host_turn - 1
-    if prior_turn < fleet_chain_start_floor(host_turn, turn.settings):
+    if prior_turn < accelerated_ensure_floor(turn.settings, host_turn):
         return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
 
     fleet_services = _resolve_fleet_services(
@@ -295,7 +295,7 @@ def schedule_background_prior_turn_fleet_warm(
     """Kick off non-blocking per-player materialization of fleet@(host_turn - 1)."""
     host_turn = turn.settings.turn
     prior_turn = host_turn - 1
-    if prior_turn < fleet_chain_start_floor(host_turn, turn.settings) or not player_ids:
+    if prior_turn < accelerated_ensure_floor(turn.settings, host_turn) or not player_ids:
         return
 
     fleet_services = _resolve_fleet_services(

--- a/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
+++ b/packages/api/api/analytics/military_score_inference/prior_turn_fleet_torp_overlay.py
@@ -17,6 +17,7 @@ from api.analytics.military_score_inference.fleet_torp_overlay import (
     launcher_belief_set_from_fleet_records,
 )
 from api.analytics.options import TurnAnalyticsOptions
+from api.concepts.accelerated_scoreboard import fleet_chain_start_floor
 from api.models.game import TurnInfo
 
 if TYPE_CHECKING:
@@ -248,7 +249,8 @@ def resolve_prior_turn_fleet_torp_overlay(
     run export ensure (for inference table-stream scheduling).
     """
     host_turn = turn.settings.turn
-    if host_turn <= 1:
+    prior_turn = host_turn - 1
+    if prior_turn < fleet_chain_start_floor(host_turn, turn.settings):
         return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
 
     fleet_services = _resolve_fleet_services(
@@ -258,7 +260,6 @@ def resolve_prior_turn_fleet_torp_overlay(
     if fleet_services is None:
         return PriorTurnFleetTorpResolution(overlay=None, input_status="unavailable")
 
-    prior_turn = host_turn - 1
     prior_turn_info = load_turn(prior_turn)
     if prior_turn_info is None:
         return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
@@ -293,7 +294,8 @@ def schedule_background_prior_turn_fleet_warm(
 ) -> None:
     """Kick off non-blocking per-player materialization of fleet@(host_turn - 1)."""
     host_turn = turn.settings.turn
-    if host_turn <= 1 or not player_ids:
+    prior_turn = host_turn - 1
+    if prior_turn < fleet_chain_start_floor(host_turn, turn.settings) or not player_ids:
         return
 
     fleet_services = _resolve_fleet_services(
@@ -303,7 +305,6 @@ def schedule_background_prior_turn_fleet_warm(
     if fleet_services is None:
         return
 
-    prior_turn = host_turn - 1
     prior_turn_info = load_turn(prior_turn)
     if prior_turn_info is None:
         return

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -58,15 +58,13 @@ _PERSISTABLE_ROW_STATUSES = frozenset({STATUS_EXACT, STATUS_NO_EXACT_SOLUTION})
 def _scores_prior_fleet_scope(
     scope: ComputeScope,
     *,
-    settings: GameSettings | None = None,
+    settings: GameSettings,
 ) -> ComputeScope | None:
     if scope.turn == WILDCARD or not isinstance(scope.turn, int):
         return None
     if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
         return None
-    if settings is not None and scope.turn == accelerated_ensure_floor(settings, scope.turn):
-        return None
-    if scope.turn <= 1:
+    if scope.turn <= accelerated_ensure_floor(settings, scope.turn):
         return None
     return ComputeScope(
         analytic_id=FLEET_ANALYTIC_ID,

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -36,6 +36,8 @@ from api.analytics.scores.tier_row_run_registry import (
 from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import WILDCARD, ComputeScope, ScopeKeySpec, compute_scope_to_export_scope
 from api.compute.wire import DependencyOutputs, StepResult
+from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
+from api.models.game import GameSettings
 
 SCORES_MATERIALIZE = "materialize"
 SCORES_TIER_SOLVE = "tier_solve"
@@ -53,12 +55,18 @@ SCORES_COMPUTE_PROFILE = AnalyticComputeProfile(
 _PERSISTABLE_ROW_STATUSES = frozenset({STATUS_EXACT, STATUS_NO_EXACT_SOLUTION})
 
 
-def _scores_prior_fleet_scope(scope: ComputeScope) -> ComputeScope | None:
+def _scores_prior_fleet_scope(
+    scope: ComputeScope,
+    *,
+    settings: GameSettings | None = None,
+) -> ComputeScope | None:
     if scope.turn == WILDCARD or not isinstance(scope.turn, int):
         return None
-    if scope.turn <= 1:
-        return None
     if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
+        return None
+    if settings is not None and is_export_ensure_baseline_turn(scope.turn, settings):
+        return None
+    if scope.turn <= 1:
         return None
     return ComputeScope(
         analytic_id=FLEET_ANALYTIC_ID,
@@ -96,10 +104,12 @@ def _resolve_prior_fleet_for_tier_wire(
     export_scope = _export_scope_for_compute(scope)
     if export_scope is None:
         raise ValueError("scores tier_solve requires concrete scores scope")
-    if export_scope.turn <= 1:
-        return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
 
-    prior_fleet_scope = _scores_prior_fleet_scope(scope)
+    turn = ctx.load_turn(export_scope.turn)
+    if turn is None:
+        return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
+
+    prior_fleet_scope = _scores_prior_fleet_scope(scope, settings=turn.settings)
     if prior_fleet_scope is None:
         return PriorTurnFleetTorpResolution(overlay=None, input_status="not_applicable")
 
@@ -114,10 +124,6 @@ def _resolve_prior_fleet_for_tier_wire(
                 prior_export_scope,
                 prior_turn=prior_turn,
             )
-
-    turn = ctx.load_turn(export_scope.turn)
-    if turn is None:
-        return PriorTurnFleetTorpResolution(overlay=None, input_status="pending")
 
     return resolve_prior_turn_fleet_torp_overlay(
         turn=turn,

--- a/packages/api/api/analytics/scores/compute_orchestration.py
+++ b/packages/api/api/analytics/scores/compute_orchestration.py
@@ -36,7 +36,7 @@ from api.analytics.scores.tier_row_run_registry import (
 from api.compute.profile import AnalyticComputeProfile, ComputeStepSpec
 from api.compute.scope import WILDCARD, ComputeScope, ScopeKeySpec, compute_scope_to_export_scope
 from api.compute.wire import DependencyOutputs, StepResult
-from api.concepts.accelerated_scoreboard import is_export_ensure_baseline_turn
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.models.game import GameSettings
 
 SCORES_MATERIALIZE = "materialize"
@@ -64,7 +64,7 @@ def _scores_prior_fleet_scope(
         return None
     if scope.player_id == WILDCARD or not isinstance(scope.player_id, int):
         return None
-    if settings is not None and is_export_ensure_baseline_turn(scope.turn, settings):
+    if settings is not None and scope.turn == accelerated_ensure_floor(settings, scope.turn):
         return None
     if scope.turn <= 1:
         return None

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -19,7 +19,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_TIME_LIMITED,
 )
 from api.analytics.scores.export_wire import ranked_solutions_from_wire
-from api.models.game import TurnInfo
+from api.models.game import GameSettings, TurnInfo
 from api.models.player import Score
 from api.serialization.inference_row_persistence import PersistedInferenceRow
 
@@ -110,6 +110,52 @@ def _payload_for_host_turn_from_row(
 
 
 PersistedRowLoader = Callable[[int, int], PersistedInferenceRow | None]
+
+
+def functional_host_turn_payload_from_persisted_row(
+    row: PersistedInferenceRow,
+    *,
+    source_scoreboard_turn: int,
+    target_host_turn: int,
+) -> FunctionalHostTurnPayload | None:
+    """Select held solutions for ``target_host_turn`` from one persisted inference row."""
+    return _payload_for_host_turn_from_row(
+        row,
+        scoreboard_turn=source_scoreboard_turn,
+        target_host_turn=target_host_turn,
+    )
+
+
+def resolve_accelerated_backfill_payload_when_scoreboard_turn_missing(
+    *,
+    scoreboard_turn: int,
+    settings: GameSettings,
+    get_persisted_row: PersistedRowLoader,
+    player_id: int,
+) -> FunctionalHostTurnPayload | None:
+    """Load host-turn solutions from the first reliable row when ``scoreboard_turn`` is absent.
+
+    Unreliable accelerated scoreboard turns (``1..N-1``) may be missing from storage
+    while accelerated start is still open. Fleet placeholder refine still maps
+    ``builtTurn`` to ``scores@(builtTurn + 1)``; this helper resolves the same
+    functional payload from ``scores@N`` ``hostTurnTargets``.
+    """
+    if not needs_accelerated_backfill(scoreboard_turn, settings):
+        return None
+    target_host_turn = scoreboard_host_turn(scoreboard_turn)
+    if target_host_turn is None:
+        return None
+    source_turn_number = first_reliable_accelerated_scoreboard_turn(settings)
+    if source_turn_number is None:
+        return None
+    source_row = get_persisted_row(source_turn_number, player_id)
+    if source_row is None:
+        return None
+    return functional_host_turn_payload_from_persisted_row(
+        source_row,
+        source_scoreboard_turn=source_turn_number,
+        target_host_turn=target_host_turn,
+    )
 
 
 def resolve_functional_host_turn_payload(

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -112,33 +112,19 @@ def _payload_for_host_turn_from_row(
 PersistedRowLoader = Callable[[int, int], PersistedInferenceRow | None]
 
 
-def functional_host_turn_payload_from_persisted_row(
-    row: PersistedInferenceRow,
-    *,
-    source_scoreboard_turn: int,
-    target_host_turn: int,
-) -> FunctionalHostTurnPayload | None:
-    """Select held solutions for ``target_host_turn`` from one persisted inference row."""
-    return _payload_for_host_turn_from_row(
-        row,
-        scoreboard_turn=source_scoreboard_turn,
-        target_host_turn=target_host_turn,
-    )
-
-
-def resolve_accelerated_backfill_payload_when_scoreboard_turn_missing(
+def accelerated_backfill_host_turn_payload(
     *,
     scoreboard_turn: int,
     settings: GameSettings,
     get_persisted_row: PersistedRowLoader,
     player_id: int,
 ) -> FunctionalHostTurnPayload | None:
-    """Load host-turn solutions from the first reliable row when ``scoreboard_turn`` is absent.
+    """Load ``hostTurnTargets`` for an unreliable scoreboard turn from ``scores@N``.
 
-    Unreliable accelerated scoreboard turns (``1..N-1``) may be missing from storage
-    while accelerated start is still open. Fleet placeholder refine still maps
-    ``builtTurn`` to ``scores@(builtTurn + 1)``; this helper resolves the same
-    functional payload from ``scores@N`` ``hostTurnTargets``.
+    Unreliable accelerated scoreboard turns (``1..N-1``) may lack their own row
+    while accelerated start is still open. Both scores export and fleet held-
+    solution lookup resolve the functional payload from the first reliable
+    scoreboard row's ``hostTurnTargets``.
     """
     if not needs_accelerated_backfill(scoreboard_turn, settings):
         return None
@@ -151,9 +137,9 @@ def resolve_accelerated_backfill_payload_when_scoreboard_turn_missing(
     source_row = get_persisted_row(source_turn_number, player_id)
     if source_row is None:
         return None
-    return functional_host_turn_payload_from_persisted_row(
+    return _payload_for_host_turn_from_row(
         source_row,
-        source_scoreboard_turn=source_turn_number,
+        scoreboard_turn=source_turn_number,
         target_host_turn=target_host_turn,
     )
 
@@ -181,24 +167,12 @@ def resolve_functional_host_turn_payload(
         if payload is not None:
             return payload
 
-    if (
-        score is None
-        or load_scoreboard_turn is None
-        or get_persisted_row is None
-        or not needs_accelerated_backfill(scoreboard_turn, turn.settings)
-    ):
+    if score is None or load_scoreboard_turn is None or get_persisted_row is None:
         return None
 
-    source_turn_number = first_reliable_accelerated_scoreboard_turn(turn.settings)
-    if source_turn_number is None:
-        return None
-
-    source_row = get_persisted_row(source_turn_number, score.ownerid)
-    if source_row is None:
-        return None
-
-    return _payload_for_host_turn_from_row(
-        source_row,
-        scoreboard_turn=source_turn_number,
-        target_host_turn=target_host_turn,
+    return accelerated_backfill_host_turn_payload(
+        scoreboard_turn=scoreboard_turn,
+        settings=turn.settings,
+        get_persisted_row=get_persisted_row,
+        player_id=score.ownerid,
     )

--- a/packages/api/api/analytics/scores/host_turn_export.py
+++ b/packages/api/api/analytics/scores/host_turn_export.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 from api.analytics.military_score_inference.accelerated_start import (
-    first_reliable_accelerated_scoreboard_turn,
     needs_accelerated_backfill,
     scoreboard_host_turn,
 )
@@ -19,6 +18,7 @@ from api.analytics.military_score_inference.solver import (
     STATUS_TIME_LIMITED,
 )
 from api.analytics.scores.export_wire import ranked_solutions_from_wire
+from api.concepts.accelerated_scoreboard import first_reliable_accelerated_scoreboard_turn
 from api.models.game import GameSettings, TurnInfo
 from api.models.player import Score
 from api.serialization.inference_row_persistence import PersistedInferenceRow

--- a/packages/api/api/compute/dag.py
+++ b/packages/api/api/compute/dag.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from api.analytics.export_context import AnalyticQueryContext
 from api.analytics.export_dependency_walk import (
     dependency_scope_for,
+    ensure_dependency_turn_floor,
     walk_dependency_tree,
 )
 from api.analytics.export_types import ExportScope
@@ -75,7 +76,13 @@ def plan_compute_dag(
         dependency_scopes: list[ComputeScope] = []
         for dependency in catalog.ensure_dependencies:
             dependency_export_scope = dependency_scope_for(pending_scope, dependency)
-            if dependency_export_scope.turn < 1:
+            turn_floor = ensure_dependency_turn_floor(
+                ctx,
+                pending_scope,
+                analytic_id=pending_analytic_id,
+                dependency_analytic_id=dependency.analytic_id,
+            )
+            if dependency_export_scope.turn < turn_floor:
                 continue
             dependency_key = _pending_key(dependency.analytic_id, dependency_export_scope)
             if dependency_key not in pending_by_key:

--- a/packages/api/api/compute/dag.py
+++ b/packages/api/api/compute/dag.py
@@ -76,12 +76,7 @@ def plan_compute_dag(
         dependency_scopes: list[ComputeScope] = []
         for dependency in catalog.ensure_dependencies:
             dependency_export_scope = dependency_scope_for(pending_scope, dependency)
-            turn_floor = ensure_dependency_turn_floor(
-                ctx,
-                pending_scope,
-                analytic_id=pending_analytic_id,
-                dependency_analytic_id=dependency.analytic_id,
-            )
+            turn_floor = ensure_dependency_turn_floor(ctx, pending_scope)
             if dependency_export_scope.turn < turn_floor:
                 continue
             dependency_key = _pending_key(dependency.analytic_id, dependency_export_scope)

--- a/packages/api/api/concepts/accelerated_scoreboard.py
+++ b/packages/api/api/concepts/accelerated_scoreboard.py
@@ -56,6 +56,54 @@ def accelerated_turn_count(settings: GameSettings) -> int:
     return max(0, settings.acceleratedturns)
 
 
+def first_reliable_accelerated_scoreboard_turn(settings: GameSettings) -> int | None:
+    """Scoreboard turn N when accelerated start is enabled; otherwise None."""
+    accelerated = accelerated_turn_count(settings)
+    return accelerated if accelerated > 0 else None
+
+
+def fleet_chain_start_floor(turn_number: int, settings: GameSettings) -> int:
+    """Lowest turn fleet gap-fill may materialize when targeting ``turn_number``.
+
+    Normal games and unreliable accelerated turns (``turn_number < N``): turn 1.
+    Once the target is at or above the first reliable scoreboard turn N, chain from
+    N so missing/unreliable turns ``1..N-1`` are not required.
+    """
+    accelerated = accelerated_turn_count(settings)
+    if accelerated > 0 and turn_number >= accelerated:
+        return accelerated
+    return 1
+
+
+def export_ensure_turn_floor(settings: GameSettings, *, scope_turn: int) -> int:
+    """Ensure-unwind floor for dependencies of a scope at ``scope_turn``.
+
+    Same rule as ``fleet_chain_start_floor``: accelerated floor N applies only
+    when the requesting scope is at or above N.
+    """
+    return fleet_chain_start_floor(scope_turn, settings)
+
+
+def is_below_export_ensure_turn_floor(
+    turn_number: int,
+    settings: GameSettings,
+    *,
+    scope_turn: int,
+) -> bool:
+    """Whether a dependency turn is below the ensure floor for ``scope_turn``."""
+    return turn_number < export_ensure_turn_floor(settings, scope_turn=scope_turn)
+
+
+def is_export_ensure_baseline_turn(turn_number: int, settings: GameSettings) -> bool:
+    """Whether this turn is a fleet/scores ensure baseline (no prior fleet leg)."""
+    return turn_number == fleet_chain_start_floor(turn_number, settings)
+
+
+def is_unreliable_accelerated_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:
+    accelerated = accelerated_turn_count(settings)
+    return accelerated > 0 and 1 <= turn_number < accelerated
+
+
 def is_first_reliable_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:
     accelerated = accelerated_turn_count(settings)
     return accelerated > 0 and turn_number == accelerated

--- a/packages/api/api/concepts/accelerated_scoreboard.py
+++ b/packages/api/api/concepts/accelerated_scoreboard.py
@@ -62,41 +62,19 @@ def first_reliable_accelerated_scoreboard_turn(settings: GameSettings) -> int | 
     return accelerated if accelerated > 0 else None
 
 
-def fleet_chain_start_floor(turn_number: int, settings: GameSettings) -> int:
-    """Lowest turn fleet gap-fill may materialize when targeting ``turn_number``.
+def accelerated_ensure_floor(settings: GameSettings, scope_turn: int) -> int:
+    """Lowest turn ensure/fleet may require when targeting ``scope_turn``.
 
-    Normal games and unreliable accelerated turns (``turn_number < N``): turn 1.
-    Once the target is at or above the first reliable scoreboard turn N, chain from
+    Normal games and unreliable accelerated turns (``scope_turn < N``): turn 1.
+    Once the target is at or above the first reliable scoreboard turn N, floor is
     N so missing/unreliable turns ``1..N-1`` are not required.
+
+    Call sites compare directly: ``dep_turn < floor`` or ``turn == floor``.
     """
     accelerated = accelerated_turn_count(settings)
-    if accelerated > 0 and turn_number >= accelerated:
+    if accelerated > 0 and scope_turn >= accelerated:
         return accelerated
     return 1
-
-
-def export_ensure_turn_floor(settings: GameSettings, *, scope_turn: int) -> int:
-    """Ensure-unwind floor for dependencies of a scope at ``scope_turn``.
-
-    Same rule as ``fleet_chain_start_floor``: accelerated floor N applies only
-    when the requesting scope is at or above N.
-    """
-    return fleet_chain_start_floor(scope_turn, settings)
-
-
-def is_below_export_ensure_turn_floor(
-    turn_number: int,
-    settings: GameSettings,
-    *,
-    scope_turn: int,
-) -> bool:
-    """Whether a dependency turn is below the ensure floor for ``scope_turn``."""
-    return turn_number < export_ensure_turn_floor(settings, scope_turn=scope_turn)
-
-
-def is_export_ensure_baseline_turn(turn_number: int, settings: GameSettings) -> bool:
-    """Whether this turn is a fleet/scores ensure baseline (no prior fleet leg)."""
-    return turn_number == fleet_chain_start_floor(turn_number, settings)
 
 
 def is_unreliable_accelerated_scoreboard_turn(turn_number: int, settings: GameSettings) -> bool:

--- a/packages/api/tests/fixtures/export_framework/harness.py
+++ b/packages/api/tests/fixtures/export_framework/harness.py
@@ -58,10 +58,14 @@ def make_fixture_query_context(
 
 
 def clone_turn_at(turn: TurnInfo, turn_number: int) -> TurnInfo:
-    """Shallow clone with a different settings.turn for multi-turn fixture chains."""
+    """Shallow clone with a different settings.turn for multi-turn fixture chains.
+
+    Forces acceleratedturns=0 so export-framework harnesses are isolated from
+    accelerated-start ensure-floor semantics (covered by dedicated accel tests).
+    """
     from dataclasses import replace
 
-    settings = replace(turn.settings, turn=turn_number)
+    settings = replace(turn.settings, turn=turn_number, acceleratedturns=0)
     game = replace(turn.game, turn=turn_number)
     return replace(turn, settings=settings, game=game)
 

--- a/packages/api/tests/test_accelerated_ensure_floor.py
+++ b/packages/api/tests/test_accelerated_ensure_floor.py
@@ -1,0 +1,183 @@
+"""Regression: accelerated-start ensure floor (game 680224 shape).
+
+Mid-accelerated games often store the first reliable scoreboard turn N and later
+turns while omitting unreliable turns 1..N-1 for a perspective (or leaving a
+hole such as turn 1 present and turn 2 missing). Scores/fleet ensure must not
+walk into those turns, and fleet gap-fill must start at N.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from api.analytics.export_dependency_walk import walk_dependency_tree
+from api.analytics.export_types import ExportScope
+from api.analytics.fleet.chain import (
+    _first_stored_rst_turn,
+    get_or_materialize_fleet_ledger_for_player,
+)
+from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
+from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
+    resolve_prior_turn_fleet_torp_overlay,
+)
+from api.concepts.accelerated_scoreboard import (
+    export_ensure_turn_floor,
+    fleet_chain_start_floor,
+    is_below_export_ensure_turn_floor,
+    is_export_ensure_baseline_turn,
+)
+from api.storage.memory_asset import MemoryAssetBackend
+
+from tests.export_chain_test_fixtures import export_chain_query_context
+from tests.scores_exports_helpers import first_player_id
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GAME_680224_TURNS = REPO_ROOT / ".data" / "games" / "680224" / "2" / "turns"
+
+
+def _turn_at(sample_turn, turn_number: int, *, acceleratedturns: int = 3):
+    return replace(
+        sample_turn,
+        settings=replace(
+            sample_turn.settings,
+            turn=turn_number,
+            acceleratedturns=acceleratedturns,
+        ),
+        game=replace(sample_turn.game, turn=turn_number),
+    )
+
+
+def _680224_shaped_store(sample_turn) -> dict[int, object]:
+    """Stored turns shaped like mid-accel game 680224: {1, 3, 4}, hole at 2."""
+    return {
+        1: _turn_at(sample_turn, 1),
+        3: _turn_at(sample_turn, 3),
+        4: _turn_at(sample_turn, 4),
+    }
+
+
+def test_export_ensure_turn_floor_helpers(sample_turn):
+    normal = replace(sample_turn.settings, acceleratedturns=0)
+    assert export_ensure_turn_floor(normal, scope_turn=5) == 1
+    assert fleet_chain_start_floor(1, normal) == 1
+    assert is_export_ensure_baseline_turn(1, normal)
+    assert is_below_export_ensure_turn_floor(0, normal, scope_turn=5)
+    assert not is_below_export_ensure_turn_floor(1, normal, scope_turn=5)
+
+    accel = replace(sample_turn.settings, acceleratedturns=3)
+    assert export_ensure_turn_floor(accel, scope_turn=2) == 1
+    assert export_ensure_turn_floor(accel, scope_turn=3) == 3
+    assert export_ensure_turn_floor(accel, scope_turn=4) == 3
+    assert fleet_chain_start_floor(1, accel) == 1
+    assert fleet_chain_start_floor(3, accel) == 3
+    assert is_export_ensure_baseline_turn(1, accel)
+    assert is_export_ensure_baseline_turn(3, accel)
+    assert not is_export_ensure_baseline_turn(4, accel)
+    assert is_below_export_ensure_turn_floor(2, accel, scope_turn=4)
+    assert not is_below_export_ensure_turn_floor(2, accel, scope_turn=2)
+    assert not is_below_export_ensure_turn_floor(3, accel, scope_turn=4)
+
+
+def test_scores_ensure_walk_skips_missing_turn_below_accelerated_floor(sample_turn):
+    """scores@4 must not fail with turn_not_stored when turn 2 is absent (680224)."""
+    stored = _680224_shaped_store(sample_turn)
+    turn4 = stored[4]
+    player_id = first_player_id(sample_turn)
+    ctx = export_chain_query_context(turn4, stored_turns=stored)
+    scope = ExportScope(
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        turn=4,
+        player_id=player_id,
+    )
+
+    walk = walk_dependency_tree(ctx, "scores", scope, visiting=set(), force_root=True)
+
+    assert walk.turn_unavailable is None
+    pending_turns = {(analytic_id, scope.turn) for analytic_id, scope, _ in walk.pending_ensure}
+    assert ("scores", 4) in pending_turns
+    assert ("fleet", 3) in pending_turns
+    assert ("scores", 3) in pending_turns
+    assert ("fleet", 2) not in pending_turns
+    assert ("fleet", 1) not in pending_turns
+
+
+def test_scores_ensure_walk_at_first_reliable_turn_skips_prior_fleet(sample_turn):
+    stored = _680224_shaped_store(sample_turn)
+    turn3 = stored[3]
+    player_id = first_player_id(sample_turn)
+    ctx = export_chain_query_context(turn3, stored_turns=stored)
+    scope = ExportScope(
+        game_id=ctx.game_id,
+        perspective=ctx.perspective,
+        turn=3,
+        player_id=player_id,
+    )
+
+    walk = walk_dependency_tree(ctx, "scores", scope, visiting=set(), force_root=True)
+
+    assert walk.turn_unavailable is None
+    pending_turns = {(analytic_id, scope.turn) for analytic_id, scope, _ in walk.pending_ensure}
+    assert ("scores", 3) in pending_turns
+    assert ("fleet", 2) not in pending_turns
+
+
+def test_fleet_chain_starts_at_accelerated_floor_with_turn_two_hole(sample_turn):
+    stored = _680224_shaped_store(sample_turn)
+    turn4 = stored[4]
+    player_id = first_player_id(sample_turn)
+
+    def load_turn(turn_number: int):
+        return stored.get(turn_number)
+
+    assert _first_stored_rst_turn(load_turn, 4) == 1
+    assert _first_stored_rst_turn(load_turn, 4, min_turn=3) == 3
+
+    persistence = FleetSnapshotPersistenceService(MemoryAssetBackend(initial={}))
+    persisted = get_or_materialize_fleet_ledger_for_player(
+        persistence,
+        turn4.game.id,
+        turn4.player.id,
+        player_id,
+        turn4,
+        load_turn=load_turn,
+        inference_materialization=None,
+        query_context=None,
+    )
+
+    assert persisted.ledger.player_id == player_id
+    assert persistence.get_ledger(turn4.game.id, turn4.player.id, 4, player_id) is not None
+    assert persistence.get_ledger(turn4.game.id, turn4.player.id, 3, player_id) is not None
+    assert persistence.get_ledger(turn4.game.id, turn4.player.id, 2, player_id) is None
+    assert persistence.get_ledger(turn4.game.id, turn4.player.id, 1, player_id) is None
+
+    floor_ledger = persistence.get_ledger(turn4.game.id, turn4.player.id, 3, player_id)
+    assert floor_ledger is not None
+    assert floor_ledger.provenance.prior_ledger_at_n_minus_1 is True
+
+
+def test_prior_fleet_torp_overlay_not_applicable_at_first_reliable_turn(sample_turn):
+    turn3 = _turn_at(sample_turn, 3)
+    resolution = resolve_prior_turn_fleet_torp_overlay(
+        turn=turn3,
+        player_id=first_player_id(sample_turn),
+        load_turn=lambda n: turn3 if n == 3 else None,
+        export_services=None,
+        ensure=False,
+    )
+    assert resolution.input_status == "not_applicable"
+    assert resolution.overlay is None
+
+
+@pytest.mark.skipif(
+    not GAME_680224_TURNS.joinpath("4.json").is_file(),
+    reason="local .data/games/680224 only",
+)
+def test_680224_local_store_missing_turn_two():
+    """Sanity-check the real local corpus still matches the regression shape."""
+    stored = sorted(int(path.stem) for path in GAME_680224_TURNS.glob("*.json"))
+    assert 2 not in stored
+    assert 3 in stored
+    assert 4 in stored

--- a/packages/api/tests/test_accelerated_ensure_floor.py
+++ b/packages/api/tests/test_accelerated_ensure_floor.py
@@ -22,12 +22,7 @@ from api.analytics.fleet.persistence import FleetSnapshotPersistenceService
 from api.analytics.military_score_inference.prior_turn_fleet_torp_overlay import (
     resolve_prior_turn_fleet_torp_overlay,
 )
-from api.concepts.accelerated_scoreboard import (
-    export_ensure_turn_floor,
-    fleet_chain_start_floor,
-    is_below_export_ensure_turn_floor,
-    is_export_ensure_baseline_turn,
-)
+from api.concepts.accelerated_scoreboard import accelerated_ensure_floor
 from api.storage.memory_asset import MemoryAssetBackend
 
 from tests.export_chain_test_fixtures import export_chain_query_context
@@ -58,26 +53,26 @@ def _680224_shaped_store(sample_turn) -> dict[int, object]:
     }
 
 
-def test_export_ensure_turn_floor_helpers(sample_turn):
+def test_accelerated_ensure_floor(sample_turn):
     normal = replace(sample_turn.settings, acceleratedturns=0)
-    assert export_ensure_turn_floor(normal, scope_turn=5) == 1
-    assert fleet_chain_start_floor(1, normal) == 1
-    assert is_export_ensure_baseline_turn(1, normal)
-    assert is_below_export_ensure_turn_floor(0, normal, scope_turn=5)
-    assert not is_below_export_ensure_turn_floor(1, normal, scope_turn=5)
+    assert accelerated_ensure_floor(normal, 5) == 1
+    assert accelerated_ensure_floor(normal, 1) == 1
+    # Call-site patterns: turn == floor (baseline), dep < floor
+    assert 1 == accelerated_ensure_floor(normal, 1)
+    assert 0 < accelerated_ensure_floor(normal, 5)
+    assert not (1 < accelerated_ensure_floor(normal, 5))
 
     accel = replace(sample_turn.settings, acceleratedturns=3)
-    assert export_ensure_turn_floor(accel, scope_turn=2) == 1
-    assert export_ensure_turn_floor(accel, scope_turn=3) == 3
-    assert export_ensure_turn_floor(accel, scope_turn=4) == 3
-    assert fleet_chain_start_floor(1, accel) == 1
-    assert fleet_chain_start_floor(3, accel) == 3
-    assert is_export_ensure_baseline_turn(1, accel)
-    assert is_export_ensure_baseline_turn(3, accel)
-    assert not is_export_ensure_baseline_turn(4, accel)
-    assert is_below_export_ensure_turn_floor(2, accel, scope_turn=4)
-    assert not is_below_export_ensure_turn_floor(2, accel, scope_turn=2)
-    assert not is_below_export_ensure_turn_floor(3, accel, scope_turn=4)
+    assert accelerated_ensure_floor(accel, 2) == 1
+    assert accelerated_ensure_floor(accel, 3) == 3
+    assert accelerated_ensure_floor(accel, 4) == 3
+    assert accelerated_ensure_floor(accel, 1) == 1
+    assert 1 == accelerated_ensure_floor(accel, 1)
+    assert 3 == accelerated_ensure_floor(accel, 3)
+    assert 4 != accelerated_ensure_floor(accel, 4)
+    assert 2 < accelerated_ensure_floor(accel, 4)
+    assert not (2 < accelerated_ensure_floor(accel, 2))
+    assert not (3 < accelerated_ensure_floor(accel, 4))
 
 
 def test_scores_ensure_walk_skips_missing_turn_below_accelerated_floor(sample_turn):

--- a/packages/api/tests/test_fleet_inference_ingest.py
+++ b/packages/api/tests/test_fleet_inference_ingest.py
@@ -1124,6 +1124,66 @@ def test_accelerated_first_reliable_refines_without_scores_diagnostics():
         assert record.build_option_sets[0].combo_id == "combo_96_9_5_6_4_2"
 
 
+def test_accelerated_window_refine_when_intermediate_scoreboard_turn_missing():
+    """680224 shape: turn 2 absent; refine builtTurn=1 from scores@3 hostTurnTargets."""
+    turn = load_turn_fixture("628580/1/turns/3.json")
+    player_id = 2
+    score = next(entry for entry in turn.scores if entry.ownerid == player_id)
+    inference_payload = infer_military_score_build(score, turn)
+    wire_complete = inference_api_payload_to_wire_complete(inference_payload)
+    host_turn_targets = list(host_turn_targets_from_wire_event(wire_complete))
+    assert host_turn_targets
+    assert any(target.host_turn == 1 for target in host_turn_targets)
+
+    persistence = InferenceRowPersistenceService(MemoryAssetBackend(initial={}))
+    persistence.put_row(
+        628580,
+        1,
+        3,
+        player_id,
+        PersistedInferenceRow(
+            status=str(inference_payload["status"]),
+            summary=str(inference_payload["summary"]),
+            solution_count=int(inference_payload["solutionCount"]),
+            is_complete=True,
+            solutions=inference_payload["solutions"],
+            diagnostics=None,
+            host_turn_targets=host_turn_targets,
+        ),
+    )
+
+    def load_turn(turn_number: int):
+        # Mid-accelerated storage: first reliable turn present, unreliable turn 2 absent.
+        if turn_number == 3:
+            return turn
+        return None
+
+    snapshot = apply_fleet_turn_delta(
+        ensure_fleet_baseline(628580, 1, turn),
+        turn,
+        inference_materialization=FleetInferenceMaterialization(
+            inference=FleetInferenceSupport(
+                scores_services=ScoresExportContext(persistence=persistence)
+            ),
+            load_turn=load_turn,
+        ),
+    )
+
+    ledger = ledger_for_player(snapshot, player_id)
+    starting_rows = _homeworld_starting_freighter_rows(ledger, shell_turn=3)
+    window_row = next(
+        record
+        for record in _inferred_freighter_rows(ledger, shell_turn=3)
+        if record not in starting_rows and _known_built_turn(record) == 1
+    )
+    assert window_row.build_option_sets
+    assert window_row.build_option_sets[0].combo_id == "combo_freighter"
+    assert window_row.build_option_sets[0].label == "Freighter"
+    inference_event = next(event for event in window_row.events if event.kind == "inference_update")
+    assert inference_event.payload["acceleratedIngest"] is True
+    assert inference_event.payload["segmentHostTurn"] == 1
+
+
 def test_accelerated_first_reliable_window_freighter_placeholder():
     turn = load_turn_fixture("628580/1/turns/3.json")
     player_id = 2

--- a/packages/api/tests/test_fleet_materialization_provenance_policy.py
+++ b/packages/api/tests/test_fleet_materialization_provenance_policy.py
@@ -32,6 +32,7 @@ from tests.scores_exports_helpers import (
 def _turn_context() -> FleetTurnContext:
     turn = MagicMock()
     turn.scores = []
+    turn.settings.acceleratedturns = 0
     return FleetTurnContext(turn=turn, max_ship_id_bound=100)
 
 


### PR DESCRIPTION
## Summary
- Treat the first reliable accelerated scoreboard turn N as the ensure and fleet chain floor when requesting scopes at or above N, so missing unreliable turns `1..N-1` (common while accelerated start is still open) no longer make scores/fleet unavailable.
- When fleet placeholder refine needs `scores@(builtTurn+1)` and that turn is not stored, resolve solutions from `scores@N` `hostTurnTargets` via one shared backfill helper.
- Collapse the floor API to `accelerated_ensure_floor`, own shared accelerated predicates in `concepts/`, and apply the floor from settings for all ensure edges (not a scores/fleet ID allowlist).

## Test plan
- [x] `make test` (full suite)
- [ ] Manually: mid-accelerated game (e.g. 680224 / 628580) with hole at turn 2 -- open scores and fleet on turn >= N and confirm they render
- [ ] After clearing analytic persistence, ensure recompute succeeds without `turn_not_stored` on early missing turns


Made with [Cursor](https://cursor.com)