### PR TITLE
Map region overlay: hybrid coverage primitive (#248)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -288,6 +288,18 @@ _Avoid_: keepPreviousData (implementation detail; not the product concept), stal
 One analytic's contribution to the combined map graph -- nodes and/or edges merged with **base map** and other enabled map analytics via id-prefixing.
 _Avoid_: overlay (acceptable informally; prefer map layer in docs)
 
+**Map region overlay**:
+A shaded designated area on the map used to highlight a region rather than a single planet or ship. v1 wire field is **`regionOverlays`**: a **hybrid coverage** payload of disk unions (centers + radii) where coverage is ideal, plus **nebula-local coverage patches** (1 ly RLE rasters) where \(V(P)\) / **Nebula Scanner** distort the footprint -- so payloads stay small on empty-nebula maps while Core still owns coverage truth. Style metadata (fill color, kind id) travels with the geometry. Shared rendering and merge concern across map analytics; the SPA blits disks and patches. Distinct from cartography hazard circles (`overlayCircles`) and from **homeworld region overlay** arcs.
+_Avoid_: overlay circle (cartography-specific), cartography layer (Stellar Cartography only), homeworld region overlay (that analytic's candidate envelope), client-side reimplementation of coverage policy, full-map 1 ly boolean grids as the default wire
+
+**Visibility analytic**:
+A map-only **turn analytic** (`analytic_id` `visibility`) that draws **map region overlay**s for sensor coverage from the **viewpoint** (plus **Share Intel** partners as scan origins). Per-**visibility region kind** toggles and **base colors** are **client preferences** persisted globally in localStorage (sticky across sessions and games, same pattern as **Cartography layer** toggles): checkbox + color control; client may override wire defaults. Fresh install defaults: all three kinds on with distinct default base colors; overlapping kinds use independent semi-transparent fills (fixed z-order). Distinct from **Fleet player visibility**.
+_Avoid_: fleet player visibility, sensor picture (homeworld evidence sense), scan radius alone (one of several region kinds), per-game preference scope for these toggles
+
+**Visibility region kind**:
+One toggleable shaded coverage family inside the **Visibility analytic**. v1 kinds: **ship scan coverage** (where non-special-case ships are detectable within ship-scan range of **planet and ship** origins -- starbases are not separate origins; they share planet coordinates); **active Sensor Sweep coverage** (union of sensor-mission range disks around ships whose mission is **Sensor Sweep** or **Bioscan** this turn); **potential Sensor Sweep coverage** (same range around non-bioscan ships that could set Sensor Sweep, plus bioscan hulls that use Bioscan instead). Geometry is boolean coverage footprint -- industry and defense-post gates describe what reports are possible inside those regions, not the disk shape. Probability banding is out of scope for v1. Sensor-mission range defaults to 200 ly (Host "Sensor mission range"); bind a `GameSettings` field if one is present. Advanced Bioscan nebula-planet exceptions are a documented follow-on if they differ from the shared \(V(P)\) model. Scan origins for all kinds include the viewpoint player's units and **Share Intel** partners' units (product approximation). Partner detection uses turn **Relation** edges once their integer codes are mapped to diplomacy tiers (spike required -- codes are not yet documented in Console or vault help). Full Alliance adds no extra region-origin rules beyond Share Intel for this analytic. Nebula handling is the same for ship and planet visibility: at point \(P\), effective range is \(\min(\mathrm{baseRange},\, V(P))\) when \(P\) is in a nebula (else `baseRange`), using Core cartography \(V(P)\) from density. **Nebula Scanner**–equipped origins apply to all three **visibility region kinds**: inside a nebula, effective reach is \(\max(\min(\mathrm{baseRange},\, V(P)),\, 100)\) (the 100 ly floor only matters where density would otherwise cut deeper than 100; if `baseRange < 100`, cap by `baseRange`). Coverage is emitted as hybrid **map region overlay** geometry (ideal disks + nebula-local patches). Cloak, Stealth Armor range reduction, Hide in Warp Well, and other special detection abilities remain v1 exclusions (documented, not drawn).
+_Avoid_: cartography layer, fleet player visibility, detection probability field, treating Sensor Sweep nebula rules as a boolean punch-out distinct from ship \(V(P)\)
+
 **Stellar Cartography**:
 NuHost optional map geography (star clusters, nebulae, wormholes, black holes, debris disks, and related ion-storm behavior). Exposed in the console as one map-only **turn analytic** with per-element layer toggles.
 _Avoid_: SC (in user-facing copy), space hazards (too broad)
@@ -931,6 +943,15 @@ Use **homeworld planet** in Console prose and UI for map inference. Do not say "
 
 Use **perspective** in storage paths and API path segments; use **viewpoint** in UI copy; use **Player** when referring to model fields or upstream payload entities. Do not say "player 3" when you mean perspective slot 3 unless the prose explicitly ties slot to the `Player` record.
 
+**Visibility analytic vs Fleet player visibility**:
+- **Visibility analytic** -- map **map region overlay**s for sensor / ship-detection coverage from the **viewpoint**.
+- **Fleet player visibility** -- which **Player**s' fleet rows and map markers are enabled in the fleet analytic UI.
+
+Do not shorten either to "visibility" alone in tickets or UI copy when both could apply.
+
+**Nebula visibility vs some help text**:
+For Console **Visibility analytic** geometry, nebula modulation for planet visibility matches ship visibility (\(V(P)\) at the target), plus **Nebula Scanner** 100 ly islands. Some Planets.nu help text describes ordinary sensor/bioscan as failing on nebular planets; that wording must not drive a separate boolean punch-out for Sensor Sweep coverage in this product.
+
 ## Example dialogue
 
 **Dev:** I'm wiring a new map analytic. What scope does it need?  
@@ -965,4 +986,7 @@ Use **perspective** in storage paths and API path segments; use **viewpoint** in
 
 **Dev:** Where is my Planets.nu API key stored?  
 **Expert:** In the **`credentials/accounts/{name}`** account **document**, under **machine-bound obfuscation**. **Log out** clears the remembered name; optional **account API key drop** deletes the stored key on this server. Auth failure triggers **account API key invalidation** (same key deletion) and opens the modal.
+
+**Dev:** I need shaded sensor coverage on the map for the viewpoint. Is that Stellar Cartography?  
+**Expert:** No. That's the **Visibility analytic** -- it emits **map region overlay**s (hybrid disks plus nebula patches) for each **visibility region kind**. Cartography is hazards and geography; **Fleet player visibility** only toggles which players' fleets show.
 

--- a/packages/api/api/analytics/catalog.py
+++ b/packages/api/api/analytics/catalog.py
@@ -53,6 +53,13 @@ TURN_ANALYTIC_CATALOG: tuple[TurnAnalyticCatalogEntry, ...] = (
         supports_map=True,
         type="selectable",
     ),
+    TurnAnalyticCatalogEntry(
+        id="map-region-demo",
+        name="Map region demo",
+        supports_table=False,
+        supports_map=True,
+        type="selectable",
+    ),
 )
 
 _CATALOG_BY_ID: dict[str, TurnAnalyticCatalogEntry] = {

--- a/packages/api/api/analytics/map_region_demo.py
+++ b/packages/api/api/analytics/map_region_demo.py
@@ -1,0 +1,89 @@
+"""Temporary map-only demo analytic for hybrid map region overlays (#248).
+
+Produces shaded coverage via the shared Core hybrid coverage helper so the SPA
+can merge and blit without the Visibility analytic. Remove this registration
+when Visibility lands and consumes ``regionOverlays`` instead.
+"""
+
+from __future__ import annotations
+
+from api.analytics.catalog import catalog_entry
+from api.analytics.compute_context import AnalyticComputeContext, invoke_analytic_compute
+from api.analytics.exports.empty import empty_export_catalog_for
+from api.analytics.options import TurnAnalyticsOptions
+from api.analytics.registration import TurnAnalyticRegistration
+from api.concepts.map_region_coverage import (
+    CoverageOrigin,
+    build_hybrid_coverage,
+    hybrid_coverage_to_overlay,
+    map_region_overlay_to_wire,
+)
+from api.models.game import TurnInfo
+
+ANALYTIC_ID = "map-region-demo"
+
+# Demo style defaults (Visibility will own client overrides later).
+_DEMO_KIND = "demo"
+_DEMO_OVERLAY_ID = "demo-coverage"
+_DEMO_FILL_COLOR = "#22c55e"
+_DEMO_FILL_OPACITY = 0.25
+_DEMO_BASE_RANGE_LY = 150.0
+_DEMO_MAX_ORIGINS = 2
+
+
+def _demo_origins(turn: TurnInfo) -> list[CoverageOrigin]:
+    """Pick owned planets plus a nebula-local origin when nebulas exist.
+
+    Planet origins show compact disk-only coverage on empty maps. A origin at
+    the first nebula center ensures nebula-local patches appear for demo blit.
+    """
+    viewpoint_id = turn.player.id
+    owned = [p for p in turn.planets if p.ownerid == viewpoint_id]
+    candidates = owned if owned else list(turn.planets)
+    origins: list[CoverageOrigin] = []
+    for planet in candidates[:_DEMO_MAX_ORIGINS]:
+        origins.append(CoverageOrigin(x=planet.x, y=planet.y, base_range=_DEMO_BASE_RANGE_LY))
+    if turn.nebulas:
+        nebula = turn.nebulas[0]
+        origins.append(
+            CoverageOrigin(
+                x=nebula.x,
+                y=nebula.y,
+                base_range=max(_DEMO_BASE_RANGE_LY, float(nebula.radius) + 20.0),
+            )
+        )
+    return origins
+
+
+def compute_map_region_demo_map(ctx: AnalyticComputeContext) -> dict:
+    """Return hybrid ``regionOverlays`` for demo map rendering."""
+    turn = ctx.turn
+    coverage = build_hybrid_coverage(_demo_origins(turn), turn.nebulas)
+    overlay = hybrid_coverage_to_overlay(
+        coverage,
+        kind=_DEMO_KIND,
+        overlay_id=_DEMO_OVERLAY_ID,
+        fill_color=_DEMO_FILL_COLOR,
+        fill_opacity=_DEMO_FILL_OPACITY,
+    )
+    return {
+        "analyticId": ANALYTIC_ID,
+        "regionOverlays": [map_region_overlay_to_wire(overlay)],
+        "nodes": [],
+        "edges": [],
+    }
+
+
+def get_map_region_demo_map(
+    turn: TurnInfo,
+    options: TurnAnalyticsOptions | None = None,
+) -> dict:
+    """Convenience entry for tests and direct callers."""
+    return invoke_analytic_compute(compute_map_region_demo_map, turn, options)
+
+
+REGISTRATION = TurnAnalyticRegistration(
+    catalog_entry=catalog_entry(ANALYTIC_ID),
+    compute=compute_map_region_demo_map,
+    export_catalog=empty_export_catalog_for(ANALYTIC_ID),
+)

--- a/packages/api/api/analytics/map_region_demo.py
+++ b/packages/api/api/analytics/map_region_demo.py
@@ -1,4 +1,4 @@
-"""Temporary map-only demo analytic for hybrid map region overlays (#248).
+"""Temporary map-only demo analytic for hybrid map region overlays.
 
 Produces shaded coverage via the shared Core hybrid coverage helper so the SPA
 can merge and blit without the Visibility analytic. Remove this registration

--- a/packages/api/api/analytics/registry.py
+++ b/packages/api/api/analytics/registry.py
@@ -10,6 +10,7 @@ from api.analytics.catalog import (
 from api.analytics.compute_context import make_analytic_compute_context
 from api.analytics.connections import REGISTRATION as CONNECTIONS_REGISTRATION
 from api.analytics.fleet.registration import REGISTRATION as FLEET_REGISTRATION
+from api.analytics.map_region_demo import REGISTRATION as MAP_REGION_DEMO_REGISTRATION
 from api.analytics.options import TurnAnalyticsOptions
 from api.analytics.registration import (
     TurnAnalyticHandler,
@@ -27,6 +28,7 @@ _IMPORTED_REGISTRATIONS: tuple[TurnAnalyticRegistration, ...] = (
     CONNECTIONS_REGISTRATION,
     STELLAR_CARTOGRAPHY_REGISTRATION,
     FLEET_REGISTRATION,
+    MAP_REGION_DEMO_REGISTRATION,
 )
 
 validate_turn_analytic_registrations(_IMPORTED_REGISTRATIONS)

--- a/packages/api/api/concepts/map_region_coverage.py
+++ b/packages/api/api/concepts/map_region_coverage.py
@@ -1,8 +1,8 @@
 """Hybrid map-region coverage: ideal disks plus nebula-local patches.
 
 Core owns coverage truth. The SPA blits disks and patches; it does not
-reimplement V(P) modulation. Patch AABBs are exclusive authority for blit
-(clip disks against them, then paint the patch raster).
+reimplement V(P) modulation. Patch AABBs are a non-overlapping partition and
+exclusive blit authority (clip disks against them, then paint each patch once).
 """
 
 from __future__ import annotations
@@ -20,6 +20,9 @@ from api.concepts.stellar_cartography.nebula_visibility import (
 # Optional hook: (base_range, density) -> effective range at a modulated cell.
 # Default applies min(base_range, V(P)). Nebula Scanner and similar land later.
 EffectiveRangeFn = Callable[[float, float], float]
+
+# Inclusive map-cell AABB: (min_x, min_y, max_x, max_y).
+CellAabb = tuple[int, int, int, int]
 
 
 @dataclass(frozen=True)
@@ -114,7 +117,7 @@ def _disk_intersects_nebula(origin: CoverageOrigin, nebula: NebulaCenter) -> boo
     )
 
 
-def _nebula_aabb(nebula: NebulaCenter) -> tuple[int, int, int, int]:
+def _nebula_aabb(nebula: NebulaCenter) -> CellAabb:
     """Inclusive AABB of the nebula disk as integer map cells."""
     r = nebula.radius
     return (
@@ -123,6 +126,56 @@ def _nebula_aabb(nebula: NebulaCenter) -> tuple[int, int, int, int]:
         nebula.x + r,
         nebula.y + r,
     )
+
+
+def _aabbs_overlap(a: CellAabb, b: CellAabb) -> bool:
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+def _aabb_union(a: CellAabb, b: CellAabb) -> CellAabb:
+    return (min(a[0], b[0]), min(a[1], b[1]), max(a[2], b[2]), max(a[3], b[3]))
+
+
+def _merged_patch_aabbs(
+    origins: Sequence[CoverageOrigin],
+    nebulas: Sequence[NebulaCenter],
+) -> list[CellAabb]:
+    """Union intersecting nebula AABBs that touch at least one coverage disk.
+
+    Returns a non-overlapping partition (connected components of AABB overlap).
+    """
+    boxes: list[CellAabb] = []
+    for nebula in nebulas:
+        if not any(_disk_intersects_nebula(o, nebula) for o in origins):
+            continue
+        boxes.append(_nebula_aabb(nebula))
+    if not boxes:
+        return []
+
+    parent = list(range(len(boxes)))
+
+    def find(i: int) -> int:
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i: int, j: int) -> None:
+        root_i, root_j = find(i), find(j)
+        if root_i != root_j:
+            parent[root_j] = root_i
+
+    for i in range(len(boxes)):
+        for j in range(i + 1, len(boxes)):
+            if _aabbs_overlap(boxes[i], boxes[j]):
+                union(i, j)
+
+    merged: dict[int, CellAabb] = {}
+    for i, box in enumerate(boxes):
+        root = find(i)
+        existing = merged.get(root)
+        merged[root] = box if existing is None else _aabb_union(existing, box)
+    return list(merged.values())
 
 
 def _cell_covered(
@@ -143,14 +196,14 @@ def _cell_covered(
     return False
 
 
-def _build_patch_for_nebula(
-    nebula: NebulaCenter,
+def _build_patch_for_aabb(
+    aabb: CellAabb,
     origins: Sequence[CoverageOrigin],
     nebulas: Sequence[NebulaCenter],
     *,
     effective_range: EffectiveRangeFn,
 ) -> MapRegionOverlayPatch | None:
-    min_x, min_y, max_x, max_y = _nebula_aabb(nebula)
+    min_x, min_y, max_x, max_y = aabb
     width = max_x - min_x + 1
     height = max_y - min_y + 1
     if width <= 0 or height <= 0:
@@ -187,10 +240,10 @@ def build_hybrid_coverage(
 ) -> HybridCoverage:
     """Build ideal disks plus nebula-local patches for the given origins.
 
-    Disks are one per origin at ``base_range``. Patches are emitted only for
-    nebula footprints that intersect at least one disk. Inside a patch AABB,
-    coverage truth includes ideal reach outside density and V(P)-modulated
-    reach where density > 0 (so the AABB is exclusive blit authority).
+    Disks are one per origin at ``base_range``. Patches cover merged AABBs of
+    disk-intersecting nebulas (connected components of AABB overlap) so patch
+    regions never overlap. Inside a patch AABB, coverage truth includes ideal
+    reach outside density and V(P)-modulated reach where density > 0.
     """
     active_origins = [o for o in origins if o.base_range > 0]
     disks = tuple(MapRegionOverlayDisk(x=o.x, y=o.y, radius=o.base_range) for o in active_origins)
@@ -199,11 +252,9 @@ def build_hybrid_coverage(
 
     modulation = effective_range or default_effective_range
     patches: list[MapRegionOverlayPatch] = []
-    for nebula in nebulas:
-        if not any(_disk_intersects_nebula(o, nebula) for o in active_origins):
-            continue
-        patch = _build_patch_for_nebula(
-            nebula,
+    for aabb in _merged_patch_aabbs(active_origins, nebulas):
+        patch = _build_patch_for_aabb(
+            aabb,
             active_origins,
             nebulas,
             effective_range=modulation,

--- a/packages/api/api/concepts/map_region_coverage.py
+++ b/packages/api/api/concepts/map_region_coverage.py
@@ -1,0 +1,281 @@
+"""Hybrid map-region coverage: ideal disks plus nebula-local patches.
+
+Core owns coverage truth. The SPA blits disks and patches; it does not
+reimplement V(P) modulation. Patch AABBs are exclusive authority for blit
+(clip disks against them, then paint the patch raster).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from api.concepts.stellar_cartography.nebula_visibility import (
+    NebulaCenter,
+    distance_ly,
+    nebula_density_at,
+    nebula_visibility_ly,
+)
+
+# Optional hook: (base_range, density) -> effective range at a modulated cell.
+# Default applies min(base_range, V(P)). Nebula Scanner and similar land later.
+EffectiveRangeFn = Callable[[float, float], float]
+
+
+@dataclass(frozen=True)
+class CoverageOrigin:
+    """Scan origin for hybrid coverage."""
+
+    x: int
+    y: int
+    base_range: float
+
+
+@dataclass(frozen=True)
+class MapRegionOverlayDisk:
+    """Ideal coverage disk in game ly."""
+
+    x: int
+    y: int
+    radius: float
+
+
+@dataclass(frozen=True)
+class CoverageRleRun:
+    """One run-length segment of a patch coverage mask."""
+
+    length: int
+    covered: bool
+
+
+@dataclass(frozen=True)
+class MapRegionOverlayPatch:
+    """Nebula-local coverage patch (1 ly cells, row-major RLE)."""
+
+    origin_x: int
+    origin_y: int
+    width: int
+    height: int
+    coverage_rle: tuple[CoverageRleRun, ...]
+
+
+@dataclass(frozen=True)
+class HybridCoverage:
+    """Disk union where unmodulated, plus patches where nebulae distort."""
+
+    disks: tuple[MapRegionOverlayDisk, ...]
+    patches: tuple[MapRegionOverlayPatch, ...]
+
+
+@dataclass(frozen=True)
+class MapRegionOverlay:
+    """Analytic-agnostic shaded region overlay for the combined map."""
+
+    kind: str
+    id: str
+    fill_color: str
+    fill_opacity: float
+    disks: tuple[MapRegionOverlayDisk, ...]
+    patches: tuple[MapRegionOverlayPatch, ...]
+
+
+def default_effective_range(base_range: float, density: float) -> float:
+    """Effective reach at a cell: ``min(base_range, V(P))`` when density > 0."""
+    if density <= 0:
+        return base_range
+    visibility = nebula_visibility_ly(density)
+    if visibility is None:
+        return base_range
+    return min(base_range, float(visibility))
+
+
+def _encode_coverage_rle(cells: Sequence[bool]) -> tuple[CoverageRleRun, ...]:
+    if not cells:
+        return ()
+    runs: list[CoverageRleRun] = []
+    current = cells[0]
+    length = 1
+    for covered in cells[1:]:
+        if covered == current:
+            length += 1
+            continue
+        runs.append(CoverageRleRun(length=length, covered=current))
+        current = covered
+        length = 1
+    runs.append(CoverageRleRun(length=length, covered=current))
+    return tuple(runs)
+
+
+def _disk_intersects_nebula(origin: CoverageOrigin, nebula: NebulaCenter) -> bool:
+    if nebula.radius <= 0 or nebula.id < 0 or origin.base_range <= 0:
+        return False
+    return distance_ly(origin.x, origin.y, nebula.x, nebula.y) <= (
+        origin.base_range + nebula.radius
+    )
+
+
+def _nebula_aabb(nebula: NebulaCenter) -> tuple[int, int, int, int]:
+    """Inclusive AABB of the nebula disk as integer map cells."""
+    r = nebula.radius
+    return (
+        nebula.x - r,
+        nebula.y - r,
+        nebula.x + r,
+        nebula.y + r,
+    )
+
+
+def _cell_covered(
+    x: int,
+    y: int,
+    origins: Sequence[CoverageOrigin],
+    nebulas: Sequence[NebulaCenter],
+    *,
+    effective_range: EffectiveRangeFn,
+) -> bool:
+    density = nebula_density_at(nebulas, x, y)
+    for origin in origins:
+        if origin.base_range <= 0:
+            continue
+        reach = effective_range(origin.base_range, density) if density > 0 else origin.base_range
+        if distance_ly(origin.x, origin.y, x, y) <= reach:
+            return True
+    return False
+
+
+def _build_patch_for_nebula(
+    nebula: NebulaCenter,
+    origins: Sequence[CoverageOrigin],
+    nebulas: Sequence[NebulaCenter],
+    *,
+    effective_range: EffectiveRangeFn,
+) -> MapRegionOverlayPatch | None:
+    min_x, min_y, max_x, max_y = _nebula_aabb(nebula)
+    width = max_x - min_x + 1
+    height = max_y - min_y + 1
+    if width <= 0 or height <= 0:
+        return None
+
+    cells: list[bool] = []
+    for row in range(height):
+        y = min_y + row
+        for col in range(width):
+            x = min_x + col
+            cells.append(
+                _cell_covered(
+                    x,
+                    y,
+                    origins,
+                    nebulas,
+                    effective_range=effective_range,
+                )
+            )
+    return MapRegionOverlayPatch(
+        origin_x=min_x,
+        origin_y=min_y,
+        width=width,
+        height=height,
+        coverage_rle=_encode_coverage_rle(cells),
+    )
+
+
+def build_hybrid_coverage(
+    origins: Sequence[CoverageOrigin],
+    nebulas: Sequence[NebulaCenter],
+    *,
+    effective_range: EffectiveRangeFn | None = None,
+) -> HybridCoverage:
+    """Build ideal disks plus nebula-local patches for the given origins.
+
+    Disks are one per origin at ``base_range``. Patches are emitted only for
+    nebula footprints that intersect at least one disk. Inside a patch AABB,
+    coverage truth includes ideal reach outside density and V(P)-modulated
+    reach where density > 0 (so the AABB is exclusive blit authority).
+    """
+    active_origins = [o for o in origins if o.base_range > 0]
+    disks = tuple(MapRegionOverlayDisk(x=o.x, y=o.y, radius=o.base_range) for o in active_origins)
+    if not active_origins:
+        return HybridCoverage(disks=(), patches=())
+
+    modulation = effective_range or default_effective_range
+    patches: list[MapRegionOverlayPatch] = []
+    for nebula in nebulas:
+        if not any(_disk_intersects_nebula(o, nebula) for o in active_origins):
+            continue
+        patch = _build_patch_for_nebula(
+            nebula,
+            active_origins,
+            nebulas,
+            effective_range=modulation,
+        )
+        if patch is not None:
+            patches.append(patch)
+
+    return HybridCoverage(disks=disks, patches=tuple(patches))
+
+
+def map_region_overlay_to_wire(overlay: MapRegionOverlay) -> dict:
+    """Serialize a map region overlay to camelCase JSON for map payloads."""
+    return {
+        "kind": overlay.kind,
+        "id": overlay.id,
+        "fillColor": overlay.fill_color,
+        "fillOpacity": overlay.fill_opacity,
+        "disks": [{"x": d.x, "y": d.y, "radius": d.radius} for d in overlay.disks],
+        "patches": [
+            {
+                "originX": p.origin_x,
+                "originY": p.origin_y,
+                "width": p.width,
+                "height": p.height,
+                "coverageRle": [
+                    {"length": run.length, "covered": run.covered} for run in p.coverage_rle
+                ],
+            }
+            for p in overlay.patches
+        ],
+    }
+
+
+def hybrid_coverage_to_overlay(
+    coverage: HybridCoverage,
+    *,
+    kind: str,
+    overlay_id: str,
+    fill_color: str,
+    fill_opacity: float,
+) -> MapRegionOverlay:
+    """Wrap hybrid geometry with style metadata for the wire."""
+    return MapRegionOverlay(
+        kind=kind,
+        id=overlay_id,
+        fill_color=fill_color,
+        fill_opacity=fill_opacity,
+        disks=coverage.disks,
+        patches=coverage.patches,
+    )
+
+
+def decode_patch_coverage(patch: MapRegionOverlayPatch) -> list[bool]:
+    """Expand RLE to a flat row-major boolean mask (tests / tooling)."""
+    expected = patch.width * patch.height
+    cells: list[bool] = []
+    for run in patch.coverage_rle:
+        if run.length < 0:
+            raise ValueError(f"negative RLE length: {run.length}")
+        cells.extend([run.covered] * run.length)
+    if len(cells) != expected:
+        raise ValueError(f"RLE length {len(cells)} does not match patch size {expected}")
+    return cells
+
+
+def patch_cell_covered(patch: MapRegionOverlayPatch, x: int, y: int) -> bool | None:
+    """Return coverage at ``(x, y)`` if inside the patch AABB, else ``None``."""
+    if x < patch.origin_x or y < patch.origin_y:
+        return None
+    col = x - patch.origin_x
+    row = y - patch.origin_y
+    if col >= patch.width or row >= patch.height:
+        return None
+    cells = decode_patch_coverage(patch)
+    return cells[row * patch.width + col]

--- a/packages/api/api/concepts/map_region_coverage.py
+++ b/packages/api/api/concepts/map_region_coverage.py
@@ -136,13 +136,36 @@ def _aabb_union(a: CellAabb, b: CellAabb) -> CellAabb:
     return (min(a[0], b[0]), min(a[1], b[1]), max(a[2], b[2]), max(a[3], b[3]))
 
 
+def _merge_until_disjoint(boxes: Sequence[CellAabb]) -> list[CellAabb]:
+    """Merge AABBs until no two results overlap.
+
+    Needed because AABB-union of an overlap connected component can still
+    contain a disjoint box that sits in a pocket of the union rectangle.
+    """
+    out = list(boxes)
+    changed = True
+    while changed:
+        changed = False
+        next_out: list[CellAabb] = []
+        for box in out:
+            for i, existing in enumerate(next_out):
+                if _aabbs_overlap(box, existing):
+                    next_out[i] = _aabb_union(existing, box)
+                    changed = True
+                    break
+            else:
+                next_out.append(box)
+        out = next_out
+    return out
+
+
 def _merged_patch_aabbs(
     origins: Sequence[CoverageOrigin],
     nebulas: Sequence[NebulaCenter],
 ) -> list[CellAabb]:
-    """Union intersecting nebula AABBs that touch at least one coverage disk.
+    """Union nebula AABBs that touch at least one coverage disk.
 
-    Returns a non-overlapping partition (connected components of AABB overlap).
+    Returns a non-overlapping partition of covering AABBs (merge until disjoint).
     """
     boxes: list[CellAabb] = []
     for nebula in nebulas:
@@ -151,31 +174,7 @@ def _merged_patch_aabbs(
         boxes.append(_nebula_aabb(nebula))
     if not boxes:
         return []
-
-    parent = list(range(len(boxes)))
-
-    def find(i: int) -> int:
-        while parent[i] != i:
-            parent[i] = parent[parent[i]]
-            i = parent[i]
-        return i
-
-    def union(i: int, j: int) -> None:
-        root_i, root_j = find(i), find(j)
-        if root_i != root_j:
-            parent[root_j] = root_i
-
-    for i in range(len(boxes)):
-        for j in range(i + 1, len(boxes)):
-            if _aabbs_overlap(boxes[i], boxes[j]):
-                union(i, j)
-
-    merged: dict[int, CellAabb] = {}
-    for i, box in enumerate(boxes):
-        root = find(i)
-        existing = merged.get(root)
-        merged[root] = box if existing is None else _aabb_union(existing, box)
-    return list(merged.values())
+    return _merge_until_disjoint(boxes)
 
 
 def _cell_covered(
@@ -241,9 +240,9 @@ def build_hybrid_coverage(
     """Build ideal disks plus nebula-local patches for the given origins.
 
     Disks are one per origin at ``base_range``. Patches cover merged AABBs of
-    disk-intersecting nebulas (connected components of AABB overlap) so patch
-    regions never overlap. Inside a patch AABB, coverage truth includes ideal
-    reach outside density and V(P)-modulated reach where density > 0.
+    disk-intersecting nebulas (merge until no two patch AABBs overlap). Inside
+    a patch AABB, coverage truth includes ideal reach outside density and
+    V(P)-modulated reach where density > 0.
     """
     active_origins = [o for o in origins if o.base_range > 0]
     disks = tuple(MapRegionOverlayDisk(x=o.x, y=o.y, radius=o.base_range) for o in active_origins)

--- a/packages/api/api/concepts/stellar_cartography/nebula_visibility.py
+++ b/packages/api/api/concepts/stellar_cartography/nebula_visibility.py
@@ -1,0 +1,51 @@
+"""Host-aligned nebula density and visibility V(P) at a map cell.
+
+Shared by Stellar Cartography ``sample_at`` tooltips and hybrid map-region coverage.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Protocol
+
+# Host-aligned tooltip math (Planets.nu client / Meteor's Library).
+NEBULA_VISIBILITY_NUMERATOR = 4000
+NEBULA_VISIBILITY_MAX_LY = 250
+
+
+class NebulaCenter(Protocol):
+    """Minimal nebula center fields needed for density sampling."""
+
+    id: int
+    x: int
+    y: int
+    radius: int
+    intensity: int
+
+
+def distance_ly(x: float, y: float, fx: float, fy: float) -> float:
+    """Euclidean distance in light-years between two map points."""
+    return math.hypot(x - fx, y - fy)
+
+
+def nebula_density_at(centers: Sequence[NebulaCenter], x: int, y: int) -> float:
+    """Summed host density at integer map cell ``(x, y)``."""
+    total = 0.0
+    for center in centers:
+        if center.radius <= 0 or center.id < 0:
+            continue
+        dist = distance_ly(x, y, center.x, center.y)
+        if dist <= center.radius:
+            total += math.ceil(center.intensity * (1.0 - dist / center.radius))
+    return total
+
+
+def nebula_visibility_ly(density: float) -> int | None:
+    """Visibility range V(P) in ly from host density, or ``None`` outside fog."""
+    if density <= 0:
+        return None
+    return min(
+        NEBULA_VISIBILITY_MAX_LY,
+        int(round(NEBULA_VISIBILITY_NUMERATOR / (density + 1))),
+    )

--- a/packages/api/api/concepts/stellar_cartography/sample_at.py
+++ b/packages/api/api/concepts/stellar_cartography/sample_at.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from collections import defaultdict
 
 from api.analytics.stellar_cartography import ion_storm_class
@@ -18,6 +17,13 @@ from api.concepts.stellar_cartography.layers import (
     LAYER_STAR_CLUSTERS,
     PAINT_ORDER,
 )
+from api.concepts.stellar_cartography.nebula_visibility import (
+    NEBULA_VISIBILITY_MAX_LY,
+    NEBULA_VISIBILITY_NUMERATOR,
+    distance_ly,
+    nebula_density_at,
+    nebula_visibility_ly,
+)
 from api.concepts.stellar_cartography.star_clusters import (
     format_neutrino_movement_bonus,
     format_neutrino_warp_9_max_range,
@@ -29,6 +35,13 @@ from api.concepts.stellar_cartography.star_clusters import (
 from api.models.game import TurnInfo
 from api.models.space import IonStorm, Nebula
 
+# Re-export for callers that historically imported constants from this module.
+__all__ = (
+    "NEBULA_VISIBILITY_MAX_LY",
+    "NEBULA_VISIBILITY_NUMERATOR",
+    "sample_at",
+)
+
 ION_CLASS_NAMES: dict[int, str] = {
     1: "Harmless",
     2: "Moderate",
@@ -37,13 +50,9 @@ ION_CLASS_NAMES: dict[int, str] = {
     5: "Very dangerous",
 }
 
-# Host-aligned tooltip math (Planets.nu client / Meteor's Library).
-NEBULA_VISIBILITY_NUMERATOR = 4000
-NEBULA_VISIBILITY_MAX_LY = 250
-
 
 def _distance_ly(x: int, y: int, fx: int, fy: int) -> float:
-    return math.hypot(x - fx, y - fy)
+    return distance_ly(x, y, fx, fy)
 
 
 def _ion_storm_groups(ionstorms: list[IonStorm]) -> list[list[IonStorm]]:
@@ -146,26 +155,6 @@ def _black_hole_entries(turn: TurnInfo, x: int, y: int) -> list[dict]:
     return entries
 
 
-def _nebula_density_at(centers: list[Nebula], x: int, y: int) -> float:
-    total = 0.0
-    for center in centers:
-        if center.radius <= 0 or center.id < 0:
-            continue
-        dist = _distance_ly(x, y, center.x, center.y)
-        if dist <= center.radius:
-            total += math.ceil(center.intensity * (1.0 - dist / center.radius))
-    return total
-
-
-def _nebula_visibility_ly(density: float) -> int | None:
-    if density <= 0:
-        return None
-    return min(
-        NEBULA_VISIBILITY_MAX_LY,
-        int(round(NEBULA_VISIBILITY_NUMERATOR / (density + 1))),
-    )
-
-
 def _nebula_entries(turn: TurnInfo, x: int, y: int) -> list[dict]:
     by_name: dict[str, list[Nebula]] = defaultdict(list)
     for nebula in turn.nebulas:
@@ -173,8 +162,8 @@ def _nebula_entries(turn: TurnInfo, x: int, y: int) -> list[dict]:
 
     entries: list[dict] = []
     for name, centers in by_name.items():
-        density = _nebula_density_at(centers, x, y)
-        visibility = _nebula_visibility_ly(density)
+        density = nebula_density_at(centers, x, y)
+        visibility = nebula_visibility_ly(density)
         if visibility is None:
             continue
         entries.append(

--- a/packages/api/tests/test_map_region_coverage.py
+++ b/packages/api/tests/test_map_region_coverage.py
@@ -115,3 +115,52 @@ def test_wire_round_trip_shape():
     assert patch["height"] == 31
     assert isinstance(patch["coverageRle"], list)
     assert patch["coverageRle"][0].keys() >= {"length", "covered"}
+
+
+def _patch_aabb(patch) -> tuple[int, int, int, int]:
+    return (
+        patch.origin_x,
+        patch.origin_y,
+        patch.origin_x + patch.width - 1,
+        patch.origin_y + patch.height - 1,
+    )
+
+
+def _aabbs_overlap(
+    a: tuple[int, int, int, int],
+    b: tuple[int, int, int, int],
+) -> bool:
+    return not (a[2] < b[0] or b[2] < a[0] or a[3] < b[1] or b[3] < a[1])
+
+
+def test_overlapping_nebulas_merge_into_one_non_overlapping_patch():
+    origin = CoverageOrigin(x=0, y=0, base_range=200)
+    n1 = Nebula(id=1, x=50, y=0, name="A", radius=40, intensity=40)
+    n2 = Nebula(id=2, x=70, y=0, name="B", radius=40, intensity=40)
+    coverage = build_hybrid_coverage([origin], [n1, n2])
+
+    assert len(coverage.disks) == 1
+    assert len(coverage.patches) == 1
+    patch = coverage.patches[0]
+    # Union of [10,-40]..[90,40] and [30,-40]..[110,40]
+    assert patch.origin_x == 10
+    assert patch.origin_y == -40
+    assert patch.width == 101
+    assert patch.height == 81
+    # Overlap cell is owned by exactly one patch (the merged AABB).
+    assert patch_cell_covered(patch, 60, 0) is not None
+
+
+def test_disjoint_nebulas_emit_non_overlapping_patches():
+    origin = CoverageOrigin(x=0, y=0, base_range=500)
+    n1 = Nebula(id=1, x=100, y=0, name="West", radius=20, intensity=40)
+    n2 = Nebula(id=2, x=400, y=0, name="East", radius=20, intensity=40)
+    coverage = build_hybrid_coverage([origin], [n1, n2])
+
+    assert len(coverage.patches) == 2
+    a, b = coverage.patches
+    assert not _aabbs_overlap(_patch_aabb(a), _patch_aabb(b))
+    assert patch_cell_covered(a, 100, 0) is not None
+    assert patch_cell_covered(b, 100, 0) is None
+    assert patch_cell_covered(b, 400, 0) is not None
+    assert patch_cell_covered(a, 400, 0) is None

--- a/packages/api/tests/test_map_region_coverage.py
+++ b/packages/api/tests/test_map_region_coverage.py
@@ -1,0 +1,117 @@
+"""Tests for hybrid map-region coverage (disks + nebula-local patches)."""
+
+from api.concepts.map_region_coverage import (
+    CoverageOrigin,
+    build_hybrid_coverage,
+    decode_patch_coverage,
+    hybrid_coverage_to_overlay,
+    map_region_overlay_to_wire,
+    patch_cell_covered,
+)
+from api.concepts.stellar_cartography.nebula_visibility import nebula_visibility_ly
+from api.models.space import Nebula
+
+
+def test_empty_origins_yield_empty_coverage():
+    coverage = build_hybrid_coverage(
+        [],
+        [Nebula(id=1, x=0, y=0, radius=50, intensity=40)],
+    )
+    assert coverage.disks == ()
+    assert coverage.patches == ()
+
+
+def test_disk_only_no_nebulas():
+    coverage = build_hybrid_coverage(
+        [
+            CoverageOrigin(x=100, y=200, base_range=150),
+            CoverageOrigin(x=300, y=200, base_range=80),
+        ],
+        [],
+    )
+    assert len(coverage.disks) == 2
+    assert coverage.disks[0].x == 100
+    assert coverage.disks[0].y == 200
+    assert coverage.disks[0].radius == 150
+    assert coverage.disks[1].radius == 80
+    assert coverage.patches == ()
+
+
+def test_zero_base_range_origins_omitted():
+    coverage = build_hybrid_coverage(
+        [CoverageOrigin(x=0, y=0, base_range=0)],
+        [Nebula(id=1, x=0, y=0, radius=10, intensity=40)],
+    )
+    assert coverage.disks == ()
+    assert coverage.patches == ()
+
+
+def test_nebula_far_from_disk_emits_no_patch():
+    coverage = build_hybrid_coverage(
+        [CoverageOrigin(x=0, y=0, base_range=50)],
+        [Nebula(id=1, x=1000, y=1000, radius=20, intensity=40)],
+    )
+    assert len(coverage.disks) == 1
+    assert coverage.patches == ()
+
+
+def test_nebula_dented_coverage_patch_is_local():
+    # Dense nebula: V(P) at center is well below base_range, so the ideal disk
+    # is dented inside the nebula AABB.
+    origin = CoverageOrigin(x=0, y=0, base_range=200)
+    nebula = Nebula(id=1, x=100, y=0, name="Fog", radius=40, intensity=72)
+    coverage = build_hybrid_coverage([origin], [nebula])
+
+    assert len(coverage.disks) == 1
+    assert len(coverage.patches) == 1
+    patch = coverage.patches[0]
+    assert patch.origin_x == 60
+    assert patch.origin_y == -40
+    assert patch.width == 81
+    assert patch.height == 81
+
+    density_at_center = 72.0  # ceil(72 * 1.0) at center
+    visibility = nebula_visibility_ly(density_at_center)
+    assert visibility is not None
+    assert visibility < 200
+
+    # Center of nebula: dist from origin is 100; covered iff 100 <= V(P).
+    center_covered = patch_cell_covered(patch, 100, 0)
+    assert center_covered == (100 <= visibility)
+
+    # Cell outside nebula radius but inside AABB corner: density 0, ideal reach.
+    corner = patch_cell_covered(patch, 60, -40)
+    assert corner is not None
+    # Dist from (0,0) to (60,-40) = hypot(60,40)=72.11 < 200 → covered
+    assert corner is True
+
+    cells = decode_patch_coverage(patch)
+    assert len(cells) == patch.width * patch.height
+    assert sum(1 for c in cells if c) < len(cells)
+
+
+def test_wire_round_trip_shape():
+    coverage = build_hybrid_coverage(
+        [CoverageOrigin(x=10, y=20, base_range=50)],
+        [Nebula(id=1, x=30, y=20, radius=15, intensity=39)],
+    )
+    overlay = hybrid_coverage_to_overlay(
+        coverage,
+        kind="demo",
+        overlay_id="demo-1",
+        fill_color="#22c55e",
+        fill_opacity=0.25,
+    )
+    wire = map_region_overlay_to_wire(overlay)
+    assert wire["kind"] == "demo"
+    assert wire["id"] == "demo-1"
+    assert wire["fillColor"] == "#22c55e"
+    assert wire["fillOpacity"] == 0.25
+    assert wire["disks"] == [{"x": 10, "y": 20, "radius": 50}]
+    assert len(wire["patches"]) == 1
+    patch = wire["patches"][0]
+    assert patch["originX"] == 15
+    assert patch["width"] == 31
+    assert patch["height"] == 31
+    assert isinstance(patch["coverageRle"], list)
+    assert patch["coverageRle"][0].keys() >= {"length", "covered"}

--- a/packages/api/tests/test_map_region_coverage.py
+++ b/packages/api/tests/test_map_region_coverage.py
@@ -164,3 +164,26 @@ def test_disjoint_nebulas_emit_non_overlapping_patches():
     assert patch_cell_covered(b, 100, 0) is None
     assert patch_cell_covered(b, 400, 0) is not None
     assert patch_cell_covered(a, 400, 0) is None
+
+
+def test_l_shaped_nebula_chain_merges_pocket_nebula_into_one_patch():
+    """L-chain AABB union leaves a pocket; a nebula there must still merge.
+
+    Connected-component union alone emits two overlapping patch AABBs; exclusive
+    blit authority requires a single non-overlapping covering AABB.
+    """
+    origin = CoverageOrigin(x=0, y=0, base_range=200)
+    n1 = Nebula(id=1, x=0, y=0, name="A", radius=30, intensity=40)
+    n2 = Nebula(id=2, x=60, y=0, name="B", radius=30, intensity=40)
+    n3 = Nebula(id=3, x=0, y=60, name="C", radius=30, intensity=40)
+    n4 = Nebula(id=4, x=60, y=60, name="D", radius=20, intensity=40)
+    coverage = build_hybrid_coverage([origin], [n1, n2, n3, n4])
+
+    assert len(coverage.patches) == 1
+    patch = coverage.patches[0]
+    assert patch.origin_x == -30
+    assert patch.origin_y == -30
+    assert patch.width == 121
+    assert patch.height == 121
+    assert patch_cell_covered(patch, 0, 0) is not None
+    assert patch_cell_covered(patch, 60, 60) is not None

--- a/packages/api/tests/test_map_region_demo.py
+++ b/packages/api/tests/test_map_region_demo.py
@@ -1,0 +1,49 @@
+"""Tests for the temporary map-region-demo analytic."""
+
+import json
+from pathlib import Path
+
+import pytest
+from api.analytics.map_region_demo import ANALYTIC_ID, get_map_region_demo_map
+from api.analytics.options import TurnAnalyticsOptions
+from api.serialization.turn import turn_info_from_json
+
+ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
+
+
+@pytest.fixture
+def stellar_cartography_turn():
+    with open(ASSETS_DIR / "turn_stellar_cartography_sample.json") as f:
+        return turn_info_from_json(json.load(f))
+
+
+@pytest.fixture
+def sample_turn():
+    with open(ASSETS_DIR / "turn_sample.json") as f:
+        return turn_info_from_json(json.load(f))
+
+
+def test_map_region_demo_emits_region_overlays_disk_only(sample_turn):
+    data = get_map_region_demo_map(sample_turn, TurnAnalyticsOptions())
+    assert data["analyticId"] == ANALYTIC_ID
+    assert data["nodes"] == []
+    assert data["edges"] == []
+    overlays = data["regionOverlays"]
+    assert len(overlays) == 1
+    overlay = overlays[0]
+    assert overlay["kind"] == "demo"
+    assert overlay["fillColor"] == "#22c55e"
+    assert overlay["fillOpacity"] == 0.25
+    assert len(overlay["disks"]) >= 1
+    assert overlay["patches"] == [] or isinstance(overlay["patches"], list)
+
+
+def test_map_region_demo_emits_nebula_patches_when_present(stellar_cartography_turn):
+    data = get_map_region_demo_map(stellar_cartography_turn, TurnAnalyticsOptions())
+    overlay = data["regionOverlays"][0]
+    assert len(overlay["disks"]) >= 1
+    assert len(overlay["patches"]) >= 1
+    for patch in overlay["patches"]:
+        assert patch["width"] * patch["height"] == sum(
+            run["length"] for run in patch["coverageRle"]
+        )

--- a/packages/api/tests/test_stellar_cartography_sample.py
+++ b/packages/api/tests/test_stellar_cartography_sample.py
@@ -38,17 +38,17 @@ def test_nebula_name_at_center(stellar_cartography_turn):
 
 
 def test_nebula_visibility_can_exceed_hundred_ly():
-    from api.concepts.stellar_cartography.sample_at import _nebula_visibility_ly
+    from api.concepts.stellar_cartography.nebula_visibility import nebula_visibility_ly
 
-    assert _nebula_visibility_ly(38) == 103
-    assert _nebula_visibility_ly(39) == 100
+    assert nebula_visibility_ly(38) == 103
+    assert nebula_visibility_ly(39) == 100
 
 
 def test_nebula_visibility_capped_at_two_fifty_ly():
-    from api.concepts.stellar_cartography.sample_at import _nebula_visibility_ly
+    from api.concepts.stellar_cartography.nebula_visibility import nebula_visibility_ly
 
-    assert _nebula_visibility_ly(1) == 250
-    assert _nebula_visibility_ly(15) == 250
+    assert nebula_visibility_ly(1) == 250
+    assert nebula_visibility_ly(15) == 250
 
 
 def test_nebula_groups_overlapping_centers_by_name(stellar_cartography_turn):

--- a/packages/bff/bff/analytics/map_region_demo.py
+++ b/packages/bff/bff/analytics/map_region_demo.py
@@ -1,0 +1,29 @@
+"""BFF map-region-demo analytic handler (passthrough)."""
+
+from api.analytics.catalog import catalog_entry
+from api.diagnostics import Diagnostics
+
+from bff.analytics.descriptor import AnalyticDescriptor
+from bff.analytics.models import (
+    ConnectionsMapQuery,
+    CoreAnalyticsLoader,
+    TurnScope,
+    load_core_analytic,
+)
+
+ANALYTIC_ID = "map-region-demo"
+
+
+def get_map(
+    scope: TurnScope,
+    _query: ConnectionsMapQuery,
+    load_core: CoreAnalyticsLoader,
+    diagnostics: Diagnostics,
+) -> dict:
+    return load_core_analytic(load_core, scope, ANALYTIC_ID, diagnostics=diagnostics)
+
+
+DESCRIPTOR = AnalyticDescriptor.from_catalog_entry(
+    catalog_entry(ANALYTIC_ID),
+    get_map=get_map,
+)

--- a/packages/bff/bff/analytics/registry.py
+++ b/packages/bff/bff/analytics/registry.py
@@ -7,7 +7,7 @@ from bff.analytics.descriptor import AnalyticDescriptor
 from bff.analytics.models import ConnectionsMapQuery, CoreAnalyticsLoader, TurnScope
 from bff.errors import BFFValidationError
 
-from . import base_map, connections, fleet, scores, stellar_cartography
+from . import base_map, connections, fleet, map_region_demo, scores, stellar_cartography
 
 _BFF_DESCRIPTORS_BY_ID: dict[str, AnalyticDescriptor] = {
     base_map.DESCRIPTOR.id: base_map.DESCRIPTOR,
@@ -15,6 +15,7 @@ _BFF_DESCRIPTORS_BY_ID: dict[str, AnalyticDescriptor] = {
     connections.DESCRIPTOR.id: connections.DESCRIPTOR,
     stellar_cartography.DESCRIPTOR.id: stellar_cartography.DESCRIPTOR,
     fleet.DESCRIPTOR.id: fleet.DESCRIPTOR,
+    map_region_demo.DESCRIPTOR.id: map_region_demo.DESCRIPTOR,
 }
 
 

--- a/packages/bff/bff/routers/analytics.py
+++ b/packages/bff/bff/routers/analytics.py
@@ -132,6 +132,8 @@ def get_analytic_map(
 
     **stellar-cartography** returns overlay circles and wormhole graph geometry.
 
+    **map-region-demo** returns hybrid ``regionOverlays`` (ideal disks + nebula-local patches).
+
     Nodes use fixed Cartesian coordinates (x, y). The SPA fetches base-map first, then
     enabled map analytics, and merges layers (see docs/design-connections-analytic.md).
     """

--- a/packages/bff/tests/test_analytics.py
+++ b/packages/bff/tests/test_analytics.py
@@ -267,6 +267,37 @@ def test_list_analytics_includes_stellar_cartography_map_analytic():
     assert stellar["type"] == "selectable"
 
 
+def test_list_analytics_includes_map_region_demo_map_analytic():
+    response = client.get("/analytics")
+    assert response.status_code == 200
+    analytics = response.json()["analytics"]
+    demo = next(a for a in analytics if a["id"] == "map-region-demo")
+    assert demo == {
+        "id": "map-region-demo",
+        "name": "Map region demo",
+        "supportsTable": False,
+        "supportsMap": True,
+        "type": "selectable",
+    }
+
+
+def test_map_region_demo_map_returns_region_overlays():
+    storage = get_storage()
+    with open(ASSETS_DIR / "turn_stellar_cartography_sample.json") as f:
+        storage.put(f"games/{GAME_ID}/{PERSPECTIVE}/turns/{HOST_TURN}", json.load(f))
+    response = client.get(f"/analytics/map-region-demo/map?{SCOPE_QS}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["analyticId"] == "map-region-demo"
+    assert isinstance(data["regionOverlays"], list)
+    assert len(data["regionOverlays"]) == 1
+    overlay = data["regionOverlays"][0]
+    assert overlay["kind"] == "demo"
+    assert "disks" in overlay
+    assert "patches" in overlay
+    assert "fillColor" in overlay
+
+
 def test_list_analytics_includes_fleet_table_and_map_analytic():
     response = client.get("/analytics")
     assert response.status_code == 200

--- a/packages/frontend/src/analytics/map-region-demo/mapAnalytic.ts
+++ b/packages/frontend/src/analytics/map-region-demo/mapAnalytic.ts
@@ -1,0 +1,16 @@
+import type { MapAnalyticRegistration } from '../mapAnalyticRegistry'
+import { MAP_REGION_DEMO_ANALYTIC_ID } from '../mapAnalyticIds'
+
+/**
+ * Temporary demo analytic: merge Core hybrid ``regionOverlays`` into the combined map.
+ * Remove when the Visibility analytic lands.
+ */
+export const mapRegionDemoMapAnalytic: MapAnalyticRegistration = {
+  mergeLayer(data, context) {
+    const overlays = data.regionOverlays
+    if (overlays == null || overlays.length === 0) return
+    context.regionOverlays.push(...overlays)
+  },
+}
+
+export { MAP_REGION_DEMO_ANALYTIC_ID }

--- a/packages/frontend/src/analytics/mapAnalyticIds.ts
+++ b/packages/frontend/src/analytics/mapAnalyticIds.ts
@@ -10,7 +10,7 @@ export const STELLAR_CARTOGRAPHY_ANALYTIC_ID = 'stellar-cartography'
 /** Canonical id for the Fleet map overlay analytic. */
 export const FLEET_ANALYTIC_ID = 'fleet'
 
-/** Temporary demo analytic for hybrid map region overlays (#248). */
+/** Temporary demo analytic for hybrid map region overlays. */
 export const MAP_REGION_DEMO_ANALYTIC_ID = 'map-region-demo'
 
 /** Prefix for merged Stellar Cartography node and edge ids on the combined map. */

--- a/packages/frontend/src/analytics/mapAnalyticIds.ts
+++ b/packages/frontend/src/analytics/mapAnalyticIds.ts
@@ -10,5 +10,8 @@ export const STELLAR_CARTOGRAPHY_ANALYTIC_ID = 'stellar-cartography'
 /** Canonical id for the Fleet map overlay analytic. */
 export const FLEET_ANALYTIC_ID = 'fleet'
 
+/** Temporary demo analytic for hybrid map region overlays (#248). */
+export const MAP_REGION_DEMO_ANALYTIC_ID = 'map-region-demo'
+
 /** Prefix for merged Stellar Cartography node and edge ids on the combined map. */
 export const STELLAR_CARTOGRAPHY_NODE_ID_PREFIX = `${STELLAR_CARTOGRAPHY_ANALYTIC_ID}:`

--- a/packages/frontend/src/analytics/mapAnalyticRegistry.test.ts
+++ b/packages/frontend/src/analytics/mapAnalyticRegistry.test.ts
@@ -6,6 +6,7 @@ import {
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
   FLEET_ANALYTIC_ID,
+  MAP_REGION_DEMO_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
 } from './mapAnalyticIds'
 import {
@@ -17,6 +18,7 @@ import {
   REGISTERED_MAP_ANALYTIC_IDS,
   isRegisteredMapAnalytic,
 } from './mapAnalyticRegistry'
+import { mapRegionDemoMapAnalytic } from './map-region-demo/mapAnalytic'
 import {
   defaultConnectionsParams,
   sampleScope,
@@ -35,6 +37,7 @@ describe('map analytic registry', () => {
       CONNECTIONS_ANALYTIC_ID,
       STELLAR_CARTOGRAPHY_ANALYTIC_ID,
       FLEET_ANALYTIC_ID,
+      MAP_REGION_DEMO_ANALYTIC_ID,
     ])
     for (const analyticId of REGISTERED_MAP_ANALYTIC_IDS) {
       expect(isRegisteredMapAnalytic(analyticId)).toBe(true)
@@ -45,6 +48,7 @@ describe('map analytic registry', () => {
       stellarCartographyMapAnalytic
     )
     expect(mapAnalyticRegistrationFor(FLEET_ANALYTIC_ID)).toBe(fleetMapAnalytic)
+    expect(mapAnalyticRegistrationFor(MAP_REGION_DEMO_ANALYTIC_ID)).toBe(mapRegionDemoMapAnalytic)
   })
 
   it('throws for unregistered map analytics', () => {

--- a/packages/frontend/src/analytics/mapAnalyticRegistry.ts
+++ b/packages/frontend/src/analytics/mapAnalyticRegistry.ts
@@ -11,10 +11,12 @@ import {
   BASE_MAP_ANALYTIC_ID,
   CONNECTIONS_ANALYTIC_ID,
   FLEET_ANALYTIC_ID,
+  MAP_REGION_DEMO_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
 } from './mapAnalyticIds'
 import { stellarCartographyMapAnalytic } from './stellar-cartography/mapAnalytic'
 import { fleetMapAnalytic } from './fleet/mapAnalytic'
+import { mapRegionDemoMapAnalytic } from './map-region-demo/mapAnalytic'
 import type { CombineMapDataOptionsBase } from './mapLayers'
 
 export type MapAnalyticQueryContext = {
@@ -34,6 +36,7 @@ export type MapLayerMergeContext = {
   nodes: CombinedMapData['nodes']
   edges: MapEdge[]
   overlayCircles: CombinedMapData['overlayCircles']
+  regionOverlays: CombinedMapData['regionOverlays']
   wormholeUnknownEntrances: CombinedMapData['wormholeUnknownEntrances']
   waypointsByKey: Map<string, { x: number; y: number }>
   nuIonStorms: boolean | undefined
@@ -105,6 +108,7 @@ const mapAnalyticRegistry: Record<string, MapAnalyticRegistration> = {
   [CONNECTIONS_ANALYTIC_ID]: connectionsMapAnalytic,
   [STELLAR_CARTOGRAPHY_ANALYTIC_ID]: stellarCartographyMapAnalytic,
   [FLEET_ANALYTIC_ID]: fleetMapAnalytic,
+  [MAP_REGION_DEMO_ANALYTIC_ID]: mapRegionDemoMapAnalytic,
 }
 
 /** Canonical map analytic ids with explicit registry entries. */
@@ -113,6 +117,7 @@ export const REGISTERED_MAP_ANALYTIC_IDS = [
   CONNECTIONS_ANALYTIC_ID,
   STELLAR_CARTOGRAPHY_ANALYTIC_ID,
   FLEET_ANALYTIC_ID,
+  MAP_REGION_DEMO_ANALYTIC_ID,
 ] as const satisfies readonly string[]
 
 export type RegisteredMapAnalyticId = (typeof REGISTERED_MAP_ANALYTIC_IDS)[number]

--- a/packages/frontend/src/analytics/mapLayers.test.ts
+++ b/packages/frontend/src/analytics/mapLayers.test.ts
@@ -189,6 +189,35 @@ describe('combineMapData', () => {
     expect(combined.overlayCircles).toHaveLength(2)
   })
 
+  it('merges region overlays from the map-region-demo analytic', () => {
+    const demo: MapDataResponse = {
+      analyticId: 'map-region-demo',
+      nodes: [],
+      edges: [],
+      regionOverlays: [
+        {
+          kind: 'demo',
+          id: 'demo-coverage',
+          fillColor: '#22c55e',
+          fillOpacity: 0.25,
+          disks: [{ x: 10, y: 20, radius: 150 }],
+          patches: [],
+        },
+      ],
+    }
+
+    const combined = combineMapData(['map-region-demo'], [demo], {
+      liveConnectionsParams: null,
+    })
+
+    expect(combined.regionOverlays).toHaveLength(1)
+    expect(combined.regionOverlays[0]).toMatchObject({
+      kind: 'demo',
+      fillColor: '#22c55e',
+      disks: [{ x: 10, y: 20, radius: 150 }],
+    })
+  })
+
   it('records unknown-target wormhole entrances when no edge is emitted', () => {
     const sc: MapDataResponse = {
       analyticId: 'stellar-cartography',

--- a/packages/frontend/src/analytics/mapLayers.ts
+++ b/packages/frontend/src/analytics/mapLayers.ts
@@ -25,12 +25,14 @@ export function combineMapData(
   const nodes: CombinedMapData['nodes'] = []
   const edges: MapEdge[] = []
   const overlayCircles: CombinedMapData['overlayCircles'] = []
+  const regionOverlays: CombinedMapData['regionOverlays'] = []
   const wormholeUnknownEntrances: CombinedMapData['wormholeUnknownEntrances'] = []
   const context: MapLayerMergeContext = {
     baseMapAnalyticId,
     nodes,
     edges,
     overlayCircles,
+    regionOverlays,
     wormholeUnknownEntrances,
     waypointsByKey: new Map<string, { x: number; y: number }>(),
     nuIonStorms: undefined,
@@ -45,6 +47,7 @@ export function combineMapData(
     edges,
     routeWaypoints: routeWaypointsFromMap(context.waypointsByKey),
     overlayCircles: context.overlayCircles,
+    regionOverlays: context.regionOverlays,
     wormholeUnknownEntrances,
     nuIonStorms: context.nuIonStorms,
   }

--- a/packages/frontend/src/analytics/stellar-cartography/cartographyDisplayModel.test.ts
+++ b/packages/frontend/src/analytics/stellar-cartography/cartographyDisplayModel.test.ts
@@ -58,6 +58,7 @@ const sampleData = {
       warp: 5,
     },
   ],
+  regionOverlays: [],
   wormholeUnknownEntrances: [{ x: 50, y: 60 }],
 } satisfies CombinedMapData
 

--- a/packages/frontend/src/analytics/stellar-cartography/cartographyVisibilityPolicy.test.ts
+++ b/packages/frontend/src/analytics/stellar-cartography/cartographyVisibilityPolicy.test.ts
@@ -147,6 +147,7 @@ describe('cartographyVisibilityPolicy', () => {
         edges: [wormholeEdge],
         routeWaypoints: [],
         overlayCircles: [],
+        regionOverlays: [],
         wormholeUnknownEntrances: [{ x: 50, y: 60 }],
       }
       const policy = cartographyVisibilityPolicy({
@@ -168,6 +169,7 @@ describe('cartographyVisibilityPolicy', () => {
         edges: [wormholeEdge],
         routeWaypoints: [],
         overlayCircles: [],
+        regionOverlays: [],
         wormholeUnknownEntrances: [{ x: 50, y: 60 }],
       }
       const parts = cartographyVisibilityPolicy(baseConfig).mapFrameParts(data)

--- a/packages/frontend/src/api/bffCartographyTypes.ts
+++ b/packages/frontend/src/api/bffCartographyTypes.ts
@@ -4,6 +4,9 @@
  */
 
 import type { components } from './schema-games'
+import type { MapRegionOverlay } from './mapRegionOverlayTypes'
+
+export type { MapRegionOverlay } from './mapRegionOverlayTypes'
 
 /** Game map cell coordinates from OpenAPI `MapCellModel`. */
 export type MapCell = components['schemas']['MapCellModel']
@@ -175,6 +178,8 @@ export type MapDataResponse = {
   edges: MapEdge[]
   routes?: PlanetPairRoute[]
   overlayCircles?: StellarCartographyOverlayCircle[]
+  /** Hybrid shaded regions (disks + nebula-local patches); not cartography circles. */
+  regionOverlays?: MapRegionOverlay[]
   meta?: {
     nebulae?: number
     ionStorms?: number
@@ -204,6 +209,8 @@ export type CombinedMapData = {
   routeWaypoints: RouteMapWaypoint[]
   /** Unfiltered merged Stellar Cartography disc overlays; visibility applied at render time. */
   overlayCircles: StellarCartographyOverlayCircle[]
+  /** Merged hybrid map region overlays (disks + nebula-local patches). */
+  regionOverlays: MapRegionOverlay[]
   /** Wormhole entrances with unknown targets (6px sky dots). */
   wormholeUnknownEntrances: WormholeUnknownEntrance[]
   /** Stellar Cartography ion storm mode from turn settings (`nuionstorms`). */

--- a/packages/frontend/src/api/mapRegionOverlayTypes.ts
+++ b/packages/frontend/src/api/mapRegionOverlayTypes.ts
@@ -1,0 +1,32 @@
+/**
+ * Analytic-agnostic map region overlay wire types (hybrid disks + nebula patches).
+ * Distinct from Stellar Cartography ``overlayCircles``.
+ */
+
+export type MapRegionCoverageRleRun = {
+  length: number
+  covered: boolean
+}
+
+export type MapRegionOverlayDisk = {
+  x: number
+  y: number
+  radius: number
+}
+
+export type MapRegionOverlayPatch = {
+  originX: number
+  originY: number
+  width: number
+  height: number
+  coverageRle: MapRegionCoverageRleRun[]
+}
+
+export type MapRegionOverlay = {
+  kind: string
+  id: string
+  fillColor: string
+  fillOpacity: number
+  disks: MapRegionOverlayDisk[]
+  patches: MapRegionOverlayPatch[]
+}

--- a/packages/frontend/src/api/normalizeMapDataResponse.ts
+++ b/packages/frontend/src/api/normalizeMapDataResponse.ts
@@ -13,6 +13,7 @@ import type {
   StellarCartographyOverlayCircle,
 } from "./bffCartographyTypes"
 import { normalizeOverlayCircle } from "./normalizeMapOverlayCircle"
+import { normalizeMapRegionOverlays } from "./normalizeMapRegionOverlay"
 import {
   parseFiniteNumberPair,
   parseJsonFiniteNumber,
@@ -203,6 +204,10 @@ export function normalizeMapDataResponse(raw: unknown): MapDataResponse {
     out.overlayCircles = overlayCircles
       .map(normalizeOverlayCircle)
       .filter((c): c is StellarCartographyOverlayCircle => c != null)
+  }
+  const regionOverlaysRaw = o.regionOverlays ?? o.region_overlays
+  if (Array.isArray(regionOverlaysRaw)) {
+    out.regionOverlays = normalizeMapRegionOverlays(regionOverlaysRaw)
   }
   const metaRaw = o.meta
   const meta = normalizeMapMeta(metaRaw)

--- a/packages/frontend/src/api/normalizeMapRegionOverlay.test.ts
+++ b/packages/frontend/src/api/normalizeMapRegionOverlay.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMapRegionOverlay, normalizeMapRegionOverlays } from './normalizeMapRegionOverlay'
+import { normalizeMapDataResponse } from './normalizeMapDataResponse'
+
+describe('normalizeMapRegionOverlay', () => {
+  const validOverlay = {
+    kind: 'demo',
+    id: 'demo-1',
+    fillColor: '#22c55e',
+    fillOpacity: 0.25,
+    disks: [{ x: 10, y: 20, radius: 50 }],
+    patches: [
+      {
+        originX: 0,
+        originY: 0,
+        width: 2,
+        height: 2,
+        coverageRle: [
+          { length: 2, covered: true },
+          { length: 2, covered: false },
+        ],
+      },
+    ],
+  }
+
+  it('accepts a well-formed overlay', () => {
+    expect(normalizeMapRegionOverlay(validOverlay)).toEqual(validOverlay)
+  })
+
+  it('rejects RLE that does not match patch size', () => {
+    expect(
+      normalizeMapRegionOverlay({
+        ...validOverlay,
+        patches: [
+          {
+            originX: 0,
+            originY: 0,
+            width: 2,
+            height: 2,
+            coverageRle: [{ length: 1, covered: true }],
+          },
+        ],
+      })
+    ).toBeNull()
+  })
+
+  it('normalizes regionOverlays on map data responses', () => {
+    const out = normalizeMapDataResponse({
+      analyticId: 'map-region-demo',
+      nodes: [],
+      edges: [],
+      regionOverlays: [validOverlay],
+    })
+    expect(out.regionOverlays).toEqual([validOverlay])
+  })
+
+  it('filters invalid overlays from a list', () => {
+    expect(normalizeMapRegionOverlays([validOverlay, { kind: 'x' }, null])).toEqual([
+      validOverlay,
+    ])
+  })
+})

--- a/packages/frontend/src/api/normalizeMapRegionOverlay.ts
+++ b/packages/frontend/src/api/normalizeMapRegionOverlay.ts
@@ -1,0 +1,90 @@
+/**
+ * Normalize map region overlay wire JSON (syntactic parsing before UI merge).
+ */
+
+import type {
+  MapRegionCoverageRleRun,
+  MapRegionOverlay,
+  MapRegionOverlayDisk,
+  MapRegionOverlayPatch,
+} from './mapRegionOverlayTypes'
+import { parseJsonFiniteNumber, parseJsonInteger } from './normalizeMapWireParsing'
+
+function normalizeCoverageRleRun(raw: unknown): MapRegionCoverageRleRun | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const length = parseJsonInteger(o.length)
+  if (length == null || length < 0) return null
+  if (typeof o.covered !== 'boolean') return null
+  return { length, covered: o.covered }
+}
+
+function normalizeDisk(raw: unknown): MapRegionOverlayDisk | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const x = parseJsonFiniteNumber(o.x)
+  const y = parseJsonFiniteNumber(o.y)
+  const radius = parseJsonFiniteNumber(o.radius)
+  if (x == null || y == null || radius == null || radius < 0) return null
+  return { x, y, radius }
+}
+
+function normalizePatch(raw: unknown): MapRegionOverlayPatch | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const originX = parseJsonInteger(o.originX ?? o.origin_x)
+  const originY = parseJsonInteger(o.originY ?? o.origin_y)
+  const width = parseJsonInteger(o.width)
+  const height = parseJsonInteger(o.height)
+  if (originX == null || originY == null || width == null || height == null) return null
+  if (width <= 0 || height <= 0) return null
+  const rleRaw = o.coverageRle ?? o.coverage_rle
+  if (!Array.isArray(rleRaw)) return null
+  const coverageRle = rleRaw
+    .map(normalizeCoverageRleRun)
+    .filter((run): run is MapRegionCoverageRleRun => run != null)
+  const expected = width * height
+  const total = coverageRle.reduce((sum, run) => sum + run.length, 0)
+  if (total !== expected) return null
+  return { originX, originY, width, height, coverageRle }
+}
+
+export function normalizeMapRegionOverlay(raw: unknown): MapRegionOverlay | null {
+  if (raw == null || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const kind = typeof o.kind === 'string' ? o.kind : null
+  const id = typeof o.id === 'string' ? o.id : null
+  if (kind == null || id == null || kind === '' || id === '') return null
+  const fillColor =
+    typeof o.fillColor === 'string'
+      ? o.fillColor
+      : typeof o.fill_color === 'string'
+        ? o.fill_color
+        : null
+  const fillOpacity = parseJsonFiniteNumber(o.fillOpacity ?? o.fill_opacity)
+  if (fillColor == null || fillOpacity == null) return null
+  if (fillOpacity < 0 || fillOpacity > 1) return null
+  const disksRaw = o.disks
+  const patchesRaw = o.patches
+  if (!Array.isArray(disksRaw) || !Array.isArray(patchesRaw)) return null
+  const disks: MapRegionOverlayDisk[] = []
+  for (const raw of disksRaw) {
+    const disk = normalizeDisk(raw)
+    if (disk == null) return null
+    disks.push(disk)
+  }
+  const patches: MapRegionOverlayPatch[] = []
+  for (const raw of patchesRaw) {
+    const patch = normalizePatch(raw)
+    if (patch == null) return null
+    patches.push(patch)
+  }
+  return { kind, id, fillColor, fillOpacity, disks, patches }
+}
+
+export function normalizeMapRegionOverlays(raw: unknown): MapRegionOverlay[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map(normalizeMapRegionOverlay)
+    .filter((o): o is MapRegionOverlay => o != null)
+}

--- a/packages/frontend/src/api/schema-analytics.ts
+++ b/packages/frontend/src/api/schema-analytics.ts
@@ -215,6 +215,8 @@ export interface paths {
          *
          *     **stellar-cartography** returns overlay circles and wormhole graph geometry.
          *
+         *     **map-region-demo** returns hybrid ``regionOverlays`` (ideal disks + nebula-local patches).
+         *
          *     Nodes use fixed Cartesian coordinates (x, y). The SPA fetches base-map first, then
          *     enabled map analytics, and merges layers (see docs/design-connections-analytic.md).
          */

--- a/packages/frontend/src/components/MainArea.test.tsx
+++ b/packages/frontend/src/components/MainArea.test.tsx
@@ -83,6 +83,7 @@ const emptyCombined = {
   edges: [],
   routeWaypoints: [],
   overlayCircles: [],
+  regionOverlays: [],
   wormholeUnknownEntrances: [],
 }
 

--- a/packages/frontend/src/components/MapGraph.tsx
+++ b/packages/frontend/src/components/MapGraph.tsx
@@ -28,6 +28,7 @@ import { clientToFlowPosition } from './map-graph/geometry'
 import { nodeTypes, toFlowNodes } from './map-graph/nodes'
 import { edgeTypes, toEdges } from './map-graph/edges'
 import { StellarCartographyOverlayPane } from './map-graph/StellarCartographyOverlayPane'
+import { MapRegionOverlayPane } from './map-graph/MapRegionOverlayPane'
 import {
   WormholeInteractionProvider,
   useWormholeInteractionState,
@@ -209,6 +210,7 @@ function MapGraphFlow({
           nuIonStorms={data.nuIonStorms}
         />
       ) : null}
+      <MapRegionOverlayPane regionOverlays={data.regionOverlays} />
       <NormalWarpWellOutlinesOverlay mapNodes={planetMapNodes} />
       <FixedSizeDotsOverlay
         planetGrid={planetGrid}

--- a/packages/frontend/src/components/map-graph/MapRegionOverlayPane.tsx
+++ b/packages/frontend/src/components/map-graph/MapRegionOverlayPane.tsx
@@ -9,8 +9,9 @@ import { useOverlayPaneSize } from './useOverlayPaneSize'
  * Blit hybrid map region overlays.
  *
  * Disks: opaque SVG circles under one group opacity (union, no stacked alpha).
- * Patches: cached map-space PNGs, reprojected only. Patch AABBs are punched from
- * the disk mask so disks and patches never double-paint.
+ * Patches: cached map-space PNGs, reprojected only. Patch AABBs are a
+ * non-overlapping partition punched from the disk mask so disks and patches
+ * never double-paint.
  */
 export function MapRegionOverlayPane({
   regionOverlays,

--- a/packages/frontend/src/components/map-graph/MapRegionOverlayPane.tsx
+++ b/packages/frontend/src/components/map-graph/MapRegionOverlayPane.tsx
@@ -1,0 +1,112 @@
+import { useId } from 'react'
+import { useStore } from '@xyflow/react'
+import type { MapRegionOverlay } from '../../api/mapRegionOverlayTypes'
+import { buildMapRegionOverlayPaneShapes } from '../../lib/mapRegionOverlay'
+import { safeZoomScale } from './geometry'
+import { useOverlayPaneSize } from './useOverlayPaneSize'
+
+/**
+ * Blit hybrid map region overlays.
+ *
+ * Disks: opaque SVG circles under one group opacity (union, no stacked alpha).
+ * Patches: cached map-space PNGs, reprojected only. Patch AABBs are punched from
+ * the disk mask so disks and patches never double-paint.
+ */
+export function MapRegionOverlayPane({
+  regionOverlays,
+}: {
+  regionOverlays: readonly MapRegionOverlay[]
+}) {
+  const domNode = useStore((s) => s.domNode ?? null)
+  const transform = useStore((s) => s.transform)
+  const { width, height } = useOverlayPaneSize(domNode)
+  const reactId = useId()
+  const idPrefix = `map-region-${reactId.replace(/:/g, '')}`
+
+  if (!transform || width <= 0 || height <= 0) return null
+  if (regionOverlays.length === 0) return null
+
+  const [tx, ty, rawScale] = transform
+  const scale = safeZoomScale(rawScale)
+  const { groups } = buildMapRegionOverlayPaneShapes(regionOverlays, {
+    width,
+    height,
+    tx,
+    ty,
+    scale,
+  })
+  if (groups.length === 0) return null
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-[6]" aria-hidden>
+      <svg className="h-full w-full" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+        <defs>
+          {groups.map((group) => {
+            if (group.disks.length === 0) return null
+            const maskId = `${idPrefix}-disks-${group.key}`
+            return (
+              <mask
+                key={maskId}
+                id={maskId}
+                maskUnits="userSpaceOnUse"
+                x={0}
+                y={0}
+                width={width}
+                height={height}
+              >
+                <rect x={0} y={0} width={width} height={height} fill="black" />
+                {group.disks.map((disk) => (
+                  <circle
+                    key={disk.key}
+                    cx={disk.cx}
+                    cy={disk.cy}
+                    r={disk.r}
+                    fill="white"
+                  />
+                ))}
+                {group.patchMaskRects.map((rect, i) => (
+                  <rect
+                    key={`${group.key}-punch-${i}`}
+                    x={rect.x}
+                    y={rect.y}
+                    width={rect.width}
+                    height={rect.height}
+                    fill="black"
+                  />
+                ))}
+              </mask>
+            )
+          })}
+        </defs>
+        {groups.map((group) => {
+          const maskId = `${idPrefix}-disks-${group.key}`
+          return (
+            <g key={group.key} opacity={group.fillOpacity}>
+              {group.disks.length > 0 ? (
+                <rect
+                  x={0}
+                  y={0}
+                  width={width}
+                  height={height}
+                  fill={group.fillColor}
+                  mask={`url(#${maskId})`}
+                />
+              ) : null}
+              {group.patches.map((patch) => (
+                <image
+                  key={patch.key}
+                  href={patch.imageDataUrl}
+                  x={patch.left}
+                  y={patch.top}
+                  width={patch.width}
+                  height={patch.height}
+                  preserveAspectRatio="none"
+                />
+              ))}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/shell/MapShellContent.test.tsx
+++ b/packages/frontend/src/components/shell/MapShellContent.test.tsx
@@ -22,6 +22,7 @@ const displayMapData = {
   edges: [],
   routeWaypoints: [],
   overlayCircles: [],
+  regionOverlays: [],
   wormholeUnknownEntrances: [],
 }
 

--- a/packages/frontend/src/lib/mapDisplayTestFixtures.ts
+++ b/packages/frontend/src/lib/mapDisplayTestFixtures.ts
@@ -5,6 +5,7 @@ export const sampleMap: CombinedMapData = {
   edges: [],
   routeWaypoints: [],
   overlayCircles: [],
+  regionOverlays: [],
   wormholeUnknownEntrances: [],
 }
 

--- a/packages/frontend/src/lib/mapRegionOverlay.test.ts
+++ b/packages/frontend/src/lib/mapRegionOverlay.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildMapRegionOverlayPaneShapes,
+  patchRasterDataUrl,
+} from './mapRegionOverlay'
+import type { MapRegionOverlay } from '../api/mapRegionOverlayTypes'
+
+function mockCanvas2d() {
+  let written: Uint8ClampedArray | null = null
+  const mockCtx = {
+    createImageData: (w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+    }),
+    putImageData: (image: ImageData) => {
+      written = new Uint8ClampedArray(image.data)
+    },
+  }
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    mockCtx as unknown as CanvasRenderingContext2D
+  )
+  vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue(
+    'data:image/png;base64,mock'
+  )
+  return () => written
+}
+
+describe('buildMapRegionOverlayPaneShapes', () => {
+  const viewport = { width: 800, height: 600, tx: 0, ty: 0, scale: 1 }
+
+  beforeEach(() => {
+    mockCanvas2d()
+  })
+
+  it('projects disks and cached patches without recompositing the full map', () => {
+    const overlay: MapRegionOverlay = {
+      kind: 'demo',
+      id: 'demo-1',
+      fillColor: '#22c55e',
+      fillOpacity: 0.25,
+      disks: [
+        { x: 10, y: 20, radius: 50 },
+        { x: 40, y: 20, radius: 50 },
+      ],
+      patches: [
+        {
+          originX: 0,
+          originY: 0,
+          width: 2,
+          height: 2,
+          coverageRle: [
+            { length: 2, covered: true },
+            { length: 2, covered: false },
+          ],
+        },
+      ],
+    }
+
+    const first = buildMapRegionOverlayPaneShapes([overlay], viewport)
+    const second = buildMapRegionOverlayPaneShapes([overlay], {
+      ...viewport,
+      tx: 100,
+      scale: 2,
+    })
+
+    expect(first.groups).toHaveLength(1)
+    expect(first.groups[0]!.disks).toHaveLength(2)
+    expect(first.groups[0]!.patches).toHaveLength(1)
+    expect(first.groups[0]!.patchMaskRects).toHaveLength(1)
+    expect(second.groups[0]!.patches[0]!.imageDataUrl).toBe(
+      first.groups[0]!.patches[0]!.imageDataUrl
+    )
+    expect(second.groups[0]!.disks[0]!.cx).not.toBe(first.groups[0]!.disks[0]!.cx)
+  })
+
+  it('emits disk-only groups with no patch work', () => {
+    const overlay: MapRegionOverlay = {
+      kind: 'demo',
+      id: 'demo-2',
+      fillColor: '#22c55e',
+      fillOpacity: 0.25,
+      disks: [{ x: 0, y: 0, radius: 100 }],
+      patches: [],
+    }
+    const shapes = buildMapRegionOverlayPaneShapes([overlay], viewport)
+    expect(shapes.groups[0]!.disks).toHaveLength(1)
+    expect(shapes.groups[0]!.patches).toEqual([])
+  })
+})
+
+describe('patchRasterDataUrl', () => {
+  it('flips map-south RLE rows to image-top and caches by patch identity', () => {
+    const getWritten = mockCanvas2d()
+    const patch = {
+      originX: 0,
+      originY: 0,
+      width: 1,
+      height: 2,
+      coverageRle: [
+        { length: 1, covered: true },
+        { length: 1, covered: false },
+      ],
+    }
+
+    const urlA = patchRasterDataUrl('#112233', patch)
+    const written = getWritten()
+    expect(urlA).toContain('data:image/png')
+    expect(written).not.toBeNull()
+    expect(written![3]).toBe(0)
+    expect(written![7]).toBe(255)
+
+    const toDataURL = vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+    const urlB = patchRasterDataUrl('#112233', patch)
+    expect(urlB).toBe(urlA)
+    expect(toDataURL).not.toHaveBeenCalled()
+  })
+})

--- a/packages/frontend/src/lib/mapRegionOverlay.test.ts
+++ b/packages/frontend/src/lib/mapRegionOverlay.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   buildMapRegionOverlayPaneShapes,
+  parseCssColorToRgb,
   patchRasterDataUrl,
 } from './mapRegionOverlay'
-import type { MapRegionOverlay } from '../api/mapRegionOverlayTypes'
+import type { MapRegionOverlay, MapRegionOverlayPatch } from '../api/mapRegionOverlayTypes'
 
 function mockCanvas2d() {
   let written: Uint8ClampedArray | null = null
@@ -22,6 +23,17 @@ function mockCanvas2d() {
     'data:image/png;base64,mock'
   )
   return () => written
+}
+
+function patchAabbsOverlap(
+  a: Pick<MapRegionOverlayPatch, 'originX' | 'originY' | 'width' | 'height'>,
+  b: Pick<MapRegionOverlayPatch, 'originX' | 'originY' | 'width' | 'height'>
+): boolean {
+  const aMaxX = a.originX + a.width - 1
+  const aMaxY = a.originY + a.height - 1
+  const bMaxX = b.originX + b.width - 1
+  const bMaxY = b.originY + b.height - 1
+  return !(aMaxX < b.originX || bMaxX < a.originX || aMaxY < b.originY || bMaxY < a.originY)
 }
 
 describe('buildMapRegionOverlayPaneShapes', () => {
@@ -85,6 +97,78 @@ describe('buildMapRegionOverlayPaneShapes', () => {
     expect(shapes.groups[0]!.disks).toHaveLength(1)
     expect(shapes.groups[0]!.patches).toEqual([])
   })
+
+  it('keeps patch mask rects non-overlapping for partitioned patch AABBs', () => {
+    const west: MapRegionOverlayPatch = {
+      originX: 0,
+      originY: 0,
+      width: 10,
+      height: 10,
+      coverageRle: [{ length: 100, covered: true }],
+    }
+    const east: MapRegionOverlayPatch = {
+      originX: 20,
+      originY: 0,
+      width: 10,
+      height: 10,
+      coverageRle: [{ length: 100, covered: true }],
+    }
+    expect(patchAabbsOverlap(west, east)).toBe(false)
+
+    const overlay: MapRegionOverlay = {
+      kind: 'demo',
+      id: 'demo-partition',
+      fillColor: '#22c55e',
+      fillOpacity: 0.25,
+      disks: [{ x: 0, y: 0, radius: 100 }],
+      patches: [west, east],
+    }
+    const shapes = buildMapRegionOverlayPaneShapes([overlay], viewport)
+    const rects = shapes.groups[0]!.patchMaskRects
+    expect(rects).toHaveLength(2)
+    const [a, b] = rects
+    expect(
+      !(
+        a!.x + a!.width <= b!.x ||
+        b!.x + b!.width <= a!.x ||
+        a!.y + a!.height <= b!.y ||
+        b!.y + b!.height <= a!.y
+      )
+    ).toBe(false)
+    expect(shapes.groups[0]!.patches).toHaveLength(2)
+  })
+
+  it('skips patch punch and raster when fillColor is not hex', () => {
+    const overlay: MapRegionOverlay = {
+      kind: 'demo',
+      id: 'demo-bad-color',
+      fillColor: 'rgb(34, 197, 94)',
+      fillOpacity: 0.25,
+      disks: [{ x: 0, y: 0, radius: 50 }],
+      patches: [
+        {
+          originX: 0,
+          originY: 0,
+          width: 1,
+          height: 1,
+          coverageRle: [{ length: 1, covered: true }],
+        },
+      ],
+    }
+    const shapes = buildMapRegionOverlayPaneShapes([overlay], viewport)
+    expect(shapes.groups[0]!.disks).toHaveLength(1)
+    expect(shapes.groups[0]!.patches).toEqual([])
+    expect(shapes.groups[0]!.patchMaskRects).toEqual([])
+  })
+})
+
+describe('parseCssColorToRgb', () => {
+  it('parses hex and rejects unsupported colors', () => {
+    expect(parseCssColorToRgb('#112233')).toEqual({ r: 17, g: 34, b: 51 })
+    expect(parseCssColorToRgb('#abc')).toEqual({ r: 170, g: 187, b: 204 })
+    expect(parseCssColorToRgb('green')).toBeNull()
+    expect(parseCssColorToRgb('rgb(1,2,3)')).toBeNull()
+  })
 })
 
 describe('patchRasterDataUrl', () => {
@@ -112,5 +196,17 @@ describe('patchRasterDataUrl', () => {
     const urlB = patchRasterDataUrl('#112233', patch)
     expect(urlB).toBe(urlA)
     expect(toDataURL).not.toHaveBeenCalled()
+  })
+
+  it('returns empty string for non-hex fillColor', () => {
+    mockCanvas2d()
+    const patch = {
+      originX: 0,
+      originY: 0,
+      width: 1,
+      height: 1,
+      coverageRle: [{ length: 1, covered: true }],
+    }
+    expect(patchRasterDataUrl('not-a-color', patch)).toBe('')
   })
 })

--- a/packages/frontend/src/lib/mapRegionOverlay.ts
+++ b/packages/frontend/src/lib/mapRegionOverlay.ts
@@ -1,0 +1,210 @@
+/**
+ * Pane shapes for hybrid map region overlays.
+ *
+ * Disks are SVG (opaque under one group opacity -- no alpha stacking, cheap on
+ * pan/zoom). Nebula patches are small map-space PNGs cached by patch identity
+ * and only reprojected each frame.
+ */
+
+import type { MapRegionOverlay } from '../api/mapRegionOverlayTypes'
+import {
+  flowToPane,
+  gameMapCellCenterToFlow,
+  mapLyToFlow,
+  type CartographyOverlayViewport,
+} from './cartography/cartographyOverlayGeometry'
+import { flowLySpanToPanePixels } from './cartography/stellarCartographyOverlay'
+
+export type MapRegionOverlayDiskShape = {
+  key: string
+  cx: number
+  cy: number
+  r: number
+}
+
+export type MapRegionOverlayPatchShape = {
+  key: string
+  left: number
+  top: number
+  width: number
+  height: number
+  imageDataUrl: string
+}
+
+export type MapRegionOverlayPaneGroup = {
+  key: string
+  fillColor: string
+  fillOpacity: number
+  disks: MapRegionOverlayDiskShape[]
+  patches: MapRegionOverlayPatchShape[]
+  /** Patch AABBs in pane px; punched from the disk-union mask. */
+  patchMaskRects: { x: number; y: number; width: number; height: number }[]
+}
+
+export type MapRegionOverlayPaneShapes = {
+  groups: MapRegionOverlayPaneGroup[]
+}
+
+type PatchRasterCacheEntry = {
+  fillColor: string
+  imageDataUrl: string
+}
+
+/** Weak cache keyed by patch object identity (stable across pan/zoom). */
+const patchRasterCache = new WeakMap<object, PatchRasterCacheEntry>()
+
+function expandCoverageRle(
+  width: number,
+  height: number,
+  runs: readonly { length: number; covered: boolean }[]
+): boolean[] {
+  const expected = width * height
+  const cells: boolean[] = []
+  for (const run of runs) {
+    for (let i = 0; i < run.length; i++) cells.push(run.covered)
+  }
+  if (cells.length !== expected) {
+    throw new Error(`RLE length ${cells.length} does not match patch size ${expected}`)
+  }
+  return cells
+}
+
+function parseCssColorToRgb(fillColor: string): { r: number; g: number; b: number } {
+  const hex = fillColor.trim()
+  if (/^#[0-9a-fA-F]{6}$/.test(hex)) {
+    return {
+      r: parseInt(hex.slice(1, 3), 16),
+      g: parseInt(hex.slice(3, 5), 16),
+      b: parseInt(hex.slice(5, 7), 16),
+    }
+  }
+  if (/^#[0-9a-fA-F]{3}$/.test(hex)) {
+    return {
+      r: parseInt(hex[1]! + hex[1]!, 16),
+      g: parseInt(hex[2]! + hex[2]!, 16),
+      b: parseInt(hex[3]! + hex[3]!, 16),
+    }
+  }
+  return { r: 34, g: 197, b: 94 }
+}
+
+/**
+ * Rasterize one nebula-local patch at 1 px/ly (map space).
+ * RLE row 0 is map-south; canvas row 0 is image-top (map-north).
+ */
+export function patchRasterDataUrl(
+  fillColor: string,
+  patch: MapRegionOverlay['patches'][number]
+): string {
+  const cached = patchRasterCache.get(patch)
+  if (cached != null && cached.fillColor === fillColor) return cached.imageDataUrl
+
+  if (typeof document === 'undefined') return ''
+  const cells = expandCoverageRle(patch.width, patch.height, patch.coverageRle)
+  const canvas = document.createElement('canvas')
+  canvas.width = patch.width
+  canvas.height = patch.height
+  const ctx = canvas.getContext('2d')
+  if (ctx == null) return ''
+  const image = ctx.createImageData(patch.width, patch.height)
+  const { r, g, b } = parseCssColorToRgb(fillColor)
+  for (let row = 0; row < patch.height; row++) {
+    const sourceRow = patch.height - 1 - row
+    for (let col = 0; col < patch.width; col++) {
+      if (!cells[sourceRow * patch.width + col]) continue
+      const offset = (row * patch.width + col) * 4
+      image.data[offset] = r
+      image.data[offset + 1] = g
+      image.data[offset + 2] = b
+      image.data[offset + 3] = 255
+    }
+  }
+  ctx.putImageData(image, 0, 0)
+  const imageDataUrl = canvas.toDataURL('image/png')
+  patchRasterCache.set(patch, { fillColor, imageDataUrl })
+  return imageDataUrl
+}
+
+function patchPaneRect(
+  patch: MapRegionOverlay['patches'][number],
+  viewport: CartographyOverlayViewport
+): { left: number; top: number; width: number; height: number } {
+  const { cx: leftGx, cy: topCy } = mapLyToFlow(
+    patch.originX,
+    patch.originY + patch.height
+  )
+  const { cx: rightGx, cy: bottomCy } = mapLyToFlow(
+    patch.originX + patch.width,
+    patch.originY
+  )
+  const topLeft = flowToPane(leftGx, topCy, viewport)
+  const bottomRight = flowToPane(rightGx, bottomCy, viewport)
+  const left = Math.min(topLeft.px, bottomRight.px)
+  const top = Math.min(topLeft.py, bottomRight.py)
+  const width = Math.abs(bottomRight.px - topLeft.px)
+  const height = Math.abs(bottomRight.py - topLeft.py)
+  return { left, top, width, height }
+}
+
+/**
+ * Project overlays into pane shapes. Expensive patch PNGs are cached; each call
+ * only recomputes pane positions from the viewport.
+ */
+export function buildMapRegionOverlayPaneShapes(
+  overlays: readonly MapRegionOverlay[],
+  viewport: CartographyOverlayViewport
+): MapRegionOverlayPaneShapes {
+  const groups: MapRegionOverlayPaneGroup[] = []
+
+  for (const overlay of overlays) {
+    const disks: MapRegionOverlayDiskShape[] = []
+    const patches: MapRegionOverlayPatchShape[] = []
+    const patchMaskRects: MapRegionOverlayPaneGroup['patchMaskRects'] = []
+
+    for (let i = 0; i < overlay.disks.length; i++) {
+      const disk = overlay.disks[i]!
+      const { cx, cy } = gameMapCellCenterToFlow(disk.x, disk.y)
+      const { px, py } = flowToPane(cx, cy, viewport)
+      const r = flowLySpanToPanePixels(cx, cy, disk.radius * 2, viewport) / 2
+      disks.push({
+        key: `${overlay.id}-disk-${i}`,
+        cx: px,
+        cy: py,
+        r,
+      })
+    }
+
+    for (let i = 0; i < overlay.patches.length; i++) {
+      const patch = overlay.patches[i]!
+      const rect = patchPaneRect(patch, viewport)
+      patchMaskRects.push({
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      })
+      const imageDataUrl = patchRasterDataUrl(overlay.fillColor, patch)
+      if (imageDataUrl === '') continue
+      patches.push({
+        key: `${overlay.id}-patch-${i}`,
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        imageDataUrl,
+      })
+    }
+
+    if (disks.length === 0 && patches.length === 0) continue
+    groups.push({
+      key: overlay.id,
+      fillColor: overlay.fillColor,
+      fillOpacity: overlay.fillOpacity,
+      disks,
+      patches,
+      patchMaskRects,
+    })
+  }
+
+  return { groups }
+}

--- a/packages/frontend/src/lib/mapRegionOverlay.ts
+++ b/packages/frontend/src/lib/mapRegionOverlay.ts
@@ -69,7 +69,10 @@ function expandCoverageRle(
   return cells
 }
 
-function parseCssColorToRgb(fillColor: string): { r: number; g: number; b: number } {
+/** Hex `#rgb` / `#rrggbb` only; null if the wire color is not a supported hex. */
+export function parseCssColorToRgb(
+  fillColor: string
+): { r: number; g: number; b: number } | null {
   const hex = fillColor.trim()
   if (/^#[0-9a-fA-F]{6}$/.test(hex)) {
     return {
@@ -85,12 +88,13 @@ function parseCssColorToRgb(fillColor: string): { r: number; g: number; b: numbe
       b: parseInt(hex[3]! + hex[3]!, 16),
     }
   }
-  return { r: 34, g: 197, b: 94 }
+  return null
 }
 
 /**
  * Rasterize one nebula-local patch at 1 px/ly (map space).
  * RLE row 0 is map-south; canvas row 0 is image-top (map-north).
+ * Returns empty string when fillColor is not a supported hex (fail closed).
  */
 export function patchRasterDataUrl(
   fillColor: string,
@@ -100,6 +104,8 @@ export function patchRasterDataUrl(
   if (cached != null && cached.fillColor === fillColor) return cached.imageDataUrl
 
   if (typeof document === 'undefined') return ''
+  const rgb = parseCssColorToRgb(fillColor)
+  if (rgb == null) return ''
   const cells = expandCoverageRle(patch.width, patch.height, patch.coverageRle)
   const canvas = document.createElement('canvas')
   canvas.width = patch.width
@@ -107,7 +113,7 @@ export function patchRasterDataUrl(
   const ctx = canvas.getContext('2d')
   if (ctx == null) return ''
   const image = ctx.createImageData(patch.width, patch.height)
-  const { r, g, b } = parseCssColorToRgb(fillColor)
+  const { r, g, b } = rgb
   for (let row = 0; row < patch.height; row++) {
     const sourceRow = patch.height - 1 - row
     for (let col = 0; col < patch.width; col++) {
@@ -176,6 +182,9 @@ export function buildMapRegionOverlayPaneShapes(
 
     for (let i = 0; i < overlay.patches.length; i++) {
       const patch = overlay.patches[i]!
+      const imageDataUrl = patchRasterDataUrl(overlay.fillColor, patch)
+      // Fail closed: non-hex fillColor skips punch + raster (no invented color, no holes).
+      if (imageDataUrl === '') continue
       const rect = patchPaneRect(patch, viewport)
       patchMaskRects.push({
         x: rect.left,
@@ -183,8 +192,6 @@ export function buildMapRegionOverlayPaneShapes(
         width: rect.width,
         height: rect.height,
       })
-      const imageDataUrl = patchRasterDataUrl(overlay.fillColor, patch)
-      if (imageDataUrl === '') continue
       patches.push({
         key: `${overlay.id}-patch-${i}`,
         left: rect.left,


### PR DESCRIPTION
## Summary
- Adds shared Core hybrid coverage (`ideal disks` + nebula-local RLE patches) and an analytic-agnostic `regionOverlays` wire distinct from cartography `overlayCircles`.
- SPA merges overlays into the combined map and blits via a dedicated pane (disk masks + cached patch PNGs); temporary `map-region-demo` analytic makes the primitive demoable without Visibility.
- Patch AABBs merge until disjoint so exclusive blit authority holds (including L-pocket nebulas); non-hex fill colors fail closed instead of inventing green.

## Test plan
- [ ] `cd packages/api && uv run pytest tests/test_map_region_coverage.py tests/test_map_region_demo.py`
- [ ] Enable **Map region demo** on a map with nebulas and confirm shaded disks + dented patches (no double-paint / stacked alpha in overlaps)
- [ ] Enable on a nebula-free map and confirm compact disk-only overlays (no huge rasters)
- [ ] Pan/zoom the map and confirm patch rasters stay sharp and responsive
- [ ] Confirm `regionOverlays` is separate from Stellar Cartography `overlayCircles`


Made with [Cursor](https://cursor.com)