### PR TITLE
Extract shared table-stream reschedule lock choreography (#257)

### DIFF
--- a/docs/adr/0004-addendum-table-stream-session-framework.md
+++ b/docs/adr/0004-addendum-table-stream-session-framework.md
@@ -15,7 +15,7 @@ Extract a **thin shared framework** under `packages/api/api/streaming/table_stre
 | `multiplex.py` | Generic round-robin drain over per-row `event_queue`, `is_stream_active`, `wake_event`, terminal-type predicate |
 | `scope_guard.py` | `TableStreamScopeGuard` composed into both schedulers (`begin_scope`, `owns_table_stream`, `end_table_stream`) |
 | `registry.py` | Generic scope-keyed controller registry (attach/detach, in-place reschedule lookup) |
-| `controller_base.py` | Shared controller state (`pending_wire_events`, `wake_multiplex`, scheduled-row map) |
+| `controller_base.py` | Shared controller state (`pending_wire_events`, `wake_multiplex`, scheduled-row map); safe reschedule lock choreography (`reschedule_one` / `reschedule_all` / `install_admission_dispatch` -- never hold `stream_lock` across cancel, schedule, or orchestrator submit) |
 | `connect.py` | `iter_table_stream_connect` / `iter_table_stream_connect_with_scope` with guaranteed `finally` scope teardown |
 | `row_stream_resolution.py` | Analytic-independent row terminal FSM (`OPEN` / `SOFT_PROVISIONAL` / `HARD_TERMINAL` / `CANCELED`) plus `multiplex_closed` drain bit |
 | `row_stream_resolution_registry.py` | Process-wide FIFO-bounded resolution table; stores delivery state + `multiplex_closed` (not a public drain write API) |

--- a/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_controller.py
@@ -83,6 +83,27 @@ class FleetTableStreamController(
             )
         return AdmissionDispatch(scheduled=scheduled)
 
+    def _active_run_id_for_player(self, player_id: int) -> str | None:
+        active = self.scheduler.row_run_for_player(self.scope, player_id)
+        if active is None:
+            return None
+        return active.session.run_id
+
+    def _resolve_player_admission(
+        self,
+        player_id: int,
+        *,
+        force_schedule: bool = False,
+    ) -> PlayerStreamAdmission:
+        return resolve_player_stream_admission(
+            self.persistence,
+            game_id=self.fleet_services.game_id,
+            perspective=self.fleet_services.perspective,
+            turn_number=self.turn.settings.turn,
+            player_id=player_id,
+            force_schedule=force_schedule,
+        )
+
     def reschedule_player(self, player_id: int) -> bool:
         """Cancel and re-admit one player without holding ``stream_lock`` across schedule.
 
@@ -90,89 +111,22 @@ class FleetTableStreamController(
         re-enter ``reschedule_player`` via invalidation. Holding ``stream_lock``
         across that path self-deadlocks (non-reentrant ``Lock``).
         """
-        cancel_run_ids: list[str] = []
-        with self.stream_lock:
-            old_row = self.scheduled_rows.get(player_id)
-            if old_row is not None:
-                cancel_run_ids.append(old_row.session.run_id)
-                self.scheduled_rows.pop(player_id, None)
-            else:
-                active = self.scheduler.row_run_for_player(self.scope, player_id)
-                if active is not None:
-                    cancel_run_ids.append(active.session.run_id)
-        for run_id in cancel_run_ids:
-            self.scheduler.cancel_player_run(run_id)
-        with self.stream_lock:
-            if player_id in self.scheduled_rows:
-                self.wake_multiplex.set()
-                return True
-        admission = resolve_player_stream_admission(
-            self.persistence,
-            game_id=self.fleet_services.game_id,
-            perspective=self.fleet_services.perspective,
-            turn_number=self.turn.settings.turn,
-            player_id=player_id,
+        return self.reschedule_one(
+            player_id,
+            cancel_run_id=self.scheduler.cancel_player_run,
+            resolve_admission=self._resolve_player_admission,
+            active_run_id_for_player=self._active_run_id_for_player,
         )
-        dispatch = self.dispatch_admission(player_id, admission)
-        if dispatch.schedule_failed:
-            return False
-        return self._install_admission_dispatch(player_id, dispatch)
 
     def reschedule_all_players(self, *, force_schedule: bool = False) -> bool:
         """Cancel and re-admit every player; schedule/submit outside ``stream_lock``."""
-        cancel_run_ids: list[str] = []
-        with self.stream_lock:
-            for player_id in self.player_ids:
-                old_row = self.scheduled_rows.get(player_id)
-                if old_row is not None:
-                    cancel_run_ids.append(old_row.session.run_id)
-            self.scheduled_rows.clear()
-        for run_id in cancel_run_ids:
-            self.scheduler.cancel_player_run(run_id)
-
-        dispatches: list[tuple[int, AdmissionDispatch[ScheduledFleetPlayer]]] = []
-        for player_id in self.player_ids:
-            admission = resolve_player_stream_admission(
-                self.persistence,
-                game_id=self.fleet_services.game_id,
-                perspective=self.fleet_services.perspective,
-                turn_number=self.turn.settings.turn,
-                player_id=player_id,
+        return self.reschedule_all(
+            cancel_run_id=self.scheduler.cancel_player_run,
+            resolve_admission=lambda player_id: self._resolve_player_admission(
+                player_id,
                 force_schedule=force_schedule,
-            )
-            dispatch = self.dispatch_admission(player_id, admission)
-            if dispatch.schedule_failed:
-                for _, prior in dispatches:
-                    if prior.scheduled is not None:
-                        self.scheduler.cancel_player_run(prior.scheduled.session.run_id)
-                return False
-            dispatches.append((player_id, dispatch))
-
-        for player_id, dispatch in dispatches:
-            if not self._install_admission_dispatch(player_id, dispatch):
-                return False
-        return True
-
-    def _install_admission_dispatch(
-        self,
-        player_id: int,
-        dispatch: AdmissionDispatch[ScheduledFleetPlayer],
-    ) -> bool:
-        """Apply one admission result under ``stream_lock``; cancel raced schedules."""
-        raced_run_id: str | None = None
-        with self.stream_lock:
-            if player_id in self.scheduled_rows:
-                if dispatch.scheduled is not None:
-                    raced_run_id = dispatch.scheduled.session.run_id
-            else:
-                if dispatch.wire_events:
-                    self.pending_wire_events.extend(dispatch.wire_events)
-                if dispatch.scheduled is not None:
-                    self.scheduled_rows[player_id] = dispatch.scheduled
-        if raced_run_id is not None:
-            self.scheduler.cancel_player_run(raced_run_id)
-        self.wake_multiplex.set()
-        return True
+            ),
+        )
 
     def attach(self) -> None:
         attach_fleet_table_stream(self)

--- a/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
+++ b/packages/api/api/analytics/military_score_inference/inference_table_stream_controller.py
@@ -154,6 +154,12 @@ class InferenceTableStreamController(
         if self.reload_host_turn is not None:
             self.turn = self.reload_host_turn()
 
+    def _active_run_id_for_player(self, player_id: int) -> str | None:
+        active = self.scheduler.row_run_for_player(self.scope, player_id)
+        if active is None:
+            return None
+        return active.session.run_id
+
     def reschedule_row(self, player_id: int) -> bool:
         """Cancel and re-admit one row without holding ``stream_lock`` across schedule.
 
@@ -161,32 +167,17 @@ class InferenceTableStreamController(
         fleet ledger persist (or soft-defer delivery) can re-enter ``reschedule_row`` or
         ``deliver_domain_event``. Holding ``stream_lock`` across that path self-deadlocks
         on the non-reentrant lock (fleet ``reschedule_player`` parity).
+
+        Cancel runs outside ``stream_lock``: cancel aborts orchestrator scopes and drains
+        node-complete listeners that call ``deliver_domain_event`` (needs this lock).
         """
-        cancel_run_ids: list[str] = []
-        with self.stream_lock:
-            self._refresh_host_turn()
-            old_row = self.scheduled_rows.get(player_id)
-            if old_row is not None:
-                cancel_run_ids.append(old_row.session.run_id)
-                self.scheduled_rows.pop(player_id, None)
-            else:
-                active = self.scheduler.row_run_for_player(self.scope, player_id)
-                if active is not None:
-                    cancel_run_ids.append(active.session.run_id)
-        # Cancel outside stream_lock: cancel aborts orchestrator scopes and drains
-        # node-complete listeners that call ``deliver_domain_event`` (needs this lock).
-        for run_id in cancel_run_ids:
-            self.scheduler.cancel_row_run(run_id)
-        with self.stream_lock:
-            if player_id in self.scheduled_rows:
-                # Concurrent admit/reschedule already replaced the row.
-                self.wake_multiplex.set()
-                return True
-        admission = self.resolve_row_admission(player_id)
-        dispatch = self.dispatch_admission(player_id, admission)
-        if dispatch.schedule_failed:
-            return False
-        return self._install_admission_dispatch(player_id, dispatch)
+        return self.reschedule_one(
+            player_id,
+            cancel_run_id=self.scheduler.cancel_row_run,
+            resolve_admission=self.resolve_row_admission,
+            active_run_id_for_player=self._active_run_id_for_player,
+            before_collect_cancels=self._refresh_host_turn,
+        )
 
     def adopt_admission_scheduled_row(
         self,
@@ -198,27 +189,6 @@ class InferenceTableStreamController(
             row,
             cancel_run_id=self.scheduler.cancel_row_run,
         )
-
-    def _install_admission_dispatch(
-        self,
-        player_id: int,
-        dispatch: AdmissionDispatch[ScheduledInferenceRow],
-    ) -> bool:
-        """Apply one admission result under ``stream_lock``; cancel raced schedules."""
-        raced_run_id: str | None = None
-        with self.stream_lock:
-            if player_id in self.scheduled_rows:
-                if dispatch.scheduled is not None:
-                    raced_run_id = dispatch.scheduled.session.run_id
-            else:
-                if dispatch.wire_events:
-                    self.pending_wire_events.extend(dispatch.wire_events)
-                if dispatch.scheduled is not None:
-                    self.scheduled_rows[player_id] = dispatch.scheduled
-        if raced_run_id is not None:
-            self.scheduler.cancel_row_run(raced_run_id)
-        self.wake_multiplex.set()
-        return True
 
     def push_admission_wire_terminal(self, session: InferenceRowStreamSession) -> bool:
         """Push immediate/cached admission wire for an empty peer complete.
@@ -295,35 +265,14 @@ class InferenceTableStreamController(
 
     def reschedule_all_rows(self, *, force_schedule: bool = False) -> bool:
         """Cancel and re-admit every row; schedule/submit outside ``stream_lock``."""
-        cancel_run_ids: list[str] = []
-        with self.stream_lock:
-            self._refresh_host_turn()
-            for player_id in self.player_ids:
-                old_row = self.scheduled_rows.get(player_id)
-                if old_row is not None:
-                    cancel_run_ids.append(old_row.session.run_id)
-            self.scheduled_rows.clear()
-        for run_id in cancel_run_ids:
-            self.scheduler.cancel_row_run(run_id)
-
-        dispatches: list[tuple[int, AdmissionDispatch[ScheduledInferenceRow]]] = []
-        for player_id in self.player_ids:
-            admission = self.resolve_row_admission(
+        return self.reschedule_all(
+            cancel_run_id=self.scheduler.cancel_row_run,
+            resolve_admission=lambda player_id: self.resolve_row_admission(
                 player_id,
                 force_schedule=force_schedule,
-            )
-            dispatch = self.dispatch_admission(player_id, admission)
-            if dispatch.schedule_failed:
-                for _, prior in dispatches:
-                    if prior.scheduled is not None:
-                        self.scheduler.cancel_row_run(prior.scheduled.session.run_id)
-                return False
-            dispatches.append((player_id, dispatch))
-
-        for player_id, dispatch in dispatches:
-            if not self._install_admission_dispatch(player_id, dispatch):
-                return False
-        return True
+            ),
+            before_collect_cancels=self._refresh_host_turn,
+        )
 
     def attach(self) -> None:
         attach_inference_table_stream(self)

--- a/packages/api/api/streaming/table_stream/controller_base.py
+++ b/packages/api/api/streaming/table_stream/controller_base.py
@@ -1,4 +1,19 @@
-"""Shared controller state for one multiplexed table NDJSON stream."""
+"""Shared controller state for one multiplexed table NDJSON stream.
+
+Lock invariant
+--------------
+Never hold ``stream_lock`` across cancel, ``dispatch_admission``, schedule, or
+orchestrator submit/drain. Those paths may re-enter the controller (invalidation
+→ reschedule, domain-event delivery) and ``stream_lock`` is not reentrant.
+
+Safe choreography (see ``reschedule_one`` / ``reschedule_all`` /
+``install_admission_dispatch``):
+
+1. Under lock: snapshot cancel targets / clear scheduled rows; optional refresh.
+2. Outside lock: cancel runs, resolve admission, ``dispatch_admission`` (schedule).
+3. Under lock again: install wires/scheduled via ``install_admission_dispatch``;
+   cancel raced schedules outside the lock.
+"""
 
 from __future__ import annotations
 
@@ -72,6 +87,16 @@ class TableStreamControllerBase(Generic[ScheduledT, AdmissionT]):
         raise NotImplementedError
 
     def register_admitted_schedule(self, player_id: int, admission: AdmissionT) -> bool:
+        """Legacy helper: dispatch then mutate scheduled/pending **without** ``stream_lock``.
+
+        Connect uses ``dispatch_admission`` + ``adopt_admission_scheduled_row`` instead.
+        Reschedule paths must use ``reschedule_one`` / ``reschedule_all`` (cancel and
+        schedule outside the lock; install via ``install_admission_dispatch``).
+
+        Do **not** call this while holding ``stream_lock``, and do not use it from
+        reschedule: ``dispatch_admission`` may schedule/submit and re-enter the
+        controller, which deadlocks on the non-reentrant lock.
+        """
         dispatch = self.dispatch_admission(player_id, admission)
         if dispatch.schedule_failed:
             return False
@@ -79,6 +104,107 @@ class TableStreamControllerBase(Generic[ScheduledT, AdmissionT]):
             self.pending_wire_events.extend(dispatch.wire_events)
         if dispatch.scheduled is not None:
             self.scheduled_rows[player_id] = dispatch.scheduled
+        return True
+
+    def install_admission_dispatch(
+        self,
+        player_id: int,
+        dispatch: AdmissionDispatch[ScheduledT],
+        *,
+        cancel_run_id: Callable[[str], None],
+    ) -> bool:
+        """Apply one admission result under ``stream_lock``; cancel raced schedules."""
+        raced_run_id: str | None = None
+        with self.stream_lock:
+            if player_id in self.scheduled_rows:
+                if dispatch.scheduled is not None:
+                    raced_run_id = self._run_id_for_scheduled_row(dispatch.scheduled)
+            else:
+                if dispatch.wire_events:
+                    self.pending_wire_events.extend(dispatch.wire_events)
+                if dispatch.scheduled is not None:
+                    self.scheduled_rows[player_id] = dispatch.scheduled
+        if raced_run_id is not None:
+            cancel_run_id(raced_run_id)
+        self.wake_multiplex.set()
+        return True
+
+    def reschedule_one(
+        self,
+        player_id: int,
+        *,
+        cancel_run_id: Callable[[str], None],
+        resolve_admission: Callable[[int], AdmissionT],
+        active_run_id_for_player: Callable[[int], str | None] | None = None,
+        before_collect_cancels: Callable[[], None] | None = None,
+    ) -> bool:
+        """Cancel and re-admit one player without holding ``stream_lock`` across schedule."""
+        cancel_run_ids: list[str] = []
+        with self.stream_lock:
+            if before_collect_cancels is not None:
+                before_collect_cancels()
+            old_row = self.scheduled_rows.get(player_id)
+            if old_row is not None:
+                cancel_run_ids.append(self._run_id_for_scheduled_row(old_row))
+                self.scheduled_rows.pop(player_id, None)
+            elif active_run_id_for_player is not None:
+                active_run_id = active_run_id_for_player(player_id)
+                if active_run_id is not None:
+                    cancel_run_ids.append(active_run_id)
+        for run_id in cancel_run_ids:
+            cancel_run_id(run_id)
+        with self.stream_lock:
+            if player_id in self.scheduled_rows:
+                self.wake_multiplex.set()
+                return True
+        admission = resolve_admission(player_id)
+        dispatch = self.dispatch_admission(player_id, admission)
+        if dispatch.schedule_failed:
+            return False
+        return self.install_admission_dispatch(
+            player_id,
+            dispatch,
+            cancel_run_id=cancel_run_id,
+        )
+
+    def reschedule_all(
+        self,
+        *,
+        cancel_run_id: Callable[[str], None],
+        resolve_admission: Callable[[int], AdmissionT],
+        before_collect_cancels: Callable[[], None] | None = None,
+    ) -> bool:
+        """Cancel and re-admit every player; schedule/submit outside ``stream_lock``."""
+        cancel_run_ids: list[str] = []
+        with self.stream_lock:
+            if before_collect_cancels is not None:
+                before_collect_cancels()
+            for player_id in self.player_ids:
+                old_row = self.scheduled_rows.get(player_id)
+                if old_row is not None:
+                    cancel_run_ids.append(self._run_id_for_scheduled_row(old_row))
+            self.scheduled_rows.clear()
+        for run_id in cancel_run_ids:
+            cancel_run_id(run_id)
+
+        dispatches: list[tuple[int, AdmissionDispatch[ScheduledT]]] = []
+        for player_id in self.player_ids:
+            admission = resolve_admission(player_id)
+            dispatch = self.dispatch_admission(player_id, admission)
+            if dispatch.schedule_failed:
+                for _, prior in dispatches:
+                    if prior.scheduled is not None:
+                        cancel_run_id(self._run_id_for_scheduled_row(prior.scheduled))
+                return False
+            dispatches.append((player_id, dispatch))
+
+        for player_id, dispatch in dispatches:
+            if not self.install_admission_dispatch(
+                player_id,
+                dispatch,
+                cancel_run_id=cancel_run_id,
+            ):
+                return False
         return True
 
     def _run_id_for_scheduled_row(self, row: ScheduledT) -> str:

--- a/packages/api/tests/table_stream_lock_helpers.py
+++ b/packages/api/tests/table_stream_lock_helpers.py
@@ -1,0 +1,21 @@
+"""Shared assertions for table-stream ``stream_lock`` choreography."""
+
+from __future__ import annotations
+
+import threading
+
+
+def assert_stream_lock_not_held(
+    stream_lock: threading.Lock,
+    *,
+    message: str,
+) -> None:
+    """Fail if ``stream_lock`` is held (schedule must not run under the lock).
+
+    Used by fleet/scores deadlock regressions: nested schedule/invalidation must
+    observe a free lock; a failed non-blocking acquire is the 0% CPU hang fingerprint.
+    """
+    acquired = stream_lock.acquire(blocking=False)
+    if not acquired:
+        raise AssertionError(message)
+    stream_lock.release()

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -31,6 +31,8 @@ from api.services.inference_row_persistence_service import InferenceRowPersisten
 from api.storage.memory_asset import MemoryAssetBackend
 from api.transport.fleet_table_stream import fleet_complete_event
 
+from tests.table_stream_lock_helpers import assert_stream_lock_not_held
+
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
 
@@ -668,13 +670,13 @@ def test_reschedule_player_does_not_deadlock_when_schedule_reenters_invalidation
         if nest_depth["n"] == 1:
             # Same-thread re-entry fingerprint: scores persist invalidation while
             # outer reschedule still holds stream_lock (before the lock-order fix).
-            acquired = controller.stream_lock.acquire(blocking=False)
-            if not acquired:
-                raise AssertionError(
+            assert_stream_lock_not_held(
+                controller.stream_lock,
+                message=(
                     "reschedule_player deadlocked (schedule re-entered stream_lock "
                     "via scores→fleet invalidation)"
-                )
-            controller.stream_lock.release()
+                ),
+            )
             from api.analytics.fleet.fleet_table_stream_registry import (
                 reschedule_fleet_table_player,
             )

--- a/packages/api/tests/test_scores_reschedule_stream_lock_deadlock.py
+++ b/packages/api/tests/test_scores_reschedule_stream_lock_deadlock.py
@@ -7,10 +7,10 @@ Fleet already fixed the sibling hang: ``FleetTableStreamController.reschedule_pl
 must not hold ``stream_lock`` across ``dispatch_admission`` / schedule / orchestrator
 submit (see ``test_reschedule_player_does_not_deadlock_when_schedule_reenters_invalidation``).
 
-Scores ``InferenceTableStreamController.reschedule_row`` still holds ``stream_lock``
-across ``register_admitted_schedule`` → ``schedule_player_row`` → ``enqueue_tier_ladder``
-(and submit when not deferred). Nested ``deliver_domain_event`` / ``reschedule_row``
-needs the same non-reentrant lock and self-deadlocks.
+Scores ``InferenceTableStreamController.reschedule_row`` must use the same shared
+choreography (``TableStreamControllerBase.reschedule_one``): cancel and schedule
+outside the lock; install under lock only. Nested ``deliver_domain_event`` /
+``reschedule_row`` needs the same non-reentrant lock and self-deadlocks if held.
 """
 
 from __future__ import annotations
@@ -42,6 +42,8 @@ from api.compute.runtime import reset_orchestrators_for_tests
 from api.streaming.table_stream.row_stream_resolution_registry import (
     clear_stream_resolutions,
 )
+
+from tests.table_stream_lock_helpers import assert_stream_lock_not_held
 
 
 @pytest.fixture(autouse=True)
@@ -80,10 +82,10 @@ def test_reschedule_row_does_not_hold_stream_lock_across_schedule(
 ) -> None:
     """Schedule under stream_lock must not re-enter reschedule (fleet parity).
 
-    Production hang: ``reschedule_row`` held ``stream_lock`` across
-    ``register_admitted_schedule`` → ``schedule_player_row``. Nested invalidation /
-    domain delivery / another ``reschedule_row`` blocks forever on the same
-    non-reentrant lock (0% CPU; turn-11 workers stuck behind wedged inFlight).
+    Production hang: ``reschedule_row`` held ``stream_lock`` across schedule.
+    Nested invalidation / domain delivery / another ``reschedule_row`` blocks
+    forever on the same non-reentrant lock (0% CPU; turn-11 workers stuck
+    behind wedged inFlight).
     """
     player_id = sample_turn.scores[0].ownerid
     stream_scope = InferenceStreamScope(
@@ -117,13 +119,13 @@ def test_reschedule_row_does_not_hold_stream_lock_across_schedule(
         if nest_depth["n"] == 1:
             # Same-thread re-entry fingerprint: nested work while outer reschedule
             # still holds stream_lock (before the lock-order fix).
-            acquired = controller.stream_lock.acquire(blocking=False)
-            if not acquired:
-                raise AssertionError(
+            assert_stream_lock_not_held(
+                controller.stream_lock,
+                message=(
                     "reschedule_row deadlocked (schedule re-entered stream_lock "
                     "via nested scores invalidation / re-admit; 680224 turn-11 hang)"
-                )
-            controller.stream_lock.release()
+                ),
+            )
             assert controller.reschedule_row(player_id) is True
         session = _session(sample_turn, player_id=player_id)
         return ScheduledInferenceRow(player_id=player_id, session=session)


### PR DESCRIPTION
## Summary
- Lift fleet/scores table-stream reschedule + install admission choreography into `TableStreamControllerBase` so cancel/schedule/submit never hold `stream_lock` (single owner for the 680224 deadlock fix).
- Thin fleet (`reschedule_player` / `reschedule_all_players`) and scores (`reschedule_row` / `reschedule_all_rows`) wrappers; document `register_admitted_schedule` as unsafe for reschedule.
- Share `assert_stream_lock_not_held` across both deadlock regressions; note the invariant in ADR 0004 addendum.

## Test plan
- [x] `pytest` deadlock regressions: `test_reschedule_player_does_not_deadlock_when_schedule_reenters_invalidation`, `test_reschedule_row_does_not_hold_stream_lock_across_schedule`
- [x] Broader stream suite: fleet/scores invalidation, table stream, scope teardown (53 passed)
- [x] Spot-check open fleet + scores table streams still reschedule on invalidation without hang


Made with [Cursor](https://cursor.com)