### PR TITLE
Fix add-issue-to-project GraphQL field (projectItem → item)

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -28,12 +28,13 @@ jobs:
           PROJECT_NODE_ID="${PROJECT_NODE_ID:-PVT_kwHOAFd56s4BRlN7}"
           ISSUE_NODE_ID="${{ github.event.issue.node_id }}"
           res=$(curl -sS -w "\n%{http_code}" -X POST -H "Authorization: bearer $TOKEN" -H "Content-Type: application/json" \
-            -d "{\"query\":\"mutation { addProjectV2ItemById(input: {projectId: \\\"$PROJECT_NODE_ID\\\", contentId: \\\"$ISSUE_NODE_ID\\\"}) { projectItem { id } } }\"}" \
+            -d "{\"query\":\"mutation { addProjectV2ItemById(input: {projectId: \\\"$PROJECT_NODE_ID\\\", contentId: \\\"$ISSUE_NODE_ID\\\"}) { item { id } } }\"}" \
             https://api.github.com/graphql)
           http_code=$(echo "$res" | tail -n1)
           body=$(echo "$res" | sed '$d')
           if [ "$http_code" != "200" ] || echo "$body" | grep -q '"errors"'; then
-            echo "Response ($http_code): $body"
+            echo "Response ($http_code):"
+            echo "$body" | jq -r '.errors // .' 2>/dev/null || echo "$body"
             exit 1
           fi
           echo "Issue added to project."


### PR DESCRIPTION
## Summary
- Correct `addProjectV2ItemById` selection set: `projectItem` → `item` (matches current GitHub GraphQL schema / docs).
- Print GraphQL `errors` more clearly on failure (`jq` with raw-body fallback).

This Actions workflow has never succeeded (147 failures since intro); issues that landed on the project were via other paths. Root cause was an invalid field name on the mutation payload, not a recent API break tied to ~#142.

## Test plan
- [ ] Open (or reopen) a test issue and confirm **Add issue to project** succeeds
- [ ] Confirm the issue appears on the Planets Console project board


Made with [Cursor](https://cursor.com)