### PR TITLE
Fix fleet table-stream hang holding scheduler lock across get_ledger

### DIFF
--- a/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
+++ b/packages/api/api/analytics/fleet/fleet_table_stream_scheduler.py
@@ -54,6 +54,16 @@ class _FleetPlayerOrchestratorRun:
     root_scope: ComputeScope
 
 
+@dataclass(frozen=True)
+class _EnqueueAdmissionEarlyReturn:
+    """Early return from ``enqueue_player_run`` admission checks under the lock.
+
+    ``session`` is an existing run to reuse, or ``None`` to reject.
+    """
+
+    session: FleetPlayerStreamSession | None
+
+
 class FleetTableStreamScheduler:
     """Table-stream adapter: one orchestrator submission per player (fair submit).
 
@@ -109,49 +119,65 @@ class FleetTableStreamScheduler:
         persistence: FleetSnapshotPersistenceService,
         stream_token: str | None = None,
     ) -> FleetPlayerStreamSession | None:
+        """Admit one fleet player run and submit ``force_fresh``.
+
+        Persistence reads (``get_ledger`` / chain-anchor walk / deep-copy) and
+        ``orchestrator.submit`` must run **outside** ``self._lock``. Scores
+        ``tier_solve`` admits call ``reschedule_fleet_table_player`` on the pool
+        worker; holding this lock across storage deep-copy wedged all workers and
+        the fleet multiplex ``owns_table_stream`` poll (game 680224 turn 13→14).
+        """
         submit_binding: _FleetStreamOrchestratorBinding | None = None
         submit_scope: ComputeScope | None = None
+        host_turn = session.turn
+        host_turn_number = host_turn.settings.turn
+        player_id = session.player_id
+        game_id = fleet_services.game_id
+        perspective = fleet_services.perspective
+
         with self._lock:
-            if (
-                stream_token is not None
-                and self._scope_guard.active_table_stream_token != stream_token
-            ):
-                return None
-            for existing in self._runs.values():
-                if existing.session.player_id == session.player_id:
-                    return existing.session
+            early = self._enqueue_admission_early_return_locked(
+                player_id, stream_token=stream_token
+            )
+            if early is not None:
+                return early.session
 
-            if stream_token is None:
-                return None
+        # Ledger load deep-copies the fleet document -- never under ``self._lock``.
+        before_persisted = persistence.get_ledger(
+            game_id,
+            perspective,
+            host_turn_number,
+            player_id,
+        )
+        wire_before = _initial_wire_before_ledger(
+            persistence=persistence,
+            game_id=game_id,
+            perspective=perspective,
+            player_id=player_id,
+            host_turn=host_turn,
+            before_persisted=before_persisted,
+        )
 
+        with self._lock:
+            early = self._enqueue_admission_early_return_locked(
+                player_id, stream_token=stream_token
+            )
+            if early is not None:
+                return early.session
+            assert stream_token is not None
             binding = self._binding_for_stream_locked(
                 stream_token,
-                host_turn=session.turn,
+                host_turn=host_turn,
                 fleet_services=fleet_services,
             )
-            host_turn_number = session.turn.settings.turn
-            player_id = session.player_id
-            before_persisted = persistence.get_ledger(
-                fleet_services.game_id,
-                fleet_services.perspective,
-                host_turn_number,
-                player_id,
-            )
             progress_tracker = FleetLedgerWireProgressTracker(
-                host_turn=session.turn,
-                wire_before=_initial_wire_before_ledger(
-                    persistence=persistence,
-                    game_id=fleet_services.game_id,
-                    perspective=fleet_services.perspective,
-                    player_id=player_id,
-                    host_turn=session.turn,
-                    before_persisted=before_persisted,
-                ),
+                host_turn=host_turn,
+                wire_before=wire_before,
             )
             root_scope = ComputeScope(
                 analytic_id=ANALYTIC_ID,
-                game_id=fleet_services.game_id,
-                perspective=fleet_services.perspective,
+                game_id=game_id,
+                perspective=perspective,
                 turn=host_turn_number,
                 player_id=player_id,
             )
@@ -181,6 +207,25 @@ class FleetTableStreamScheduler:
                 )
             )
         return session
+
+    def _enqueue_admission_early_return_locked(
+        self,
+        player_id: int,
+        *,
+        stream_token: str | None,
+    ) -> _EnqueueAdmissionEarlyReturn | None:
+        """Return an early outcome, or ``None`` when admission may proceed.
+
+        ``session`` is the existing run to reuse, or ``None`` to reject.
+        """
+        if stream_token is not None and self._scope_guard.active_table_stream_token != stream_token:
+            return _EnqueueAdmissionEarlyReturn(session=None)
+        for existing in self._runs.values():
+            if existing.session.player_id == player_id:
+                return _EnqueueAdmissionEarlyReturn(session=existing.session)
+        if stream_token is None:
+            return _EnqueueAdmissionEarlyReturn(session=None)
+        return None
 
     def cancel_player_run(self, run_id: str) -> None:
         """Token-only cancel -- no scores-style shell admission or abort_scope.

--- a/packages/api/tests/table_stream_lock_helpers.py
+++ b/packages/api/tests/table_stream_lock_helpers.py
@@ -1,8 +1,25 @@
-"""Shared assertions for table-stream ``stream_lock`` choreography."""
+"""Shared assertions for table-stream lock choreography."""
 
 from __future__ import annotations
 
 import threading
+
+
+def assert_lock_not_held(
+    lock: threading.Lock,
+    *,
+    message: str,
+) -> None:
+    """Fail if ``lock`` is held (nested work must not run under the lock).
+
+    Used by fleet/scores deadlock regressions: nested schedule/invalidation or
+    persistence I/O must observe a free lock; a failed non-blocking acquire is
+    the 0% CPU hang fingerprint.
+    """
+    acquired = lock.acquire(blocking=False)
+    if not acquired:
+        raise AssertionError(message)
+    lock.release()
 
 
 def assert_stream_lock_not_held(
@@ -10,12 +27,5 @@ def assert_stream_lock_not_held(
     *,
     message: str,
 ) -> None:
-    """Fail if ``stream_lock`` is held (schedule must not run under the lock).
-
-    Used by fleet/scores deadlock regressions: nested schedule/invalidation must
-    observe a free lock; a failed non-blocking acquire is the 0% CPU hang fingerprint.
-    """
-    acquired = stream_lock.acquire(blocking=False)
-    if not acquired:
-        raise AssertionError(message)
-    stream_lock.release()
+    """Fail if ``stream_lock`` is held (schedule must not run under the lock)."""
+    assert_lock_not_held(stream_lock, message=message)

--- a/packages/api/tests/test_fleet_table_stream_invalidation.py
+++ b/packages/api/tests/test_fleet_table_stream_invalidation.py
@@ -31,7 +31,7 @@ from api.services.inference_row_persistence_service import InferenceRowPersisten
 from api.storage.memory_asset import MemoryAssetBackend
 from api.transport.fleet_table_stream import fleet_complete_event
 
-from tests.table_stream_lock_helpers import assert_stream_lock_not_held
+from tests.table_stream_lock_helpers import assert_lock_not_held, assert_stream_lock_not_held
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
 
@@ -698,3 +698,106 @@ def test_reschedule_player_does_not_deadlock_when_schedule_reenters_invalidation
     assert controller.reschedule_player(player_id) is True
     assert nest_depth["n"] >= 2
     assert player_id in controller.scheduled_rows
+
+
+def test_enqueue_player_run_does_not_hold_scheduler_lock_across_get_ledger(
+    sample_turn,
+    monkeypatch,
+    memory_backend,
+    request,
+) -> None:
+    """Persistence deep-copy must not run under fleet scheduler ``_lock``.
+
+    Production hang (game 680224, turn 13→14): scores ``tier_solve`` admitted a
+    solution on each pool worker → ``on_inference_evidence_updated`` →
+    ``reschedule_fleet_table_player`` → ``enqueue_player_run`` held ``_lock``
+    across ``get_ledger`` / ``deep_copy_value``. Sibling workers blocked in
+    ``cancel_player_run`` and the fleet multiplex poll blocked in
+    ``owns_table_stream`` (timeline frozen; ~0% CPU; multi-GB RSS).
+    """
+    import concurrent.futures
+
+    from api.analytics.fleet.compute_services import (
+        FleetComputeServices,
+        build_ephemeral_fleet_compute_services,
+    )
+    from api.analytics.fleet.fleet_table_player_run import FleetPlayerStreamSession
+    from api.compute.orchestrator import ComputeOrchestrator
+    from api.compute.pools import reset_compute_worker_pool_for_tests
+    from api.compute.runtime import reset_orchestrators_for_tests
+
+    reset_fleet_table_stream_registry_for_tests()
+    reset_orchestrators_for_tests()
+    reset_compute_worker_pool_for_tests(worker_count=0)
+    scheduler = FleetTableStreamScheduler()
+    persistence = FleetSnapshotPersistenceService(memory_backend)
+    ephemeral = build_ephemeral_fleet_compute_services(
+        sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    fleet_services = FleetComputeServices(
+        persistence=persistence,
+        game_id=628580,
+        perspective=1,
+        load_turn=ephemeral.load_turn,
+        inference_materialization=ephemeral.inference_materialization,
+    )
+    player_id = sample_turn.scores[0].ownerid
+    scope = _stream_scope(sample_turn)
+    stream_token = scheduler.begin_scope(scope)
+
+    def cleanup() -> None:
+        scheduler.end_fleet_table_stream(scope, (), stream_token=stream_token)
+        reset_fleet_table_stream_registry_for_tests()
+        reset_orchestrators_for_tests()
+        reset_compute_worker_pool_for_tests(worker_count=1)
+        reset_fleet_table_stream_scheduler_for_tests()
+
+    request.addfinalizer(cleanup)
+
+    real_get_ledger = persistence.get_ledger
+    saw_get_ledger = {"n": 0}
+
+    def get_ledger_asserts_lock_free(*args, **kwargs):
+        saw_get_ledger["n"] += 1
+        assert_lock_not_held(
+            scheduler._lock,
+            message=(
+                "enqueue_player_run held scheduler _lock across get_ledger "
+                "(680224 turn-14 hang fingerprint)"
+            ),
+        )
+        # Concurrent cancel and multiplex ownership polls must take the lock
+        # during persistence I/O (both blocked in the production hang).
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            cancel_future = pool.submit(scheduler.cancel_player_run, "nonexistent-run")
+            owns_future = pool.submit(scheduler.owns_table_stream, stream_token)
+            try:
+                cancel_future.result(timeout=2.0)
+                assert owns_future.result(timeout=2.0) is True
+            except concurrent.futures.TimeoutError as exc:
+                raise AssertionError(
+                    "cancel_player_run or owns_table_stream blocked on scheduler "
+                    "_lock during get_ledger (680224 turn-14 hang fingerprint)"
+                ) from exc
+        return real_get_ledger(*args, **kwargs)
+
+    monkeypatch.setattr(persistence, "get_ledger", get_ledger_asserts_lock_free)
+    monkeypatch.setattr(ComputeOrchestrator, "submit", lambda self, request: None)
+
+    session = FleetPlayerStreamSession(
+        player_id=player_id,
+        turn=sample_turn,
+        game_id=628580,
+        perspective=1,
+    )
+    result = scheduler.enqueue_player_run(
+        session,
+        fleet_services=fleet_services,
+        persistence=persistence,
+        stream_token=stream_token,
+    )
+    assert result is session
+    assert saw_get_ledger["n"] >= 1
+    assert player_id in {run.session.player_id for run in scheduler._runs.values()}


### PR DESCRIPTION
## Summary
- Stop holding `FleetTableStreamScheduler._lock` across ledger persistence deep-copy (`get_ledger` / chain-anchor walk); admit, load outside the lock, re-admit, then submit.
- Fixes the game 680224 turn 13→14 hang where scores `tier_solve` reschedule wedged pool workers in `cancel_player_run` and multiplex `owns_table_stream` (~0% CPU).
- Add regression coverage that concurrent cancel and ownership polls succeed during `get_ledger`.

## Test plan
- [x] `pytest tests/test_fleet_table_stream_invalidation.py::test_enqueue_player_run_does_not_hold_scheduler_lock_across_get_ledger`
- [ ] Existing fleet invalidation / stream_lock deadlock regressions still pass
- [ ] Smoke: open fleet table stream while scores evidence updates reschedule players (no frozen multiplex / stalled workers)


Made with [Cursor](https://cursor.com)