### PR TITLE
Keep shell error panes inside the main content area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ local/
 .sampler_data/
 
 # Frontend (packages/frontend has its own .gitignore for node_modules, dist)
+node_modules/

--- a/packages/frontend/src/components/shell/ShellPlaceholders.test.tsx
+++ b/packages/frontend/src/components/shell/ShellPlaceholders.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ShellCenterPane, ShellErrorPane } from './ShellPlaceholders'
+
+describe('ShellPlaceholders', () => {
+  it('ShellCenterPane fills the main content flex slot without a width cap', () => {
+    const { container } = render(<ShellCenterPane message="Loading…" />)
+    const pane = container.querySelector('main')
+    expect(pane).toHaveClass('flex-1', 'min-w-0')
+    expect(pane).not.toHaveClass('max-w-3xl')
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('ShellErrorPane fills the content area and caps text inside, not the pane', () => {
+    const longDetail = [
+      'Map: TypeError: Failed to fetch - GET /bff/analytics/base-map/map?game_id=1',
+      'Connections: TypeError: Failed to fetch - GET /bff/analytics/connections/map?game_id=1',
+    ].join('\n')
+
+    const { container } = render(
+      <ShellErrorPane title="Failed to load map data" error={new Error(longDetail)} />
+    )
+
+    const pane = container.querySelector('main')
+    expect(pane).toHaveClass('flex-1', 'min-w-0', 'overflow-auto')
+    expect(pane).not.toHaveClass('max-w-3xl')
+
+    const textBox = pane?.firstElementChild
+    expect(textBox).toHaveClass('w-full', 'max-w-3xl', 'min-w-0')
+
+    expect(screen.getByText('Failed to load map data')).toBeInTheDocument()
+    expect(screen.getByText(/base-map\/map/)).toBeInTheDocument()
+  })
+})

--- a/packages/frontend/src/components/shell/ShellPlaceholders.tsx
+++ b/packages/frontend/src/components/shell/ShellPlaceholders.tsx
@@ -2,7 +2,7 @@ import { errorDetailFromUnknown } from '../../lib/queryRetry'
 
 export function ShellCenterPane({ message }: { message: string }) {
   return (
-    <main className="flex flex-1 items-center justify-center bg-black p-8 text-gray-400">
+    <main className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-black p-8 text-gray-400">
       {message}
     </main>
   )
@@ -21,14 +21,16 @@ export function ShellErrorPane({
 }) {
   const detail = errorDetailFromUnknown(error, fallbackDetail ?? 'Unknown error')
   return (
-    <main className="flex max-w-3xl flex-1 flex-col items-center justify-center gap-2 bg-black p-8 text-red-400">
-      <p className="text-center font-medium">{title}</p>
-      <p className="whitespace-pre-wrap break-words text-left text-sm text-red-300/90">
-        {detail}
-      </p>
-      {footer != null ? (
-        <p className="text-center text-sm text-gray-500">{footer}</p>
-      ) : null}
+    <main className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center overflow-auto bg-black p-8 text-red-400">
+      <div className="flex w-full max-w-3xl min-w-0 flex-col gap-2">
+        <p className="text-center font-medium">{title}</p>
+        <p className="whitespace-pre-wrap break-words text-left text-sm text-red-300/90">
+          {detail}
+        </p>
+        {footer != null ? (
+          <p className="text-center text-sm text-gray-500">{footer}</p>
+        ) : null}
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- Constrain `ShellErrorPane` text with an inner `max-w-3xl` wrapper so long map-load failures stay in the main content area instead of overflowing the analytics sidebar
- Add layout regression coverage for shell placeholders
- Ignore root `node_modules/` (accidental Vite cache; frontend deps stay under `packages/frontend`)

## Test plan
- [ ] Stop the BFF, open Map view, confirm "Failed to load map data" is centered in the black map pane and does not overlay the analytics bar
- [ ] Confirm long multi-line fetch errors wrap within the content area and remain scrollable if needed
- [ ] Spot-check a normal loading placeholder (`ShellCenterPane`) still fills the main area
- [ ] `cd packages/frontend && npm test -- src/components/shell/ShellPlaceholders.test.tsx src/components/shell/MapShellContent.test.tsx`


Made with [Cursor](https://cursor.com)