### PR TITLE
Weaken Privateer ship-travel envelope ownership evidence

### DIFF
--- a/docs/design-homeworld-locator-analytic.md
+++ b/docs/design-homeworld-locator-analytic.md
@@ -236,7 +236,7 @@ Strengthens **homeworld owner** attribution for **homeworld sectors** (whose HW 
 | Hyperdrive | **Ignore** HYP-capable hulls for envelopes (hull ability / known HYP hull set -- not FC=`HYP` alone) |
 | Chunnel / tow / wormhole | No special handling in v1 (envelope is the naive warp budget) |
 
-**Sector reduction (ship → owner):** For ship of `ownerid` *X* at (*x*,*y*) with envelope radius *R*, the reachable **homeworld sectors** are those whose **preferred sector HW position** (definite planet if any; else most-probable; else closest-to-mid candidate; else sector annular mid when no candidates) lies within *R* of the ship. Intersect that reachable set into owner *X*'s remaining possible-sector set (initialized to all eligible sectors). When owner *X*'s possible-sector set shrinks to a single sector, add *X* to that sector's possible-owner set with a **ship-travel-envelope** provenance summary (ship id, turn, radius, age source).
+**Sector reduction (ship → owner):** For ship of `ownerid` *X* at (*x*,*y*) with envelope radius *R*, the reachable **homeworld sectors** are those whose **preferred sector HW position** (definite planet if any; else most-probable; else closest-to-mid candidate; else sector annular mid when no candidates) lies within *R* of the ship. Intersect that reachable set into owner *X*'s remaining possible-sector set (initialized to all eligible sectors). When owner *X*'s possible-sector set shrinks to a single sector, add *X* to that sector's possible-owner set with a **ship-travel-envelope** provenance summary (ship id, turn, radius, age source). Strength of that provenance is **strong** for non-Privateer owners and **weak** for Privateer owners (`raceid` 5): Rob + tow-capture can place Privateer-owned ships near foreign homeworlds without travel from the Privateer HW (Crystal tow-capture is deliberately out of scope).
 
 **Planetary ownership sightings:**
 
@@ -288,8 +288,8 @@ Opinionated joint set over **homeworld sectors** (same eligibility gate as secto
 | Location | Origin-distance observation | weak |
 | Location | Baseline profile match; single-starbase new-build | strong |
 | Location | UI “this planet is the HW” | asserted |
-| Ownership | `nearby_planet_ownership`; `preferred_candidate_ownership` (preferred not yet location-definite) | weak |
-| Ownership | `preferred_candidate_ownership` when preferred is location-**definite**; `ship_travel_envelope` | strong |
+| Ownership | `nearby_planet_ownership`; `preferred_candidate_ownership` (preferred not yet location-definite); `ship_travel_envelope` for **Privateer** owners (Rob + tow-capture can relocate owned ships) | weak |
+| Ownership | `preferred_candidate_ownership` when preferred is location-**definite**; `ship_travel_envelope` for non-Privateer owners | strong |
 | Ownership | UI owner assert | asserted |
 
 Geometry / co-sector / definite-neighborhood culls do not mint provenances.
@@ -536,3 +536,4 @@ Grill locks: §4.2 FE display row, §10 (this doc). CONTEXT: **homeworld region 
 | 2026-08-03 | #37 grill: dual-axis tiered provenances (weak/strong/asserted); game-global asserts + merge-above-read; positive location only; no race annotation; refresh = full machine wipe; ADR 0010; §4.4 / §11.6 |
 | 2026-08-03 | #283: sector accordion panel + region selection (Pinned/Unpinned/Selected, default Selected, initial set = all) + Show overlays checkbox; thin FE hovers; candidate flash/pan; replaces #35 display mode; §4.2 / §10 / §11.7 |
 | 2026-08-05 | #283 docs: region selection ownership -- Pinned/Unpinned derive-at-read (empty persist); MapGraph-only materialize; Tile overlay query + read/action selection hook (§4.2 / §10 / CONTEXT) |
+| 2026-08-06 | Ownership: Privateer `ship_travel_envelope` strength demoted to weak (Rob/tow-capture); Crystal tow-capture left strong by product choice |

--- a/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
+++ b/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
@@ -49,7 +49,7 @@ from api.analytics.homeworld_locator.types import (
     empty_candidate_view,
     ensure_candidates_for_asserted_locations,
 )
-from api.analytics.turn_roster import players_by_id
+from api.analytics.turn_roster import players_by_id, race_id_by_owner_slot
 from api.concepts.homeworld_layout import (
     homeworld_locator_inactive_reason,
     homeworld_settings_fingerprint,
@@ -347,9 +347,7 @@ def materialize_homeworld_candidates(
     adjusted = derive_candidates_from_merged_evidence(
         adjusted,
         merged,
-        race_id_by_owner_slot={
-            player_id: player.raceid for player_id, player in players_by_id(shell_turn).items()
-        },
+        race_id_by_owner_slot=race_id_by_owner_slot(shell_turn),
         planet_sector_index=(
             dict(partition.planet_sector_index) if partition is not None else None
         ),

--- a/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
+++ b/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
@@ -350,6 +350,9 @@ def materialize_homeworld_candidates(
         planet_sector_index=(
             dict(partition.planet_sector_index) if partition is not None else None
         ),
+        race_id_by_owner_slot={
+            player_id: player.raceid for player_id, player in players_by_id(shell_turn).items()
+        },
     )
     adjusted = apply_definite_keyed_candidate_culls(
         adjusted,

--- a/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
+++ b/packages/api/api/analytics/homeworld_locator/baseline_ensure.py
@@ -347,12 +347,12 @@ def materialize_homeworld_candidates(
     adjusted = derive_candidates_from_merged_evidence(
         adjusted,
         merged,
-        planet_sector_index=(
-            dict(partition.planet_sector_index) if partition is not None else None
-        ),
         race_id_by_owner_slot={
             player_id: player.raceid for player_id, player in players_by_id(shell_turn).items()
         },
+        planet_sector_index=(
+            dict(partition.planet_sector_index) if partition is not None else None
+        ),
     )
     adjusted = apply_definite_keyed_candidate_culls(
         adjusted,

--- a/packages/api/api/analytics/homeworld_locator/evidence_strength.py
+++ b/packages/api/api/analytics/homeworld_locator/evidence_strength.py
@@ -72,8 +72,8 @@ def ownership_provenance_strength(
     ``ship_travel_envelope`` stays strong for non-Privateer owners; Privateer
     owners (``owner_race_id``) demote to weak because Rob/tow-capture can put
     owned ships near foreign homeworlds without travel from the Privateer HW.
-    Missing ``owner_race_id`` keeps the default strong mapping (callers that
-    have a turn roster should pass race ids).
+    Missing ``owner_race_id`` keeps the default strong mapping (``resolve_ownership_axis``
+    looks up race from the required ``race_id_by_owner_slot`` map).
     """
     if kind == PROVENANCE_PREFERRED_CANDIDATE_OWNERSHIP and preferred_location_definite:
         return STRENGTH_STRONG
@@ -175,12 +175,17 @@ def _member_winning_strength(
 def resolve_ownership_axis(
     members: Sequence[SectorOwnerMember],
     *,
+    race_id_by_owner_slot: Mapping[int, int],
     location_definite_planet_ids: frozenset[int] | None = None,
-    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> OwnershipAxisResolution:
-    """Resolve ownership from member provenances: max strength wins; ties stay ambiguous."""
+    """Resolve ownership from member provenances: max strength wins; ties stay ambiguous.
+
+    ``race_id_by_owner_slot`` is required so race-sensitive kinds (Privateer
+    ``ship_travel_envelope``) cannot silently stay strong via omitted race context.
+    Empty maps are allowed when the caller has no roster (e.g. tests without
+    race-sensitive members); unknown slots still resolve as non-Privateer.
+    """
     definite_ids = location_definite_planet_ids or frozenset()
-    race_by_slot = race_id_by_owner_slot or {}
     if not members:
         return OwnershipAxisResolution(
             winning_strength=None,
@@ -193,7 +198,7 @@ def resolve_ownership_axis(
         strength = _member_winning_strength(
             member,
             location_definite_planet_ids=definite_ids,
-            race_id_by_owner_slot=race_by_slot,
+            race_id_by_owner_slot=race_id_by_owner_slot,
         )
         if strength is None:
             continue

--- a/packages/api/api/analytics/homeworld_locator/evidence_strength.py
+++ b/packages/api/api/analytics/homeworld_locator/evidence_strength.py
@@ -4,6 +4,8 @@ Kind → ``weak`` < ``strong`` < ``asserted``. Decision/display state uses only
 provenances at the highest present class; same-strength conflicts stay unresolved.
 ``preferred_candidate_ownership`` is strong only when its planet is already
 location-definite (caller supplies that context at resolve time).
+``ship_travel_envelope`` is weak for Privateer owners (Rob + tow-capture can
+place ships outside a true travel path from their homeworld).
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ from api.analytics.homeworld_locator.models import (
     LocationProvenance,
     SectorOwnerMember,
 )
+from api.concepts.races import is_privateer
 
 STRENGTH_WEAK = "weak"
 STRENGTH_STRONG = "strong"
@@ -60,14 +63,26 @@ def ownership_provenance_strength(
     kind: str,
     *,
     preferred_location_definite: bool = False,
+    owner_race_id: int | None = None,
 ) -> str:
     """Map an ownership provenance kind to its homeworld evidence strength class.
 
     ``preferred_candidate_ownership`` upgrades to strong when the preferred
     candidate is already definite on the location axis.
+    ``ship_travel_envelope`` stays strong for non-Privateer owners; Privateer
+    owners (``owner_race_id``) demote to weak because Rob/tow-capture can put
+    owned ships near foreign homeworlds without travel from the Privateer HW.
+    Missing ``owner_race_id`` keeps the default strong mapping (callers that
+    have a turn roster should pass race ids).
     """
     if kind == PROVENANCE_PREFERRED_CANDIDATE_OWNERSHIP and preferred_location_definite:
         return STRENGTH_STRONG
+    if (
+        kind == PROVENANCE_SHIP_TRAVEL_ENVELOPE
+        and owner_race_id is not None
+        and is_privateer(owner_race_id)
+    ):
+        return STRENGTH_WEAK
     strength = _OWNERSHIP_KIND_STRENGTH.get(kind)
     if strength is None:
         raise ValueError(f"unknown homeworld ownership provenance kind: {kind!r}")
@@ -137,8 +152,10 @@ def _member_winning_strength(
     member: SectorOwnerMember,
     *,
     location_definite_planet_ids: frozenset[int],
+    race_id_by_owner_slot: Mapping[int, int],
 ) -> str | None:
     strengths: list[str] = []
+    owner_race_id = race_id_by_owner_slot.get(member.owner_slot)
     for provenance in member.provenances:
         preferred_definite = (
             provenance.kind == PROVENANCE_PREFERRED_CANDIDATE_OWNERSHIP
@@ -149,6 +166,7 @@ def _member_winning_strength(
             ownership_provenance_strength(
                 provenance.kind,
                 preferred_location_definite=preferred_definite,
+                owner_race_id=owner_race_id,
             )
         )
     return _max_strength(strengths)
@@ -158,9 +176,11 @@ def resolve_ownership_axis(
     members: Sequence[SectorOwnerMember],
     *,
     location_definite_planet_ids: frozenset[int] | None = None,
+    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> OwnershipAxisResolution:
     """Resolve ownership from member provenances: max strength wins; ties stay ambiguous."""
     definite_ids = location_definite_planet_ids or frozenset()
+    race_by_slot = race_id_by_owner_slot or {}
     if not members:
         return OwnershipAxisResolution(
             winning_strength=None,
@@ -173,6 +193,7 @@ def resolve_ownership_axis(
         strength = _member_winning_strength(
             member,
             location_definite_planet_ids=definite_ids,
+            race_id_by_owner_slot=race_by_slot,
         )
         if strength is None:
             continue

--- a/packages/api/api/analytics/homeworld_locator/materialize_from_provenances.py
+++ b/packages/api/api/analytics/homeworld_locator/materialize_from_provenances.py
@@ -55,8 +55,8 @@ def derive_candidates_from_merged_evidence(
     candidates: Sequence[HomeworldCandidateRecord],
     merged: MergedHomeworldEvidence,
     *,
+    race_id_by_owner_slot: Mapping[int, int],
     planet_sector_index: Mapping[int, int] | None = None,
-    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> tuple[HomeworldCandidateRecord, ...]:
     """Apply location strength resolution and asserted cues onto candidate rows.
 
@@ -64,6 +64,7 @@ def derive_candidates_from_merged_evidence(
     merged sets. Otherwise planet-keyed asserted ownership is used. Unique
     ownership binds ``perspective`` only when the row is still unbound
     (``perspective is None``) -- both keying modes share that preserve policy.
+    ``race_id_by_owner_slot`` is required (empty map allowed when no race context).
     """
     has_location_provenances = bool(merged.location_provenances)
     location_resolution = resolve_location_axis(merged.location_provenances)
@@ -72,7 +73,6 @@ def derive_candidates_from_merged_evidence(
         if location_resolution.is_definite and location_resolution.resolved_planet_id is not None
         else frozenset()
     )
-    race_by_slot = race_id_by_owner_slot or {}
     sector_members: dict[int, tuple[SectorOwnerMember, ...]] = dict(merged.sector_owner_sets)
     planet_members: dict[int, tuple[SectorOwnerMember, ...]] = dict(merged.planet_owner_sets)
 
@@ -97,8 +97,8 @@ def derive_candidates_from_merged_evidence(
                 ownership_for_cue = sector_members.get(sector_index, ())
                 ownership_resolution = resolve_ownership_axis(
                     ownership_for_cue,
+                    race_id_by_owner_slot=race_id_by_owner_slot,
                     location_definite_planet_ids=definite_ids,
-                    race_id_by_owner_slot=race_by_slot,
                 )
                 if ownership_resolution.is_unique and perspective is None:
                     perspective = ownership_resolution.resolved_owner_slot
@@ -106,8 +106,8 @@ def derive_candidates_from_merged_evidence(
             ownership_for_cue = planet_members[row.planet_id]
             ownership_resolution = resolve_ownership_axis(
                 ownership_for_cue,
+                race_id_by_owner_slot=race_id_by_owner_slot,
                 location_definite_planet_ids=definite_ids,
-                race_id_by_owner_slot=race_by_slot,
             )
             if ownership_resolution.is_unique and perspective is None:
                 perspective = ownership_resolution.resolved_owner_slot

--- a/packages/api/api/analytics/homeworld_locator/materialize_from_provenances.py
+++ b/packages/api/api/analytics/homeworld_locator/materialize_from_provenances.py
@@ -56,6 +56,7 @@ def derive_candidates_from_merged_evidence(
     merged: MergedHomeworldEvidence,
     *,
     planet_sector_index: Mapping[int, int] | None = None,
+    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> tuple[HomeworldCandidateRecord, ...]:
     """Apply location strength resolution and asserted cues onto candidate rows.
 
@@ -71,6 +72,7 @@ def derive_candidates_from_merged_evidence(
         if location_resolution.is_definite and location_resolution.resolved_planet_id is not None
         else frozenset()
     )
+    race_by_slot = race_id_by_owner_slot or {}
     sector_members: dict[int, tuple[SectorOwnerMember, ...]] = dict(merged.sector_owner_sets)
     planet_members: dict[int, tuple[SectorOwnerMember, ...]] = dict(merged.planet_owner_sets)
 
@@ -96,6 +98,7 @@ def derive_candidates_from_merged_evidence(
                 ownership_resolution = resolve_ownership_axis(
                     ownership_for_cue,
                     location_definite_planet_ids=definite_ids,
+                    race_id_by_owner_slot=race_by_slot,
                 )
                 if ownership_resolution.is_unique and perspective is None:
                     perspective = ownership_resolution.resolved_owner_slot
@@ -104,6 +107,7 @@ def derive_candidates_from_merged_evidence(
             ownership_resolution = resolve_ownership_axis(
                 ownership_for_cue,
                 location_definite_planet_ids=definite_ids,
+                race_id_by_owner_slot=race_by_slot,
             )
             if ownership_resolution.is_unique and perspective is None:
                 perspective = ownership_resolution.resolved_owner_slot

--- a/packages/api/api/analytics/homeworld_locator/ownership_projection.py
+++ b/packages/api/api/analytics/homeworld_locator/ownership_projection.py
@@ -65,6 +65,7 @@ def project_sector_owner_sets_for_overlays(
     *,
     location_definite_planet_ids: frozenset[int] = frozenset(),
     settled_owner_home_by_slot: Mapping[int, int] | None = None,
+    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> dict[int, SectorOwnerOverlayProjection]:
     """Project durable sector owner sets for overlay wire facts.
 
@@ -81,6 +82,7 @@ def project_sector_owner_sets_for_overlays(
     if not sector_owner_sets:
         return {}
 
+    race_by_slot = race_id_by_owner_slot or {}
     strength_filtered: dict[int, tuple[SectorOwnerMember, ...]] = {}
     resolutions: dict[int, OwnershipAxisResolution] = {}
     for sector_index, members in sector_owner_sets.items():
@@ -88,6 +90,7 @@ def project_sector_owner_sets_for_overlays(
         resolution = resolve_ownership_axis(
             member_tuple,
             location_definite_planet_ids=location_definite_planet_ids,
+            race_id_by_owner_slot=race_by_slot,
         )
         resolutions[sector_index] = resolution
         contenders = frozenset(resolution.contending_owner_slots)
@@ -134,6 +137,7 @@ def project_sector_owner_sets_for_overlays(
             winning_strength=_winning_strength_for_projected(
                 members,
                 location_definite_planet_ids=location_definite_planet_ids,
+                race_id_by_owner_slot=race_by_slot,
                 prior_resolution=resolutions.get(sector_index),
             ),
         )
@@ -145,6 +149,7 @@ def _winning_strength_for_projected(
     members: tuple[SectorOwnerMember, ...],
     *,
     location_definite_planet_ids: frozenset[int],
+    race_id_by_owner_slot: Mapping[int, int],
     prior_resolution: OwnershipAxisResolution | None,
 ) -> str | None:
     if not members:
@@ -157,6 +162,7 @@ def _winning_strength_for_projected(
     return ownership_winning_strength_for_members(
         members,
         location_definite_planet_ids=location_definite_planet_ids,
+        race_id_by_owner_slot=race_id_by_owner_slot,
     )
 
 
@@ -164,6 +170,7 @@ def ownership_winning_strength_for_members(
     members: Sequence[SectorOwnerMember],
     *,
     location_definite_planet_ids: frozenset[int] = frozenset(),
+    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> str | None:
     """Winning ownership strength for a unique projected owner set, else None.
 
@@ -176,6 +183,7 @@ def ownership_winning_strength_for_members(
     resolution = resolve_ownership_axis(
         members,
         location_definite_planet_ids=location_definite_planet_ids,
+        race_id_by_owner_slot=race_id_by_owner_slot,
     )
     if not resolution.is_unique:
         return None

--- a/packages/api/api/analytics/homeworld_locator/ownership_projection.py
+++ b/packages/api/api/analytics/homeworld_locator/ownership_projection.py
@@ -63,9 +63,9 @@ def settled_owner_homes_from_location_pins(
 def project_sector_owner_sets_for_overlays(
     sector_owner_sets: Mapping[int, Sequence[SectorOwnerMember]],
     *,
+    race_id_by_owner_slot: Mapping[int, int],
     location_definite_planet_ids: frozenset[int] = frozenset(),
     settled_owner_home_by_slot: Mapping[int, int] | None = None,
-    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> dict[int, SectorOwnerOverlayProjection]:
     """Project durable sector owner sets for overlay wire facts.
 
@@ -78,19 +78,19 @@ def project_sector_owner_sets_for_overlays(
     Returns projected members plus ``winning_strength`` for unique sets
     (``None`` when ownership is ambiguous). Reuses the first-pass axis resolution
     when cross-sector trim does not change contender membership.
+    ``race_id_by_owner_slot`` is required (empty map allowed when no race context).
     """
     if not sector_owner_sets:
         return {}
 
-    race_by_slot = race_id_by_owner_slot or {}
     strength_filtered: dict[int, tuple[SectorOwnerMember, ...]] = {}
     resolutions: dict[int, OwnershipAxisResolution] = {}
     for sector_index, members in sector_owner_sets.items():
         member_tuple = tuple(members)
         resolution = resolve_ownership_axis(
             member_tuple,
+            race_id_by_owner_slot=race_id_by_owner_slot,
             location_definite_planet_ids=location_definite_planet_ids,
-            race_id_by_owner_slot=race_by_slot,
         )
         resolutions[sector_index] = resolution
         contenders = frozenset(resolution.contending_owner_slots)
@@ -137,7 +137,7 @@ def project_sector_owner_sets_for_overlays(
             winning_strength=_winning_strength_for_projected(
                 members,
                 location_definite_planet_ids=location_definite_planet_ids,
-                race_id_by_owner_slot=race_by_slot,
+                race_id_by_owner_slot=race_id_by_owner_slot,
                 prior_resolution=resolutions.get(sector_index),
             ),
         )
@@ -169,21 +169,22 @@ def _winning_strength_for_projected(
 def ownership_winning_strength_for_members(
     members: Sequence[SectorOwnerMember],
     *,
+    race_id_by_owner_slot: Mapping[int, int],
     location_definite_planet_ids: frozenset[int] = frozenset(),
-    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> str | None:
     """Winning ownership strength for a unique projected owner set, else None.
 
     Sector ``ownershipWinningStrength`` is only meaningful when ``|set|=1``.
     Ambiguous ties keep contenders but omit the field so clients cannot apply a
     sector-wide max strength to every owner.
+    ``race_id_by_owner_slot`` is required (empty map allowed when no race context).
     """
     if not members:
         return None
     resolution = resolve_ownership_axis(
         members,
-        location_definite_planet_ids=location_definite_planet_ids,
         race_id_by_owner_slot=race_id_by_owner_slot,
+        location_definite_planet_ids=location_definite_planet_ids,
     )
     if not resolution.is_unique:
         return None

--- a/packages/api/api/analytics/homeworld_locator/sector_overlays.py
+++ b/packages/api/api/analytics/homeworld_locator/sector_overlays.py
@@ -470,6 +470,7 @@ def build_homeworld_sector_overlays(
     possible_owner_label_by_slot: Mapping[int, str] | None = None,
     location_definite_planet_ids: frozenset[int] = frozenset(),
     perspective_by_planet_id: Mapping[int, int] | None = None,
+    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> tuple[MapRegionOverlay, ...]:
     """Build one boundary overlay per equal angular sector.
 
@@ -529,6 +530,7 @@ def build_homeworld_sector_overlays(
         dict(sector_owner_sets or ()),
         location_definite_planet_ids=location_definite_planet_ids,
         settled_owner_home_by_slot=settled_from_location,
+        race_id_by_owner_slot=race_id_by_owner_slot,
     )
 
     pin_sector = sector_index_for_angle(pin_angle, pin_angle=pin_angle, player_count=player_count)
@@ -674,6 +676,9 @@ def build_homeworld_sector_overlays_for_turn(
         game_info=game_info,
         game_id=resolved_game_id,
     )
+    race_id_by_owner_slot = {
+        player_id: player.raceid for player_id, player in players_by_id(turn).items()
+    }
 
     return build_homeworld_sector_overlays(
         center=center,
@@ -692,6 +697,7 @@ def build_homeworld_sector_overlays_for_turn(
         possible_owner_label_by_slot=owner_slot_labels,
         location_definite_planet_ids=location_definite_ids,
         perspective_by_planet_id=perspective_by_planet,
+        race_id_by_owner_slot=race_id_by_owner_slot,
     )
 
 

--- a/packages/api/api/analytics/homeworld_locator/sector_overlays.py
+++ b/packages/api/api/analytics/homeworld_locator/sector_overlays.py
@@ -463,6 +463,7 @@ def build_homeworld_sector_overlays(
     candidate_planet_ids: frozenset[int],
     slot_anchored_planet_ids: frozenset[int],
     scan_origins: Sequence[CoverageOrigin],
+    race_id_by_owner_slot: Mapping[int, int],
     nebulas: Sequence[NebulaCenter] = (),
     pinned_player_label_by_planet_id: Mapping[int, str] | None = None,
     most_probable_planet_ids: frozenset[int] = frozenset(),
@@ -470,7 +471,6 @@ def build_homeworld_sector_overlays(
     possible_owner_label_by_slot: Mapping[int, str] | None = None,
     location_definite_planet_ids: frozenset[int] = frozenset(),
     perspective_by_planet_id: Mapping[int, int] | None = None,
-    race_id_by_owner_slot: Mapping[int, int] | None = None,
 ) -> tuple[MapRegionOverlay, ...]:
     """Build one boundary overlay per equal angular sector.
 
@@ -492,6 +492,8 @@ def build_homeworld_sector_overlays(
     projected (winning-strength + cross-sector settled trim) -- not raw durable
     membership. ``perspective_by_planet_id`` supplies slot-anchored owner slots
     so definite location pins also settle owners for cross-sector trim.
+    ``race_id_by_owner_slot`` is required for ownership strength projection
+    (empty map allowed when no race context).
     """
     if player_count < 2:
         return ()
@@ -528,9 +530,9 @@ def build_homeworld_sector_overlays(
 
     owner_sets = project_sector_owner_sets_for_overlays(
         dict(sector_owner_sets or ()),
+        race_id_by_owner_slot=race_id_by_owner_slot,
         location_definite_planet_ids=location_definite_planet_ids,
         settled_owner_home_by_slot=settled_from_location,
-        race_id_by_owner_slot=race_id_by_owner_slot,
     )
 
     pin_sector = sector_index_for_angle(pin_angle, pin_angle=pin_angle, player_count=player_count)

--- a/packages/api/api/analytics/homeworld_locator/sector_overlays.py
+++ b/packages/api/api/analytics/homeworld_locator/sector_overlays.py
@@ -27,7 +27,7 @@ from api.analytics.homeworld_locator.ownership_projection import (
     settled_owner_homes_from_location_pins,
 )
 from api.analytics.homeworld_locator.types import HomeworldCandidateView
-from api.analytics.turn_roster import players_by_id
+from api.analytics.turn_roster import players_by_id, race_id_by_owner_slot
 from api.concepts.game_category import GameCategory
 from api.concepts.homeworld_layout import (
     CLOSE_PLANETS_MAX_LY,
@@ -678,10 +678,6 @@ def build_homeworld_sector_overlays_for_turn(
         game_info=game_info,
         game_id=resolved_game_id,
     )
-    race_id_by_owner_slot = {
-        player_id: player.raceid for player_id, player in players_by_id(turn).items()
-    }
-
     return build_homeworld_sector_overlays(
         center=center,
         pin=pin,
@@ -699,7 +695,7 @@ def build_homeworld_sector_overlays_for_turn(
         possible_owner_label_by_slot=owner_slot_labels,
         location_definite_planet_ids=location_definite_ids,
         perspective_by_planet_id=perspective_by_planet,
-        race_id_by_owner_slot=race_id_by_owner_slot,
+        race_id_by_owner_slot=race_id_by_owner_slot(turn),
     )
 
 

--- a/packages/api/api/analytics/turn_roster.py
+++ b/packages/api/api/analytics/turn_roster.py
@@ -21,6 +21,13 @@ def players_by_id(turn: TurnInfo) -> dict[int, Player]:
     return {player.id: player for player in iter_turn_players(turn)}
 
 
+def race_id_by_owner_slot(turn: TurnInfo) -> dict[int, int]:
+    """Map owner slot (player id) to race id from the turn roster."""
+    return {
+        player_id: player.raceid for player_id, player in players_by_id(turn).items()
+    }
+
+
 def player_by_id(turn: TurnInfo, player_id: int) -> Player:
     player = players_by_id(turn).get(player_id)
     if player is None:

--- a/packages/api/api/analytics/turn_roster.py
+++ b/packages/api/api/analytics/turn_roster.py
@@ -23,9 +23,7 @@ def players_by_id(turn: TurnInfo) -> dict[int, Player]:
 
 def race_id_by_owner_slot(turn: TurnInfo) -> dict[int, int]:
     """Map owner slot (player id) to race id from the turn roster."""
-    return {
-        player_id: player.raceid for player_id, player in players_by_id(turn).items()
-    }
+    return {player_id: player.raceid for player_id, player in players_by_id(turn).items()}
 
 
 def player_by_id(turn: TurnInfo, player_id: int) -> Player:

--- a/packages/api/api/concepts/races.py
+++ b/packages/api/api/concepts/races.py
@@ -9,6 +9,7 @@ from api.models.game import GameSettings
 EVIL_EMPIRE_RACE_ID = 8
 HORWASP_RACE_ID = 12
 SOLAR_FEDERATION_RACE_ID = 1
+PRIVATEER_RACE_ID = 5
 CRYSTAL_RACE_ID = 7
 
 EVIL_EMPIRE_FREE_STARBASE_FIGHTERS_BASE = 5
@@ -28,6 +29,11 @@ def is_horwasp(race_id: int) -> bool:
 def is_solar_federation(race_id: int) -> bool:
     """Solar Federation (raceid 1) -- Super Refit can arm unarmed military hulls later."""
     return race_id == SOLAR_FEDERATION_RACE_ID
+
+
+def is_privateer(race_id: int) -> bool:
+    """The Privateer Bands (raceid 5) -- Rob + tow-capture can relocate owned ships."""
+    return race_id == PRIVATEER_RACE_ID
 
 
 def is_crystal(race_id: int) -> bool:

--- a/packages/api/tests/test_concepts_race_climate.py
+++ b/packages/api/tests/test_concepts_race_climate.py
@@ -4,12 +4,20 @@ from api.concepts.races import (
     CRYSTAL_DESERT_PREFERRED_HOMEWORLD_TEMP_W,
     CRYSTAL_RACE_ID,
     DEFAULT_PREFERRED_HOMEWORLD_TEMP_W,
+    PRIVATEER_RACE_ID,
+    is_privateer,
     preferred_homeworld_temp_w,
 )
 
 
 def test_crystal_race_id_is_seven() -> None:
     assert CRYSTAL_RACE_ID == 7
+
+
+def test_privateer_race_id_is_five() -> None:
+    assert PRIVATEER_RACE_ID == 5
+    assert is_privateer(5) is True
+    assert is_privateer(7) is False
 
 
 def test_preferred_homeworld_temp_crystal_defaults_to_desert_peak() -> None:

--- a/packages/api/tests/test_homeworld_assertions_phase1.py
+++ b/packages/api/tests/test_homeworld_assertions_phase1.py
@@ -485,6 +485,7 @@ def test_derive_candidates_sets_definite_and_asserted_cue() -> None:
     derived = derive_candidates_from_merged_evidence(
         candidates,
         merged,
+        race_id_by_owner_slot={},
         planet_sector_index={20: 0},
     )
     by_planet = {row.planet_id: row for row in derived}
@@ -530,7 +531,9 @@ def test_derive_ownership_assert_sets_cue_without_location_asserted() -> None:
             ),
         ),
     )
-    derived = derive_candidates_from_merged_evidence(candidates, merged)
+    derived = derive_candidates_from_merged_evidence(
+        candidates, merged, race_id_by_owner_slot={}
+    )
     assert len(derived) == 1
     assert derived[0].asserted_cue is True
     assert derived[0].location_asserted is False
@@ -564,7 +567,9 @@ def test_derive_asserted_wins_over_machine_strong_despite_prior_definite() -> No
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(candidates, merged)
+    derived = derive_candidates_from_merged_evidence(
+        candidates, merged, race_id_by_owner_slot={}
+    )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[20].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[20].asserted_cue is True
@@ -595,7 +600,9 @@ def test_derive_asserted_wins_over_machine_strong_despite_prior_definite() -> No
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(candidates, merged)
+    derived = derive_candidates_from_merged_evidence(
+        candidates, merged, race_id_by_owner_slot={}
+    )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[20].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[10].confidence_tier == CONFIDENCE_POSSIBLE
@@ -625,7 +632,9 @@ def test_derive_empty_location_list_keeps_prior_tier() -> None:
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(candidates, merged)
+    derived = derive_candidates_from_merged_evidence(
+        candidates, merged, race_id_by_owner_slot={}
+    )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[10].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[20].confidence_tier == CONFIDENCE_POSSIBLE
@@ -673,6 +682,7 @@ def test_derive_unique_ownership_bind_preserves_existing_perspective(
         derived = derive_candidates_from_merged_evidence(
             candidates,
             merged,
+            race_id_by_owner_slot={},
             planet_sector_index={20: 0},
         )
     else:
@@ -681,7 +691,9 @@ def test_derive_unique_ownership_bind_preserves_existing_perspective(
             sector_owner_sets=(),
             planet_owner_sets=((20, unique_owner),),
         )
-        derived = derive_candidates_from_merged_evidence(candidates, merged)
+        derived = derive_candidates_from_merged_evidence(
+            candidates, merged, race_id_by_owner_slot={}
+        )
 
     assert len(derived) == 1
     assert derived[0].perspective == expected_perspective

--- a/packages/api/tests/test_homeworld_assertions_phase1.py
+++ b/packages/api/tests/test_homeworld_assertions_phase1.py
@@ -531,9 +531,7 @@ def test_derive_ownership_assert_sets_cue_without_location_asserted() -> None:
             ),
         ),
     )
-    derived = derive_candidates_from_merged_evidence(
-        candidates, merged, race_id_by_owner_slot={}
-    )
+    derived = derive_candidates_from_merged_evidence(candidates, merged, race_id_by_owner_slot={})
     assert len(derived) == 1
     assert derived[0].asserted_cue is True
     assert derived[0].location_asserted is False
@@ -567,9 +565,7 @@ def test_derive_asserted_wins_over_machine_strong_despite_prior_definite() -> No
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(
-        candidates, merged, race_id_by_owner_slot={}
-    )
+    derived = derive_candidates_from_merged_evidence(candidates, merged, race_id_by_owner_slot={})
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[20].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[20].asserted_cue is True
@@ -600,9 +596,7 @@ def test_derive_asserted_wins_over_machine_strong_despite_prior_definite() -> No
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(
-        candidates, merged, race_id_by_owner_slot={}
-    )
+    derived = derive_candidates_from_merged_evidence(candidates, merged, race_id_by_owner_slot={})
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[20].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[10].confidence_tier == CONFIDENCE_POSSIBLE
@@ -632,9 +626,7 @@ def test_derive_empty_location_list_keeps_prior_tier() -> None:
         sector_owner_sets=(),
         planet_owner_sets=(),
     )
-    derived = derive_candidates_from_merged_evidence(
-        candidates, merged, race_id_by_owner_slot={}
-    )
+    derived = derive_candidates_from_merged_evidence(candidates, merged, race_id_by_owner_slot={})
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[10].confidence_tier == CONFIDENCE_DEFINITE
     assert by_planet[20].confidence_tier == CONFIDENCE_POSSIBLE

--- a/packages/api/tests/test_homeworld_evidence_refine.py
+++ b/packages/api/tests/test_homeworld_evidence_refine.py
@@ -578,6 +578,7 @@ def test_origin_distance_observations_do_not_promote_to_definite() -> None:
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     assert derived[0].confidence_tier == CONFIDENCE_POSSIBLE
     # OD-only lists do not feed definite-keyed culls as a promote path either.
@@ -612,6 +613,7 @@ def test_single_starbase_promotion_materializes_without_owner_assignment() -> No
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     candidates = apply_definite_keyed_candidate_culls(
         derived,
@@ -771,6 +773,7 @@ def test_culls_after_strength_resolve_drop_demoted_machine_near_assert(
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[2].confidence_tier == CONFIDENCE_DEFINITE
@@ -1138,6 +1141,7 @@ def test_floor_algorithm_rewrite_backfills_baseline_profile_before_od_demotion(
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[10].confidence_tier == CONFIDENCE_DEFINITE

--- a/packages/api/tests/test_homeworld_evidence_strength.py
+++ b/packages/api/tests/test_homeworld_evidence_strength.py
@@ -198,7 +198,7 @@ def test_resolve_ownership_asserted_wins_over_strong() -> None:
             provenances=(OwnershipProvenance(kind=PROVENANCE_ASSERTED, turn=5),),
         ),
     )
-    resolved = resolve_ownership_axis(members)
+    resolved = resolve_ownership_axis(members, race_id_by_owner_slot={})
     assert resolved.winning_strength == STRENGTH_ASSERTED
     assert resolved.resolved_owner_slot == 2
     assert resolved.is_unique is True
@@ -215,7 +215,7 @@ def test_resolve_ownership_same_strength_conflict_stays_ambiguous() -> None:
             provenances=(OwnershipProvenance(kind=PROVENANCE_ASSERTED, turn=6),),
         ),
     )
-    resolved = resolve_ownership_axis(members)
+    resolved = resolve_ownership_axis(members, race_id_by_owner_slot={})
     assert resolved.winning_strength == STRENGTH_ASSERTED
     assert resolved.resolved_owner_slot is None
     assert resolved.is_unique is False
@@ -246,11 +246,19 @@ def test_resolve_ownership_preferred_strong_when_planet_location_definite() -> N
             ),
         ),
     )
-    weak = resolve_ownership_axis(members, location_definite_planet_ids=frozenset())
+    weak = resolve_ownership_axis(
+        members,
+        race_id_by_owner_slot={},
+        location_definite_planet_ids=frozenset(),
+    )
     assert weak.winning_strength == STRENGTH_WEAK
     assert weak.contending_owner_slots == (3, 4)
 
-    strong = resolve_ownership_axis(members, location_definite_planet_ids=frozenset({42}))
+    strong = resolve_ownership_axis(
+        members,
+        race_id_by_owner_slot={},
+        location_definite_planet_ids=frozenset({42}),
+    )
     assert strong.winning_strength == STRENGTH_STRONG
     assert strong.resolved_owner_slot == 3
     assert strong.is_unique is True

--- a/packages/api/tests/test_homeworld_evidence_strength.py
+++ b/packages/api/tests/test_homeworld_evidence_strength.py
@@ -24,6 +24,7 @@ from api.analytics.homeworld_locator.models import (
     OwnershipProvenance,
     SectorOwnerMember,
 )
+from api.concepts.races import PRIVATEER_RACE_ID
 
 
 def test_location_kind_strength_mapping() -> None:
@@ -61,7 +62,96 @@ def test_ownership_kind_strength_mapping() -> None:
         == STRENGTH_STRONG
     )
     assert ownership_provenance_strength(PROVENANCE_SHIP_TRAVEL_ENVELOPE) == STRENGTH_STRONG
+    assert (
+        ownership_provenance_strength(
+            PROVENANCE_SHIP_TRAVEL_ENVELOPE,
+            owner_race_id=1,
+        )
+        == STRENGTH_STRONG
+    )
+    assert (
+        ownership_provenance_strength(
+            PROVENANCE_SHIP_TRAVEL_ENVELOPE,
+            owner_race_id=PRIVATEER_RACE_ID,
+        )
+        == STRENGTH_WEAK
+    )
     assert ownership_provenance_strength(PROVENANCE_ASSERTED) == STRENGTH_ASSERTED
+
+
+def test_resolve_ownership_privateer_envelope_is_weak_not_definite() -> None:
+    """Privateer ship envelopes stay in the set but cannot win at strong strength."""
+    members = (
+        SectorOwnerMember(
+            owner_slot=5,
+            provenances=(
+                OwnershipProvenance(
+                    kind=PROVENANCE_SHIP_TRAVEL_ENVELOPE,
+                    turn=10,
+                    ship_id=39,
+                    radius_ly=82.0,
+                ),
+            ),
+        ),
+    )
+    alone = resolve_ownership_axis(
+        members,
+        race_id_by_owner_slot={5: PRIVATEER_RACE_ID},
+    )
+    assert alone.winning_strength == STRENGTH_WEAK
+    assert alone.is_unique is True
+    assert alone.resolved_owner_slot == 5
+
+    with_nearby = (
+        *members,
+        SectorOwnerMember(
+            owner_slot=2,
+            provenances=(
+                OwnershipProvenance(
+                    kind=PROVENANCE_NEARBY_PLANET_OWNERSHIP,
+                    turn=10,
+                    planet_id=45,
+                    distance_ly=50.0,
+                ),
+            ),
+        ),
+    )
+    ambiguous = resolve_ownership_axis(
+        with_nearby,
+        race_id_by_owner_slot={5: PRIVATEER_RACE_ID, 2: 2},
+    )
+    assert ambiguous.winning_strength == STRENGTH_WEAK
+    assert ambiguous.is_unique is False
+    assert ambiguous.contending_owner_slots == (2, 5)
+
+
+def test_resolve_ownership_non_privateer_envelope_stays_strong() -> None:
+    members = (
+        SectorOwnerMember(
+            owner_slot=3,
+            provenances=(
+                OwnershipProvenance(kind=PROVENANCE_SHIP_TRAVEL_ENVELOPE, turn=4, ship_id=9),
+            ),
+        ),
+        SectorOwnerMember(
+            owner_slot=2,
+            provenances=(
+                OwnershipProvenance(
+                    kind=PROVENANCE_NEARBY_PLANET_OWNERSHIP,
+                    turn=4,
+                    planet_id=10,
+                    distance_ly=40.0,
+                ),
+            ),
+        ),
+    )
+    resolved = resolve_ownership_axis(
+        members,
+        race_id_by_owner_slot={3: 4, 2: 2},
+    )
+    assert resolved.winning_strength == STRENGTH_STRONG
+    assert resolved.is_unique is True
+    assert resolved.resolved_owner_slot == 3
 
 
 def test_resolve_location_asserted_wins_over_strong() -> None:

--- a/packages/api/tests/test_homeworld_location_evidence.py
+++ b/packages/api/tests/test_homeworld_location_evidence.py
@@ -278,6 +278,7 @@ def test_single_starbase_provenance_derives_possible_to_definite() -> None:
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[10].confidence_tier == CONFIDENCE_DEFINITE
@@ -391,6 +392,7 @@ def test_single_starbase_promotion_does_not_assign_homeworld_owner_from_ship_own
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     assert derived[0].confidence_tier == CONFIDENCE_DEFINITE
     assert derived[0].perspective is None
@@ -523,6 +525,7 @@ def test_collect_backfills_baseline_profile_when_prior_empty_and_od_present() ->
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     by_planet = {row.planet_id: row for row in derived}
     assert by_planet[10].confidence_tier == CONFIDENCE_DEFINITE
@@ -536,5 +539,6 @@ def test_collect_backfills_baseline_profile_when_prior_empty_and_od_present() ->
             sector_owner_sets=(),
             planet_owner_sets=(),
         ),
+        race_id_by_owner_slot={},
     )
     assert {row.planet_id: row.confidence_tier for row in demoted}[10] == CONFIDENCE_POSSIBLE

--- a/packages/api/tests/test_homeworld_ownership_projection.py
+++ b/packages/api/tests/test_homeworld_ownership_projection.py
@@ -38,7 +38,7 @@ def test_strength_filter_drops_weaker_members() -> None:
             _member(2, PROVENANCE_NEARBY_PLANET_OWNERSHIP, planet_id=99),
         ),
     }
-    projected = project_sector_owner_sets_for_overlays(sets)
+    projected = project_sector_owner_sets_for_overlays(sets, race_id_by_owner_slot={})
     assert [m.owner_slot for m in projected[0].members] == [1]
 
 
@@ -73,7 +73,7 @@ def test_cross_sector_trim_removes_settled_owner_elsewhere() -> None:
             _member(5, PROVENANCE_NEARBY_PLANET_OWNERSHIP, planet_id=51),
         ),
     }
-    projected = project_sector_owner_sets_for_overlays(sets)
+    projected = project_sector_owner_sets_for_overlays(sets, race_id_by_owner_slot={})
     assert [m.owner_slot for m in projected[0].members] == [3]
     assert [m.owner_slot for m in projected[1].members] == [5]
 
@@ -88,6 +88,7 @@ def test_location_pin_settles_owner_for_cross_sector_trim() -> None:
     }
     projected = project_sector_owner_sets_for_overlays(
         sets,
+        race_id_by_owner_slot={},
         settled_owner_home_by_slot={2: 0},
     )
     assert projected[0].members == ()
@@ -139,6 +140,7 @@ def test_preferred_upgrades_when_planet_location_definite() -> None:
     }
     projected = project_sector_owner_sets_for_overlays(
         sets,
+        race_id_by_owner_slot={},
         location_definite_planet_ids=frozenset({42}),
     )
     assert [m.owner_slot for m in projected[0].members] == [3]
@@ -152,29 +154,34 @@ def test_asserted_settles_for_cross_sector_trim() -> None:
             _member(7, PROVENANCE_NEARBY_PLANET_OWNERSHIP, planet_id=10),
         ),
     }
-    projected = project_sector_owner_sets_for_overlays(sets)
+    projected = project_sector_owner_sets_for_overlays(sets, race_id_by_owner_slot={})
     assert [m.owner_slot for m in projected[1].members] == [7]
 
 
 def test_winning_strength_emitted_only_when_unique() -> None:
     unique = (_member(1, PROVENANCE_SHIP_TRAVEL_ENVELOPE),)
-    projected = project_sector_owner_sets_for_overlays({0: unique})
+    projected = project_sector_owner_sets_for_overlays({0: unique}, race_id_by_owner_slot={})
     assert projected[0].winning_strength == "strong"
 
     ambiguous_strong = (
         _member(2, PROVENANCE_SHIP_TRAVEL_ENVELOPE),
         _member(5, PROVENANCE_SHIP_TRAVEL_ENVELOPE),
     )
-    projected = project_sector_owner_sets_for_overlays({0: ambiguous_strong})
+    projected = project_sector_owner_sets_for_overlays(
+        {0: ambiguous_strong}, race_id_by_owner_slot={}
+    )
     assert projected[0].winning_strength is None
 
-    projected = project_sector_owner_sets_for_overlays({0: ()})
+    projected = project_sector_owner_sets_for_overlays({0: ()}, race_id_by_owner_slot={})
     assert projected[0].winning_strength is None
 
-    assert ownership_winning_strength_for_members(unique) == "strong"
-    assert ownership_winning_strength_for_members(ambiguous_strong) is None
+    assert ownership_winning_strength_for_members(unique, race_id_by_owner_slot={}) == "strong"
+    assert (
+        ownership_winning_strength_for_members(ambiguous_strong, race_id_by_owner_slot={})
+        is None
+    )
     empty: tuple[SectorOwnerMember, ...] = ()
-    assert ownership_winning_strength_for_members(empty) is None
+    assert ownership_winning_strength_for_members(empty, race_id_by_owner_slot={}) is None
 
 
 def test_winning_strength_omitted_for_ambiguous_preferred_upgrade() -> None:
@@ -185,18 +192,21 @@ def test_winning_strength_omitted_for_ambiguous_preferred_upgrade() -> None:
     )
     projected = project_sector_owner_sets_for_overlays(
         {0: members},
+        race_id_by_owner_slot={},
         location_definite_planet_ids=frozenset({42, 43}),
     )
     assert projected[0].winning_strength is None
     unique = (_member(3, PROVENANCE_PREFERRED_CANDIDATE_OWNERSHIP, planet_id=42),)
     projected = project_sector_owner_sets_for_overlays(
         {0: unique},
+        race_id_by_owner_slot={},
         location_definite_planet_ids=frozenset({42}),
     )
     assert projected[0].winning_strength == "strong"
     assert (
         ownership_winning_strength_for_members(
             members,
+            race_id_by_owner_slot={},
             location_definite_planet_ids=frozenset({42, 43}),
         )
         is None
@@ -204,6 +214,7 @@ def test_winning_strength_omitted_for_ambiguous_preferred_upgrade() -> None:
     assert (
         ownership_winning_strength_for_members(
             unique,
+            race_id_by_owner_slot={},
             location_definite_planet_ids=frozenset({42}),
         )
         == "strong"

--- a/packages/api/tests/test_homeworld_ownership_projection.py
+++ b/packages/api/tests/test_homeworld_ownership_projection.py
@@ -15,6 +15,7 @@ from api.analytics.homeworld_locator.ownership_projection import (
     project_sector_owner_sets_for_overlays,
     settled_owner_homes_from_location_pins,
 )
+from api.concepts.races import PRIVATEER_RACE_ID
 
 
 def _member(slot: int, *kinds: str, planet_id: int | None = None) -> SectorOwnerMember:
@@ -39,6 +40,29 @@ def test_strength_filter_drops_weaker_members() -> None:
     }
     projected = project_sector_owner_sets_for_overlays(sets)
     assert [m.owner_slot for m in projected[0].members] == [1]
+
+
+def test_privateer_envelope_does_not_outrank_nearby_planet_ownership() -> None:
+    """Privateer Rob/tow-capture makes ship envelopes weak -- stay ambiguous with nearby."""
+    sets = {
+        0: (
+            _member(5, PROVENANCE_SHIP_TRAVEL_ENVELOPE),
+            _member(2, PROVENANCE_NEARBY_PLANET_OWNERSHIP, planet_id=45),
+        ),
+    }
+    projected = project_sector_owner_sets_for_overlays(
+        sets,
+        race_id_by_owner_slot={5: PRIVATEER_RACE_ID, 2: 2},
+    )
+    assert [m.owner_slot for m in projected[0].members] == [5, 2]
+    assert projected[0].winning_strength is None
+
+    alone = project_sector_owner_sets_for_overlays(
+        {0: (_member(5, PROVENANCE_SHIP_TRAVEL_ENVELOPE),)},
+        race_id_by_owner_slot={5: PRIVATEER_RACE_ID},
+    )
+    assert [m.owner_slot for m in alone[0].members] == [5]
+    assert alone[0].winning_strength == "weak"
 
 
 def test_cross_sector_trim_removes_settled_owner_elsewhere() -> None:

--- a/packages/api/tests/test_homeworld_ownership_projection.py
+++ b/packages/api/tests/test_homeworld_ownership_projection.py
@@ -177,8 +177,7 @@ def test_winning_strength_emitted_only_when_unique() -> None:
 
     assert ownership_winning_strength_for_members(unique, race_id_by_owner_slot={}) == "strong"
     assert (
-        ownership_winning_strength_for_members(ambiguous_strong, race_id_by_owner_slot={})
-        is None
+        ownership_winning_strength_for_members(ambiguous_strong, race_id_by_owner_slot={}) is None
     )
     empty: tuple[SectorOwnerMember, ...] = ()
     assert ownership_winning_strength_for_members(empty, race_id_by_owner_slot={}) is None

--- a/packages/api/tests/test_homeworld_sector_overlays.py
+++ b/packages/api/tests/test_homeworld_sector_overlays.py
@@ -196,6 +196,7 @@ def test_build_overlays_sector_count_band_and_pin(template_planet) -> None:
         candidate_planet_ids=frozenset(candidate_ids),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         pinned_player_label_by_planet_id={pin.id: "koshling (The Lizard Alliance)"},
     )
@@ -245,6 +246,7 @@ def test_fully_observed_zero_candidates_error_no_disks(template_planet) -> None:
         candidate_planet_ids=frozenset({pin.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
     )
     assert len(overlays) == 4
@@ -293,6 +295,7 @@ def test_incomplete_observation_uses_unobserved_point(template_planet) -> None:
         candidate_planet_ids=frozenset({pin.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
     )
     opposite = next(overlay for overlay in overlays if overlay.id == "homeworld-sector-2")
@@ -345,6 +348,7 @@ def test_envelope_center_closest_candidate_to_sector_mid(template_planet) -> Non
         candidate_planet_ids=frozenset({pin.id, inner.id, mid.id, outer.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
     )
     sector_one = next(overlay for overlay in overlays if overlay.id == "homeworld-sector-1")
@@ -373,6 +377,7 @@ def test_envelope_center_prefers_most_probable_over_sector_mid(template_planet) 
         candidate_planet_ids=frozenset({pin.id, mid.id, most_probable.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         most_probable_planet_ids=frozenset({most_probable.id}),
     )
@@ -400,6 +405,7 @@ def test_incomplete_with_candidates_prefers_candidate_center(template_planet) ->
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
     )
     sector_one = next(overlay for overlay in overlays if overlay.id == "homeworld-sector-1")
@@ -551,6 +557,7 @@ def test_possible_owners_emit_provenance_kind_counts(template_planet) -> None:
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         sector_owner_sets={sector_index: members},
         possible_owner_label_by_slot={3: "enlar (The Privateers)"},
@@ -623,6 +630,7 @@ def test_sector_overlay_omits_ownership_winning_strength_when_ambiguous(
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         sector_owner_sets={sector_index: members},
         possible_owner_label_by_slot={3: "enlar (The Privateers)", 7: "koshling (Lizards)"},
@@ -663,6 +671,7 @@ def test_cross_sector_trim_applied_through_overlay_builder(template_planet) -> N
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         sector_owner_sets={
             settled_sector: (
@@ -743,6 +752,7 @@ def test_possible_owners_emit_asserted_winning_strength(template_planet) -> None
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         sector_owner_sets={
             sector_index: (
@@ -783,6 +793,7 @@ def test_possible_owners_emit_weak_winning_strength(template_planet) -> None:
         candidate_planet_ids=frozenset({pin.id, orphan.id}),
         slot_anchored_planet_ids=frozenset({pin.id}),
         scan_origins=origins,
+        race_id_by_owner_slot={},
         nebulas=(),
         sector_owner_sets={
             sector_index: (

--- a/packages/api/tests/test_turn_roster.py
+++ b/packages/api/tests/test_turn_roster.py
@@ -5,7 +5,12 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from api.analytics.turn_roster import iter_turn_players, player_by_id, players_by_id
+from api.analytics.turn_roster import (
+    iter_turn_players,
+    player_by_id,
+    players_by_id,
+    race_id_by_owner_slot,
+)
 from api.serialization.turn import turn_info_from_json
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent / "api" / "storage" / "assets"
@@ -37,6 +42,16 @@ def test_players_by_id_dedupes_perspective_record(sample_turn):
     turn = replace(sample_turn, players=[*sample_turn.players, duplicate_in_roster])
     roster = players_by_id(turn)
     assert roster[sample_turn.player.id].username == sample_turn.player.username
+
+
+def test_race_id_by_owner_slot_maps_roster_raceids(sample_turn):
+    race_map = race_id_by_owner_slot(sample_turn)
+    roster = players_by_id(sample_turn)
+    assert race_map == {
+        player_id: player.raceid for player_id, player in roster.items()
+    }
+    assert sample_turn.player.id in race_map
+    assert race_map[sample_turn.player.id] == sample_turn.player.raceid
 
 
 def test_player_by_id_raises_for_unknown_id(sample_turn):

--- a/packages/api/tests/test_turn_roster.py
+++ b/packages/api/tests/test_turn_roster.py
@@ -47,9 +47,7 @@ def test_players_by_id_dedupes_perspective_record(sample_turn):
 def test_race_id_by_owner_slot_maps_roster_raceids(sample_turn):
     race_map = race_id_by_owner_slot(sample_turn)
     roster = players_by_id(sample_turn)
-    assert race_map == {
-        player_id: player.raceid for player_id, player in roster.items()
-    }
+    assert race_map == {player_id: player.raceid for player_id, player in roster.items()}
     assert sample_turn.player.id in race_map
     assert race_map[sample_turn.player.id] == sample_turn.player.raceid
 


### PR DESCRIPTION
## Summary
- Demote `ship_travel_envelope` ownership strength to **weak** for Privateer owners (`raceid` 5), because Rob + tow-capture can place Privateer-owned ships near foreign homeworlds without travel from the Privateer HW.
- Keep envelopes **strong** for all other races (Crystal tow-capture left out of scope by product choice).
- Thread turn-roster race ids into ownership strength resolution / overlay projection; update design docs and unit tests.

## Test plan
- [x] `make test_api` (1949 passed)
- [ ] Open game 680224 (Lizard perspective) after clearing homeworld persistence; confirm Enlar sector near p45 is no longer ownership **definite** from ship envelopes alone
- [ ] Spot-check a non-Privateer unique envelope still shows ownership **definite**


Made with [Cursor](https://cursor.com)