### PR TITLE
Player color Settings UI (#289)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -653,24 +653,32 @@ Single NDJSON connection for all **fleet player visibility**-enabled players on 
 _Avoid_: per-player HTTP connections, admission-order wire drain, separate map NDJSON protocol, map-mode `GET …/fleet/map` as the live SPA path, treating the stream as table-only
 
 **Player color**:
-Shared SPA identity color for a **Player**, used by any analytic or chrome that needs per-player paint (including **fleet location ring**s). Resolved under the active **player color mode**. Consumers keep calling `usePlayerColor(playerId)` / `colorForPlayerId(playerId)`; shell + Settings install the resolution inputs. Default palette when not overridden and when outside a **diplomacy color family**: `playerId % 16` into `#38bdf8 #f472b6 #a78bfa #34d399 #fbbf24 #fb7185 #22d3ee #a3e635 #f97316 #818cf8 #2dd4bf #e879f9 #60a5fa #f43f5e #c084fc #84cc16`. Policy knobs and per-player overrides are global localStorage ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)), not per-analytic sidebar state.
+Shared SPA identity color for a **Player**, used by any analytic or chrome that needs per-player paint (including **fleet location ring**s). Resolved under the active **player color mode**. Consumers keep calling `usePlayerColor(playerId)` / `colorForPlayerId(playerId)`; shell + Settings install the resolution inputs. Default palette in **per-player** mode (when not overridden): `playerId % 16` into `#38bdf8 #f472b6 #a78bfa #34d399 #fbbf24 #fb7185 #22d3ee #a3e635 #f97316 #818cf8 #2dd4bf #e879f9 #60a5fa #f43f5e #c084fc #84cc16`. Policy knobs and per-player overrides are global localStorage ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)), not per-analytic sidebar state.
 _Avoid_: fleet-only color store, relying on often-empty host `Relation.color` as the sole source, baking Settings UI into every consumer, changing every paint call site when mode inputs change
 
 **Player color mode**:
-Mutually exclusive paint policy for **player color**: **per-player** (independent override or default per **Player**) or **diplomacy-family** (members of the **diplomacy color family** share a **family base color** with deterministic tonal variants; everyone else uses the default palette). Switching modes changes which policy paints; both modes' settings are preserved.
-_Avoid_: hybrid overlay of overrides on top of diplomacy families, Nu multi-bucket Allied/Enemy/You palettes as the Console policy
+Mutually exclusive paint policy for **player color**: **per-player** (independent override or default per **Player**) or **diplomacy-family** (two families -- **diplomacy color family** and **non-diplomacy color family** -- each with its own base color and tonal variants). Switching modes changes which policy paints; both modes' settings are preserved.
+_Avoid_: hybrid overlay of overrides on top of diplomacy families, Nu multi-bucket Allied/Enemy/You palettes as the Console policy, mixing default preset hues into diplomacy-family paint
 
 **Diplomacy color family**:
-The set of other **Player**s whose inbound grant to the current shell **viewpoint** meets the **diplomacy color threshold** -- on that viewpoint's turn `Relation` rows, `relationfrom >= threshold`. Missing relation row counts as inbound None (not in family). Viewpoint/self is not a family member. Membership recomputes when viewpoint, turn relations, or threshold change.
-_Avoid_: using what you grant them (`relationto`), OR-ing both directions (Visibility Share-Intel partners), host `Relation.color`
+The current shell **viewpoint** (always -- implicit self-ally) plus other **Player**s whose inbound grant to that viewpoint meets the **diplomacy color threshold** -- on that viewpoint's turn `Relation` rows, `relationfrom >= threshold`. Missing relation row counts as inbound None (not in this family). Members share the **family base color** with tonal variants; the viewpoint always receives the brightest tone. Membership recomputes when viewpoint, turn relations, or threshold change.
+_Avoid_: using what you grant them (`relationto`), OR-ing both directions (Visibility Share-Intel partners), host `Relation.color`, excluding self from the family
+
+**Non-diplomacy color family**:
+In **diplomacy-family** **player color mode**, every roster **Player** not in the **diplomacy color family**. Members share the **out-of-circle base color** with deterministic tonal variants (no special brightest member). Guarantees contrast with the diplomacy circle instead of falling back to the per-player preset palette.
+_Avoid_: default preset for out-of-circle players, treating out-of-circle as ungrouped individuals
 
 **Diplomacy color threshold**:
-Minimum diplomacy tier for **diplomacy color family** membership. User-selectable among Ambassador, Safe Passage, Share Intel, and Full Alliance; default **Safe Passage**. Blocked and None are not offered as thresholds.
+Minimum diplomacy tier for **diplomacy color family** membership (other players). User-selectable among Ambassador, Safe Passage, Share Intel, and Full Alliance; default **Safe Passage**. Blocked and None are not offered as thresholds. Does not gate the viewpoint's own membership.
 _Avoid_: ally threshold, conflict level
 
 **Family base color**:
-User-chosen base hue for the **diplomacy color family**. Family members receive deterministic tonal variants derived from this base (stable for a given base, member id, and family size); the exact tone recipe is not a user setting.
+User-chosen base hue for the **diplomacy color family**. Family members receive deterministic tonal variants derived from this base (stable for a given base, member id, family size, and brightest/viewpoint id); the viewpoint is always the brightest tone. The exact tone recipe is not a user setting.
 _Avoid_: per-member color pickers in diplomacy-family mode, Relation.color
+
+**Out-of-circle base color**:
+User-chosen base hue for the **non-diplomacy color family**. Chosen independently of the **family base color** so the two circles stay visually distinct.
+_Avoid_: reusing the per-player preset for out-of-circle paint
 
 **Military score build inference**:
 Core **turn analytic** behavior (optional on the **Scores** analytic) that explains one player's scoreboard deltas on a turn as a ranked set of feasible build and load actions, not a single proved history. Requests run **per scoreboard row** with top-K **20**. No fixed row time budget once **#71** ships -- SPA runs continue until the ladder finishes, **inference global pause** freezes them, or the stream is **cancelled** (scope change, disable build inference, explicit cancel/recompute -- **not** disconnect). Disconnect is detach-only; see **Inference stream cancellation**. See [design-military-score-build-inference.md](docs/design-military-score-build-inference.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -653,8 +653,24 @@ Single NDJSON connection for all **fleet player visibility**-enabled players on 
 _Avoid_: per-player HTTP connections, admission-order wire drain, separate map NDJSON protocol, map-mode `GET …/fleet/map` as the live SPA path, treating the stream as table-only
 
 **Player color**:
-Shared SPA identity color for a **Player**, used by any analytic or chrome that needs per-player paint (including **fleet location ring**s). Read API and defaults live in a shared module: `colorForPlayerId(playerId)` uses `playerId % 16` into this preset table (dark-map friendly): `#38bdf8 #f472b6 #a78bfa #34d399 #fbbf24 #fb7185 #22d3ee #a3e635 #f97316 #818cf8 #2dd4bf #e879f9 #60a5fa #f43f5e #c084fc #84cc16`. Persistable overrides use a storage abstraction the Settings UI ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)) can later wire without changing callers. Overrides are global localStorage, not inside one analytic sidebar.
-_Avoid_: fleet-only color store, relying on often-empty host `Relation.color` as the sole source, baking Settings UI into every consumer
+Shared SPA identity color for a **Player**, used by any analytic or chrome that needs per-player paint (including **fleet location ring**s). Resolved under the active **player color mode**. Consumers keep calling `usePlayerColor(playerId)` / `colorForPlayerId(playerId)`; shell + Settings install the resolution inputs. Default palette when not overridden and when outside a **diplomacy color family**: `playerId % 16` into `#38bdf8 #f472b6 #a78bfa #34d399 #fbbf24 #fb7185 #22d3ee #a3e635 #f97316 #818cf8 #2dd4bf #e879f9 #60a5fa #f43f5e #c084fc #84cc16`. Policy knobs and per-player overrides are global localStorage ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)), not per-analytic sidebar state.
+_Avoid_: fleet-only color store, relying on often-empty host `Relation.color` as the sole source, baking Settings UI into every consumer, changing every paint call site when mode inputs change
+
+**Player color mode**:
+Mutually exclusive paint policy for **player color**: **per-player** (independent override or default per **Player**) or **diplomacy-family** (members of the **diplomacy color family** share a **family base color** with deterministic tonal variants; everyone else uses the default palette). Switching modes changes which policy paints; both modes' settings are preserved.
+_Avoid_: hybrid overlay of overrides on top of diplomacy families, Nu multi-bucket Allied/Enemy/You palettes as the Console policy
+
+**Diplomacy color family**:
+The set of other **Player**s whose inbound grant to the current shell **viewpoint** meets the **diplomacy color threshold** -- on that viewpoint's turn `Relation` rows, `relationfrom >= threshold`. Missing relation row counts as inbound None (not in family). Viewpoint/self is not a family member. Membership recomputes when viewpoint, turn relations, or threshold change.
+_Avoid_: using what you grant them (`relationto`), OR-ing both directions (Visibility Share-Intel partners), host `Relation.color`
+
+**Diplomacy color threshold**:
+Minimum diplomacy tier for **diplomacy color family** membership. User-selectable among Ambassador, Safe Passage, Share Intel, and Full Alliance; default **Safe Passage**. Blocked and None are not offered as thresholds.
+_Avoid_: ally threshold, conflict level
+
+**Family base color**:
+User-chosen base hue for the **diplomacy color family**. Family members receive deterministic tonal variants derived from this base (stable for a given base, member id, and family size); the exact tone recipe is not a user setting.
+_Avoid_: per-member color pickers in diplomacy-family mode, Relation.color
 
 **Military score build inference**:
 Core **turn analytic** behavior (optional on the **Scores** analytic) that explains one player's scoreboard deltas on a turn as a ranked set of feasible build and load actions, not a single proved history. Requests run **per scoreboard row** with top-K **20**. No fixed row time budget once **#71** ships -- SPA runs continue until the ladder finishes, **inference global pause** freezes them, or the stream is **cancelled** (scope change, disable build inference, explicit cancel/recompute -- **not** disconnect). Disconnect is detach-only; see **Inference stream cancellation**. See [design-military-score-build-inference.md](docs/design-military-score-build-inference.md).

--- a/docs/adr/0013-player-color-resolution-context.md
+++ b/docs/adr/0013-player-color-resolution-context.md
@@ -4,18 +4,30 @@ Status: accepted
 
 ## Context
 
-**Player color** started as `colorForPlayerId(playerId)` with an override storage port so Settings ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)) could wire persistence without touching paint call sites. **Player color mode** adds a **diplomacy-family** policy that also needs shell **viewpoint**, turn `Relation` inbound grants, **diplomacy color threshold**, and **family base color**. Threading those inputs through every consumer would make fleet rings and future chrome diplomacy-aware at every call site.
+**Player color** started as `colorForPlayerId(playerId)` with an override storage port so Settings ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)) could wire persistence without touching paint call sites. **Player color mode** adds a **diplomacy-family** policy with two families (**diplomacy color family** and **non-diplomacy color family**) that also needs shell **viewpoint**, turn `Relation` inbound grants, **diplomacy color threshold**, **family base color**, **out-of-circle base color**, and the current game roster. Threading those inputs through every consumer would make fleet rings and future chrome diplomacy-aware at every call site.
 
 ## Decision
 
 - Keep consumer entry points as `usePlayerColor(playerId)` / `colorForPlayerId(playerId)`.
-- Install a shell-level **player color resolution context** (active **player color mode**, per-player overrides, **diplomacy color threshold**, **family base color**, viewpoint id, inbound relations from the loaded turn) that those entry points consult -- same port pattern as today's override store.
+- Install a shell-level **player color paint snapshot** (built from resolution inputs) that those entry points consult -- same port pattern as today's override store. Inputs:
+  - active **player color mode**
+  - per-player overrides
+  - **diplomacy color threshold**
+  - **family base color** (in-circle)
+  - **out-of-circle base color** (non-diplomacy family)
+  - viewpoint id
+  - inbound relations from the loaded turn (`relationfrom` by other player id)
+  - roster player ids (for out-of-circle membership)
+- In **diplomacy-family** mode:
+  - **Diplomacy color family**: viewpoint is always a member (implicit self-ally, brightest tone) plus others with inbound `relationfrom >= threshold`; members share **family base color** with tonal variants.
+  - **Non-diplomacy color family**: every roster player not in the diplomacy circle; members share **out-of-circle base color** with tonal variants (no special brightest member).
+  - Fall back to the default per-player palette only when viewpoint (and thus family membership) is unavailable -- not for out-of-circle players when families are active.
 - Expose the minimal turn `Relation` fields to the SPA for membership; do not use host `Relation.color`.
 
 ## Consequences
 
 - Call sites stay mode-agnostic; Settings + shell own wiring.
-- Missing relations / no viewpoint fall back to the default palette.
-- [#289](https://github.com/SteveDraper/Planets-Console/issues/289) owns both modes and the BFF relations slice.
+- Out-of-circle players stay in the second family; they do not revert to the default preset while diplomacy-family mode has a viewpoint.
+- [#289](https://github.com/SteveDraper/Planets-Console/issues/289) owns both modes, both family bases, and the BFF relations slice.
 
-Glossary: **Player color**, **player color mode**, **diplomacy color family**, **diplomacy color threshold**, **family base color** in [CONTEXT.md](../../CONTEXT.md).
+Glossary: **Player color**, **player color mode**, **diplomacy color family**, **non-diplomacy color family**, **diplomacy color threshold**, **family base color**, **out-of-circle base color** in [CONTEXT.md](../../CONTEXT.md).

--- a/docs/adr/0013-player-color-resolution-context.md
+++ b/docs/adr/0013-player-color-resolution-context.md
@@ -1,0 +1,21 @@
+# Player color resolution context
+
+Status: accepted
+
+## Context
+
+**Player color** started as `colorForPlayerId(playerId)` with an override storage port so Settings ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)) could wire persistence without touching paint call sites. **Player color mode** adds a **diplomacy-family** policy that also needs shell **viewpoint**, turn `Relation` inbound grants, **diplomacy color threshold**, and **family base color**. Threading those inputs through every consumer would make fleet rings and future chrome diplomacy-aware at every call site.
+
+## Decision
+
+- Keep consumer entry points as `usePlayerColor(playerId)` / `colorForPlayerId(playerId)`.
+- Install a shell-level **player color resolution context** (active **player color mode**, per-player overrides, **diplomacy color threshold**, **family base color**, viewpoint id, inbound relations from the loaded turn) that those entry points consult -- same port pattern as today's override store.
+- Expose the minimal turn `Relation` fields to the SPA for membership; do not use host `Relation.color`.
+
+## Consequences
+
+- Call sites stay mode-agnostic; Settings + shell own wiring.
+- Missing relations / no viewpoint fall back to the default palette.
+- [#289](https://github.com/SteveDraper/Planets-Console/issues/289) owns both modes and the BFF relations slice.
+
+Glossary: **Player color**, **player color mode**, **diplomacy color family**, **diplomacy color threshold**, **family base color** in [CONTEXT.md](../../CONTEXT.md).

--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -470,7 +470,7 @@ Critical path: `0 -> 1 -> 2 -> 3 -> 4 -> 5`.
 | **Fleet gap-fill coordinator** ([#161](https://github.com/SteveDraper/Planets-Console/issues/161), scope [#179](https://github.com/SteveDraper/Planets-Console/issues/179)) | Singleflight per `(gameId, perspective, playerId)`; forward unwind; see section 5.1 |
 | **Fleet F7** (ADR 0004) | Per-player persistence, provenance, table stream -- [#163](https://github.com/SteveDraper/Planets-Console/issues/163) epic; section 15 |
 | **#143** | Neutral scores-inference revision for fleet refetch; superseded for refinement updates once F7 stream ships |
-| **Player color Settings** [#289](https://github.com/SteveDraper/Planets-Console/issues/289) | Settings UI for **player color** overrides; #128 ships defaults + storage seam only |
+| **Player color Settings** [#289](https://github.com/SteveDraper/Planets-Console/issues/289) | Settings UI for **player color mode** (per-player overrides + diplomacy-family); #128 ships defaults + storage seam; [ADR 0013](adr/0013-player-color-resolution-context.md) |
 | **Fleet heading trails** [#290](https://github.com/SteveDraper/Planets-Console/issues/290) | Map rays for known heading/speed (observed ships); optional multi-turn forward/back opacity ramp; stream wire enrichment |
 
 ### `$.composition` export branch (#154)

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import {
   type ConnectionsMapParams,
 } from './api/bff'
 import { useEnabledAnalyticsStore } from './stores/enabledAnalytics'
-// Side-effect: install persisted player-color override port for map/table paint (#289).
+// Side-effect: install persisted player-color resolution port for map/table paint (#289).
 import './stores/playerColors'
 import { useScoresTablePreferencesStore } from './stores/scoresTablePreferences'
 import { useSessionStore } from './stores/session'

--- a/packages/frontend/src/api/bff.ts
+++ b/packages/frontend/src/api/bff.ts
@@ -1,4 +1,5 @@
 import { turnUsernamesByPlayerIdFromPayload } from '../lib/turnPlayerUsernames'
+import { turnRelationsFromPayload, type TurnRelationEdge } from '../lib/turnRelations'
 
 import { appendConnectionsMapQueryParams } from '../analytics/connections/api'
 import type { ConnectionsMapParams } from '../analytics/connections/api'
@@ -481,7 +482,11 @@ export async function fetchLoadAllTurnsStatus(
 export async function ensureTurnData(
   gameId: string,
   params: EnsureTurnParams
-): Promise<{ ready: true; turnUsernamesByPlayerId: Map<number, string> }> {
+): Promise<{
+  ready: true
+  turnUsernamesByPlayerId: Map<number, string>
+  turnRelations: TurnRelationEdge[]
+}> {
   const trimmedUser = params.username.trim()
   const body: {
     turn: number
@@ -514,6 +519,7 @@ export async function ensureTurnData(
   return {
     ready: true,
     turnUsernamesByPlayerId: turnUsernamesByPlayerIdFromPayload(payload),
+    turnRelations: turnRelationsFromPayload(payload),
   }
 }
 

--- a/packages/frontend/src/components/SettingsModal.test.tsx
+++ b/packages/frontend/src/components/SettingsModal.test.tsx
@@ -19,8 +19,10 @@ describe('SettingsModal player colors', () => {
       mode: 'per_player',
       diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
       familyBaseColor: '#34d399',
+      outOfCircleBaseColor: '#f43f5e',
       viewpointPlayerId: null,
       inboundRelationFromByPlayerId: new Map(),
+      rosterPlayerIds: [],
       paintRevision: 0,
     })
     resetPlayerColorResolutionPort()
@@ -61,7 +63,8 @@ describe('SettingsModal player colors', () => {
     await user.click(screen.getByText('Player Colors'))
     await user.selectOptions(screen.getByLabelText(/color by/i), 'diplomacy_family')
     expect(screen.getByLabelText(/minimum inbound status/i)).toBeInTheDocument()
-    expect(screen.getByLabelText(/family base color/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/diplomacy circle base color/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/others base color/i)).toBeInTheDocument()
     expect(usePlayerColorsStore.getState().mode).toBe('diplomacy_family')
   })
 })

--- a/packages/frontend/src/components/SettingsModal.test.tsx
+++ b/packages/frontend/src/components/SettingsModal.test.tsx
@@ -7,6 +7,7 @@ import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
 import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
 import {
   installPlayerColorsStorePort,
+  resetPlayerColorsStoreState,
   usePlayerColorsStore,
 } from '../stores/playerColors'
 import { useShellStore } from '../stores/shell'
@@ -14,16 +15,8 @@ import { resetPlayerColorResolutionPort } from '../lib/playerColor'
 
 describe('SettingsModal player colors', () => {
   beforeEach(() => {
-    usePlayerColorsStore.setState({
-      overrides: {},
-      mode: 'per_player',
+    resetPlayerColorsStoreState({
       diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
-      familyBaseColor: '#34d399',
-      outOfCircleBaseColor: '#f43f5e',
-      viewpointPlayerId: null,
-      inboundRelationFromByPlayerId: new Map(),
-      rosterPlayerIds: [],
-      paintRevision: 0,
     })
     resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()

--- a/packages/frontend/src/components/SettingsModal.test.tsx
+++ b/packages/frontend/src/components/SettingsModal.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SettingsModal } from './SettingsModal'
+import { DiplomacyTier } from '../lib/diplomacyTier'
+import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
+import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
+import {
+  installPlayerColorsStorePort,
+  usePlayerColorsStore,
+} from '../stores/playerColors'
+import { useShellStore } from '../stores/shell'
+import { resetPlayerColorResolutionPort } from '../lib/playerColor'
+
+describe('SettingsModal player colors', () => {
+  beforeEach(() => {
+    usePlayerColorsStore.setState({
+      overrides: {},
+      mode: 'per_player',
+      diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
+      familyBaseColor: '#34d399',
+      viewpointPlayerId: null,
+      inboundRelationFromByPlayerId: new Map(),
+      paintRevision: 0,
+    })
+    resetPlayerColorResolutionPort()
+    installPlayerColorsStorePort()
+    useShellStore.setState({ gameInfoContext: null })
+  })
+
+  it('shows empty state for per-player mode when no game is loaded', async () => {
+    const user = userEvent.setup()
+    render(<SettingsModal isOpen onClose={() => {}} />)
+    await user.click(screen.getByText('Player Colors'))
+    expect(screen.getByText(/load a game to set player colors/i)).toBeInTheDocument()
+  })
+
+  it('lists roster and can set an override when a game is loaded', async () => {
+    const user = userEvent.setup()
+    useShellStore.setState({
+      gameInfoContext: {
+        turn: 5,
+        isGameFinished: false,
+        perspectives: [perspectiveRow(1, 'Alice'), perspectiveRow(2, 'Bob')],
+        sectorDisplayName: null,
+        stellarCartographyGates: EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES,
+        homeworldInactiveReason: null,
+      },
+    })
+    render(<SettingsModal isOpen onClose={() => {}} />)
+    await user.click(screen.getByText('Player Colors'))
+    const colorInput = screen.getByLabelText(/color for alice/i) as HTMLInputElement
+    expect(colorInput).toBeInTheDocument()
+    fireEvent.change(colorInput, { target: { value: '#abcdef' } })
+    expect(usePlayerColorsStore.getState().overrides['1']).toBe('#abcdef')
+  })
+
+  it('shows diplomacy knobs when mode is diplomacy-family', async () => {
+    const user = userEvent.setup()
+    render(<SettingsModal isOpen onClose={() => {}} />)
+    await user.click(screen.getByText('Player Colors'))
+    await user.selectOptions(screen.getByLabelText(/color by/i), 'diplomacy_family')
+    expect(screen.getByLabelText(/minimum inbound status/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/family base color/i)).toBeInTheDocument()
+    expect(usePlayerColorsStore.getState().mode).toBe('diplomacy_family')
+  })
+})

--- a/packages/frontend/src/components/SettingsModal.test.tsx
+++ b/packages/frontend/src/components/SettingsModal.test.tsx
@@ -60,4 +60,19 @@ describe('SettingsModal player colors', () => {
     expect(screen.getByLabelText(/others base color/i)).toBeInTheDocument()
     expect(usePlayerColorsStore.getState().mode).toBe('diplomacy_family')
   })
+
+  it('ignores invalid mode and threshold select values', async () => {
+    const user = userEvent.setup()
+    render(<SettingsModal isOpen onClose={() => {}} />)
+    await user.click(screen.getByText('Player Colors'))
+
+    fireEvent.change(screen.getByLabelText(/color by/i), { target: { value: 'not_a_mode' } })
+    expect(usePlayerColorsStore.getState().mode).toBe('per_player')
+
+    await user.selectOptions(screen.getByLabelText(/color by/i), 'diplomacy_family')
+    fireEvent.change(screen.getByLabelText(/minimum inbound status/i), {
+      target: { value: '99' },
+    })
+    expect(usePlayerColorsStore.getState().diplomacyThreshold).toBe(DiplomacyTier.SAFE_PASSAGE)
+  })
 })

--- a/packages/frontend/src/components/SettingsModal.tsx
+++ b/packages/frontend/src/components/SettingsModal.tsx
@@ -3,10 +3,21 @@ import { useModalKeydownFocusTrap } from '../lib/modalKeydownFocusTrap'
 import { restoreFocusToElementOrFallback } from '../lib/restoreFocus'
 import { cn } from '../lib/utils'
 import {
+  DIPLOMACY_COLOR_THRESHOLD_OPTIONS,
+  type DiplomacyColorThreshold,
+} from '../lib/diplomacyTier'
+import { formatViewpointRowLabel } from '../lib/displayFormatters'
+import {
+  defaultColorForPlayerId,
+  type PlayerColorMode,
+} from '../lib/playerColor'
+import {
   useDisplayPreferencesStore,
   type PlayerListLabelMode,
   type SectorListLabelMode,
 } from '../stores/displayPreferences'
+import { usePlayerColorsStore } from '../stores/playerColors'
+import { useShellStore } from '../stores/shell'
 
 type SettingsModalProps = {
   isOpen: boolean
@@ -82,6 +93,119 @@ function DisplayOptionsSection() {
   )
 }
 
+function PlayerColorsSection() {
+  const playerListLabelMode = useDisplayPreferencesStore((s) => s.playerListLabelMode)
+  const perspectives = useShellStore((s) => s.gameInfoContext?.perspectives)
+  const mode = usePlayerColorsStore((s) => s.mode)
+  const diplomacyThreshold = usePlayerColorsStore((s) => s.diplomacyThreshold)
+  const familyBaseColor = usePlayerColorsStore((s) => s.familyBaseColor)
+  const overrides = usePlayerColorsStore((s) => s.overrides)
+  const setPlayerColorMode = usePlayerColorsStore((s) => s.setPlayerColorMode)
+  const setDiplomacyThreshold = usePlayerColorsStore((s) => s.setDiplomacyThreshold)
+  const setFamilyBaseColor = usePlayerColorsStore((s) => s.setFamilyBaseColor)
+  const setPlayerColorOverride = usePlayerColorsStore((s) => s.setPlayerColorOverride)
+
+  return (
+    <div className="flex flex-col gap-3 pt-2">
+      <div className="flex flex-col gap-1">
+        <label htmlFor="settings-player-color-mode" className="text-xs text-slate-400">
+          Color by
+        </label>
+        <select
+          id="settings-player-color-mode"
+          value={mode}
+          onChange={(e) => setPlayerColorMode(e.target.value as PlayerColorMode)}
+          className={selectClassName}
+        >
+          <option value="per_player">Per player</option>
+          <option value="diplomacy_family">Diplomacy family</option>
+        </select>
+      </div>
+
+      {mode === 'diplomacy_family' ? (
+        <>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="settings-diplomacy-color-threshold"
+              className="text-xs text-slate-400"
+            >
+              Minimum inbound status
+            </label>
+            <select
+              id="settings-diplomacy-color-threshold"
+              value={diplomacyThreshold}
+              onChange={(e) =>
+                setDiplomacyThreshold(Number(e.target.value) as DiplomacyColorThreshold)
+              }
+              className={selectClassName}
+            >
+              {DIPLOMACY_COLOR_THRESHOLD_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="settings-family-base-color"
+              className="text-xs text-slate-400"
+            >
+              Family base color
+            </label>
+            <input
+              id="settings-family-base-color"
+              type="color"
+              aria-label="Family base color"
+              value={familyBaseColor}
+              onChange={(e) => setFamilyBaseColor(e.target.value)}
+              className="h-8 w-12 cursor-pointer rounded border border-[#52575d] bg-transparent p-0"
+            />
+          </div>
+        </>
+      ) : perspectives == null || perspectives.length === 0 ? (
+        <p className="text-xs text-slate-400">Load a game to set player colors.</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {perspectives.map((row) => {
+            const key = String(row.playerId)
+            const override = overrides[key]
+            const effective = override ?? defaultColorForPlayerId(row.playerId)
+            const label = formatViewpointRowLabel(
+              playerListLabelMode,
+              row.name,
+              row.raceName
+            )
+            return (
+              <li
+                key={row.playerId}
+                className="flex items-center gap-2 text-xs text-slate-200"
+              >
+                <span className="min-w-0 flex-1 truncate">{label}</span>
+                <input
+                  type="color"
+                  aria-label={`Color for ${label}`}
+                  value={effective}
+                  onChange={(e) => setPlayerColorOverride(row.playerId, e.target.value)}
+                  className="h-6 w-7 shrink-0 cursor-pointer rounded border border-[#52575d] bg-transparent p-0"
+                />
+                <button
+                  type="button"
+                  className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-slate-400 hover:bg-white/10 hover:text-slate-200 disabled:opacity-40"
+                  disabled={override == null}
+                  onClick={() => setPlayerColorOverride(row.playerId, null)}
+                >
+                  Reset
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 type SettingsSectionDef = {
   id: string
   title: string
@@ -93,6 +217,11 @@ const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     id: 'display-options',
     title: 'Display Options',
     Content: DisplayOptionsSection,
+  },
+  {
+    id: 'player-colors',
+    title: 'Player Colors',
+    Content: PlayerColorsSection,
   },
 ].sort((a, b) => a.title.localeCompare(b.title))
 

--- a/packages/frontend/src/components/SettingsModal.tsx
+++ b/packages/frontend/src/components/SettingsModal.tsx
@@ -4,12 +4,12 @@ import { restoreFocusToElementOrFallback } from '../lib/restoreFocus'
 import { cn } from '../lib/utils'
 import {
   DIPLOMACY_COLOR_THRESHOLD_OPTIONS,
-  type DiplomacyColorThreshold,
+  isDiplomacyColorThreshold,
 } from '../lib/diplomacyTier'
 import { formatViewpointRowLabel } from '../lib/displayFormatters'
 import {
   defaultColorForPlayerId,
-  type PlayerColorMode,
+  isPlayerColorMode,
 } from '../lib/playerColor'
 import {
   useDisplayPreferencesStore,
@@ -116,7 +116,11 @@ function PlayerColorsSection() {
         <select
           id="settings-player-color-mode"
           value={mode}
-          onChange={(e) => setPlayerColorMode(e.target.value as PlayerColorMode)}
+          onChange={(e) => {
+            if (isPlayerColorMode(e.target.value)) {
+              setPlayerColorMode(e.target.value)
+            }
+          }}
           className={selectClassName}
         >
           <option value="per_player">Per player</option>
@@ -136,9 +140,12 @@ function PlayerColorsSection() {
             <select
               id="settings-diplomacy-color-threshold"
               value={diplomacyThreshold}
-              onChange={(e) =>
-                setDiplomacyThreshold(Number(e.target.value) as DiplomacyColorThreshold)
-              }
+              onChange={(e) => {
+                const next = Number(e.target.value)
+                if (isDiplomacyColorThreshold(next)) {
+                  setDiplomacyThreshold(next)
+                }
+              }}
               className={selectClassName}
             >
               {DIPLOMACY_COLOR_THRESHOLD_OPTIONS.map((o) => (

--- a/packages/frontend/src/components/SettingsModal.tsx
+++ b/packages/frontend/src/components/SettingsModal.tsx
@@ -99,10 +99,12 @@ function PlayerColorsSection() {
   const mode = usePlayerColorsStore((s) => s.mode)
   const diplomacyThreshold = usePlayerColorsStore((s) => s.diplomacyThreshold)
   const familyBaseColor = usePlayerColorsStore((s) => s.familyBaseColor)
+  const outOfCircleBaseColor = usePlayerColorsStore((s) => s.outOfCircleBaseColor)
   const overrides = usePlayerColorsStore((s) => s.overrides)
   const setPlayerColorMode = usePlayerColorsStore((s) => s.setPlayerColorMode)
   const setDiplomacyThreshold = usePlayerColorsStore((s) => s.setDiplomacyThreshold)
   const setFamilyBaseColor = usePlayerColorsStore((s) => s.setFamilyBaseColor)
+  const setOutOfCircleBaseColor = usePlayerColorsStore((s) => s.setOutOfCircleBaseColor)
   const setPlayerColorOverride = usePlayerColorsStore((s) => s.setPlayerColorOverride)
 
   return (
@@ -151,14 +153,30 @@ function PlayerColorsSection() {
               htmlFor="settings-family-base-color"
               className="text-xs text-slate-400"
             >
-              Family base color
+              Diplomacy circle base
             </label>
             <input
               id="settings-family-base-color"
               type="color"
-              aria-label="Family base color"
+              aria-label="Diplomacy circle base color"
               value={familyBaseColor}
               onChange={(e) => setFamilyBaseColor(e.target.value)}
+              className="h-8 w-12 cursor-pointer rounded border border-[#52575d] bg-transparent p-0"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="settings-out-of-circle-base-color"
+              className="text-xs text-slate-400"
+            >
+              Others base
+            </label>
+            <input
+              id="settings-out-of-circle-base-color"
+              type="color"
+              aria-label="Others base color"
+              value={outOfCircleBaseColor}
+              onChange={(e) => setOutOfCircleBaseColor(e.target.value)}
               className="h-8 w-12 cursor-pointer rounded border border-[#52575d] bg-transparent p-0"
             />
           </div>

--- a/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
+++ b/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
@@ -104,8 +104,10 @@ describe('FleetLocationRingsOverlay', () => {
       mode: 'per_player',
       diplomacyThreshold: 2,
       familyBaseColor: '#34d399',
+      outOfCircleBaseColor: '#f43f5e',
       viewpointPlayerId: null,
       inboundRelationFromByPlayerId: new Map(),
+      rosterPlayerIds: [],
       paintRevision: 0,
     })
     resetPlayerColorResolutionPort()

--- a/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
+++ b/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react'
 import { FleetLocationRingsOverlay } from './FleetLocationRingsOverlay'
 import {
   installPlayerColorsStorePort,
+  resetPlayerColorsStoreState,
   usePlayerColorsStore,
 } from '../../stores/playerColors'
 import { defaultColorForPlayerId, resetPlayerColorResolutionPort } from '../../lib/playerColor'
@@ -99,16 +100,8 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe('FleetLocationRingsOverlay', () => {
   beforeEach(() => {
-    usePlayerColorsStore.setState({
-      overrides: {},
-      mode: 'per_player',
+    resetPlayerColorsStoreState({
       diplomacyThreshold: 2,
-      familyBaseColor: '#34d399',
-      outOfCircleBaseColor: '#f43f5e',
-      viewpointPlayerId: null,
-      inboundRelationFromByPlayerId: new Map(),
-      rosterPlayerIds: [],
-      paintRevision: 0,
     })
     resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()

--- a/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
+++ b/packages/frontend/src/components/map-graph/FleetLocationRingsOverlay.test.tsx
@@ -7,7 +7,7 @@ import {
   installPlayerColorsStorePort,
   usePlayerColorsStore,
 } from '../../stores/playerColors'
-import { defaultColorForPlayerId, resetPlayerColorOverrideStore } from '../../lib/playerColor'
+import { defaultColorForPlayerId, resetPlayerColorResolutionPort } from '../../lib/playerColor'
 import type { FleetLocationRingStack } from '../../analytics/fleet/fleetLocationRings'
 
 vi.mock('@xyflow/react', () => ({
@@ -99,8 +99,16 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe('FleetLocationRingsOverlay', () => {
   beforeEach(() => {
-    usePlayerColorsStore.setState({ overrides: {} })
-    resetPlayerColorOverrideStore()
+    usePlayerColorsStore.setState({
+      overrides: {},
+      mode: 'per_player',
+      diplomacyThreshold: 2,
+      familyBaseColor: '#34d399',
+      viewpointPlayerId: null,
+      inboundRelationFromByPlayerId: new Map(),
+      paintRevision: 0,
+    })
+    resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()
   })
 

--- a/packages/frontend/src/lib/colorTone.ts
+++ b/packages/frontend/src/lib/colorTone.ts
@@ -1,0 +1,128 @@
+/**
+ * Hex / HSL tonal helpers for deterministic family color variants.
+ * Reuses {@link hexToRgb} from cartographyColor.
+ */
+
+import { hexToRgb } from './cartography/cartographyColor'
+
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  const rn = r / 255
+  const gn = g / 255
+  const bn = b / 255
+  const max = Math.max(rn, gn, bn)
+  const min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  if (max === min) {
+    return [0, 0, l]
+  }
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h = 0
+  switch (max) {
+    case rn:
+      h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6
+      break
+    case gn:
+      h = ((bn - rn) / d + 2) / 6
+      break
+    default:
+      h = ((rn - gn) / d + 4) / 6
+      break
+  }
+  return [h, s, l]
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  let tt = t
+  if (tt < 0) tt += 1
+  if (tt > 1) tt -= 1
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt
+  if (tt < 1 / 2) return q
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6
+  return p
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return [v, v, v]
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  return [
+    Math.round(hueToRgb(p, q, h + 1 / 3) * 255),
+    Math.round(hueToRgb(p, q, h) * 255),
+    Math.round(hueToRgb(p, q, h - 1 / 3) * 255),
+  ]
+}
+
+function componentToHex(value: number): string {
+  const clamped = Math.max(0, Math.min(255, value))
+  return clamped.toString(16).padStart(2, '0')
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`
+}
+
+/** Normalize to lowercase `#rrggbb`, or null if not a 6-digit hex color. */
+export function normalizeHexColor(hex: string): string | null {
+  const trimmed = hex.trim()
+  const raw = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
+  if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
+    return null
+  }
+  return `#${raw.toLowerCase()}`
+}
+
+/**
+ * Tone assignment order: other members by ascending id, then ``brightestMemberId``
+ * last so they receive the highest lightness.
+ */
+export function diplomacyFamilyToneOrderIds(
+  familyMemberIds: readonly number[],
+  brightestMemberId: number | null | undefined
+): number[] {
+  const sorted = [...familyMemberIds].sort((a, b) => a - b)
+  if (brightestMemberId == null || !sorted.includes(brightestMemberId)) {
+    return sorted
+  }
+  return [...sorted.filter((id) => id !== brightestMemberId), brightestMemberId]
+}
+
+/**
+ * Deterministic tonal variant of ``familyBaseColor`` for one family member.
+ * Stable for a given (base, memberPlayerId, familyMemberIds set, brightestMemberId).
+ * ``brightestMemberId`` always gets the brightest tone when present.
+ */
+export function tonalVariantForFamilyMember(
+  familyBaseColor: string,
+  memberPlayerId: number,
+  familyMemberIds: readonly number[],
+  brightestMemberId?: number | null
+): string {
+  const normalizedBase = normalizeHexColor(familyBaseColor) ?? '#34d399'
+  const ordered = diplomacyFamilyToneOrderIds(familyMemberIds, brightestMemberId)
+  const index = ordered.indexOf(memberPlayerId)
+  if (index < 0) {
+    return normalizedBase
+  }
+  const n = ordered.length
+  const [r, g, b] = hexToRgb(normalizedBase)
+  const [h, s, baseL] = rgbToHsl(r, g, b)
+  if (n <= 1) {
+    return normalizedBase
+  }
+  const span = Math.min(0.28, 0.08 * (n - 1))
+  const t = index / (n - 1)
+  const lightness = clamp01(baseL - span / 2 + t * span)
+  const saturation = clamp01(s * (0.92 + 0.16 * (1 - Math.abs(t - 0.5) * 2)))
+  const [nr, ng, nb] = hslToRgb(h, saturation, lightness)
+  return rgbToHex(nr, ng, nb)
+}

--- a/packages/frontend/src/lib/diplomacyTier.ts
+++ b/packages/frontend/src/lib/diplomacyTier.ts
@@ -1,0 +1,36 @@
+/**
+ * Planets.nu Relation.relationto / relationfrom ladder.
+ * Mirrors Core ``api.concepts.diplomacy.DiplomacyTier``.
+ */
+export const DiplomacyTier = {
+  BLOCKED: -1,
+  NONE: 0,
+  AMBASSADOR: 1,
+  SAFE_PASSAGE: 2,
+  SHARE_INTEL: 3,
+  FULL_ALLIANCE: 4,
+} as const
+
+export type DiplomacyTierCode = (typeof DiplomacyTier)[keyof typeof DiplomacyTier]
+
+/** Thresholds offered in Settings for diplomacy-family mode (Blocked/None excluded). */
+export const DIPLOMACY_COLOR_THRESHOLD_OPTIONS = [
+  { value: DiplomacyTier.AMBASSADOR, label: 'Ambassador' },
+  { value: DiplomacyTier.SAFE_PASSAGE, label: 'Safe Passage' },
+  { value: DiplomacyTier.SHARE_INTEL, label: 'Share Intel' },
+  { value: DiplomacyTier.FULL_ALLIANCE, label: 'Full Alliance' },
+] as const
+
+export type DiplomacyColorThreshold = (typeof DIPLOMACY_COLOR_THRESHOLD_OPTIONS)[number]['value']
+
+export const DEFAULT_DIPLOMACY_COLOR_THRESHOLD: DiplomacyColorThreshold =
+  DiplomacyTier.SAFE_PASSAGE
+
+export function isDiplomacyColorThreshold(value: number): value is DiplomacyColorThreshold {
+  return (
+    value === DiplomacyTier.AMBASSADOR ||
+    value === DiplomacyTier.SAFE_PASSAGE ||
+    value === DiplomacyTier.SHARE_INTEL ||
+    value === DiplomacyTier.FULL_ALLIANCE
+  )
+}

--- a/packages/frontend/src/lib/playerColor.test.ts
+++ b/packages/frontend/src/lib/playerColor.test.ts
@@ -5,6 +5,7 @@ import {
   colorForPlayerId,
   defaultColorForPlayerId,
   diplomacyColorFamilyMemberIds,
+  outOfCircleFamilyMemberIds,
   resetPlayerColorResolutionPort,
   setPlayerColorResolutionPort,
   tonalVariantForFamilyMember,
@@ -17,8 +18,10 @@ function port(partial: Partial<PlayerColorResolutionPort>): PlayerColorResolutio
     getOverride: () => undefined,
     getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
     getFamilyBaseColor: () => '#34d399',
+    getOutOfCircleBaseColor: () => '#f43f5e',
     getViewpointPlayerId: () => null,
     getInboundRelationFromByPlayerId: () => new Map(),
+    getRosterPlayerIds: () => [],
     ...partial,
   }
 }
@@ -54,7 +57,7 @@ describe('playerColor', () => {
     expect(colorForPlayerId(9)).toBe(defaultColorForPlayerId(9))
   })
 
-  it('lists diplomacy family members from inbound grants at or above threshold', () => {
+  it('lists diplomacy family members including viewpoint plus inbound grants at threshold', () => {
     const inbound = new Map([
       [2, DiplomacyTier.SAFE_PASSAGE],
       [3, DiplomacyTier.AMBASSADOR],
@@ -62,47 +65,79 @@ describe('playerColor', () => {
     ])
     expect(
       diplomacyColorFamilyMemberIds(inbound, 1, DiplomacyTier.SAFE_PASSAGE)
-    ).toEqual([2, 4])
+    ).toEqual([1, 2, 4])
+    expect(outOfCircleFamilyMemberIds([1, 2, 3, 4, 5], [1, 2, 4])).toEqual([3, 5])
   })
 
-  it('paints family tones in diplomacy-family mode and defaults otherwise', () => {
+  it('paints two family bases in diplomacy-family mode with viewpoint brightest in-circle', () => {
     const inbound = new Map([
       [2, DiplomacyTier.SAFE_PASSAGE],
       [3, DiplomacyTier.NONE],
       [4, DiplomacyTier.SHARE_INTEL],
     ])
+    const roster = [1, 2, 3, 4]
     setPlayerColorResolutionPort(
       port({
         getMode: () => 'diplomacy_family',
         getViewpointPlayerId: () => 1,
         getInboundRelationFromByPlayerId: () => inbound,
         getFamilyBaseColor: () => '#336699',
+        getOutOfCircleBaseColor: () => '#aa3333',
         getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
+        getRosterPlayerIds: () => roster,
       })
     )
-    const family = [2, 4]
-    expect(colorForPlayerId(2)).toBe(tonalVariantForFamilyMember('#336699', 2, family))
-    expect(colorForPlayerId(4)).toBe(tonalVariantForFamilyMember('#336699', 4, family))
-    expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
-    expect(colorForPlayerId(1)).toBe(defaultColorForPlayerId(1))
+    const inCircle = [1, 2, 4]
+    const outCircle = [3]
+    expect(colorForPlayerId(1)).toBe(
+      tonalVariantForFamilyMember('#336699', 1, inCircle, 1)
+    )
+    expect(colorForPlayerId(2)).toBe(
+      tonalVariantForFamilyMember('#336699', 2, inCircle, 1)
+    )
+    expect(colorForPlayerId(4)).toBe(
+      tonalVariantForFamilyMember('#336699', 4, inCircle, 1)
+    )
+    expect(colorForPlayerId(3)).toBe(
+      tonalVariantForFamilyMember('#aa3333', 3, outCircle, null)
+    )
+    expect(colorForPlayerId(3)).not.toBe(defaultColorForPlayerId(3))
+    const viewpointRgb = hexLightness(colorForPlayerId(1))
+    expect(viewpointRgb).toBeGreaterThan(hexLightness(colorForPlayerId(2)))
+    expect(viewpointRgb).toBeGreaterThan(hexLightness(colorForPlayerId(4)))
   })
 
-  it('treats missing inbound relation as not in family', () => {
+  it('paints missing-relation roster players with the out-of-circle base', () => {
     setPlayerColorResolutionPort(
       port({
         getMode: () => 'diplomacy_family',
         getViewpointPlayerId: () => 1,
         getInboundRelationFromByPlayerId: () => new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+        getOutOfCircleBaseColor: () => '#aa3333',
+        getRosterPlayerIds: () => [1, 2, 9],
       })
     )
-    expect(colorForPlayerId(9)).toBe(defaultColorForPlayerId(9))
+    expect(colorForPlayerId(9)).toBe(
+      tonalVariantForFamilyMember('#aa3333', 9, [9], null)
+    )
   })
 
   it('produces stable tonal variants for the same family inputs', () => {
-    const a = tonalVariantForFamilyMember('#34d399', 2, [2, 5, 9])
-    const b = tonalVariantForFamilyMember('#34d399', 2, [9, 2, 5])
+    const a = tonalVariantForFamilyMember('#34d399', 2, [1, 2, 5, 9], 1)
+    const b = tonalVariantForFamilyMember('#34d399', 2, [9, 1, 2, 5], 1)
     expect(a).toBe(b)
     expect(a).toMatch(/^#[0-9a-f]{6}$/)
-    expect(tonalVariantForFamilyMember('#34d399', 5, [2, 5, 9])).not.toBe(a)
+    expect(tonalVariantForFamilyMember('#34d399', 5, [1, 2, 5, 9], 1)).not.toBe(a)
+    expect(hexLightness(tonalVariantForFamilyMember('#34d399', 1, [1, 2, 5], 1))).toBeGreaterThan(
+      hexLightness(tonalVariantForFamilyMember('#34d399', 2, [1, 2, 5], 1))
+    )
   })
 })
+
+function hexLightness(hex: string): number {
+  const raw = hex.startsWith('#') ? hex.slice(1) : hex
+  const r = parseInt(raw.slice(0, 2), 16) / 255
+  const g = parseInt(raw.slice(2, 4), 16) / 255
+  const b = parseInt(raw.slice(4, 6), 16) / 255
+  return (Math.max(r, g, b) + Math.min(r, g, b)) / 2
+}

--- a/packages/frontend/src/lib/playerColor.test.ts
+++ b/packages/frontend/src/lib/playerColor.test.ts
@@ -7,6 +7,7 @@ import {
   defaultColorForPlayerId,
   defaultPlayerColorPaintSnapshotInputs,
   diplomacyColorFamilyMemberIds,
+  isPlayerColorMode,
   outOfCircleFamilyMemberIds,
   resetPlayerColorResolutionPort,
   resolvePlayerColor,
@@ -40,6 +41,13 @@ describe('playerColor', () => {
     expect(defaultColorForPlayerId(15)).toBe(PLAYER_COLOR_PRESET[15])
     expect(defaultColorForPlayerId(16)).toBe(PLAYER_COLOR_PRESET[0])
     expect(defaultColorForPlayerId(-1)).toBe(PLAYER_COLOR_PRESET[15])
+  })
+
+  it('accepts only known player color modes', () => {
+    expect(isPlayerColorMode('per_player')).toBe(true)
+    expect(isPlayerColorMode('diplomacy_family')).toBe(true)
+    expect(isPlayerColorMode('unknown')).toBe(false)
+    expect(isPlayerColorMode('')).toBe(false)
   })
 
   it('uses defaults when the resolution port is empty', () => {

--- a/packages/frontend/src/lib/playerColor.test.ts
+++ b/packages/frontend/src/lib/playerColor.test.ts
@@ -1,19 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { DiplomacyTier } from './diplomacyTier'
 import {
   PLAYER_COLOR_PRESET,
   colorForPlayerId,
   defaultColorForPlayerId,
-  resetPlayerColorOverrideStore,
-  setPlayerColorOverrideStore,
+  diplomacyColorFamilyMemberIds,
+  resetPlayerColorResolutionPort,
+  setPlayerColorResolutionPort,
+  tonalVariantForFamilyMember,
+  type PlayerColorResolutionPort,
 } from './playerColor'
+
+function port(partial: Partial<PlayerColorResolutionPort>): PlayerColorResolutionPort {
+  return {
+    getMode: () => 'per_player',
+    getOverride: () => undefined,
+    getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
+    getFamilyBaseColor: () => '#34d399',
+    getViewpointPlayerId: () => null,
+    getInboundRelationFromByPlayerId: () => new Map(),
+    ...partial,
+  }
+}
 
 describe('playerColor', () => {
   beforeEach(() => {
-    resetPlayerColorOverrideStore()
+    resetPlayerColorResolutionPort()
   })
 
   afterEach(() => {
-    resetPlayerColorOverrideStore()
+    resetPlayerColorResolutionPort()
   })
 
   it('maps playerId % 16 into the preset table', () => {
@@ -24,15 +40,69 @@ describe('playerColor', () => {
     expect(defaultColorForPlayerId(-1)).toBe(PLAYER_COLOR_PRESET[15])
   })
 
-  it('uses defaults when the override store is empty', () => {
+  it('uses defaults when the resolution port is empty', () => {
     expect(colorForPlayerId(8)).toBe(defaultColorForPlayerId(8))
   })
 
-  it('consults the override store before defaults', () => {
-    setPlayerColorOverrideStore({
-      getOverride: (playerId) => (playerId === 8 ? '#ffffff' : undefined),
-    })
+  it('consults overrides in per-player mode', () => {
+    setPlayerColorResolutionPort(
+      port({
+        getOverride: (playerId) => (playerId === 8 ? '#ffffff' : undefined),
+      })
+    )
     expect(colorForPlayerId(8)).toBe('#ffffff')
     expect(colorForPlayerId(9)).toBe(defaultColorForPlayerId(9))
+  })
+
+  it('lists diplomacy family members from inbound grants at or above threshold', () => {
+    const inbound = new Map([
+      [2, DiplomacyTier.SAFE_PASSAGE],
+      [3, DiplomacyTier.AMBASSADOR],
+      [4, DiplomacyTier.FULL_ALLIANCE],
+    ])
+    expect(
+      diplomacyColorFamilyMemberIds(inbound, 1, DiplomacyTier.SAFE_PASSAGE)
+    ).toEqual([2, 4])
+  })
+
+  it('paints family tones in diplomacy-family mode and defaults otherwise', () => {
+    const inbound = new Map([
+      [2, DiplomacyTier.SAFE_PASSAGE],
+      [3, DiplomacyTier.NONE],
+      [4, DiplomacyTier.SHARE_INTEL],
+    ])
+    setPlayerColorResolutionPort(
+      port({
+        getMode: () => 'diplomacy_family',
+        getViewpointPlayerId: () => 1,
+        getInboundRelationFromByPlayerId: () => inbound,
+        getFamilyBaseColor: () => '#336699',
+        getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
+      })
+    )
+    const family = [2, 4]
+    expect(colorForPlayerId(2)).toBe(tonalVariantForFamilyMember('#336699', 2, family))
+    expect(colorForPlayerId(4)).toBe(tonalVariantForFamilyMember('#336699', 4, family))
+    expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
+    expect(colorForPlayerId(1)).toBe(defaultColorForPlayerId(1))
+  })
+
+  it('treats missing inbound relation as not in family', () => {
+    setPlayerColorResolutionPort(
+      port({
+        getMode: () => 'diplomacy_family',
+        getViewpointPlayerId: () => 1,
+        getInboundRelationFromByPlayerId: () => new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      })
+    )
+    expect(colorForPlayerId(9)).toBe(defaultColorForPlayerId(9))
+  })
+
+  it('produces stable tonal variants for the same family inputs', () => {
+    const a = tonalVariantForFamilyMember('#34d399', 2, [2, 5, 9])
+    const b = tonalVariantForFamilyMember('#34d399', 2, [9, 2, 5])
+    expect(a).toBe(b)
+    expect(a).toMatch(/^#[0-9a-f]{6}$/)
+    expect(tonalVariantForFamilyMember('#34d399', 5, [2, 5, 9])).not.toBe(a)
   })
 })

--- a/packages/frontend/src/lib/playerColor.test.ts
+++ b/packages/frontend/src/lib/playerColor.test.ts
@@ -2,28 +2,27 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { DiplomacyTier } from './diplomacyTier'
 import {
   PLAYER_COLOR_PRESET,
+  buildPlayerColorPaintSnapshot,
   colorForPlayerId,
   defaultColorForPlayerId,
+  defaultPlayerColorPaintSnapshotInputs,
   diplomacyColorFamilyMemberIds,
   outOfCircleFamilyMemberIds,
   resetPlayerColorResolutionPort,
+  resolvePlayerColor,
   setPlayerColorResolutionPort,
   tonalVariantForFamilyMember,
-  type PlayerColorResolutionPort,
+  type PlayerColorPaintSnapshot,
+  type PlayerColorPaintSnapshotInputs,
 } from './playerColor'
 
-function port(partial: Partial<PlayerColorResolutionPort>): PlayerColorResolutionPort {
-  return {
-    getMode: () => 'per_player',
-    getOverride: () => undefined,
-    getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
-    getFamilyBaseColor: () => '#34d399',
-    getOutOfCircleBaseColor: () => '#f43f5e',
-    getViewpointPlayerId: () => null,
-    getInboundRelationFromByPlayerId: () => new Map(),
-    getRosterPlayerIds: () => [],
+function snapshot(
+  partial: Partial<PlayerColorPaintSnapshotInputs> = {}
+): PlayerColorPaintSnapshot {
+  return buildPlayerColorPaintSnapshot({
+    ...defaultPlayerColorPaintSnapshotInputs(),
     ...partial,
-  }
+  })
 }
 
 describe('playerColor', () => {
@@ -48,13 +47,13 @@ describe('playerColor', () => {
   })
 
   it('consults overrides in per-player mode', () => {
-    setPlayerColorResolutionPort(
-      port({
-        getOverride: (playerId) => (playerId === 8 ? '#ffffff' : undefined),
-      })
-    )
+    const paint = snapshot({
+      overrides: { '8': '#ffffff' },
+    })
+    setPlayerColorResolutionPort({ getSnapshot: () => paint })
     expect(colorForPlayerId(8)).toBe('#ffffff')
     expect(colorForPlayerId(9)).toBe(defaultColorForPlayerId(9))
+    expect(resolvePlayerColor(8, paint)).toBe('#ffffff')
   })
 
   it('lists diplomacy family members including viewpoint plus inbound grants at threshold', () => {
@@ -76,19 +75,20 @@ describe('playerColor', () => {
       [4, DiplomacyTier.SHARE_INTEL],
     ])
     const roster = [1, 2, 3, 4]
-    setPlayerColorResolutionPort(
-      port({
-        getMode: () => 'diplomacy_family',
-        getViewpointPlayerId: () => 1,
-        getInboundRelationFromByPlayerId: () => inbound,
-        getFamilyBaseColor: () => '#336699',
-        getOutOfCircleBaseColor: () => '#aa3333',
-        getDiplomacyThreshold: () => DiplomacyTier.SAFE_PASSAGE,
-        getRosterPlayerIds: () => roster,
-      })
-    )
+    const paint = snapshot({
+      mode: 'diplomacy_family',
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: inbound,
+      familyBaseColor: '#336699',
+      outOfCircleBaseColor: '#aa3333',
+      diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
+      rosterPlayerIds: roster,
+    })
+    setPlayerColorResolutionPort({ getSnapshot: () => paint })
     const inCircle = [1, 2, 4]
     const outCircle = [3]
+    expect(paint.inCircleMemberIds).toEqual(inCircle)
+    expect(paint.outOfCircleMemberIds).toEqual(outCircle)
     expect(colorForPlayerId(1)).toBe(
       tonalVariantForFamilyMember('#336699', 1, inCircle, 1)
     )
@@ -108,15 +108,14 @@ describe('playerColor', () => {
   })
 
   it('paints missing-relation roster players with the out-of-circle base', () => {
-    setPlayerColorResolutionPort(
-      port({
-        getMode: () => 'diplomacy_family',
-        getViewpointPlayerId: () => 1,
-        getInboundRelationFromByPlayerId: () => new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
-        getOutOfCircleBaseColor: () => '#aa3333',
-        getRosterPlayerIds: () => [1, 2, 9],
-      })
-    )
+    const paint = snapshot({
+      mode: 'diplomacy_family',
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      outOfCircleBaseColor: '#aa3333',
+      rosterPlayerIds: [1, 2, 9],
+    })
+    setPlayerColorResolutionPort({ getSnapshot: () => paint })
     expect(colorForPlayerId(9)).toBe(
       tonalVariantForFamilyMember('#aa3333', 9, [9], null)
     )

--- a/packages/frontend/src/lib/playerColor.ts
+++ b/packages/frontend/src/lib/playerColor.ts
@@ -36,6 +36,10 @@ export const PLAYER_COLOR_PRESET = [
 
 export type PlayerColorMode = 'per_player' | 'diplomacy_family'
 
+export function isPlayerColorMode(value: string): value is PlayerColorMode {
+  return value === 'per_player' || value === 'diplomacy_family'
+}
+
 /** Default base for the diplomacy circle (in-threshold) family. */
 export const DEFAULT_FAMILY_BASE_COLOR = '#34d399'
 

--- a/packages/frontend/src/lib/playerColor.ts
+++ b/packages/frontend/src/lib/playerColor.ts
@@ -4,11 +4,16 @@
  * {@link resolvePlayerColor}. Non-React callers use {@link colorForPlayerId}.
  */
 
-import { hexToRgb } from './cartography/cartographyColor'
+import { tonalVariantForFamilyMember } from './colorTone'
 import {
   DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
   type DiplomacyColorThreshold,
 } from './diplomacyTier'
+
+export {
+  diplomacyFamilyToneOrderIds,
+  tonalVariantForFamilyMember,
+} from './colorTone'
 
 export const PLAYER_COLOR_PRESET = [
   '#38bdf8',
@@ -145,127 +150,6 @@ export function colorFromOverrideOrDefault(
     return override
   }
   return defaultColorForPlayerId(playerId)
-}
-
-function clamp01(value: number): number {
-  if (value < 0) return 0
-  if (value > 1) return 1
-  return value
-}
-
-function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
-  const rn = r / 255
-  const gn = g / 255
-  const bn = b / 255
-  const max = Math.max(rn, gn, bn)
-  const min = Math.min(rn, gn, bn)
-  const l = (max + min) / 2
-  if (max === min) {
-    return [0, 0, l]
-  }
-  const d = max - min
-  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
-  let h = 0
-  switch (max) {
-    case rn:
-      h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6
-      break
-    case gn:
-      h = ((bn - rn) / d + 2) / 6
-      break
-    default:
-      h = ((rn - gn) / d + 4) / 6
-      break
-  }
-  return [h, s, l]
-}
-
-function hueToRgb(p: number, q: number, t: number): number {
-  let tt = t
-  if (tt < 0) tt += 1
-  if (tt > 1) tt -= 1
-  if (tt < 1 / 6) return p + (q - p) * 6 * tt
-  if (tt < 1 / 2) return q
-  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6
-  return p
-}
-
-function hslToRgb(h: number, s: number, l: number): [number, number, number] {
-  if (s === 0) {
-    const v = Math.round(l * 255)
-    return [v, v, v]
-  }
-  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
-  const p = 2 * l - q
-  return [
-    Math.round(hueToRgb(p, q, h + 1 / 3) * 255),
-    Math.round(hueToRgb(p, q, h) * 255),
-    Math.round(hueToRgb(p, q, h - 1 / 3) * 255),
-  ]
-}
-
-function componentToHex(value: number): string {
-  const clamped = Math.max(0, Math.min(255, value))
-  return clamped.toString(16).padStart(2, '0')
-}
-
-function rgbToHex(r: number, g: number, b: number): string {
-  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`
-}
-
-function normalizeHexColor(hex: string): string | null {
-  const trimmed = hex.trim()
-  const raw = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
-  if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
-    return null
-  }
-  return `#${raw.toLowerCase()}`
-}
-
-/**
- * Tone assignment order: other members by ascending id, then ``brightestMemberId``
- * last so they receive the highest lightness.
- */
-export function diplomacyFamilyToneOrderIds(
-  familyMemberIds: readonly number[],
-  brightestMemberId: number | null | undefined
-): number[] {
-  const sorted = [...familyMemberIds].sort((a, b) => a - b)
-  if (brightestMemberId == null || !sorted.includes(brightestMemberId)) {
-    return sorted
-  }
-  return [...sorted.filter((id) => id !== brightestMemberId), brightestMemberId]
-}
-
-/**
- * Deterministic tonal variant of ``familyBaseColor`` for one family member.
- * Stable for a given (base, memberPlayerId, familyMemberIds set, brightestMemberId).
- * ``brightestMemberId`` (viewpoint) always gets the brightest tone when present.
- */
-export function tonalVariantForFamilyMember(
-  familyBaseColor: string,
-  memberPlayerId: number,
-  familyMemberIds: readonly number[],
-  brightestMemberId?: number | null
-): string {
-  const normalizedBase = normalizeHexColor(familyBaseColor) ?? DEFAULT_FAMILY_BASE_COLOR
-  const ordered = diplomacyFamilyToneOrderIds(familyMemberIds, brightestMemberId)
-  const index = ordered.indexOf(memberPlayerId)
-  if (index < 0) {
-    return normalizedBase
-  }
-  const n = ordered.length
-  const [r, g, b] = hexToRgb(normalizedBase)
-  const [h, s, baseL] = rgbToHsl(r, g, b)
-  if (n <= 1) {
-    return normalizedBase
-  }
-  const span = Math.min(0.28, 0.08 * (n - 1))
-  const t = index / (n - 1)
-  const lightness = clamp01(baseL - span / 2 + t * span)
-  const saturation = clamp01(s * (0.92 + 0.16 * (1 - Math.abs(t - 0.5) * 2)))
-  const [nr, ng, nb] = hslToRgb(h, saturation, lightness)
-  return rgbToHex(nr, ng, nb)
 }
 
 /**

--- a/packages/frontend/src/lib/playerColor.ts
+++ b/packages/frontend/src/lib/playerColor.ts
@@ -1,7 +1,13 @@
 /**
  * Shared player identity colors for map/table paint.
- * Settings wires overrides into the storage port without changing callers.
+ * Shell + Settings install a resolution port; call sites use colorForPlayerId.
  */
+
+import { hexToRgb } from './cartography/cartographyColor'
+import {
+  DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
+  type DiplomacyColorThreshold,
+} from './diplomacyTier'
 
 export const PLAYER_COLOR_PRESET = [
   '#38bdf8',
@@ -22,27 +28,58 @@ export const PLAYER_COLOR_PRESET = [
   '#84cc16',
 ] as const
 
+export type PlayerColorMode = 'per_player' | 'diplomacy_family'
+
+export const DEFAULT_FAMILY_BASE_COLOR = '#34d399'
+
 export type PlayerColorOverrides = Readonly<Record<string, string>>
 
-/** Storage port for per-player color overrides. */
-export type PlayerColorOverrideStore = {
+const EMPTY_INBOUND = new Map<number, number>()
+
+/** Paint inputs consulted by {@link colorForPlayerId}. */
+export type PlayerColorResolutionPort = {
+  getMode: () => PlayerColorMode
   getOverride: (playerId: number) => string | undefined
+  getDiplomacyThreshold: () => DiplomacyColorThreshold
+  getFamilyBaseColor: () => string
+  getViewpointPlayerId: () => number | null
+  getInboundRelationFromByPlayerId: () => ReadonlyMap<number, number>
 }
 
-const emptyOverrideStore: PlayerColorOverrideStore = {
+const emptyResolutionPort: PlayerColorResolutionPort = {
+  getMode: () => 'per_player',
   getOverride: () => undefined,
+  getDiplomacyThreshold: () => DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
+  getFamilyBaseColor: () => DEFAULT_FAMILY_BASE_COLOR,
+  getViewpointPlayerId: () => null,
+  getInboundRelationFromByPlayerId: () => EMPTY_INBOUND,
 }
 
-let activeOverrideStore: PlayerColorOverrideStore = emptyOverrideStore
+let activeResolutionPort: PlayerColorResolutionPort = emptyResolutionPort
 
-/** Install the override store consulted by {@link colorForPlayerId}. */
-export function setPlayerColorOverrideStore(store: PlayerColorOverrideStore): void {
-  activeOverrideStore = store
+/** Install the resolution port consulted by {@link colorForPlayerId}. */
+export function setPlayerColorResolutionPort(port: PlayerColorResolutionPort): void {
+  activeResolutionPort = port
 }
 
-/** Restore the empty override store (tests / teardown). */
+/** Restore the empty resolution port (tests / teardown). */
+export function resetPlayerColorResolutionPort(): void {
+  activeResolutionPort = emptyResolutionPort
+}
+
+/** Override-only install helper for tests that do not need full resolution inputs. */
+export function setPlayerColorOverrideStore(store: {
+  getOverride: (playerId: number) => string | undefined
+}): void {
+  setPlayerColorResolutionPort({
+    ...emptyResolutionPort,
+    getOverride: store.getOverride,
+  })
+}
+
+/** Alias for {@link resetPlayerColorResolutionPort}. */
 export function resetPlayerColorOverrideStore(): void {
-  activeOverrideStore = emptyOverrideStore
+  resetPlayerColorResolutionPort()
 }
 
 export function playerColorOverrideStorageKey(playerId: number): string {
@@ -66,12 +103,163 @@ export function colorFromOverrideOrDefault(
   return defaultColorForPlayerId(playerId)
 }
 
+function clamp01(value: number): number {
+  if (value < 0) return 0
+  if (value > 1) return 1
+  return value
+}
+
+function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  const rn = r / 255
+  const gn = g / 255
+  const bn = b / 255
+  const max = Math.max(rn, gn, bn)
+  const min = Math.min(rn, gn, bn)
+  const l = (max + min) / 2
+  if (max === min) {
+    return [0, 0, l]
+  }
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  let h = 0
+  switch (max) {
+    case rn:
+      h = ((gn - bn) / d + (gn < bn ? 6 : 0)) / 6
+      break
+    case gn:
+      h = ((bn - rn) / d + 2) / 6
+      break
+    default:
+      h = ((rn - gn) / d + 4) / 6
+      break
+  }
+  return [h, s, l]
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  let tt = t
+  if (tt < 0) tt += 1
+  if (tt > 1) tt -= 1
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt
+  if (tt < 1 / 2) return q
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6
+  return p
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  if (s === 0) {
+    const v = Math.round(l * 255)
+    return [v, v, v]
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  return [
+    Math.round(hueToRgb(p, q, h + 1 / 3) * 255),
+    Math.round(hueToRgb(p, q, h) * 255),
+    Math.round(hueToRgb(p, q, h - 1 / 3) * 255),
+  ]
+}
+
+function componentToHex(value: number): string {
+  const clamped = Math.max(0, Math.min(255, value))
+  return clamped.toString(16).padStart(2, '0')
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${componentToHex(r)}${componentToHex(g)}${componentToHex(b)}`
+}
+
+function normalizeHexColor(hex: string): string | null {
+  const trimmed = hex.trim()
+  const raw = trimmed.startsWith('#') ? trimmed.slice(1) : trimmed
+  if (!/^[0-9a-fA-F]{6}$/.test(raw)) {
+    return null
+  }
+  return `#${raw.toLowerCase()}`
+}
+
 /**
- * Resolve a player's paint color from the override port, else the preset.
- * Non-React callers and render helpers use this entry point. React paint that
- * must update when Settings changes overrides should use `usePlayerColor`
- * from `stores/playerColors` (subscribes, then resolves through this function).
+ * Deterministic tonal variant of ``familyBaseColor`` for one family member.
+ * Stable for a given (base, memberPlayerId, familyMemberIds set).
+ */
+export function tonalVariantForFamilyMember(
+  familyBaseColor: string,
+  memberPlayerId: number,
+  familyMemberIds: readonly number[]
+): string {
+  const normalizedBase = normalizeHexColor(familyBaseColor) ?? DEFAULT_FAMILY_BASE_COLOR
+  const sorted = [...familyMemberIds].sort((a, b) => a - b)
+  const index = sorted.indexOf(memberPlayerId)
+  if (index < 0) {
+    return normalizedBase
+  }
+  const n = sorted.length
+  const [r, g, b] = hexToRgb(normalizedBase)
+  const [h, s, baseL] = rgbToHsl(r, g, b)
+  if (n <= 1) {
+    return normalizedBase
+  }
+  const span = Math.min(0.28, 0.08 * (n - 1))
+  const t = index / (n - 1)
+  const lightness = clamp01(baseL - span / 2 + t * span)
+  const saturation = clamp01(s * (0.92 + 0.16 * (1 - Math.abs(t - 0.5) * 2)))
+  const [nr, ng, nb] = hslToRgb(h, saturation, lightness)
+  return rgbToHex(nr, ng, nb)
+}
+
+/** Players at or above threshold for the active viewpoint (excludes viewpoint). */
+export function diplomacyColorFamilyMemberIds(
+  inboundRelationFromByPlayerId: ReadonlyMap<number, number>,
+  viewpointPlayerId: number | null,
+  threshold: number
+): number[] {
+  if (viewpointPlayerId == null) {
+    return []
+  }
+  const members: number[] = []
+  for (const [otherId, relationFrom] of inboundRelationFromByPlayerId) {
+    if (otherId === viewpointPlayerId) {
+      continue
+    }
+    if (relationFrom >= threshold) {
+      members.push(otherId)
+    }
+  }
+  members.sort((a, b) => a - b)
+  return members
+}
+
+function colorFromDiplomacyFamily(
+  playerId: number,
+  port: PlayerColorResolutionPort
+): string | null {
+  const viewpointPlayerId = port.getViewpointPlayerId()
+  if (viewpointPlayerId == null || playerId === viewpointPlayerId) {
+    return null
+  }
+  const threshold = port.getDiplomacyThreshold()
+  const inbound = port.getInboundRelationFromByPlayerId()
+  const relationFrom = inbound.get(playerId)
+  if (relationFrom == null || relationFrom < threshold) {
+    return null
+  }
+  const members = diplomacyColorFamilyMemberIds(inbound, viewpointPlayerId, threshold)
+  return tonalVariantForFamilyMember(port.getFamilyBaseColor(), playerId, members)
+}
+
+/**
+ * Resolve a player's paint color from the resolution port.
+ * Non-React callers use this entry point. React paint that must update when
+ * Settings or shell paint context change should use ``usePlayerColor``.
  */
 export function colorForPlayerId(playerId: number): string {
-  return colorFromOverrideOrDefault(playerId, activeOverrideStore.getOverride(playerId))
+  const port = activeResolutionPort
+  if (port.getMode() === 'diplomacy_family') {
+    const familyColor = colorFromDiplomacyFamily(playerId, port)
+    if (familyColor != null) {
+      return familyColor
+    }
+    return defaultColorForPlayerId(playerId)
+  }
+  return colorFromOverrideOrDefault(playerId, port.getOverride(playerId))
 }

--- a/packages/frontend/src/lib/playerColor.ts
+++ b/packages/frontend/src/lib/playerColor.ts
@@ -30,11 +30,16 @@ export const PLAYER_COLOR_PRESET = [
 
 export type PlayerColorMode = 'per_player' | 'diplomacy_family'
 
+/** Default base for the diplomacy circle (in-threshold) family. */
 export const DEFAULT_FAMILY_BASE_COLOR = '#34d399'
+
+/** Default base for the out-of-circle family -- chosen for contrast with the in-circle default. */
+export const DEFAULT_OUT_OF_CIRCLE_BASE_COLOR = '#f43f5e'
 
 export type PlayerColorOverrides = Readonly<Record<string, string>>
 
 const EMPTY_INBOUND = new Map<number, number>()
+const EMPTY_ROSTER: readonly number[] = []
 
 /** Paint inputs consulted by {@link colorForPlayerId}. */
 export type PlayerColorResolutionPort = {
@@ -42,8 +47,11 @@ export type PlayerColorResolutionPort = {
   getOverride: (playerId: number) => string | undefined
   getDiplomacyThreshold: () => DiplomacyColorThreshold
   getFamilyBaseColor: () => string
+  getOutOfCircleBaseColor: () => string
   getViewpointPlayerId: () => number | null
   getInboundRelationFromByPlayerId: () => ReadonlyMap<number, number>
+  /** Game roster player ids (for out-of-circle tone assignment). */
+  getRosterPlayerIds: () => readonly number[]
 }
 
 const emptyResolutionPort: PlayerColorResolutionPort = {
@@ -51,8 +59,10 @@ const emptyResolutionPort: PlayerColorResolutionPort = {
   getOverride: () => undefined,
   getDiplomacyThreshold: () => DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
   getFamilyBaseColor: () => DEFAULT_FAMILY_BASE_COLOR,
+  getOutOfCircleBaseColor: () => DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
   getViewpointPlayerId: () => null,
   getInboundRelationFromByPlayerId: () => EMPTY_INBOUND,
+  getRosterPlayerIds: () => EMPTY_ROSTER,
 }
 
 let activeResolutionPort: PlayerColorResolutionPort = emptyResolutionPort
@@ -179,21 +189,38 @@ function normalizeHexColor(hex: string): string | null {
 }
 
 /**
+ * Tone assignment order: other members by ascending id, then ``brightestMemberId``
+ * last so they receive the highest lightness.
+ */
+export function diplomacyFamilyToneOrderIds(
+  familyMemberIds: readonly number[],
+  brightestMemberId: number | null | undefined
+): number[] {
+  const sorted = [...familyMemberIds].sort((a, b) => a - b)
+  if (brightestMemberId == null || !sorted.includes(brightestMemberId)) {
+    return sorted
+  }
+  return [...sorted.filter((id) => id !== brightestMemberId), brightestMemberId]
+}
+
+/**
  * Deterministic tonal variant of ``familyBaseColor`` for one family member.
- * Stable for a given (base, memberPlayerId, familyMemberIds set).
+ * Stable for a given (base, memberPlayerId, familyMemberIds set, brightestMemberId).
+ * ``brightestMemberId`` (viewpoint) always gets the brightest tone when present.
  */
 export function tonalVariantForFamilyMember(
   familyBaseColor: string,
   memberPlayerId: number,
-  familyMemberIds: readonly number[]
+  familyMemberIds: readonly number[],
+  brightestMemberId?: number | null
 ): string {
   const normalizedBase = normalizeHexColor(familyBaseColor) ?? DEFAULT_FAMILY_BASE_COLOR
-  const sorted = [...familyMemberIds].sort((a, b) => a - b)
-  const index = sorted.indexOf(memberPlayerId)
+  const ordered = diplomacyFamilyToneOrderIds(familyMemberIds, brightestMemberId)
+  const index = ordered.indexOf(memberPlayerId)
   if (index < 0) {
     return normalizedBase
   }
-  const n = sorted.length
+  const n = ordered.length
   const [r, g, b] = hexToRgb(normalizedBase)
   const [h, s, baseL] = rgbToHsl(r, g, b)
   if (n <= 1) {
@@ -207,7 +234,10 @@ export function tonalVariantForFamilyMember(
   return rgbToHex(nr, ng, nb)
 }
 
-/** Players at or above threshold for the active viewpoint (excludes viewpoint). */
+/**
+ * Diplomacy circle (in-family): viewpoint (always) plus others with inbound grant
+ * ``relationfrom >= threshold``.
+ */
 export function diplomacyColorFamilyMemberIds(
   inboundRelationFromByPlayerId: ReadonlyMap<number, number>,
   viewpointPlayerId: number | null,
@@ -216,7 +246,7 @@ export function diplomacyColorFamilyMemberIds(
   if (viewpointPlayerId == null) {
     return []
   }
-  const members: number[] = []
+  const members: number[] = [viewpointPlayerId]
   for (const [otherId, relationFrom] of inboundRelationFromByPlayerId) {
     if (otherId === viewpointPlayerId) {
       continue
@@ -229,22 +259,48 @@ export function diplomacyColorFamilyMemberIds(
   return members
 }
 
+/** Roster players not in the diplomacy circle. */
+export function outOfCircleFamilyMemberIds(
+  rosterPlayerIds: readonly number[],
+  diplomacyCircleMemberIds: readonly number[]
+): number[] {
+  const inCircle = new Set(diplomacyCircleMemberIds)
+  const members = rosterPlayerIds.filter((id) => !inCircle.has(id))
+  members.sort((a, b) => a - b)
+  return members
+}
+
 function colorFromDiplomacyFamily(
   playerId: number,
   port: PlayerColorResolutionPort
 ): string | null {
   const viewpointPlayerId = port.getViewpointPlayerId()
-  if (viewpointPlayerId == null || playerId === viewpointPlayerId) {
+  if (viewpointPlayerId == null) {
     return null
   }
   const threshold = port.getDiplomacyThreshold()
   const inbound = port.getInboundRelationFromByPlayerId()
-  const relationFrom = inbound.get(playerId)
-  if (relationFrom == null || relationFrom < threshold) {
-    return null
+  const inCircle = diplomacyColorFamilyMemberIds(inbound, viewpointPlayerId, threshold)
+  if (inCircle.includes(playerId)) {
+    return tonalVariantForFamilyMember(
+      port.getFamilyBaseColor(),
+      playerId,
+      inCircle,
+      viewpointPlayerId
+    )
   }
-  const members = diplomacyColorFamilyMemberIds(inbound, viewpointPlayerId, threshold)
-  return tonalVariantForFamilyMember(port.getFamilyBaseColor(), playerId, members)
+  const roster = port.getRosterPlayerIds()
+  let outCircle = outOfCircleFamilyMemberIds(roster, inCircle)
+  if (!outCircle.includes(playerId)) {
+    // Painted id missing from roster still gets out-of-circle paint as a singleton.
+    outCircle = [...outCircle, playerId].sort((a, b) => a - b)
+  }
+  return tonalVariantForFamilyMember(
+    port.getOutOfCircleBaseColor(),
+    playerId,
+    outCircle,
+    null
+  )
 }
 
 /**

--- a/packages/frontend/src/lib/playerColor.ts
+++ b/packages/frontend/src/lib/playerColor.ts
@@ -1,6 +1,7 @@
 /**
  * Shared player identity colors for map/table paint.
- * Shell + Settings install a resolution port; call sites use colorForPlayerId.
+ * Build an immutable {@link PlayerColorPaintSnapshot}, then
+ * {@link resolvePlayerColor}. Non-React callers use {@link colorForPlayerId}.
  */
 
 import { hexToRgb } from './cartography/cartographyColor'
@@ -41,55 +42,88 @@ export type PlayerColorOverrides = Readonly<Record<string, string>>
 const EMPTY_INBOUND = new Map<number, number>()
 const EMPTY_ROSTER: readonly number[] = []
 
-/** Paint inputs consulted by {@link colorForPlayerId}. */
+/** Inputs used to build an immutable paint snapshot. */
+export type PlayerColorPaintSnapshotInputs = {
+  mode: PlayerColorMode
+  overrides: PlayerColorOverrides
+  diplomacyThreshold: DiplomacyColorThreshold
+  familyBaseColor: string
+  outOfCircleBaseColor: string
+  viewpointPlayerId: number | null
+  inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+  rosterPlayerIds: readonly number[]
+}
+
+/**
+ * Immutable paint policy inputs. Family membership is precomputed at build time
+ * so resolve is a pure lookup + tonal variant.
+ */
+export type PlayerColorPaintSnapshot = Readonly<{
+  mode: PlayerColorMode
+  overrides: PlayerColorOverrides
+  familyBaseColor: string
+  outOfCircleBaseColor: string
+  viewpointPlayerId: number | null
+  inCircleMemberIds: readonly number[]
+  outOfCircleMemberIds: readonly number[]
+}>
+
+/** Thin port: non-React {@link colorForPlayerId} reads the active snapshot. */
 export type PlayerColorResolutionPort = {
-  getMode: () => PlayerColorMode
-  getOverride: (playerId: number) => string | undefined
-  getDiplomacyThreshold: () => DiplomacyColorThreshold
-  getFamilyBaseColor: () => string
-  getOutOfCircleBaseColor: () => string
-  getViewpointPlayerId: () => number | null
-  getInboundRelationFromByPlayerId: () => ReadonlyMap<number, number>
-  /** Game roster player ids (for out-of-circle tone assignment). */
-  getRosterPlayerIds: () => readonly number[]
+  getSnapshot: () => PlayerColorPaintSnapshot
+}
+
+export const EMPTY_PLAYER_COLOR_PAINT_SNAPSHOT: PlayerColorPaintSnapshot = {
+  mode: 'per_player',
+  overrides: {},
+  familyBaseColor: DEFAULT_FAMILY_BASE_COLOR,
+  outOfCircleBaseColor: DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
+  viewpointPlayerId: null,
+  inCircleMemberIds: EMPTY_ROSTER,
+  outOfCircleMemberIds: EMPTY_ROSTER,
 }
 
 const emptyResolutionPort: PlayerColorResolutionPort = {
-  getMode: () => 'per_player',
-  getOverride: () => undefined,
-  getDiplomacyThreshold: () => DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
-  getFamilyBaseColor: () => DEFAULT_FAMILY_BASE_COLOR,
-  getOutOfCircleBaseColor: () => DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
-  getViewpointPlayerId: () => null,
-  getInboundRelationFromByPlayerId: () => EMPTY_INBOUND,
-  getRosterPlayerIds: () => EMPTY_ROSTER,
+  getSnapshot: () => EMPTY_PLAYER_COLOR_PAINT_SNAPSHOT,
 }
 
 let activeResolutionPort: PlayerColorResolutionPort = emptyResolutionPort
 
-/** Install the resolution port consulted by {@link colorForPlayerId}. */
+/** Install the snapshot port consulted by {@link colorForPlayerId}. */
 export function setPlayerColorResolutionPort(port: PlayerColorResolutionPort): void {
   activeResolutionPort = port
 }
 
-/** Restore the empty resolution port (tests / teardown). */
+/** Restore the empty snapshot port (tests / teardown). */
 export function resetPlayerColorResolutionPort(): void {
   activeResolutionPort = emptyResolutionPort
 }
 
-/** Override-only install helper for tests that do not need full resolution inputs. */
-export function setPlayerColorOverrideStore(store: {
-  getOverride: (playerId: number) => string | undefined
-}): void {
-  setPlayerColorResolutionPort({
-    ...emptyResolutionPort,
-    getOverride: store.getOverride,
-  })
-}
-
-/** Alias for {@link resetPlayerColorResolutionPort}. */
-export function resetPlayerColorOverrideStore(): void {
-  resetPlayerColorResolutionPort()
+/**
+ * Build an immutable paint snapshot, precomputing in-circle and out-of-circle
+ * membership for diplomacy-family resolve.
+ */
+export function buildPlayerColorPaintSnapshot(
+  inputs: PlayerColorPaintSnapshotInputs
+): PlayerColorPaintSnapshot {
+  const inCircleMemberIds = diplomacyColorFamilyMemberIds(
+    inputs.inboundRelationFromByPlayerId,
+    inputs.viewpointPlayerId,
+    inputs.diplomacyThreshold
+  )
+  const outOfCircleMemberIds = outOfCircleFamilyMemberIds(
+    inputs.rosterPlayerIds,
+    inCircleMemberIds
+  )
+  return {
+    mode: inputs.mode,
+    overrides: inputs.overrides,
+    familyBaseColor: inputs.familyBaseColor,
+    outOfCircleBaseColor: inputs.outOfCircleBaseColor,
+    viewpointPlayerId: inputs.viewpointPlayerId,
+    inCircleMemberIds,
+    outOfCircleMemberIds,
+  }
 }
 
 export function playerColorOverrideStorageKey(playerId: number): string {
@@ -272,50 +306,69 @@ export function outOfCircleFamilyMemberIds(
 
 function colorFromDiplomacyFamily(
   playerId: number,
-  port: PlayerColorResolutionPort
+  snapshot: PlayerColorPaintSnapshot
 ): string | null {
-  const viewpointPlayerId = port.getViewpointPlayerId()
-  if (viewpointPlayerId == null) {
+  if (snapshot.viewpointPlayerId == null) {
     return null
   }
-  const threshold = port.getDiplomacyThreshold()
-  const inbound = port.getInboundRelationFromByPlayerId()
-  const inCircle = diplomacyColorFamilyMemberIds(inbound, viewpointPlayerId, threshold)
-  if (inCircle.includes(playerId)) {
+  if (snapshot.inCircleMemberIds.includes(playerId)) {
     return tonalVariantForFamilyMember(
-      port.getFamilyBaseColor(),
+      snapshot.familyBaseColor,
       playerId,
-      inCircle,
-      viewpointPlayerId
+      snapshot.inCircleMemberIds,
+      snapshot.viewpointPlayerId
     )
   }
-  const roster = port.getRosterPlayerIds()
-  let outCircle = outOfCircleFamilyMemberIds(roster, inCircle)
+  let outCircle = snapshot.outOfCircleMemberIds
   if (!outCircle.includes(playerId)) {
     // Painted id missing from roster still gets out-of-circle paint as a singleton.
     outCircle = [...outCircle, playerId].sort((a, b) => a - b)
   }
   return tonalVariantForFamilyMember(
-    port.getOutOfCircleBaseColor(),
+    snapshot.outOfCircleBaseColor,
     playerId,
     outCircle,
     null
   )
 }
 
-/**
- * Resolve a player's paint color from the resolution port.
- * Non-React callers use this entry point. React paint that must update when
- * Settings or shell paint context change should use ``usePlayerColor``.
- */
-export function colorForPlayerId(playerId: number): string {
-  const port = activeResolutionPort
-  if (port.getMode() === 'diplomacy_family') {
-    const familyColor = colorFromDiplomacyFamily(playerId, port)
+/** Pure paint policy: resolve a player color from an immutable snapshot. */
+export function resolvePlayerColor(
+  playerId: number,
+  snapshot: PlayerColorPaintSnapshot
+): string {
+  if (snapshot.mode === 'diplomacy_family') {
+    const familyColor = colorFromDiplomacyFamily(playerId, snapshot)
     if (familyColor != null) {
       return familyColor
     }
     return defaultColorForPlayerId(playerId)
   }
-  return colorFromOverrideOrDefault(playerId, port.getOverride(playerId))
+  return colorFromOverrideOrDefault(
+    playerId,
+    snapshot.overrides[playerColorOverrideStorageKey(playerId)]
+  )
+}
+
+/**
+ * Resolve a player's paint color from the active snapshot port.
+ * Non-React callers use this entry point. React paint that must update when
+ * Settings or shell paint context change should use ``usePlayerColor``.
+ */
+export function colorForPlayerId(playerId: number): string {
+  return resolvePlayerColor(playerId, activeResolutionPort.getSnapshot())
+}
+
+/** Default snapshot inputs (empty shell context, default knobs). */
+export function defaultPlayerColorPaintSnapshotInputs(): PlayerColorPaintSnapshotInputs {
+  return {
+    mode: 'per_player',
+    overrides: {},
+    diplomacyThreshold: DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
+    familyBaseColor: DEFAULT_FAMILY_BASE_COLOR,
+    outOfCircleBaseColor: DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
+    viewpointPlayerId: null,
+    inboundRelationFromByPlayerId: EMPTY_INBOUND,
+    rosterPlayerIds: EMPTY_ROSTER,
+  }
 }

--- a/packages/frontend/src/lib/turnRelations.test.ts
+++ b/packages/frontend/src/lib/turnRelations.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  inboundRelationFromByPlayerId,
+  turnRelationsFromPayload,
+} from './turnRelations'
+
+describe('turnRelationsFromPayload', () => {
+  it('parses relation rows from turn ensure payload', () => {
+    const edges = turnRelationsFromPayload({
+      relations: [
+        {
+          playerid: 10,
+          playertoid: 2,
+          relationfrom: 2,
+          relationto: 1,
+          color: '#fff',
+        },
+        { playerid: 10, playertoid: 3, relationfrom: 0, relationto: 0 },
+        { playerid: 'bad', playertoid: 1, relationfrom: 1, relationto: 1 },
+      ],
+    })
+    expect(edges).toEqual([
+      { playerid: 10, playertoid: 2, relationfrom: 2, relationto: 1 },
+      { playerid: 10, playertoid: 3, relationfrom: 0, relationto: 0 },
+    ])
+  })
+
+  it('returns empty for missing relations', () => {
+    expect(turnRelationsFromPayload(null)).toEqual([])
+    expect(turnRelationsFromPayload({})).toEqual([])
+  })
+})
+
+describe('inboundRelationFromByPlayerId', () => {
+  it('maps other players to relationfrom for the viewpoint', () => {
+    const map = inboundRelationFromByPlayerId(
+      [
+        { playerid: 10, playertoid: 2, relationfrom: 2, relationto: 1 },
+        { playerid: 10, playertoid: 10, relationfrom: 4, relationto: 4 },
+        { playerid: 2, playertoid: 10, relationfrom: 4, relationto: 2 },
+      ],
+      10
+    )
+    expect([...map.entries()]).toEqual([[2, 2]])
+  })
+})

--- a/packages/frontend/src/lib/turnRelations.ts
+++ b/packages/frontend/src/lib/turnRelations.ts
@@ -1,0 +1,68 @@
+/** Minimal turn Relation fields needed for diplomacy-family player color. */
+export type TurnRelationEdge = {
+  playerid: number
+  playertoid: number
+  relationfrom: number
+  relationto: number
+}
+
+function readFiniteInt(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  return Math.trunc(value)
+}
+
+/** Parse ``relations`` from a turn ensure / TurnInfo JSON payload. */
+export function turnRelationsFromPayload(data: unknown): TurnRelationEdge[] {
+  if (data == null || typeof data !== 'object') {
+    return []
+  }
+  const record = data as Record<string, unknown>
+  const raw = record.relations
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const edges: TurnRelationEdge[] = []
+  for (const entry of raw) {
+    if (entry == null || typeof entry !== 'object') {
+      continue
+    }
+    const row = entry as Record<string, unknown>
+    const playerid = readFiniteInt(row.playerid)
+    const playertoid = readFiniteInt(row.playertoid)
+    const relationfrom = readFiniteInt(row.relationfrom)
+    const relationto = readFiniteInt(row.relationto)
+    if (
+      playerid == null ||
+      playertoid == null ||
+      relationfrom == null ||
+      relationto == null
+    ) {
+      continue
+    }
+    edges.push({ playerid, playertoid, relationfrom, relationto })
+  }
+  return edges
+}
+
+/**
+ * Inbound grants to ``viewpointPlayerId``: other player id → ``relationfrom``.
+ * Only rows where ``playerid === viewpoint``; self rows skipped.
+ */
+export function inboundRelationFromByPlayerId(
+  relations: readonly TurnRelationEdge[],
+  viewpointPlayerId: number
+): Map<number, number> {
+  const map = new Map<number, number>()
+  for (const edge of relations) {
+    if (edge.playerid !== viewpointPlayerId) {
+      continue
+    }
+    if (edge.playertoid === viewpointPlayerId) {
+      continue
+    }
+    map.set(edge.playertoid, edge.relationfrom)
+  }
+  return map
+}

--- a/packages/frontend/src/shell/useShellContext.test.tsx
+++ b/packages/frontend/src/shell/useShellContext.test.tsx
@@ -5,8 +5,15 @@ import type { ReactNode } from 'react'
 import { useShellContext } from './useShellContext'
 import { useShellStore } from '../stores/shell'
 import { useSessionStore } from '../stores/session'
+import {
+  installPlayerColorsStorePort,
+  resetPlayerColorsStoreState,
+  usePlayerColorsStore,
+} from '../stores/playerColors'
 import { EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES } from '../analytics/stellar-cartography/layers'
+import { DiplomacyTier } from '../lib/diplomacyTier'
 import { perspectiveRow } from '../lib/perspectiveRowTestFixtures'
+import { resetPlayerColorResolutionPort } from '../lib/playerColor'
 
 vi.mock('../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/bff')>()
@@ -34,6 +41,9 @@ describe('useShellContext', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetPlayerColorsStoreState()
+    resetPlayerColorResolutionPort()
+    installPlayerColorsStorePort()
     useSessionStore.setState({ name: 'Alice', password: '', credentialsRevision: 0 })
     useShellStore.setState({
       selectedGameId: null,
@@ -199,7 +209,11 @@ describe('useShellContext', () => {
     useSessionStore.setState({ name: 'Alice', password: 'wrong', credentialsRevision: 1 })
     vi.mocked(ensureTurnData)
       .mockRejectedValueOnce(new Error('Bad password'))
-      .mockResolvedValueOnce({ ready: true, turnUsernamesByPlayerId: new Map() })
+      .mockResolvedValueOnce({
+        ready: true,
+        turnUsernamesByPlayerId: new Map(),
+        turnRelations: [],
+      })
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     useShellStore.setState({
       selectedGameId: '628580',
@@ -367,5 +381,118 @@ describe('useShellContext', () => {
         perspective: 0,
       })
     })
+  })
+
+  it('installs player color paint context from ensure turn relations', async () => {
+    vi.mocked(ensureTurnData).mockResolvedValue({
+      ready: true,
+      turnUsernamesByPlayerId: new Map(),
+      turnRelations: [
+        {
+          playerid: 10,
+          playertoid: 20,
+          relationfrom: DiplomacyTier.SAFE_PASSAGE,
+          relationto: DiplomacyTier.AMBASSADOR,
+        },
+        {
+          playerid: 10,
+          playertoid: 30,
+          relationfrom: DiplomacyTier.NONE,
+          relationto: DiplomacyTier.NONE,
+        },
+        {
+          playerid: 20,
+          playertoid: 10,
+          relationfrom: DiplomacyTier.FULL_ALLIANCE,
+          relationto: DiplomacyTier.SAFE_PASSAGE,
+        },
+      ],
+    })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    useShellStore.setState({
+      selectedGameId: '628580',
+      gameInfoContext: {
+        turn: 10,
+        perspectives: [
+          perspectiveRow(1, 'Alice', { playerId: 10 }),
+          perspectiveRow(2, 'Bob', { playerId: 20 }),
+          perspectiveRow(3, 'Carol', { playerId: 30 }),
+        ],
+        isGameFinished: true,
+        sectorDisplayName: null,
+        stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+        homeworldInactiveReason: null,
+      },
+      selectedTurn: 5,
+    })
+
+    renderHook(() => useShellContext({ reportShellError }), {
+      wrapper: createWrapper(client),
+    })
+
+    await waitFor(() => {
+      expect(usePlayerColorsStore.getState().viewpointPlayerId).toBe(10)
+    })
+    const paint = usePlayerColorsStore.getState()
+    expect([...paint.inboundRelationFromByPlayerId.entries()]).toEqual([
+      [20, DiplomacyTier.SAFE_PASSAGE],
+      [30, DiplomacyTier.NONE],
+    ])
+    expect(paint.rosterPlayerIds).toEqual([10, 20, 30])
+    expect(paint.paintSnapshot.viewpointPlayerId).toBe(10)
+    expect(paint.paintSnapshot.inCircleMemberIds).toEqual([10, 20])
+    expect(paint.paintSnapshot.outOfCircleMemberIds).toEqual([30])
+  })
+
+  it('clears player color paint context when turn ensure is no longer ready', async () => {
+    vi.mocked(ensureTurnData).mockResolvedValue({
+      ready: true,
+      turnUsernamesByPlayerId: new Map(),
+      turnRelations: [
+        {
+          playerid: 10,
+          playertoid: 20,
+          relationfrom: DiplomacyTier.SAFE_PASSAGE,
+          relationto: DiplomacyTier.NONE,
+        },
+      ],
+    })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    useShellStore.setState({
+      selectedGameId: '628580',
+      gameInfoContext: {
+        turn: 10,
+        perspectives: [
+          perspectiveRow(1, 'Alice', { playerId: 10 }),
+          perspectiveRow(2, 'Bob', { playerId: 20 }),
+        ],
+        isGameFinished: true,
+        sectorDisplayName: null,
+        stellarCartographyGates: { ...EMPTY_STELLAR_CARTOGRAPHY_SETTINGS_GATES },
+        homeworldInactiveReason: null,
+      },
+      selectedTurn: 5,
+    })
+
+    const { rerender } = renderHook(() => useShellContext({ reportShellError }), {
+      wrapper: createWrapper(client),
+    })
+
+    await waitFor(() => {
+      expect(usePlayerColorsStore.getState().viewpointPlayerId).toBe(10)
+    })
+
+    useShellStore.setState({
+      selectedGameId: null,
+      gameInfoContext: null,
+      selectedTurn: null,
+    })
+    rerender()
+
+    await waitFor(() => {
+      expect(usePlayerColorsStore.getState().viewpointPlayerId).toBeNull()
+    })
+    expect(usePlayerColorsStore.getState().rosterPlayerIds).toEqual([])
+    expect(usePlayerColorsStore.getState().inboundRelationFromByPlayerId.size).toBe(0)
   })
 })

--- a/packages/frontend/src/shell/useShellContext.test.tsx
+++ b/packages/frontend/src/shell/useShellContext.test.tsx
@@ -12,7 +12,11 @@ vi.mock('../api/bff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../api/bff')>()
   return {
     ...actual,
-    ensureTurnData: vi.fn().mockResolvedValue({ ready: true, turnUsernamesByPlayerId: new Map() }),
+    ensureTurnData: vi.fn().mockResolvedValue({
+      ready: true,
+      turnUsernamesByPlayerId: new Map(),
+      turnRelations: [],
+    }),
     fetchStoredTurnPerspectives: vi.fn().mockResolvedValue({ perspectives: [1] }),
   }
 })

--- a/packages/frontend/src/shell/useShellContext.ts
+++ b/packages/frontend/src/shell/useShellContext.ts
@@ -5,9 +5,17 @@ import {
   fetchStoredTurnPerspectives,
   type AnalyticShellScope,
 } from '../api/bff'
-import { LOGIN_REQUIRED_FOR_GAME_SELECTION } from '../lib/gameInfoShell'
+import {
+  LOGIN_REQUIRED_FOR_GAME_SELECTION,
+  playerIdForPerspectiveOrdinal,
+} from '../lib/gameInfoShell'
+import { inboundRelationFromByPlayerId } from '../lib/turnRelations'
 import { useSessionStore } from '../stores/session'
 import { useShellStore } from '../stores/shell'
+import {
+  clearPlayerColorPaintContext,
+  usePlayerColorsStore,
+} from '../stores/playerColors'
 import {
   deriveAnalyticScope,
   deriveSelectedViewpointOrdinal,
@@ -141,6 +149,7 @@ export function useShellContext({ reportShellError }: UseShellContextOptions): S
   })
 
   const turnUsernamesByPlayerId = turnEnsureData?.turnUsernamesByPlayerId ?? null
+  const turnRelations = turnEnsureData?.turnRelations ?? null
 
   const shellInputs = useMemo(
     () => ({
@@ -179,6 +188,33 @@ export function useShellContext({ reportShellError }: UseShellContextOptions): S
     () => deriveSelectedViewpointOrdinal(shellInputs),
     [shellInputs]
   )
+
+  useEffect(() => {
+    if (!turnEnsureSuccess || turnRelations == null || gameInfoContext == null) {
+      clearPlayerColorPaintContext()
+      return
+    }
+    const viewpointPlayerId = playerIdForPerspectiveOrdinal(
+      gameInfoContext.perspectives,
+      selectedViewpointOrdinal
+    )
+    if (viewpointPlayerId == null) {
+      clearPlayerColorPaintContext()
+      return
+    }
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId,
+      inboundRelationFromByPlayerId: inboundRelationFromByPlayerId(
+        turnRelations,
+        viewpointPlayerId
+      ),
+    })
+  }, [
+    turnEnsureSuccess,
+    turnRelations,
+    gameInfoContext,
+    selectedViewpointOrdinal,
+  ])
 
   useEffect(() => {
     if (

--- a/packages/frontend/src/shell/useShellContext.ts
+++ b/packages/frontend/src/shell/useShellContext.ts
@@ -208,6 +208,7 @@ export function useShellContext({ reportShellError }: UseShellContextOptions): S
         turnRelations,
         viewpointPlayerId
       ),
+      rosterPlayerIds: gameInfoContext.perspectives.map((p) => p.playerId),
     })
   }, [
     turnEnsureSuccess,

--- a/packages/frontend/src/stores/playerColors.test.ts
+++ b/packages/frontend/src/stores/playerColors.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   clearPlayerColorPaintContext,
   installPlayerColorsStorePort,
+  PLAYER_COLORS_STORAGE_KEY,
   resetPlayerColorsStoreState,
   usePlayerColor,
   usePlayerColorsStore,
@@ -17,6 +18,7 @@ import {
 
 describe('usePlayerColorsStore', () => {
   beforeEach(() => {
+    localStorage.removeItem(PLAYER_COLORS_STORAGE_KEY)
     resetPlayerColorsStoreState()
     resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()
@@ -90,10 +92,94 @@ describe('usePlayerColorsStore', () => {
 
     usePlayerColorsStore.getState().setPaintContext({
       viewpointPlayerId: 1,
-      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.ALLIANCE]]),
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.FULL_ALLIANCE]]),
       rosterPlayerIds: [1, 2, 3],
     })
     expect(usePlayerColorsStore.getState().paintSnapshot).not.toBe(snapshotBefore)
+  })
+
+  it('persists mode, threshold, bases, and overrides to localStorage', () => {
+    usePlayerColorsStore.getState().setPlayerColorOverride(3, '#112233')
+    usePlayerColorsStore.getState().setPlayerColorMode('diplomacy_family')
+    usePlayerColorsStore.getState().setDiplomacyThreshold(DiplomacyTier.SHARE_INTEL)
+    usePlayerColorsStore.getState().setFamilyBaseColor('#336699')
+    usePlayerColorsStore.getState().setOutOfCircleBaseColor('#aa3333')
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      rosterPlayerIds: [1, 2],
+    })
+
+    const raw = localStorage.getItem(PLAYER_COLORS_STORAGE_KEY)
+    expect(raw).toBeTruthy()
+    expect(raw).toContain('"mode":"diplomacy_family"')
+    expect(raw).toContain('"diplomacyThreshold":3')
+    expect(raw).toContain('"familyBaseColor":"#336699"')
+    expect(raw).toContain('"outOfCircleBaseColor":"#aa3333"')
+    expect(raw).toContain('"3":"#112233"')
+    expect(raw).not.toContain('viewpointPlayerId')
+    expect(raw).not.toContain('inboundRelationFromByPlayerId')
+    expect(raw).not.toContain('rosterPlayerIds')
+    expect(raw).not.toContain('paintSnapshot')
+  })
+
+  it('rehydrates persisted knobs and rebuilds the paint snapshot', async () => {
+    localStorage.setItem(
+      PLAYER_COLORS_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          overrides: { '3': '#112233' },
+          mode: 'diplomacy_family',
+          diplomacyThreshold: DiplomacyTier.SHARE_INTEL,
+          familyBaseColor: '#336699',
+          outOfCircleBaseColor: '#aa3333',
+        },
+        version: 0,
+      })
+    )
+
+    await usePlayerColorsStore.persist.rehydrate()
+
+    const state = usePlayerColorsStore.getState()
+    expect(state.mode).toBe('diplomacy_family')
+    expect(state.diplomacyThreshold).toBe(DiplomacyTier.SHARE_INTEL)
+    expect(state.familyBaseColor).toBe('#336699')
+    expect(state.outOfCircleBaseColor).toBe('#aa3333')
+    expect(state.overrides['3']).toBe('#112233')
+    expect(state.viewpointPlayerId).toBeNull()
+    expect(state.rosterPlayerIds).toEqual([])
+    expect(state.paintSnapshot.mode).toBe('diplomacy_family')
+    expect(state.paintSnapshot.familyBaseColor).toBe('#336699')
+    expect(state.paintSnapshot.overrides['3']).toBe('#112233')
+  })
+
+  it('ignores invalid persisted mode and threshold on rehydrate', async () => {
+    usePlayerColorsStore.getState().setPlayerColorMode('diplomacy_family')
+    usePlayerColorsStore.getState().setDiplomacyThreshold(DiplomacyTier.FULL_ALLIANCE)
+    usePlayerColorsStore.getState().setFamilyBaseColor('#abcdef')
+
+    localStorage.setItem(
+      PLAYER_COLORS_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          overrides: { '1': '#000001' },
+          mode: 'not_a_mode',
+          diplomacyThreshold: -1,
+          familyBaseColor: '',
+          outOfCircleBaseColor: '#aa3333',
+        },
+        version: 0,
+      })
+    )
+
+    await usePlayerColorsStore.persist.rehydrate()
+
+    const state = usePlayerColorsStore.getState()
+    expect(state.mode).toBe('diplomacy_family')
+    expect(state.diplomacyThreshold).toBe(DiplomacyTier.FULL_ALLIANCE)
+    expect(state.familyBaseColor).toBe('#abcdef')
+    expect(state.outOfCircleBaseColor).toBe('#aa3333')
+    expect(state.overrides['1']).toBe('#000001')
   })
 
   it('clearPlayerColorPaintContext is a no-op when already cleared', () => {

--- a/packages/frontend/src/stores/playerColors.test.ts
+++ b/packages/frontend/src/stores/playerColors.test.ts
@@ -8,6 +8,7 @@ import {
   tonalVariantForFamilyMember,
 } from '../lib/playerColor'
 import {
+  clearPlayerColorPaintContext,
   installPlayerColorsStorePort,
   resetPlayerColorsStoreState,
   usePlayerColor,
@@ -70,5 +71,49 @@ describe('usePlayerColorsStore', () => {
       })
     })
     expect(result.current).toBe(tonalVariantForFamilyMember('#336699', 2, [1, 2], 1))
+  })
+
+  it('setPaintContext is a no-op when viewpoint, inbound map, and roster are unchanged', () => {
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      rosterPlayerIds: [1, 2, 3],
+    })
+    const snapshotBefore = usePlayerColorsStore.getState().paintSnapshot
+
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      rosterPlayerIds: [1, 2, 3],
+    })
+    expect(usePlayerColorsStore.getState().paintSnapshot).toBe(snapshotBefore)
+
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.ALLIANCE]]),
+      rosterPlayerIds: [1, 2, 3],
+    })
+    expect(usePlayerColorsStore.getState().paintSnapshot).not.toBe(snapshotBefore)
+  })
+
+  it('clearPlayerColorPaintContext is a no-op when already cleared', () => {
+    const snapshotBefore = usePlayerColorsStore.getState().paintSnapshot
+    clearPlayerColorPaintContext()
+    expect(usePlayerColorsStore.getState().paintSnapshot).toBe(snapshotBefore)
+
+    usePlayerColorsStore.getState().setPaintContext({
+      viewpointPlayerId: 1,
+      inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      rosterPlayerIds: [1, 2],
+    })
+    const painted = usePlayerColorsStore.getState().paintSnapshot
+    expect(painted).not.toBe(snapshotBefore)
+
+    clearPlayerColorPaintContext()
+    const cleared = usePlayerColorsStore.getState().paintSnapshot
+    expect(cleared).not.toBe(painted)
+
+    clearPlayerColorPaintContext()
+    expect(usePlayerColorsStore.getState().paintSnapshot).toBe(cleared)
   })
 })

--- a/packages/frontend/src/stores/playerColors.test.ts
+++ b/packages/frontend/src/stores/playerColors.test.ts
@@ -9,39 +9,26 @@ import {
 } from '../lib/playerColor'
 import {
   installPlayerColorsStorePort,
+  resetPlayerColorsStoreState,
   usePlayerColor,
   usePlayerColorsStore,
 } from './playerColors'
 
 describe('usePlayerColorsStore', () => {
   beforeEach(() => {
-    usePlayerColorsStore.setState({
-      overrides: {},
-      mode: 'per_player',
-      diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
-      familyBaseColor: '#34d399',
-      outOfCircleBaseColor: '#f43f5e',
-      viewpointPlayerId: null,
-      inboundRelationFromByPlayerId: new Map(),
-      rosterPlayerIds: [],
-      paintRevision: 0,
-    })
+    resetPlayerColorsStoreState()
     resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()
   })
 
   it('starts with empty overrides and returns preset defaults', () => {
     expect(usePlayerColorsStore.getState().overrides).toEqual({})
-    expect(usePlayerColorsStore.getState().colorForPlayerId(3)).toBe(
-      defaultColorForPlayerId(3)
-    )
     expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
   })
 
-  it('setPlayerColorOverride updates the resolution port used by colorForPlayerId', () => {
+  it('setPlayerColorOverride updates the snapshot used by colorForPlayerId', () => {
     usePlayerColorsStore.getState().setPlayerColorOverride(3, '#112233')
     expect(colorForPlayerId(3)).toBe('#112233')
-    expect(usePlayerColorsStore.getState().colorForPlayerId(3)).toBe('#112233')
 
     usePlayerColorsStore.getState().setPlayerColorOverride(3, null)
     expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))

--- a/packages/frontend/src/stores/playerColors.test.ts
+++ b/packages/frontend/src/stores/playerColors.test.ts
@@ -20,8 +20,10 @@ describe('usePlayerColorsStore', () => {
       mode: 'per_player',
       diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
       familyBaseColor: '#34d399',
+      outOfCircleBaseColor: '#f43f5e',
       viewpointPlayerId: null,
       inboundRelationFromByPlayerId: new Map(),
+      rosterPlayerIds: [],
       paintRevision: 0,
     })
     resetPlayerColorResolutionPort()
@@ -77,8 +79,9 @@ describe('usePlayerColorsStore', () => {
       usePlayerColorsStore.getState().setPaintContext({
         viewpointPlayerId: 1,
         inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+        rosterPlayerIds: [1, 2, 3],
       })
     })
-    expect(result.current).toBe(tonalVariantForFamilyMember('#336699', 2, [2]))
+    expect(result.current).toBe(tonalVariantForFamilyMember('#336699', 2, [1, 2], 1))
   })
 })

--- a/packages/frontend/src/stores/playerColors.test.ts
+++ b/packages/frontend/src/stores/playerColors.test.ts
@@ -1,9 +1,11 @@
 import { renderHook, act } from '@testing-library/react'
 import { beforeEach, describe, expect, it } from 'vitest'
+import { DiplomacyTier } from '../lib/diplomacyTier'
 import {
   colorForPlayerId,
   defaultColorForPlayerId,
-  resetPlayerColorOverrideStore,
+  resetPlayerColorResolutionPort,
+  tonalVariantForFamilyMember,
 } from '../lib/playerColor'
 import {
   installPlayerColorsStorePort,
@@ -13,8 +15,16 @@ import {
 
 describe('usePlayerColorsStore', () => {
   beforeEach(() => {
-    usePlayerColorsStore.setState({ overrides: {} })
-    resetPlayerColorOverrideStore()
+    usePlayerColorsStore.setState({
+      overrides: {},
+      mode: 'per_player',
+      diplomacyThreshold: DiplomacyTier.SAFE_PASSAGE,
+      familyBaseColor: '#34d399',
+      viewpointPlayerId: null,
+      inboundRelationFromByPlayerId: new Map(),
+      paintRevision: 0,
+    })
+    resetPlayerColorResolutionPort()
     installPlayerColorsStorePort()
   })
 
@@ -26,13 +36,22 @@ describe('usePlayerColorsStore', () => {
     expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
   })
 
-  it('setPlayerColorOverride updates the storage port used by colorForPlayerId', () => {
+  it('setPlayerColorOverride updates the resolution port used by colorForPlayerId', () => {
     usePlayerColorsStore.getState().setPlayerColorOverride(3, '#112233')
     expect(colorForPlayerId(3)).toBe('#112233')
     expect(usePlayerColorsStore.getState().colorForPlayerId(3)).toBe('#112233')
 
     usePlayerColorsStore.getState().setPlayerColorOverride(3, null)
     expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
+  })
+
+  it('preserves overrides when switching to diplomacy-family mode', () => {
+    usePlayerColorsStore.getState().setPlayerColorOverride(3, '#112233')
+    usePlayerColorsStore.getState().setPlayerColorMode('diplomacy_family')
+    expect(usePlayerColorsStore.getState().overrides['3']).toBe('#112233')
+    expect(colorForPlayerId(3)).toBe(defaultColorForPlayerId(3))
+    usePlayerColorsStore.getState().setPlayerColorMode('per_player')
+    expect(colorForPlayerId(3)).toBe('#112233')
   })
 
   it('usePlayerColor re-renders when the player override changes', () => {
@@ -48,5 +67,18 @@ describe('usePlayerColorsStore', () => {
       usePlayerColorsStore.getState().setPlayerColorOverride(3, null)
     })
     expect(result.current).toBe(defaultColorForPlayerId(3))
+  })
+
+  it('usePlayerColor re-renders when diplomacy paint context changes', () => {
+    const { result } = renderHook(() => usePlayerColor(2))
+    act(() => {
+      usePlayerColorsStore.getState().setPlayerColorMode('diplomacy_family')
+      usePlayerColorsStore.getState().setFamilyBaseColor('#336699')
+      usePlayerColorsStore.getState().setPaintContext({
+        viewpointPlayerId: 1,
+        inboundRelationFromByPlayerId: new Map([[2, DiplomacyTier.SAFE_PASSAGE]]),
+      })
+    })
+    expect(result.current).toBe(tonalVariantForFamilyMember('#336699', 2, [2]))
   })
 })

--- a/packages/frontend/src/stores/playerColors.ts
+++ b/packages/frontend/src/stores/playerColors.ts
@@ -6,13 +6,17 @@ import {
   type DiplomacyColorThreshold,
 } from '../lib/diplomacyTier'
 import {
-  colorForPlayerId as resolvePlayerColor,
+  buildPlayerColorPaintSnapshot,
   DEFAULT_FAMILY_BASE_COLOR,
   DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
+  defaultPlayerColorPaintSnapshotInputs,
   playerColorOverrideStorageKey,
+  resolvePlayerColor,
   setPlayerColorResolutionPort,
   type PlayerColorMode,
   type PlayerColorOverrides,
+  type PlayerColorPaintSnapshot,
+  type PlayerColorPaintSnapshotInputs,
 } from '../lib/playerColor'
 import { createLocalStorageOrMemoryStateStorage } from '../lib/browserPersistStorage'
 
@@ -36,8 +40,8 @@ type PlayerColorsState = PlayerColorsPersisted & {
   viewpointPlayerId: number | null
   inboundRelationFromByPlayerId: ReadonlyMap<number, number>
   rosterPlayerIds: readonly number[]
-  /** Bumps so ``usePlayerColor`` re-renders on any paint-affecting change. */
-  paintRevision: number
+  /** Immutable paint snapshot; rebuilt when knobs or shell context change. */
+  paintSnapshot: PlayerColorPaintSnapshot
   setPlayerColorOverride: (playerId: number, color: string | null) => void
   setPlayerColorMode: (mode: PlayerColorMode) => void
   setDiplomacyThreshold: (threshold: DiplomacyColorThreshold) => void
@@ -48,12 +52,47 @@ type PlayerColorsState = PlayerColorsPersisted & {
     inboundRelationFromByPlayerId: ReadonlyMap<number, number>
     rosterPlayerIds: readonly number[]
   }) => void
-  colorForPlayerId: (playerId: number) => string
 }
 
-function bumpRevision(state: PlayerColorsState): number {
-  return state.paintRevision + 1
+function snapshotInputsFromState(
+  state: PlayerColorsPersisted & {
+    viewpointPlayerId: number | null
+    inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+    rosterPlayerIds: readonly number[]
+  }
+): PlayerColorPaintSnapshotInputs {
+  return {
+    mode: state.mode,
+    overrides: state.overrides,
+    diplomacyThreshold: state.diplomacyThreshold,
+    familyBaseColor: state.familyBaseColor,
+    outOfCircleBaseColor: state.outOfCircleBaseColor,
+    viewpointPlayerId: state.viewpointPlayerId,
+    inboundRelationFromByPlayerId: state.inboundRelationFromByPlayerId,
+    rosterPlayerIds: state.rosterPlayerIds,
+  }
 }
+
+function withRebuiltSnapshot(
+  state: PlayerColorsPersisted & {
+    viewpointPlayerId: number | null
+    inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+    rosterPlayerIds: readonly number[]
+  },
+  patch: Partial<PlayerColorsPersisted> & {
+    viewpointPlayerId?: number | null
+    inboundRelationFromByPlayerId?: ReadonlyMap<number, number>
+    rosterPlayerIds?: readonly number[]
+  }
+): typeof patch & { paintSnapshot: PlayerColorPaintSnapshot } {
+  const next = { ...state, ...patch }
+  return {
+    ...patch,
+    paintSnapshot: buildPlayerColorPaintSnapshot(snapshotInputsFromState(next)),
+  }
+}
+
+const initialSnapshotInputs = defaultPlayerColorPaintSnapshotInputs()
 
 export const usePlayerColorsStore = create<PlayerColorsState>()(
   persist(
@@ -66,43 +105,41 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
       viewpointPlayerId: null,
       inboundRelationFromByPlayerId: EMPTY_INBOUND,
       rosterPlayerIds: EMPTY_ROSTER,
-      paintRevision: 0,
+      paintSnapshot: buildPlayerColorPaintSnapshot(initialSnapshotInputs),
       setPlayerColorOverride: (playerId, color) =>
         set((state) => {
           const key = playerColorOverrideStorageKey(playerId)
           if (color == null || color.length === 0) {
             const rest = { ...state.overrides }
             delete rest[key]
-            return { overrides: rest, paintRevision: bumpRevision(state) }
+            return withRebuiltSnapshot(state, { overrides: rest })
           }
-          return {
+          return withRebuiltSnapshot(state, {
             overrides: {
               ...state.overrides,
               [key]: color,
             },
-            paintRevision: bumpRevision(state),
-          }
+          })
         }),
-      setPlayerColorMode: (mode) =>
-        set((state) => ({ mode, paintRevision: bumpRevision(state) })),
+      setPlayerColorMode: (mode) => set((state) => withRebuiltSnapshot(state, { mode })),
       setDiplomacyThreshold: (diplomacyThreshold) =>
-        set((state) => ({ diplomacyThreshold, paintRevision: bumpRevision(state) })),
+        set((state) => withRebuiltSnapshot(state, { diplomacyThreshold })),
       setFamilyBaseColor: (familyBaseColor) =>
-        set((state) => ({ familyBaseColor, paintRevision: bumpRevision(state) })),
+        set((state) => withRebuiltSnapshot(state, { familyBaseColor })),
       setOutOfCircleBaseColor: (outOfCircleBaseColor) =>
-        set((state) => ({ outOfCircleBaseColor, paintRevision: bumpRevision(state) })),
+        set((state) => withRebuiltSnapshot(state, { outOfCircleBaseColor })),
       setPaintContext: ({
         viewpointPlayerId,
         inboundRelationFromByPlayerId,
         rosterPlayerIds,
       }) =>
-        set((state) => ({
-          viewpointPlayerId,
-          inboundRelationFromByPlayerId,
-          rosterPlayerIds,
-          paintRevision: bumpRevision(state),
-        })),
-      colorForPlayerId: (playerId) => resolvePlayerColor(playerId),
+        set((state) =>
+          withRebuiltSnapshot(state, {
+            viewpointPlayerId,
+            inboundRelationFromByPlayerId,
+            rosterPlayerIds,
+          })
+        ),
     }),
     {
       name: PLAYER_COLORS_STORAGE_KEY,
@@ -134,7 +171,7 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
             : current.outOfCircleBaseColor
         const overrides =
           p.overrides != null && typeof p.overrides === 'object' ? p.overrides : current.overrides
-        return {
+        const merged = {
           ...current,
           overrides,
           mode,
@@ -142,40 +179,35 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
           familyBaseColor,
           outOfCircleBaseColor,
         }
+        return {
+          ...merged,
+          paintSnapshot: buildPlayerColorPaintSnapshot(snapshotInputsFromState(merged)),
+        }
       },
     }
   )
 )
 
 /**
- * Bind zustand state into the shared {@link colorForPlayerId} resolution port.
+ * Bind zustand paint snapshot into the shared {@link colorForPlayerId} port.
  * Settings (or another always-mounted shell module) must import this module so
  * the port is installed and persisted knobs rehydrate.
  */
 export function installPlayerColorsStorePort(): void {
   setPlayerColorResolutionPort({
-    getMode: () => usePlayerColorsStore.getState().mode,
-    getOverride: (playerId) =>
-      usePlayerColorsStore.getState().overrides[playerColorOverrideStorageKey(playerId)],
-    getDiplomacyThreshold: () => usePlayerColorsStore.getState().diplomacyThreshold,
-    getFamilyBaseColor: () => usePlayerColorsStore.getState().familyBaseColor,
-    getOutOfCircleBaseColor: () => usePlayerColorsStore.getState().outOfCircleBaseColor,
-    getViewpointPlayerId: () => usePlayerColorsStore.getState().viewpointPlayerId,
-    getInboundRelationFromByPlayerId: () =>
-      usePlayerColorsStore.getState().inboundRelationFromByPlayerId,
-    getRosterPlayerIds: () => usePlayerColorsStore.getState().rosterPlayerIds,
+    getSnapshot: () => usePlayerColorsStore.getState().paintSnapshot,
   })
 }
 
 installPlayerColorsStorePort()
 
 /**
- * Reactive player color for map/table paint. Subscribes to paint-affecting
- * store changes so Settings and shell context updates re-render.
+ * Reactive player color for map/table paint. Subscribes to the paint snapshot
+ * so Settings and shell context updates re-render.
  */
 export function usePlayerColor(playerId: number): string {
-  usePlayerColorsStore((state) => state.paintRevision)
-  return resolvePlayerColor(playerId)
+  const snapshot = usePlayerColorsStore((state) => state.paintSnapshot)
+  return resolvePlayerColor(playerId, snapshot)
 }
 
 /** Clear shell paint context (no viewpoint / relations / roster). */
@@ -184,5 +216,19 @@ export function clearPlayerColorPaintContext(): void {
     viewpointPlayerId: null,
     inboundRelationFromByPlayerId: EMPTY_INBOUND,
     rosterPlayerIds: EMPTY_ROSTER,
+  })
+}
+
+/** Test helper: reset knobs + shell context and rebuild the paint snapshot. */
+export function resetPlayerColorsStoreState(
+  patch: Partial<PlayerColorPaintSnapshotInputs> = {}
+): void {
+  const inputs: PlayerColorPaintSnapshotInputs = {
+    ...defaultPlayerColorPaintSnapshotInputs(),
+    ...patch,
+  }
+  usePlayerColorsStore.setState({
+    ...inputs,
+    paintSnapshot: buildPlayerColorPaintSnapshot(inputs),
   })
 }

--- a/packages/frontend/src/stores/playerColors.ts
+++ b/packages/frontend/src/stores/playerColors.ts
@@ -1,10 +1,16 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import {
-  colorForPlayerId,
-  colorFromOverrideOrDefault,
+  DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
+  isDiplomacyColorThreshold,
+  type DiplomacyColorThreshold,
+} from '../lib/diplomacyTier'
+import {
+  colorForPlayerId as resolvePlayerColor,
+  DEFAULT_FAMILY_BASE_COLOR,
   playerColorOverrideStorageKey,
-  setPlayerColorOverrideStore,
+  setPlayerColorResolutionPort,
+  type PlayerColorMode,
   type PlayerColorOverrides,
 } from '../lib/playerColor'
 import { createLocalStorageOrMemoryStateStorage } from '../lib/browserPersistStorage'
@@ -13,67 +19,146 @@ const playerColorsPersistStorage = createLocalStorageOrMemoryStateStorage()
 
 export const PLAYER_COLORS_STORAGE_KEY = 'planets-console-player-colors'
 
-type PlayerColorsState = {
+const EMPTY_INBOUND = new Map<number, number>()
+
+type PlayerColorsPersisted = {
   overrides: PlayerColorOverrides
+  mode: PlayerColorMode
+  diplomacyThreshold: DiplomacyColorThreshold
+  familyBaseColor: string
+}
+
+type PlayerColorsState = PlayerColorsPersisted & {
+  /** Shell paint context -- not persisted. */
+  viewpointPlayerId: number | null
+  inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+  /** Bumps so ``usePlayerColor`` re-renders on any paint-affecting change. */
+  paintRevision: number
   setPlayerColorOverride: (playerId: number, color: string | null) => void
+  setPlayerColorMode: (mode: PlayerColorMode) => void
+  setDiplomacyThreshold: (threshold: DiplomacyColorThreshold) => void
+  setFamilyBaseColor: (color: string) => void
+  setPaintContext: (ctx: {
+    viewpointPlayerId: number | null
+    inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+  }) => void
   colorForPlayerId: (playerId: number) => string
+}
+
+function bumpRevision(state: PlayerColorsState): number {
+  return state.paintRevision + 1
 }
 
 export const usePlayerColorsStore = create<PlayerColorsState>()(
   persist(
-    (set, get) => ({
+    (set) => ({
       overrides: {},
+      mode: 'per_player',
+      diplomacyThreshold: DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
+      familyBaseColor: DEFAULT_FAMILY_BASE_COLOR,
+      viewpointPlayerId: null,
+      inboundRelationFromByPlayerId: EMPTY_INBOUND,
+      paintRevision: 0,
       setPlayerColorOverride: (playerId, color) =>
         set((state) => {
           const key = playerColorOverrideStorageKey(playerId)
           if (color == null || color.length === 0) {
             const rest = { ...state.overrides }
             delete rest[key]
-            return { overrides: rest }
+            return { overrides: rest, paintRevision: bumpRevision(state) }
           }
           return {
             overrides: {
               ...state.overrides,
               [key]: color,
             },
+            paintRevision: bumpRevision(state),
           }
         }),
-      colorForPlayerId: (playerId) =>
-        colorFromOverrideOrDefault(
-          playerId,
-          get().overrides[playerColorOverrideStorageKey(playerId)]
-        ),
+      setPlayerColorMode: (mode) =>
+        set((state) => ({ mode, paintRevision: bumpRevision(state) })),
+      setDiplomacyThreshold: (diplomacyThreshold) =>
+        set((state) => ({ diplomacyThreshold, paintRevision: bumpRevision(state) })),
+      setFamilyBaseColor: (familyBaseColor) =>
+        set((state) => ({ familyBaseColor, paintRevision: bumpRevision(state) })),
+      setPaintContext: ({ viewpointPlayerId, inboundRelationFromByPlayerId }) =>
+        set((state) => ({
+          viewpointPlayerId,
+          inboundRelationFromByPlayerId,
+          paintRevision: bumpRevision(state),
+        })),
+      colorForPlayerId: (playerId) => resolvePlayerColor(playerId),
     }),
     {
       name: PLAYER_COLORS_STORAGE_KEY,
       storage: createJSONStorage(() => playerColorsPersistStorage),
-      partialize: (state) => ({ overrides: state.overrides }),
+      partialize: (state) => ({
+        overrides: state.overrides,
+        mode: state.mode,
+        diplomacyThreshold: state.diplomacyThreshold,
+        familyBaseColor: state.familyBaseColor,
+      }),
+      merge: (persisted, current) => {
+        const p =
+          persisted != null && typeof persisted === 'object'
+            ? (persisted as Partial<PlayerColorsPersisted>)
+            : {}
+        const mode: PlayerColorMode =
+          p.mode === 'diplomacy_family' || p.mode === 'per_player' ? p.mode : current.mode
+        const diplomacyThreshold = isDiplomacyColorThreshold(p.diplomacyThreshold as number)
+          ? (p.diplomacyThreshold as DiplomacyColorThreshold)
+          : current.diplomacyThreshold
+        const familyBaseColor =
+          typeof p.familyBaseColor === 'string' && p.familyBaseColor.length > 0
+            ? p.familyBaseColor
+            : current.familyBaseColor
+        const overrides =
+          p.overrides != null && typeof p.overrides === 'object' ? p.overrides : current.overrides
+        return {
+          ...current,
+          overrides,
+          mode,
+          diplomacyThreshold,
+          familyBaseColor,
+        }
+      },
     }
   )
 )
 
 /**
- * Bind zustand overrides into the shared {@link colorForPlayerId} storage port.
+ * Bind zustand state into the shared {@link colorForPlayerId} resolution port.
  * Settings (or another always-mounted shell module) must import this module so
- * the port is installed and persisted overrides rehydrate.
+ * the port is installed and persisted knobs rehydrate.
  */
 export function installPlayerColorsStorePort(): void {
-  setPlayerColorOverrideStore({
+  setPlayerColorResolutionPort({
+    getMode: () => usePlayerColorsStore.getState().mode,
     getOverride: (playerId) =>
       usePlayerColorsStore.getState().overrides[playerColorOverrideStorageKey(playerId)],
+    getDiplomacyThreshold: () => usePlayerColorsStore.getState().diplomacyThreshold,
+    getFamilyBaseColor: () => usePlayerColorsStore.getState().familyBaseColor,
+    getViewpointPlayerId: () => usePlayerColorsStore.getState().viewpointPlayerId,
+    getInboundRelationFromByPlayerId: () =>
+      usePlayerColorsStore.getState().inboundRelationFromByPlayerId,
   })
 }
 
 installPlayerColorsStorePort()
 
 /**
- * Reactive player color for map/table paint. Subscribes to override changes so
- * Settings updates re-render; resolution still goes through {@link colorForPlayerId}.
+ * Reactive player color for map/table paint. Subscribes to paint-affecting
+ * store changes so Settings and shell context updates re-render.
  */
 export function usePlayerColor(playerId: number): string {
-  // Subscribe so Settings override edits re-render; hex still comes from the port.
-  usePlayerColorsStore(
-    (state) => state.overrides[playerColorOverrideStorageKey(playerId)] ?? null
-  )
-  return colorForPlayerId(playerId)
+  usePlayerColorsStore((state) => state.paintRevision)
+  return resolvePlayerColor(playerId)
+}
+
+/** Clear shell paint context (no viewpoint / relations). */
+export function clearPlayerColorPaintContext(): void {
+  usePlayerColorsStore.getState().setPaintContext({
+    viewpointPlayerId: null,
+    inboundRelationFromByPlayerId: EMPTY_INBOUND,
+  })
 }

--- a/packages/frontend/src/stores/playerColors.ts
+++ b/packages/frontend/src/stores/playerColors.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_FAMILY_BASE_COLOR,
   DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
   defaultPlayerColorPaintSnapshotInputs,
+  isPlayerColorMode,
   playerColorOverrideStorageKey,
   resolvePlayerColor,
   setPlayerColorResolutionPort,
@@ -198,10 +199,12 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
             ? (persisted as Partial<PlayerColorsPersisted>)
             : {}
         const mode: PlayerColorMode =
-          p.mode === 'diplomacy_family' || p.mode === 'per_player' ? p.mode : current.mode
-        const diplomacyThreshold = isDiplomacyColorThreshold(p.diplomacyThreshold as number)
-          ? (p.diplomacyThreshold as DiplomacyColorThreshold)
-          : current.diplomacyThreshold
+          typeof p.mode === 'string' && isPlayerColorMode(p.mode) ? p.mode : current.mode
+        const diplomacyThreshold =
+          typeof p.diplomacyThreshold === 'number' &&
+          isDiplomacyColorThreshold(p.diplomacyThreshold)
+            ? p.diplomacyThreshold
+            : current.diplomacyThreshold
         const familyBaseColor =
           typeof p.familyBaseColor === 'string' && p.familyBaseColor.length > 0
             ? p.familyBaseColor

--- a/packages/frontend/src/stores/playerColors.ts
+++ b/packages/frontend/src/stores/playerColors.ts
@@ -54,6 +54,49 @@ type PlayerColorsState = PlayerColorsPersisted & {
   }) => void
 }
 
+function inboundRelationMapsEqual(
+  a: ReadonlyMap<number, number>,
+  b: ReadonlyMap<number, number>
+): boolean {
+  if (a === b) return true
+  if (a.size !== b.size) return false
+  for (const [playerId, relation] of a) {
+    if (b.get(playerId) !== relation) return false
+  }
+  return true
+}
+
+function rosterPlayerIdsEqual(a: readonly number[], b: readonly number[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+function paintContextEquals(
+  state: {
+    viewpointPlayerId: number | null
+    inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+    rosterPlayerIds: readonly number[]
+  },
+  ctx: {
+    viewpointPlayerId: number | null
+    inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+    rosterPlayerIds: readonly number[]
+  }
+): boolean {
+  return (
+    state.viewpointPlayerId === ctx.viewpointPlayerId &&
+    inboundRelationMapsEqual(
+      state.inboundRelationFromByPlayerId,
+      ctx.inboundRelationFromByPlayerId
+    ) &&
+    rosterPlayerIdsEqual(state.rosterPlayerIds, ctx.rosterPlayerIds)
+  )
+}
+
 function snapshotInputsFromState(
   state: PlayerColorsPersisted & {
     viewpointPlayerId: number | null
@@ -96,7 +139,7 @@ const initialSnapshotInputs = defaultPlayerColorPaintSnapshotInputs()
 
 export const usePlayerColorsStore = create<PlayerColorsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       overrides: {},
       mode: 'per_player',
       diplomacyThreshold: DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
@@ -128,18 +171,16 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
         set((state) => withRebuiltSnapshot(state, { familyBaseColor })),
       setOutOfCircleBaseColor: (outOfCircleBaseColor) =>
         set((state) => withRebuiltSnapshot(state, { outOfCircleBaseColor })),
-      setPaintContext: ({
-        viewpointPlayerId,
-        inboundRelationFromByPlayerId,
-        rosterPlayerIds,
-      }) =>
+      setPaintContext: (ctx) => {
+        if (paintContextEquals(get(), ctx)) return
         set((state) =>
           withRebuiltSnapshot(state, {
-            viewpointPlayerId,
-            inboundRelationFromByPlayerId,
-            rosterPlayerIds,
+            viewpointPlayerId: ctx.viewpointPlayerId,
+            inboundRelationFromByPlayerId: ctx.inboundRelationFromByPlayerId,
+            rosterPlayerIds: ctx.rosterPlayerIds,
           })
-        ),
+        )
+      },
     }),
     {
       name: PLAYER_COLORS_STORAGE_KEY,

--- a/packages/frontend/src/stores/playerColors.ts
+++ b/packages/frontend/src/stores/playerColors.ts
@@ -8,6 +8,7 @@ import {
 import {
   colorForPlayerId as resolvePlayerColor,
   DEFAULT_FAMILY_BASE_COLOR,
+  DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
   playerColorOverrideStorageKey,
   setPlayerColorResolutionPort,
   type PlayerColorMode,
@@ -20,27 +21,32 @@ const playerColorsPersistStorage = createLocalStorageOrMemoryStateStorage()
 export const PLAYER_COLORS_STORAGE_KEY = 'planets-console-player-colors'
 
 const EMPTY_INBOUND = new Map<number, number>()
+const EMPTY_ROSTER: readonly number[] = []
 
 type PlayerColorsPersisted = {
   overrides: PlayerColorOverrides
   mode: PlayerColorMode
   diplomacyThreshold: DiplomacyColorThreshold
   familyBaseColor: string
+  outOfCircleBaseColor: string
 }
 
 type PlayerColorsState = PlayerColorsPersisted & {
   /** Shell paint context -- not persisted. */
   viewpointPlayerId: number | null
   inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+  rosterPlayerIds: readonly number[]
   /** Bumps so ``usePlayerColor`` re-renders on any paint-affecting change. */
   paintRevision: number
   setPlayerColorOverride: (playerId: number, color: string | null) => void
   setPlayerColorMode: (mode: PlayerColorMode) => void
   setDiplomacyThreshold: (threshold: DiplomacyColorThreshold) => void
   setFamilyBaseColor: (color: string) => void
+  setOutOfCircleBaseColor: (color: string) => void
   setPaintContext: (ctx: {
     viewpointPlayerId: number | null
     inboundRelationFromByPlayerId: ReadonlyMap<number, number>
+    rosterPlayerIds: readonly number[]
   }) => void
   colorForPlayerId: (playerId: number) => string
 }
@@ -56,8 +62,10 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
       mode: 'per_player',
       diplomacyThreshold: DEFAULT_DIPLOMACY_COLOR_THRESHOLD,
       familyBaseColor: DEFAULT_FAMILY_BASE_COLOR,
+      outOfCircleBaseColor: DEFAULT_OUT_OF_CIRCLE_BASE_COLOR,
       viewpointPlayerId: null,
       inboundRelationFromByPlayerId: EMPTY_INBOUND,
+      rosterPlayerIds: EMPTY_ROSTER,
       paintRevision: 0,
       setPlayerColorOverride: (playerId, color) =>
         set((state) => {
@@ -81,10 +89,17 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
         set((state) => ({ diplomacyThreshold, paintRevision: bumpRevision(state) })),
       setFamilyBaseColor: (familyBaseColor) =>
         set((state) => ({ familyBaseColor, paintRevision: bumpRevision(state) })),
-      setPaintContext: ({ viewpointPlayerId, inboundRelationFromByPlayerId }) =>
+      setOutOfCircleBaseColor: (outOfCircleBaseColor) =>
+        set((state) => ({ outOfCircleBaseColor, paintRevision: bumpRevision(state) })),
+      setPaintContext: ({
+        viewpointPlayerId,
+        inboundRelationFromByPlayerId,
+        rosterPlayerIds,
+      }) =>
         set((state) => ({
           viewpointPlayerId,
           inboundRelationFromByPlayerId,
+          rosterPlayerIds,
           paintRevision: bumpRevision(state),
         })),
       colorForPlayerId: (playerId) => resolvePlayerColor(playerId),
@@ -97,6 +112,7 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
         mode: state.mode,
         diplomacyThreshold: state.diplomacyThreshold,
         familyBaseColor: state.familyBaseColor,
+        outOfCircleBaseColor: state.outOfCircleBaseColor,
       }),
       merge: (persisted, current) => {
         const p =
@@ -112,6 +128,10 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
           typeof p.familyBaseColor === 'string' && p.familyBaseColor.length > 0
             ? p.familyBaseColor
             : current.familyBaseColor
+        const outOfCircleBaseColor =
+          typeof p.outOfCircleBaseColor === 'string' && p.outOfCircleBaseColor.length > 0
+            ? p.outOfCircleBaseColor
+            : current.outOfCircleBaseColor
         const overrides =
           p.overrides != null && typeof p.overrides === 'object' ? p.overrides : current.overrides
         return {
@@ -120,6 +140,7 @@ export const usePlayerColorsStore = create<PlayerColorsState>()(
           mode,
           diplomacyThreshold,
           familyBaseColor,
+          outOfCircleBaseColor,
         }
       },
     }
@@ -138,9 +159,11 @@ export function installPlayerColorsStorePort(): void {
       usePlayerColorsStore.getState().overrides[playerColorOverrideStorageKey(playerId)],
     getDiplomacyThreshold: () => usePlayerColorsStore.getState().diplomacyThreshold,
     getFamilyBaseColor: () => usePlayerColorsStore.getState().familyBaseColor,
+    getOutOfCircleBaseColor: () => usePlayerColorsStore.getState().outOfCircleBaseColor,
     getViewpointPlayerId: () => usePlayerColorsStore.getState().viewpointPlayerId,
     getInboundRelationFromByPlayerId: () =>
       usePlayerColorsStore.getState().inboundRelationFromByPlayerId,
+    getRosterPlayerIds: () => usePlayerColorsStore.getState().rosterPlayerIds,
   })
 }
 
@@ -155,10 +178,11 @@ export function usePlayerColor(playerId: number): string {
   return resolvePlayerColor(playerId)
 }
 
-/** Clear shell paint context (no viewpoint / relations). */
+/** Clear shell paint context (no viewpoint / relations / roster). */
 export function clearPlayerColorPaintContext(): void {
   usePlayerColorsStore.getState().setPaintContext({
     viewpointPlayerId: null,
     inboundRelationFromByPlayerId: EMPTY_INBOUND,
+    rosterPlayerIds: EMPTY_ROSTER,
   })
 }


### PR DESCRIPTION
## Summary
- Adds Settings for **player color mode**: per-player overrides or diplomacy-family paint with threshold, in-circle base, and out-of-circle base ([#289](https://github.com/SteveDraper/Planets-Console/issues/289)).
- Shell installs an immutable paint snapshot from viewpoint + turn relations + roster (ADR 0013); consumers keep `usePlayerColor` / `colorForPlayerId`.
- Diplomacy-family membership uses inbound `relationfrom` vs viewpoint; viewpoint is brightest in-circle; non-members share the out-of-circle base with tonal variants.

## Test plan
- [ ] Open Settings → Player Colors: switch modes; confirm both modes’ knobs persist across toggle and reload
- [ ] Per-player: set/clear overrides from loaded game roster; empty state with no game loaded
- [ ] Diplomacy-family: change threshold / both bases; confirm fleet rings (and other `usePlayerColor` consumers) update without call-site changes
- [ ] Change viewpoint / turn: membership recomputes from inbound relations; missing relation → out-of-circle
- [ ] `make test_frontend` (or CI) green for player color / shell / Settings coverage


Made with [Cursor](https://cursor.com)