### PR TITLE
Map hover: fleet/region merge, opaque chrome, low planet detail

### DIFF
--- a/packages/frontend/src/components/PlanetMapInfoControls.tsx
+++ b/packages/frontend/src/components/PlanetMapInfoControls.tsx
@@ -7,7 +7,11 @@ type PlanetMapInfoControlsProps = {
 
 const DETAIL_OPTIONS: { value: PlanetDetailsLevel; label: string; description: string }[] = [
   { value: 'none', label: 'None', description: 'Show only title information' },
-  { value: 'low', label: 'Low', description: 'Show basic details' },
+  {
+    value: 'low',
+    label: 'Low',
+    description: 'Owner, colonist clans, natives, and temperature when known',
+  },
   { value: 'medium', label: 'Medium', description: 'Show full resource details' },
   { value: 'debug', label: 'Debug', description: 'Show all properties' },
 ]

--- a/packages/frontend/src/components/planetMapLabelModel.test.ts
+++ b/packages/frontend/src/components/planetMapLabelModel.test.ts
@@ -9,11 +9,11 @@ import {
 } from './planetMapLabelModel'
 
 describe('planetMapLabelModel', () => {
-  it('defaults to only planet id for label options', () => {
+  it('defaults to planet id title plus low detail (owner / clans / natives)', () => {
     expect(DEFAULT_PLANET_LABEL_OPTIONS.includePlanetId).toBe(true)
     expect(DEFAULT_PLANET_LABEL_OPTIONS.includePlanetName).toBe(false)
     expect(DEFAULT_PLANET_LABEL_OPTIONS.includeCoordinates).toBe(false)
-    expect(DEFAULT_PLANET_LABEL_OPTIONS.detailsLevel).toBe('none')
+    expect(DEFAULT_PLANET_LABEL_OPTIONS.detailsLevel).toBe('low')
   })
 
   it('planetLabelOptionsShowAnyLabel is false when nothing is selected', () => {

--- a/packages/frontend/src/components/planetMapLabelModel.ts
+++ b/packages/frontend/src/components/planetMapLabelModel.ts
@@ -13,7 +13,7 @@ export const DEFAULT_PLANET_LABEL_OPTIONS: PlanetLabelOptions = {
   includePlanetId: true,
   includePlanetName: false,
   includeCoordinates: false,
-  detailsLevel: 'none',
+  detailsLevel: 'low',
 }
 
 export function planetLabelOptionsShowAnyLabel(options: PlanetLabelOptions): boolean {

--- a/packages/frontend/src/map-interaction/MapHoverChrome.tsx
+++ b/packages/frontend/src/map-interaction/MapHoverChrome.tsx
@@ -93,22 +93,23 @@ function DescriptiveHostChrome({
   const showTitles = host.sections.length > 1
   const cursorHost = host.placement.mode === 'cursor'
 
+  // Above map paint overlays (region z-6, fleet rings z-7) so the opaque panel
+  // occludes ring/fill opacity rather than letting those layers composite on top.
+  const chromeClass =
+    pos.pinned
+      ? 'pointer-events-auto absolute z-[20] isolate max-w-xs font-mono text-xs text-gray-300'
+      : 'pointer-events-none absolute z-[20] isolate max-w-xs font-mono text-xs text-gray-300'
+
   return (
     <div
-      className={
-        cursorHost
-          ? 'pointer-events-none absolute z-[6] max-w-xs font-mono text-xs text-gray-300'
-          : pos.pinned
-            ? 'pointer-events-auto absolute z-[6] max-w-xs font-mono text-xs text-gray-300'
-            : 'pointer-events-none absolute z-[6] max-w-xs font-mono text-xs text-gray-300'
-      }
+      className={chromeClass}
       style={{
         left: pos.left,
         top: pos.top,
         transform: cursorHost ? 'translateY(-100%)' : undefined,
         backgroundColor: '#000000',
         borderRadius: 6,
-        padding: cursorHost ? '4px 8px' : undefined,
+        padding: '4px 8px',
       }}
       role="tooltip"
       onClick={pos.pinned ? (e) => e.stopPropagation() : undefined}

--- a/packages/frontend/src/map-interaction/mapHoverCompositionPolicy.test.ts
+++ b/packages/frontend/src/map-interaction/mapHoverCompositionPolicy.test.ts
@@ -199,13 +199,14 @@ describe('composeMapHoverContributions', () => {
     })
   })
 
-  it('fleet and region without merge edge produce two descriptive hosts', () => {
+  it('fleet mergesWith region into one host anchored at the fleet (fleet then region)', () => {
     const result = composeMapHoverContributions([
       contribution({
         id: 'fleet:1',
         role: 'fleet',
         kind: 'descriptive',
         title: 'Fleet',
+        placement: { mode: 'anchor', flowX: 5, flowY: 6 },
       }),
       contribution({
         id: 'region:1',
@@ -215,10 +216,53 @@ describe('composeMapHoverContributions', () => {
       }),
     ])
 
-    expect(result.descriptiveHosts).toHaveLength(2)
-    expect(result.descriptiveHosts.map((h) => h.sections[0]!.role)).toEqual([
+    expect(result.suppressedIds).toEqual([])
+    expect(result.descriptiveHosts).toHaveLength(1)
+    expect(result.descriptiveHosts[0]!.placement).toEqual({
+      mode: 'anchor',
+      flowX: 5,
+      flowY: 6,
+    })
+    expect(result.descriptiveHosts[0]!.sections.map((s) => s.role)).toEqual([
       'fleet',
       'region',
+    ])
+  })
+
+  it('fleet+region merge pulls cartography into the same anchored host', () => {
+    const result = composeMapHoverContributions([
+      contribution({
+        id: 'fleet:1',
+        role: 'fleet',
+        kind: 'descriptive',
+        title: 'Fleet',
+        placement: { mode: 'anchor', flowX: 5, flowY: 6 },
+      }),
+      contribution({
+        id: 'region:1',
+        role: 'region',
+        kind: 'descriptive',
+        title: 'Region',
+      }),
+      contribution({
+        id: 'cartography:1',
+        role: 'cartography',
+        kind: 'descriptive',
+        title: 'Stellar Cartography',
+      }),
+    ])
+
+    expect(result.suppressedIds).toEqual([])
+    expect(result.descriptiveHosts).toHaveLength(1)
+    expect(result.descriptiveHosts[0]!.placement).toEqual({
+      mode: 'anchor',
+      flowX: 5,
+      flowY: 6,
+    })
+    expect(result.descriptiveHosts[0]!.sections.map((s) => s.role)).toEqual([
+      'fleet',
+      'region',
+      'cartography',
     ])
   })
 

--- a/packages/frontend/src/map-interaction/mapHoverCompositionPolicy.ts
+++ b/packages/frontend/src/map-interaction/mapHoverCompositionPolicy.ts
@@ -50,6 +50,11 @@ export const MAP_HOVER_COMPOSITION_POLICY: readonly MapHoverPolicyEdge[] = [
     to: { kind: 'descriptive', role: 'planet' },
   },
   {
+    from: { kind: 'descriptive', role: 'fleet' },
+    relation: 'mergesWith',
+    to: { kind: 'descriptive', role: 'region' },
+  },
+  {
     from: { kind: 'descriptive', role: 'region' },
     relation: 'mergesWith',
     to: { kind: 'descriptive', role: 'cartography' },


### PR DESCRIPTION
## Summary
- Merge fleet and region descriptive hover into one fleet-anchored panel (cartography joins transitively when present).
- Raise hover chrome above map paint overlays and keep a solid padded panel so ring/fill opacity no longer bleeds through text.
- Default planet label detail level to Low (owner, colonist clans, natives, temperature when known); clarify the control description.

## Test plan
- [ ] Hover a deep-space fleet over a homeworld sector: one panel with Fleet then Region sections, anchored on the ring
- [ ] Hover fleet + sector + cartography sample: single anchored panel including cartography
- [ ] Confirm hover text remains readable over fleet rings / region fills
- [ ] Fresh map session shows Low planet detail (owner/clans/natives); Detail level control still switches None/Medium/Debug
- [ ] `npx vitest run src/map-interaction/mapHoverCompositionPolicy.test.ts src/components/planetMapLabelModel.test.ts`


Made with [Cursor](https://cursor.com)