### PR TITLE
Force single-worker CP-SAT; widen orchestrator pool

### DIFF
--- a/packages/api/api/analytics/military_score_inference/near_best_structural_search.py
+++ b/packages/api/api/analytics/military_score_inference/near_best_structural_search.py
@@ -49,13 +49,23 @@ class NearBestStructuralSearchOutcome:
     top_solution_bucket_counts: dict[str, tuple[int, ...]]
 
 
-def _configured_num_search_workers(combo_count: int) -> int | None:
+def configured_sat_search_workers() -> int:
+    """Return CP-SAT ``num_workers`` for one ``Solve()`` call.
+
+    Default is **1**: multi-worker CP-SAT portfolios (LNS) routinely overshoot
+    short stream tier ``max_time_in_seconds`` budgets. Parallelism for cold
+    ensure / streams belongs on the orchestrator thread pool across per-player
+    DAG nodes, not inside one solve. Override with
+    ``MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS`` for experiments / batch jobs.
+
+    Callers must set only ``parameters.num_workers``. Also setting the deprecated
+    ``num_search_workers`` to a non-zero value makes OR-Tools return
+    ``MODEL_INVALID``.
+    """
     raw = os.environ.get("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS")
     if raw is not None:
-        return int(raw)
-    if combo_count > 100:
-        return 8
-    return None
+        return max(1, int(raw))
+    return 1
 
 
 def add_no_good_cut(
@@ -266,9 +276,10 @@ def collect_near_best_structural_hits(
             break
 
         solver.parameters.max_time_in_seconds = remaining_seconds
-        num_search_workers = _configured_num_search_workers(len(problem.ship_build_combos))
-        if num_search_workers is not None:
-            solver.parameters.num_search_workers = num_search_workers
+        # Set only ``num_workers``. Setting both ``num_workers`` and the deprecated
+        # ``num_search_workers`` to non-zero values makes OR-Tools return
+        # MODEL_INVALID on this model (empty search; fleet warships stay "?").
+        solver.parameters.num_workers = configured_sat_search_workers()
         if cancel_token is not None:
             callback = _StopSearchOnCancel(cancel_token)
             last_solver_status = solver.solve(model, callback)

--- a/packages/api/api/compute/pools.py
+++ b/packages/api/api/compute/pools.py
@@ -32,7 +32,9 @@ PRIORITY_BAND_RANK: dict[ComputePriorityBand, int] = {
     "background": 2,
 }
 
-_DEFAULT_WORKER_COUNT = 4
+# Wider than historical 4: scores ``tier_solve`` is single-threaded CP-SAT, so
+# parallelism is across per-player DAG nodes on this pool (not inside one Solve).
+_DEFAULT_WORKER_COUNT = 8
 _DEQUEUE_WAIT_SECONDS = 0.25
 
 

--- a/packages/api/tests/test_compute_pools.py
+++ b/packages/api/tests/test_compute_pools.py
@@ -517,6 +517,13 @@ def test_configured_worker_count_reads_environment(monkeypatch: pytest.MonkeyPat
     assert configured_worker_count() == 7
 
 
+def test_configured_worker_count_default_is_eight(monkeypatch: pytest.MonkeyPatch):
+    from api.compute.pools import configured_worker_count
+
+    monkeypatch.delenv("COMPUTE_ORCHESTRATOR_WORKERS", raising=False)
+    assert configured_worker_count() == 8
+
+
 def _single_step_thread_registration() -> TurnAnalyticRegistration:
     return TurnAnalyticRegistration(
         catalog_entry=_catalog_entry(),

--- a/packages/api/tests/test_military_score_inference_solver.py
+++ b/packages/api/tests/test_military_score_inference_solver.py
@@ -543,3 +543,45 @@ def test_freighter_only_zero_military_score_uses_fast_path():
     assert len(result.solutions) == 1
     assert result.solutions[0].ship_builds[0].combo_id == GENERIC_FREIGHTER_COMBO_ID
     assert result.solutions[0].ship_builds[0].count == 1
+
+
+def test_configured_sat_search_workers_defaults_to_one(monkeypatch):
+    from api.analytics.military_score_inference.near_best_structural_search import (
+        configured_sat_search_workers,
+    )
+
+    monkeypatch.delenv("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS", raising=False)
+    assert configured_sat_search_workers() == 1
+
+
+def test_configured_sat_search_workers_env_override(monkeypatch):
+    from api.analytics.military_score_inference.near_best_structural_search import (
+        configured_sat_search_workers,
+    )
+
+    monkeypatch.setenv("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS", "4")
+    assert configured_sat_search_workers() == 4
+    monkeypatch.setenv("MILITARY_SCORE_INFERENCE_NUM_SEARCH_WORKERS", "0")
+    assert configured_sat_search_workers() == 1
+
+
+def test_ortools_rejects_both_num_workers_and_num_search_workers():
+    """Regression: dual non-zero worker params → MODEL_INVALID (fleet '?' bug).
+
+    Near-best search must set only ``num_workers``, not also the deprecated
+    ``num_search_workers`` alias.
+    """
+    from ortools.sat.python import cp_model
+
+    model = cp_model.CpModel()
+    x = model.new_int_var(0, 10, "x")
+    model.maximize(x)
+
+    either = cp_model.CpSolver()
+    either.parameters.num_workers = 1
+    assert either.solve(model) == cp_model.OPTIMAL
+
+    both = cp_model.CpSolver()
+    both.parameters.num_workers = 1
+    both.parameters.num_search_workers = 1
+    assert both.solve(model) == cp_model.MODEL_INVALID


### PR DESCRIPTION
## Summary
- Default military-score CP-SAT to a single `num_workers` thread so short stream tier budgets are honored (multi-worker LNS portfolios were overshooting by minutes).
- Set only `num_workers` -- also setting deprecated `num_search_workers` makes OR-Tools return `MODEL_INVALID`, which left fleet warships as `?` after recompute.
- Raise default `COMPUTE_ORCHESTRATOR_WORKERS` from 4 to 8 so per-player scores DAG nodes still overlap on the thread pool.

## Test plan
- [ ] Unit tests for worker defaults / env override and dual-param `MODEL_INVALID` regression
- [ ] Cold ensure / clear+recompute game 680224: scores find solutions for military deltas; fleet warships show option sets (not only freighters)
- [ ] Confirm stream tiers no longer hang for multi-minute CP-SAT on large catalogs
- [ ] Pool diagnostics show configured workers = 8 (unless `COMPUTE_ORCHESTRATOR_WORKERS` is set)


Made with [Cursor](https://cursor.com)