### PR TITLE
Add fleet sidebar player color swatches (#303)

### DIFF
--- a/docs/design-fleet-analytic.md
+++ b/docs/design-fleet-analytic.md
@@ -349,6 +349,7 @@ Client projects **fleet player visibility**-filtered **`active`** rows whose `la
 - **Fleet player visibility** checklist: one toggle per **Player** for **both** map and table
 - Default: all **Players** on until the user toggles an override
 - Persisted globally (not per game), same pattern as **Cartography layer**
+- Per-player row includes a small always-visible **player color** swatch (`usePlayerColor`, same paint as map rings/trails) between the checkbox and truncated label; swatch stays when unchecked (dimmed). Row `title` shows the full untruncated label ([#303](https://github.com/SteveDraper/Planets-Console/issues/303))
 
 ### 8.2 Map (fleet stream → location rings)
 
@@ -491,6 +492,7 @@ Critical path: `0 -> 1 -> 2 -> 3 -> 4 -> 5`.
 | **Fleet F7** (ADR 0004) | Per-player persistence, provenance, table stream -- [#163](https://github.com/SteveDraper/Planets-Console/issues/163) epic; section 15 |
 | **#143** | Neutral scores-inference revision for fleet refetch; superseded for refinement updates once F7 stream ships |
 | **Player color Settings** [#289](https://github.com/SteveDraper/Planets-Console/issues/289) | Settings UI for **player color mode** (per-player overrides + diplomacy-family); #128 ships defaults + storage seam; [ADR 0013](adr/0013-player-color-resolution-context.md) |
+| **Fleet sidebar color key** [#303](https://github.com/SteveDraper/Planets-Console/issues/303) | Small always-visible player-color swatch + full-label `title` on fleet player visibility rows (section 8.1) |
 | **Fleet heading trails** [#290](https://github.com/SteveDraper/Planets-Console/issues/290) | Map rays for known heading/speed (observed ships); optional multi-turn forward/back opacity ramp; stream wire enrichment |
 
 ### `$.composition` export branch (#154)

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.test.tsx
@@ -7,6 +7,12 @@ import { FleetAnalyticTile } from './FleetAnalyticTile'
 import { seedShellViewpoint } from './fleetTestShell'
 import { useFleetPlayerVisibilityStore } from '../../stores/fleetPlayerVisibility'
 import { useFleetHeadingTrailExtendStore } from '../../stores/fleetHeadingTrailExtend'
+import {
+  installPlayerColorsStorePort,
+  resetPlayerColorsStoreState,
+  usePlayerColorsStore,
+} from '../../stores/playerColors'
+import { defaultColorForPlayerId, resetPlayerColorResolutionPort } from '../../lib/playerColor'
 import { useShellStore } from '../../stores/shell'
 
 vi.mock('../../api/bff', async (importOriginal) => {
@@ -44,6 +50,9 @@ describe('FleetAnalyticTile', () => {
   beforeEach(() => {
     useFleetPlayerVisibilityStore.setState({ overrides: {} })
     useFleetHeadingTrailExtendStore.setState({ extendTurns: 0 })
+    resetPlayerColorResolutionPort()
+    resetPlayerColorsStoreState()
+    installPlayerColorsStorePort()
     useShellStore.setState({
       selectedGameId: null,
       gameInfoContext: null,
@@ -109,5 +118,32 @@ describe('FleetAnalyticTile', () => {
     await user.click(screen.getByLabelText('Expand Fleet player visibility'))
     const trailSelect = screen.getByLabelText('Fleet heading trail extend turns')
     expect(trailSelect).toBeDisabled()
+  })
+
+  it('shows a player color swatch matching the paint color and a full-label title', async () => {
+    const user = userEvent.setup()
+    usePlayerColorsStore.getState().setPlayerColorOverride(8, '#112233')
+    renderTile()
+    await user.click(screen.getByLabelText('Expand Fleet player visibility'))
+
+    const aliceRow = screen.getByLabelText('Alice').closest('label')
+    expect(aliceRow).toHaveAttribute('title', 'Alice')
+    const aliceSwatch = screen.getByTestId('fleet-player-color-8')
+    expect(aliceSwatch).toHaveStyle({ backgroundColor: '#112233' })
+    expect(aliceSwatch).not.toHaveClass('opacity-50')
+
+    const bobSwatch = screen.getByTestId('fleet-player-color-9')
+    expect(bobSwatch).toHaveStyle({ backgroundColor: defaultColorForPlayerId(9) })
+  })
+
+  it('keeps the color swatch visible (dimmed) when a player is unchecked', async () => {
+    const user = userEvent.setup()
+    renderTile()
+    await user.click(screen.getByLabelText('Expand Fleet player visibility'))
+    await user.click(screen.getByLabelText('Bob'))
+    const bobSwatch = screen.getByTestId('fleet-player-color-9')
+    expect(bobSwatch).toBeInTheDocument()
+    expect(bobSwatch).toHaveClass('opacity-50')
+    expect(bobSwatch).toHaveStyle({ backgroundColor: defaultColorForPlayerId(9) })
   })
 })

--- a/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
+++ b/packages/frontend/src/analytics/fleet/FleetAnalyticTile.tsx
@@ -5,6 +5,7 @@ import {
   deriveShellTurnMax,
   deriveTurnView,
 } from '../../shell/shellContext'
+import type { PerspectiveRow } from '../../lib/gameInfoShell'
 import { useTurnRacePlayerLabels } from '../../lib/turnRacePlayerLabels'
 import { cn } from '../../lib/utils'
 import { useSessionStore } from '../../stores/session'
@@ -13,6 +14,7 @@ import {
   FLEET_HEADING_TRAIL_MAX_EXTEND_TURNS,
   useFleetHeadingTrailExtendStore,
 } from '../../stores/fleetHeadingTrailExtend'
+import { usePlayerColor } from '../../stores/playerColors'
 import { useShellStore } from '../../stores/shell'
 import { fleetPlayerDisplayLabel } from './fleetPlayerDisplayLabel'
 import { useOrderedFleetPlayers } from './useOrderedFleetPlayers'
@@ -29,6 +31,47 @@ type FleetAnalyticTileProps = {
   supportsMode: boolean
   depressed: boolean
   onToggle: () => void
+}
+
+type FleetPlayerVisibilityRowProps = {
+  player: Pick<PerspectiveRow, 'playerId' | 'name' | 'raceName'>
+  racePlayerLabels: Map<number, string>
+  isVisible: boolean
+  onVisibleChange: (visible: boolean) => void
+}
+
+function FleetPlayerVisibilityRow({
+  player,
+  racePlayerLabels,
+  isVisible,
+  onVisibleChange,
+}: FleetPlayerVisibilityRowProps) {
+  const color = usePlayerColor(player.playerId)
+  const playerLabel = fleetPlayerDisplayLabel(player, racePlayerLabels, undefined)
+
+  return (
+    <label
+      title={playerLabel}
+      className="flex cursor-pointer items-center gap-2"
+    >
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={(event) => onVisibleChange(event.target.checked)}
+        className="h-3.5 w-3.5 shrink-0 rounded border-[#52575d] bg-slate-700 text-slate-200 accent-slate-400 focus:ring-[#52575d] focus:ring-offset-0"
+      />
+      <span
+        aria-hidden
+        data-testid={`fleet-player-color-${player.playerId}`}
+        className={cn(
+          'h-2.5 w-2.5 shrink-0 rounded-sm border border-black/40',
+          !isVisible && 'opacity-50'
+        )}
+        style={{ backgroundColor: color }}
+      />
+      <span className="min-w-0 truncate">{playerLabel}</span>
+    </label>
+  )
 }
 
 export function FleetAnalyticTile({
@@ -166,22 +209,15 @@ export function FleetAnalyticTile({
               ))}
             </select>
           </label>
-          {orderedPlayers.map((player) => {
-            const playerLabel = fleetPlayerDisplayLabel(player, racePlayerLabels, undefined)
-            return (
-            <label key={player.playerId} className="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                checked={isPlayerVisible(player.playerId)}
-                onChange={(event) =>
-                  setFleetPlayerVisible(player.playerId, event.target.checked)
-                }
-                className="h-3.5 w-3.5 shrink-0 rounded border-[#52575d] bg-slate-700 accent-slate-400"
-              />
-              <span className="min-w-0 truncate">{playerLabel}</span>
-            </label>
-            )
-          })}
+          {orderedPlayers.map((player) => (
+            <FleetPlayerVisibilityRow
+              key={player.playerId}
+              player={player}
+              racePlayerLabels={racePlayerLabels}
+              isVisible={isPlayerVisible(player.playerId)}
+              onVisibleChange={(visible) => setFleetPlayerVisible(player.playerId, visible)}
+            />
+          ))}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- Add always-visible player color swatches to fleet analytic visibility rows (`usePlayerColor`, same paint as map rings/trails), dimmed when unchecked
- Set each row `title` to the full untruncated player label for long Race (player) names
- Document the sidebar color key in `docs/design-fleet-analytic.md` (§8.1 + coupling)

Closes #303

## Test plan
- [ ] Expand Fleet player visibility in the sidebar; confirm a color swatch appears between checkbox and name for each player
- [ ] Confirm swatch colors match map ring/trail colors (including Settings overrides)
- [ ] Uncheck a player; confirm the swatch stays visible but dimmed
- [ ] Hover a truncated long Race (player) label; confirm `title` shows the full name
- [ ] `packages/frontend` unit tests for FleetAnalyticTile swatch/title behavior pass


Made with [Cursor](https://cursor.com)